### PR TITLE
Regenerate pages and browser app

### DIFF
--- a/genes/worm/bag-1/bag-1-ai-review.html
+++ b/genes/worm/bag-1/bag-1-ai-review.html
@@ -1,0 +1,3138 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>bag-1 - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        .propagation-review {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f8fafc;
+            border-left: 3px solid #64748b;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .propagation-title {
+            font-weight: 600;
+            color: #334155;
+            margin-bottom: 0.25rem;
+        }
+
+        .propagation-row {
+            margin-top: 0.25rem;
+        }
+
+        .propagation-source {
+            margin-top: 0.5rem;
+            padding-top: 0.5rem;
+            border-top: 1px solid #e5e7eb;
+        }
+
+        .propagation-source-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #1d4ed8;
+        }
+
+        .propagation-comment {
+            color: #4b5563;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>bag-1</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/O44739" target="_blank" class="term-link">
+                        O44739
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Caenorhabditis elegans</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-complete">
+                    COMPLETE
+                </span>
+            </div>
+
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "bag-1";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="O44739" data-a="DESCRIPTION: bag-1 encodes the Caenorhabditis elegans member of..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>bag-1 encodes the Caenorhabditis elegans member of the BAG (Bcl-2-associated athanogene) family of Hsp70/Hsc70 co-chaperones. The 210-residue protein has an N-terminal ubiquitin-like domain and a C-terminal BAG domain; the BAG domain binds the nucleotide-binding (ATPase) domain of Hsp70-family chaperones and acts as a nucleotide-exchange factor, promoting ADP release and ATP-dependent discharge of client substrates from the chaperone. By accelerating the Hsp70/Hsc70 nucleotide cycle, BAG-1 modulates chaperone-assisted protein folding, and at high co-chaperone levels this activity can antagonize productive folding. In the worm, BAG-1 stimulates the ATPase activity of the constitutive Hsc70 (HSP-1) and, together with the J-domain protein DNJ-13 (Hsp40) and the paralogous BAG-domain protein UNC-23 (BAG2 ortholog), belongs to the cofactor network that tunes the Hsc70 chaperone cycle. The BAG domain adopts a helical bundle fold, and the worm protein can oligomerize into dimers and tetramers. It is a soluble, predominantly cytosolic protein.</p>
+    </div>
+
+
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
+                                    GO:0005737
+                                </a>
+                            </span>
+                            <span class="term-label">cytoplasm</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O44739" data-a="GO:0005737" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> BAG-1 is a soluble co-chaperone that acts on cytoplasmic Hsp70/Hsc70; cytoplasmic localization is expected and consistent with the absence of any transmembrane or signal-peptide features.
+                        </div>
+
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005634" target="_blank" class="term-link">
+                                    GO:0005634
+                                </a>
+                            </span>
+                            <span class="term-label">nucleus</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="O44739" data-a="GO:0005634" data-r="GO_REF:0000033" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Nuclear localization in the BAG family is a property of the mammalian BAG-1L isoform, which carries an N-terminal extension bearing a nuclear-localization region. The single 210-residue worm protein lacks that extension and there is no experimental evidence for nuclear BAG-1 in C. elegans, so this phylogenetically propagated term likely over-annotates an isoform-specific mammalian feature.
+                        </div>
+
+
+
+
+                        <div class="propagation-review">
+                            <div class="propagation-title">Propagation Review</div>
+                            <div class="propagation-row">
+                                <strong>Root cause:</strong>
+                                <span class="badge">PROPAGATION BAD</span>
+                            </div>
+
+                            <div class="propagation-row">
+                                <strong>Failure modes:</strong>
+
+                                <span class="badge">COMPARTMENT OR COMPLEX MISMATCH</span>
+
+                                <span class="badge">FUNCTIONAL DIVERGENCE</span>
+
+                            </div>
+
+
+                            <div class="propagation-source">
+                                <strong>Sources checked:</strong>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">PANTHER:PTN000269156</span>
+
+                                    &middot; BAG family node (nucleus IBA source)
+
+
+                                    <span class="badge">SUPPORTS SOURCE BUT NOT TARGET</span>
+
+
+                                    <div class="propagation-comment">Nuclear localization derives from the N-terminally extended mammalian BAG-1L isoform; the single short worm protein lacks that nuclear-targeting extension, so the source annotation is sound but does not transfer.</div>
+
+                                </div>
+
+                            </div>
+
+                        </div>
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
+                                    GO:0005829
+                                </a>
+                            </span>
+                            <span class="term-label">cytosol</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O44739" data-a="GO:0005829" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Cytosol is a more precise and appropriate location for a soluble BAG-domain nucleotide-exchange factor acting on cytosolic Hsc70; consistent with the lack of membrane or organelle-targeting features.
+                        </div>
+
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016020" target="_blank" class="term-link">
+                                    GO:0016020
+                                </a>
+                            </span>
+                            <span class="term-label">membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="O44739" data-a="GO:0016020" data-r="GO_REF:0000033" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Worm BAG-1 has no transmembrane segment, no signal peptide, and no lipid-anchor features; it is a soluble cytosolic co-chaperone. The membrane term is a weak phylogenetic propagation (partly from a BAG3-type ortholog) and is not expected to apply to this protein.
+                        </div>
+
+
+
+
+                        <div class="propagation-review">
+                            <div class="propagation-title">Propagation Review</div>
+                            <div class="propagation-row">
+                                <strong>Root cause:</strong>
+                                <span class="badge">PROPAGATION BAD</span>
+                            </div>
+
+                            <div class="propagation-row">
+                                <strong>Failure modes:</strong>
+
+                                <span class="badge">COMPARTMENT OR COMPLEX MISMATCH</span>
+
+                            </div>
+
+
+                            <div class="propagation-source">
+                                <strong>Sources checked:</strong>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">PANTHER:PTN000269156</span>
+
+                                    &middot; BAG family node (membrane IBA source)
+
+
+                                    <span class="badge">SUPPORTS SOURCE BUT NOT TARGET</span>
+
+
+                                    <div class="propagation-comment">Membrane association is not expected for a soluble BAG-domain NEF with no transmembrane segment or lipid anchor; the term is partly propagated from a BAG3-type ortholog and does not transfer to this protein.</div>
+
+                                </div>
+
+                            </div>
+
+                        </div>
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000774" target="_blank" class="term-link">
+                                    GO:0000774
+                                </a>
+                            </span>
+                            <span class="term-label">adenyl-nucleotide exchange factor activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O44739" data-a="GO:0000774" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> This is the defining molecular function of the BAG family: the BAG domain binds the Hsp70/Hsc70 ATPase domain and promotes ADP release / ATP-dependent substrate discharge, i.e. nucleotide exchange. Well supported by family biology and the worm structure, and consistent with the experimental Hsc70 ATPase stimulation measured for worm BAG-1.
+                        </div>
+
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/15333932" target="_blank" class="term-link">
+                                        PMID:15333932
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Binding of the BAG domain to the eukaryotic chaperone heat-shock protein (Hsp70) promotes ATP-dependent release of the protein substrate from Hsp70.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0050821" target="_blank" class="term-link">
+                                    GO:0050821
+                                </a>
+                            </span>
+                            <span class="term-label">protein stabilization</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="O44739" data-a="GO:0050821" data-r="GO_REF:0000033" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Plausible downstream consequence of BAG-1&#39;s modulation of the Hsp70/Hsc70 cycle, propagated from mammalian orthologs. No worm-specific evidence that BAG-1 stabilizes particular clients, so retained as a non-core biological process.
+                        </div>
+
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051087" target="_blank" class="term-link">
+                                    GO:0051087
+                                </a>
+                            </span>
+                            <span class="term-label">protein-folding chaperone binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O44739" data-a="GO:0051087" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Binding to the Hsp70/Hsc70 chaperone via the BAG domain is central to BAG-1 function and is the enabling interaction underlying its nucleotide-exchange activity. Well supported for a BAG-domain protein.
+                        </div>
+
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9873016" target="_blank" class="term-link">
+                                        PMID:9873016
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">BAG-1 binds the ATPase domains of Hsp70 and Hsc70, modulating their chaperone activity and functioning as a competitive antagonist of the co-chaperone Hip</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051087" target="_blank" class="term-link">
+                                    GO:0051087
+                                </a>
+                            </span>
+                            <span class="term-label">protein-folding chaperone binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O44739" data-a="GO:0051087" data-r="GO_REF:0000002" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> InterPro2GO electronic annotation from the BAG-domain signatures. Correctly captures Hsp70/Hsc70 chaperone binding and corroborates the phylogenetic and experimental support for this interaction (an independent evidence line for the same accepted chaperone-binding function).
+                        </div>
+
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/14704431" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:14704431
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    A map of the interactome network of the metazoan C. elegans.
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="O44739" data-a="GO:0005515" data-r="PMID:14704431" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> High-throughput yeast-two-hybrid interaction with the DUF727 protein Y43F8B.2 (Q9XWX7), a partner of unknown function that is not an Hsp70. The generic &#34;protein binding&#34; term is uninformative about BAG-1&#39;s molecular function; retained as a real but non-core experimental interaction.
+                        </div>
+
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/14704431" target="_blank" class="term-link">
+                                        PMID:14704431
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">more than 4000 interactions were identified from high-throughput, yeast two-hybrid (HT=Y2H) screens</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/19123269" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:19123269
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Empirically controlled mapping of the Caenorhabditis elegans...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="O44739" data-a="GO:0005515" data-r="PMID:19123269" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Second high-throughput yeast-two-hybrid report of the same Y43F8B.2 (Q9XWX7) interaction. As above, the generic &#34;protein binding&#34; term is uninformative about function; retained as a non-core experimental interaction rather than a core molecular function.
+                        </div>
+
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/19123269" target="_blank" class="term-link">
+                                        PMID:19123269
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">We present an expanded C. elegans protein-protein interaction network, or &#39;interactome&#39; map, derived from testing a matrix of approximately 10,000 x approximately 10,000 proteins using a highly specific, high-throughput yeast two-hybrid system.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0001671" target="_blank" class="term-link">
+                                    GO:0001671
+                                </a>
+                            </span>
+                            <span class="term-label">ATPase activator activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/25053410" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:25053410
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The balanced regulation of Hsc70 by DNJ-13 and UNC-23 is req...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O44739" data-a="GO:0001671" data-r="PMID:25053410" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Experimentally supported for worm BAG-1: as a nucleotide-exchange factor it accelerates the Hsc70 ATPase cycle. Papsdorf et al. measured ATPase stimulation and folding regulation for the BAG cofactors and report that BAG-1 acts with higher affinity than the paralog UNC-23. This mechanistically complements the nucleotide-exchange-factor annotation and is a core function.
+                        </div>
+
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/25053410" target="_blank" class="term-link">
+                                        PMID:25053410
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">C-terminal fragments of UNC-23 instead perform all Hsc70-related functions, like ATPase stimulation and regulation of folding activity, albeit with lower affinity than BAG-1</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006457" target="_blank" class="term-link">
+                                    GO:0006457
+                                </a>
+                            </span>
+                            <span class="term-label">protein folding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ISS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/9873016" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:9873016
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    An evolutionarily conserved family of Hsp70/Hsc70 molecular ...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O44739" data-a="GO:0006457" data-r="PMID:9873016" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> As an Hsp70/Hsc70 co-chaperone that regulates the ATP-driven folding cycle, BAG-1 is legitimately involved in the protein-folding process; the involved_in qualifier does not imply it is itself a foldase (indeed excess BAG can inhibit chaperone activity). The specific regulatory mechanism is captured by the nucleotide-exchange-factor and ATPase-activator annotations.
+                        </div>
+
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9873016" target="_blank" class="term-link">
+                                        PMID:9873016
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The human BAG-1, BAG-2, and BAG-3 proteins bind with high affinity (KD congruent with 1-10 nM) to the ATPase domain of Hsc70 and inhibit its chaperone activity in a Hip-repressible manner</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051087" target="_blank" class="term-link">
+                                    GO:0051087
+                                </a>
+                            </span>
+                            <span class="term-label">protein-folding chaperone binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ISS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/15333932" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:15333932
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Structural genomics of Caenorhabditis elegans: structure of ...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O44739" data-a="GO:0051087" data-r="PMID:15333932" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Sequence/structure-based inference of Hsp70 chaperone binding, supported by the crystal structure of the worm BAG domain and its documented role in Hsp70-dependent substrate release. An independent evidence line for the same accepted chaperone-binding function.
+                        </div>
+
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/15333932" target="_blank" class="term-link">
+                                        PMID:15333932
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Binding of the BAG domain to the eukaryotic chaperone heat-shock protein (Hsp70) promotes ATP-dependent release of the protein substrate from Hsp70.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>BAG-1 is a BAG-domain co-chaperone that acts as a nucleotide-exchange factor (NEF) for cytosolic Hsp70/Hsc70 (worm HSP-1). Its C-terminal BAG domain binds the chaperone&#39;s nucleotide-binding (ATPase) domain and promotes ADP release, accelerating the ATP-driven cycle and ATP-dependent discharge of client substrates. Experimentally, worm BAG-1 stimulates the Hsc70 ATPase (with higher affinity than the paralog UNC-23), and thereby tunes chaperone-assisted folding; the same activity can antagonize the chaperone when the cofactor is in excess.</h3>
+                <span class="vote-buttons" data-g="O44739" data-a="FUNCTION: BAG-1 is a BAG-domain co-chaperone that acts as a ..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000774" target="_blank" class="term-link">
+                            adenyl-nucleotide exchange factor activity
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006457" target="_blank" class="term-link">
+                                protein folding
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
+                                cytosol
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/15333932" target="_blank" class="term-link">
+                                PMID:15333932
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">Binding of the BAG domain to the eukaryotic chaperone heat-shock protein (Hsp70) promotes ATP-dependent release of the protein substrate from Hsp70.</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/9873016" target="_blank" class="term-link">
+                                PMID:9873016
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">BAG-1 binds the ATPase domains of Hsp70 and Hsc70, modulating their chaperone activity and functioning as a competitive antagonist of the co-chaperone Hip</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/25053410" target="_blank" class="term-link">
+                                PMID:25053410
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">C-terminal fragments of UNC-23 instead perform all Hsc70-related functions, like ATPase stimulation and regulation of folding activity, albeit with lower affinity than BAG-1</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000002.md" target="_blank" class="term-link">
+                            GO_REF:0000002
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation through association of InterPro records with GO terms</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
+                            GO_REF:0000033
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Annotation inferences using phylogenetic trees</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/9873016" target="_blank" class="term-link">
+                            PMID:9873016
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">An evolutionarily conserved family of Hsp70/Hsc70 molecular chaperone regulators.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/15333932" target="_blank" class="term-link">
+                            PMID:15333932
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Structural genomics of Caenorhabditis elegans: structure of the BAG domain.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/19123269" target="_blank" class="term-link">
+                            PMID:19123269
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Empirically controlled mapping of the Caenorhabditis elegans protein-protein interactome network.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/25053410" target="_blank" class="term-link">
+                            PMID:25053410
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">The balanced regulation of Hsc70 by DNJ-13 and UNC-23 is required for muscle functionality.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/14704431" target="_blank" class="term-link">
+                            PMID:14704431
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">A map of the interactome network of the metazoan C. elegans.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        file:worm/bag-1/bag-1-notes.md
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Reviewer notes for C. elegans bag-1</div>
+
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Questions for Experts</h2>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Does C. elegans BAG-1 form a physiological complex with the constitutive Hsc70 HSP-1, and is this interaction functionally distinct from that of the paralog UNC-23?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="O44739" data-a="Q: Does C. elegans BAG-1 form a physiological complex..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Does BAG-1 direct Hsc70 clients toward refolding or toward proteasomal degradation, and does its ubiquitin-like domain mediate a proteasome link as in mammalian BAG-1?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="O44739" data-a="Q: Does BAG-1 direct Hsc70 clients toward refolding o..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Experiments</h2>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Generate and phenotype a bag-1 loss-of-function allele (CRISPR deletion or RNAi), alone and combined with unc-23 loss, assaying viability, motility, thermotolerance, and aggregation/proteostasis reporters to test whether bag-1 has an independent role or is redundant with unc-23.</p>
+
+
+
+                </div>
+                <span class="vote-buttons" data-g="O44739" data-a="EXPERIMENT: Generate and phenotype a bag-1 loss-of-function al..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Affinity-purify tagged BAG-1 from worm lysates followed by mass spectrometry to define the native BAG-1 interactome (HSP-1/Hsc70 and clients), and combine with in-vitro Hsc70 ATPase and luciferase refolding assays to quantify BAG-1&#39;s effect on the chaperone cycle.</p>
+
+
+
+                </div>
+                <span class="vote-buttons" data-g="O44739" data-a="EXPERIMENT: Affinity-purify tagged BAG-1 from worm lysates fol..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Knowledge Gaps</h2>
+        <p style="color: #555; font-size: 0.92rem; margin-top: -0.3rem;">
+            What is <em>not</em> known — curated, literature-grounded statements of the open
+            unknowns (the inverse of core functions).
+        </p>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> No in-vivo client or substrate of C. elegans BAG-1 has been identified, and it is untested whether worm BAG-1 biases Hsc70-bound clients toward productive refolding or, via its ubiquitin-like domain, toward proteasomal degradation (the folding-versus-degradation decision that mammalian BAG-1 helps make).</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">BP_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> It is firmly established that BAG-1 is a BAG-domain nucleotide-exchange factor that binds the Hsp70/Hsc70 ATPase domain, stimulates the Hsc70 ATPase, and promotes ATP-dependent substrate release, and that it carries an N-terminal ubiquitin-like domain. What clients pass through this activity in the worm, and what fate BAG-1 directs them to, are unknown.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> The functional output of an Hsp70 NEF depends entirely on which clients it engages and whether it promotes their folding or clearance; without this, the worm-specific biological role of BAG-1 cannot be assigned, and its relationship to proteostasis-network aging phenotypes remains inferential.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Affinity-proteomics / co-immunoprecipitation of BAG-1 (and BAG-1-vs-UNC-23) from C. elegans to define native clients, combined with degradation/refolding reporter assays and tests of the ubiquitin-like-domain proteasome link, would close the gap.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"The mechanisms by which Hsp70 family chaperones are regulated, however, are only partly understood."</em> — PMID:9873016</li>
+
+                <li><em>"No in-vivo client or substrate has been identified for C. elegans BAG-1, and it is untested whether worm BAG-1 channels Hsc70 clients toward productive refolding or toward proteasomal degradation."</em> — file:worm/bag-1/bag-1-notes.md</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> No loss-of-function phenotype has been reported for the bag-1 gene itself in C. elegans, so it is unknown whether bag-1 is essential, is functionally redundant with its paralog unc-23, or has a distinct tissue-restricted role.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">BP_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> In this cofactor system the characterized in-vivo phenotype (severe motility dysfunction, muscle-attachment-site localization) belongs to the paralog UNC-23/BAG2, whereas BAG-1 has only been characterized biochemically (higher Hsc70 affinity than UNC-23). A bag-1 mutant or RNAi phenotype is not described in the cached literature.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Whether bag-1 is dispensable, buffered by unc-23, or independently required in a particular tissue determines its true biological role and its weight in the worm proteostasis network.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Characterization of a bag-1 deletion/RNAi (alone and in a unc-23 background) for viability, motility, stress resistance, and proteostasis reporters would define the biological role and test redundancy with unc-23.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"one of them being UNC-23, whose mutation induces severe motility dysfunctions"</em> — PMID:25053410</li>
+
+                <li><em>"No loss-of-function phenotype has been reported for the bag-1 gene itself in C. elegans, so it is unknown whether bag-1 is essential, redundant with the paralog unc-23, or has a tissue-restricted role."</em> — file:worm/bag-1/bag-1-notes.md</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> A direct physical BAG-1-to-HSP-1/Hsc70 complex in C. elegans has not been demonstrated, and the subcellular site of BAG-1 action in the worm is untested; the only experimentally reported worm partner is the DUF727 protein Y43F8B.2, whose functional relationship to BAG-1 is unexplained.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span><span class="badge">CURATION</span>
+                <span class="badge">CC_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> Family biology and the worm BAG-domain crystal structure predict binding to the Hsp70/Hsc70 ATPase domain, and biochemistry shows worm BAG-1 stimulates Hsc70; but the demonstrated worm two-hybrid partner is Y43F8B.2, not HSP-1, and no localization data exist for endogenous BAG-1.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Establishing the physiological BAG-1/Hsc70 complex and where it forms would convert the inferred co-chaperone role into a directly evidenced one and clarify the meaning (if any) of the Y43F8B.2 interaction.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Co-immunoprecipitation or proximity labeling of endogenous BAG-1 with HSP-1, plus a tagged-BAG-1 expression/localization reporter, would confirm the complex and its site of action.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"The structure may represent a new folding type of the BAG domain."</em> — PMID:15333932</li>
+
+                <li><em>"The only experimentally demonstrated physical partner of worm BAG-1 is the DUF727 protein Y43F8B.2, and a direct BAG-1 to HSP-1/Hsc70 complex in C. elegans has not been shown; the subcellular site of BAG-1 action in the worm is untested."</em> — file:worm/bag-1/bag-1-notes.md</li>
+
+            </ul>
+
+
+        </div>
+
+    </div>
+
+
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Deep Research Sections -->
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(bag-1-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="O44739" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="bag-1-c-elegans-research-notes">bag-1 (C. elegans) research notes</h1>
+<p>UniProt: <strong>O44739</strong> (BAG1_CAEEL), "BAG family molecular chaperone regulator 1".<br />
+Gene: <code>bag-1</code>; ORF <code>F57B10.11</code>; WormBase <code>WBGene00000236</code>; Chromosome I. 210 aa, 24 kDa.<br />
+NCBITaxon:6239.</p>
+<h2 id="identity-check">Identity check</h2>
+<p>Confirmed the record is the BAG-domain Hsp70/Hsc70 co-chaperone (nucleotide-exchange<br />
+factor), not a mis-named gene. UniProt DE = "BAG family molecular chaperone regulator 1";<br />
+domains: a <strong>ubiquitin-like domain (8–85)</strong> and a <strong>BAG domain (108–194)</strong>; PDB <strong>1T7S</strong><br />
+(BAG domain, residues 74–210). Family founder for the C. elegans BAG proteins together<br />
+with UNC-23 (BAG2 ortholog).</p>
+<h2 id="domain-architecture-structure">Domain architecture / structure</h2>
+<ul>
+<li>Ubiquitin-like (UBL) domain FT 8–85 (PROSITE PRU00214); BAG domain FT 108–194<br />
+  (PROSITE PRU00369). Pfam PF02179 (BAG) + PF00240 (ubiquitin). InterPro IPR017093<br />
+  (BAG-1), IPR003103/IPR036533 (BAG domain + superfamily), IPR000626 (ubiquitin-like).</li>
+<li>Crystal structure of the worm BAG domain solved by structural genomics<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/15333932" title="Binding of the BAG domain to the eukaryotic chaperone heat-shock protein (Hsp70) promotes ATP-dependent release of the protein substrate from Hsp70">PMID:15333932</a>.<br />
+  Notably the worm BAG domain adopts an unusual fold: "the Caenorhabditis elegans BAG<br />
+  domain is formed by two antiparallel helices, while the third helix is extended away"<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/15333932" title="the Caenorhabditis elegans BAG domain is formed by two antiparallel helices, while the third helix is extended away and stabilized by crystal-packing interactions">PMID:15333932</a>.<br />
+  The paper infers oligomerization: "stable functional dimers and tetramers can be formed<br />
+  in solution" <a href="https://pubmed.ncbi.nlm.nih.gov/15333932" title="intermolecular three-helix bundles are observed throughout the crystal packing and suggest that stable functional dimers and tetramers can be formed in solution">PMID:15333932</a>.<br />
+  UniProt SUBUNIT: "Homodimer or homotetramer" (ECO:0000269|PubMed:15333932).</li>
+</ul>
+<h2 id="known-well-supported-function">KNOWN (well-supported) function</h2>
+<ol>
+<li>
+<p><strong>BAG-domain co-chaperone / Hsp70(Hsc70) nucleotide-exchange factor (NEF).</strong> The<br />
+   defining activity of the BAG family. Founding paper describing the family (incl. worm<br />
+   BAG-1/BAG-2) <a href="https://pubmed.ncbi.nlm.nih.gov/9873016" title="BAG-1 binds the ATPase domains of Hsp70 and Hsc70, modulating their chaperone activity and functioning as a competitive antagonist of the co-chaperone Hip">PMID:9873016</a>.<br />
+   The BAG domain binds the Hsp70 ATPase (nucleotide-binding) domain and drives<br />
+   ATP-dependent substrate release <a href="https://pubmed.ncbi.nlm.nih.gov/15333932" title="Binding of the BAG domain to the eukaryotic chaperone heat-shock protein (Hsp70) promotes ATP-dependent release of the protein substrate from Hsp70">PMID:15333932</a>.<br />
+   → supports GO:0000774 adenyl-nucleotide exchange factor activity, GO:0051087<br />
+   protein-folding chaperone binding.</p>
+</li>
+<li>
+<p><strong>Stimulation of Hsc70 ATPase (experimental, worm).</strong> Papsdorf, Sacherl &amp; Richter 2014<br />
+   measured worm BAG proteins as Hsc70 cofactors; C-terminal fragments of UNC-23 perform<br />
+   "all Hsc70-related functions, like ATPase stimulation and regulation of folding<br />
+   activity, albeit with lower affinity than BAG-1"<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/25053410" title="C-terminal fragments of UNC-23 instead perform all Hsc70-related functions, like ATPase stimulation and regulation of folding activity, albeit with lower affinity than BAG-1">PMID:25053410</a>.<br />
+   This directly establishes that worm BAG-1 stimulates the Hsc70 ATPase and regulates its<br />
+   folding activity, with higher affinity than the muscle paralog UNC-23. WormBase used<br />
+   this paper for the experimental IDA to GO:0001671 ATPase activator activity.<br />
+   Context: worm Hsc70 (HSP-1) is regulated by two antagonistic cofactor classes — the<br />
+   J-domain protein DNJ-13 (Hsp40) and the BAG-domain protein UNC-23/BAG-1<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/25053410" title="The molecular chaperone Hsc70 assists in the folding of non-native proteins together with its J domain- and BAG domain-containing cofactors">PMID:25053410</a>.</p>
+</li>
+<li>
+<p><strong>Regulation of the Hsp70 folding/refolding cycle (mechanism, from family biology).</strong><br />
+   BAG proteins act as NEFs that accelerate ADP→ATP exchange, thereby tuning (and, at<br />
+   excess, antagonizing) the Hsp70 chaperone cycle<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/9873016" title="The human BAG-1, BAG-2, and BAG-3 proteins bind with high affinity (KD congruent with 1-10 nM) to the ATPase domain of Hsc70 and inhibit its chaperone activity in a Hip-repressible manner">PMID:9873016</a>.<br />
+   UniProt FUNCTION (by similarity): "May inhibit the chaperone activity of HSP70/HSC70 by<br />
+   promoting substrate release in an ATP-dependent manner."</p>
+</li>
+</ol>
+<h2 id="localization">Localization</h2>
+<ul>
+<li>No experimental localization for worm BAG-1 in the cached literature. No transmembrane<br />
+  segment, no signal peptide (KW: Chaperone; 3D-structure; Reference proteome only).</li>
+<li>IBA propagates cytoplasm/cytosol (defensible for a soluble co-chaperone), plus <strong>nucleus</strong><br />
+  and <strong>membrane</strong> from mammalian/fungal orthologs. Human nuclear localization is a property<br />
+  of the BAG-1L isoform (an N-terminally extended isoform with a nuclear-localization<br />
+  region); the single short (210 aa) worm protein lacks that N-terminal extension, so the<br />
+  nucleus IBA is a weak, isoform-driven inference. Membrane is not expected for a soluble<br />
+  cytosolic NEF with no TM domain.</li>
+</ul>
+<h2 id="interactions-interactome-ipi">Interactions (interactome / IPI)</h2>
+<ul>
+<li>Two HT-Y2H "protein binding" (GO:0005515) IPI annotations both report the <strong>same</strong> partner<br />
+<strong>Q9XWX7 = Y43F8B.2</strong>, a DUF727-domain protein of largely unknown function<br />
+  [PMID:14704431 worm interactome WI5; PMID:19123269 WI-2007/WI8]. These are systematic<br />
+  yeast-two-hybrid maps, not BAG-1-focused studies; UniProt records the interaction<br />
+  (IntAct EBI-323218/EBI-323231, NbExp=3). GO:0005515 "protein binding" is uninformative<br />
+  per curation guidelines; the partner is not an Hsp70 and its biological meaning is unclear.</li>
+</ul>
+<h2 id="not-known-knowledge-gaps-see-review-knowledge_gaps">NOT known / knowledge gaps (see review knowledge_gaps)</h2>
+<ul>
+<li><strong>No in-vivo client/substrate repertoire</strong> for worm BAG-1. Whether it channels Hsc70<br />
+  clients toward refolding vs. proteasomal degradation (as mammalian BAG-1 does via its UBL<br />
+  domain engaging the 26S proteasome) has not been tested in the worm, despite BAG-1<br />
+  carrying a UBL domain (FT 8–85).</li>
+<li><strong>No loss-of-function phenotype</strong> described for <code>bag-1</code> itself. The muscle-attachment<br />
+  phenotype in this cofactor system belongs to the paralog <strong>unc-23</strong> (BAG2 ortholog), not<br />
+  bag-1 <a href="https://pubmed.ncbi.nlm.nih.gov/25053410" title="one of them being UNC-23, whose mutation induces severe motility dysfunctions">PMID:25053410</a>.<br />
+  Whether bag-1 is essential, redundant with unc-23, or has a tissue-restricted role is open.</li>
+<li><strong>Direct partner of worm BAG-1 in vivo</strong> unconfirmed: family biology predicts HSP-1/Hsc70<br />
+  binding via the BAG domain, but a physical worm BAG-1–HSP-1 complex has not been<br />
+  demonstrated in the cached literature (the demonstrated worm Y2H partner is the DUF727<br />
+  protein Y43F8B.2, biologically unexplained).</li>
+</ul>
+<h2 id="annotation-by-annotation-reasoning-summary-see-yaml-for-detail">Annotation-by-annotation reasoning (summary; see YAML for detail)</h2>
+<ul>
+<li>GO:0000774 adenyl-nucleotide exchange factor activity (IBA) — ACCEPT, core.</li>
+<li>GO:0051087 protein-folding chaperone binding (IBA/IEA/ISS ×3) — ACCEPT (BAG domain binds Hsp70); one kept as core, redundant copies non-core.</li>
+<li>GO:0001671 ATPase activator activity (IDA, PMID:25053410) — ACCEPT, core (experimental, worm).</li>
+<li>GO:0006457 protein folding (ISS) — KEEP_AS_NON_CORE (co-chaperone regulates the folding cycle; does not itself fold).</li>
+<li>GO:0050821 protein stabilization (IBA) — KEEP_AS_NON_CORE (plausible, unverified in worm).</li>
+<li>GO:0005737 cytoplasm / GO:0005829 cytosol (IBA) — ACCEPT/KEEP_AS_NON_CORE (soluble co-chaperone).</li>
+<li>GO:0005634 nucleus (IBA) — MARK_AS_OVER_ANNOTATED (isoform-specific mammalian property; worm lacks BAG-1L-type N-terminal extension).</li>
+<li>GO:0016020 membrane (IBA) — MARK_AS_OVER_ANNOTATED (no TM domain; soluble protein).</li>
+<li>GO:0005515 protein binding (IPI ×2, Q9XWX7) — KEEP_AS_NON_CORE (uninformative HT-Y2H interaction).</li>
+</ul>
+<h2 id="cached-literature-status">Cached literature status</h2>
+<p>All five cited PMIDs are cached; four are abstract-only (9873016, 15333932, 25053410,<br />
+14704431), 19123269 has full text (methods/discussion only, no BAG-1 specifics). The single<br />
+experimental worm annotation (GO:0001671, PMID:25053410) is supported by the abstract text.</p>
+<h2 id="knowledge-gap-statements-plain-text-for-provenance-quoting">Knowledge-gap statements (plain text, for provenance quoting)</h2>
+<p>No in-vivo client or substrate has been identified for C. elegans BAG-1, and it is untested whether worm BAG-1 channels Hsc70 clients toward productive refolding or toward proteasomal degradation.<br />
+No loss-of-function phenotype has been reported for the bag-1 gene itself in C. elegans, so it is unknown whether bag-1 is essential, redundant with the paralog unc-23, or has a tissue-restricted role.<br />
+The only experimentally demonstrated physical partner of worm BAG-1 is the DUF727 protein Y43F8B.2, and a direct BAG-1 to HSP-1/Hsc70 complex in C. elegans has not been shown; the subcellular site of BAG-1 action in the worm is untested.</p>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: O44739
+gene_symbol: bag-1
+product_type: PROTEIN
+status: COMPLETE
+taxon:
+  id: NCBITaxon:6239
+  label: Caenorhabditis elegans
+description: &gt;-
+  bag-1 encodes the Caenorhabditis elegans member of the BAG (Bcl-2-associated
+  athanogene) family of Hsp70/Hsc70 co-chaperones. The 210-residue protein has an
+  N-terminal ubiquitin-like domain and a C-terminal BAG domain; the BAG domain
+  binds the nucleotide-binding (ATPase) domain of Hsp70-family chaperones and acts
+  as a nucleotide-exchange factor, promoting ADP release and ATP-dependent
+  discharge of client substrates from the chaperone. By accelerating the
+  Hsp70/Hsc70 nucleotide cycle, BAG-1 modulates chaperone-assisted protein
+  folding, and at high co-chaperone levels this activity can antagonize productive
+  folding. In the worm, BAG-1 stimulates the ATPase activity of the constitutive
+  Hsc70 (HSP-1) and, together with the J-domain protein DNJ-13 (Hsp40) and the
+  paralogous BAG-domain protein UNC-23 (BAG2 ortholog), belongs to the cofactor
+  network that tunes the Hsc70 chaperone cycle. The BAG domain adopts a helical
+  bundle fold, and the worm protein can oligomerize into dimers and tetramers. It
+  is a soluble, predominantly cytosolic protein.
+references:
+- id: GO_REF:0000002
+  title: Gene Ontology annotation through association of InterPro records with GO
+    terms
+  findings: []
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: &gt;-
+      InterPro2GO electronic pipeline. The BAG-domain InterPro signatures
+      (IPR003103, IPR017093, IPR036533) legitimately map to protein-folding
+      chaperone binding, consistent with the experimental and phylogenetic
+      evidence.
+- id: GO_REF:0000033
+  title: Annotation inferences using phylogenetic trees
+  findings: []
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: &gt;-
+      GO_Central IBA pipeline. Core molecular-function inferences (nucleotide
+      exchange factor activity, chaperone binding) are well founded for a BAG
+      protein; some cellular-component propagations (nucleus, membrane) reflect
+      mammalian isoform-specific properties not applicable to the single short
+      worm protein.
+- id: PMID:9873016
+  title: An evolutionarily conserved family of Hsp70/Hsc70 molecular chaperone regulators.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Founding paper of the BAG family; explicitly identifies C. elegans BAG-1
+      and BAG-2 and establishes that BAG proteins bind the Hsp70/Hsc70 ATPase
+      domain and modulate chaperone activity. PubMed-verified; abstract-only in
+      cache.
+- id: PMID:15333932
+  title: &#39;Structural genomics of Caenorhabditis elegans: structure of the BAG domain.&#39;
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Crystal structure (PDB 1T7S) of the C. elegans BAG-1 BAG domain; states the
+      BAG-domain/Hsp70 interaction promotes ATP-dependent substrate release and
+      reports an unusual worm BAG fold with dimer/tetramer packing.
+      PubMed-verified; abstract-only in cache.
+- id: PMID:19123269
+  title: Empirically controlled mapping of the Caenorhabditis elegans protein-protein
+    interactome network.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Genome-scale HT-Y2H interactome (WI-2007/WI8). Source of an IPI protein
+      binding annotation to the DUF727 protein Y43F8B.2 (Q9XWX7); systematic
+      screen, not a BAG-1-focused study, and the interaction is biologically
+      uninterpreted.
+- id: PMID:25053410
+  title: The balanced regulation of Hsc70 by DNJ-13 and UNC-23 is required for muscle
+    functionality.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Primary C. elegans biochemistry of the Hsc70 cofactor network; the abstract
+      states worm BAG-1 has higher affinity than UNC-23 for Hsc70 and that BAG
+      C-terminal fragments provide ATPase stimulation and folding regulation.
+      Basis for the experimental IDA to ATPase activator activity.
+      PubMed-verified; abstract-only in cache.
+- id: PMID:14704431
+  title: A map of the interactome network of the metazoan C. elegans.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Genome-scale HT-Y2H interactome (WI5). Source of an IPI protein binding
+      annotation to Y43F8B.2 (Q9XWX7); systematic screen, not BAG-1-specific, and
+      the interaction is biologically uninterpreted.
+- id: file:worm/bag-1/bag-1-notes.md
+  title: Reviewer notes for C. elegans bag-1
+  findings: []
+existing_annotations:
+- term:
+    id: GO:0005737
+    label: cytoplasm
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: is_active_in
+  review:
+    summary: &gt;-
+      BAG-1 is a soluble co-chaperone that acts on cytoplasmic Hsp70/Hsc70;
+      cytoplasmic localization is expected and consistent with the absence of any
+      transmembrane or signal-peptide features.
+    action: ACCEPT
+- term:
+    id: GO:0005634
+    label: nucleus
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: is_active_in
+  review:
+    summary: &gt;-
+      Nuclear localization in the BAG family is a property of the mammalian
+      BAG-1L isoform, which carries an N-terminal extension bearing a
+      nuclear-localization region. The single 210-residue worm protein lacks that
+      extension and there is no experimental evidence for nuclear BAG-1 in C.
+      elegans, so this phylogenetically propagated term likely over-annotates an
+      isoform-specific mammalian feature.
+    action: MARK_AS_OVER_ANNOTATED
+    propagation_review:
+      root_cause: PROPAGATION_BAD
+      failure_modes:
+        - COMPARTMENT_OR_COMPLEX_MISMATCH
+        - FUNCTIONAL_DIVERGENCE
+      source_entities:
+        - source_id: PANTHER:PTN000269156
+          source_label: BAG family node (nucleus IBA source)
+          source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
+          comment: &gt;-
+            Nuclear localization derives from the N-terminally extended mammalian
+            BAG-1L isoform; the single short worm protein lacks that
+            nuclear-targeting extension, so the source annotation is sound but does
+            not transfer.
+- term:
+    id: GO:0005829
+    label: cytosol
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: is_active_in
+  review:
+    summary: &gt;-
+      Cytosol is a more precise and appropriate location for a soluble BAG-domain
+      nucleotide-exchange factor acting on cytosolic Hsc70; consistent with the
+      lack of membrane or organelle-targeting features.
+    action: ACCEPT
+- term:
+    id: GO:0016020
+    label: membrane
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: is_active_in
+  review:
+    summary: &gt;-
+      Worm BAG-1 has no transmembrane segment, no signal peptide, and no
+      lipid-anchor features; it is a soluble cytosolic co-chaperone. The membrane
+      term is a weak phylogenetic propagation (partly from a BAG3-type ortholog)
+      and is not expected to apply to this protein.
+    action: MARK_AS_OVER_ANNOTATED
+    propagation_review:
+      root_cause: PROPAGATION_BAD
+      failure_modes:
+        - COMPARTMENT_OR_COMPLEX_MISMATCH
+      source_entities:
+        - source_id: PANTHER:PTN000269156
+          source_label: BAG family node (membrane IBA source)
+          source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
+          comment: &gt;-
+            Membrane association is not expected for a soluble BAG-domain NEF with
+            no transmembrane segment or lipid anchor; the term is partly propagated
+            from a BAG3-type ortholog and does not transfer to this protein.
+- term:
+    id: GO:0000774
+    label: adenyl-nucleotide exchange factor activity
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: enables
+  review:
+    summary: &gt;-
+      This is the defining molecular function of the BAG family: the BAG domain
+      binds the Hsp70/Hsc70 ATPase domain and promotes ADP release / ATP-dependent
+      substrate discharge, i.e. nucleotide exchange. Well supported by family
+      biology and the worm structure, and consistent with the experimental Hsc70
+      ATPase stimulation measured for worm BAG-1.
+    action: ACCEPT
+    supported_by:
+    - reference_id: PMID:15333932
+      supporting_text: &gt;-
+        Binding of the BAG domain to the eukaryotic chaperone heat-shock protein
+        (Hsp70) promotes ATP-dependent release of the protein substrate from
+        Hsp70.
+- term:
+    id: GO:0050821
+    label: protein stabilization
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Plausible downstream consequence of BAG-1&#39;s modulation of the Hsp70/Hsc70
+      cycle, propagated from mammalian orthologs. No worm-specific evidence that
+      BAG-1 stabilizes particular clients, so retained as a non-core biological
+      process.
+    action: KEEP_AS_NON_CORE
+- term:
+    id: GO:0051087
+    label: protein-folding chaperone binding
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Binding to the Hsp70/Hsc70 chaperone via the BAG domain is central to BAG-1
+      function and is the enabling interaction underlying its nucleotide-exchange
+      activity. Well supported for a BAG-domain protein.
+    action: ACCEPT
+    supported_by:
+    - reference_id: PMID:9873016
+      supporting_text: &gt;-
+        BAG-1 binds the ATPase domains of Hsp70 and Hsc70, modulating their
+        chaperone activity and functioning as a competitive antagonist of the
+        co-chaperone Hip
+- term:
+    id: GO:0051087
+    label: protein-folding chaperone binding
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: enables
+  review:
+    summary: &gt;-
+      InterPro2GO electronic annotation from the BAG-domain signatures.
+      Correctly captures Hsp70/Hsc70 chaperone binding and corroborates the
+      phylogenetic and experimental support for this interaction (an independent
+      evidence line for the same accepted chaperone-binding function).
+    action: ACCEPT
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:14704431
+  qualifier: enables
+  review:
+    summary: &gt;-
+      High-throughput yeast-two-hybrid interaction with the DUF727 protein
+      Y43F8B.2 (Q9XWX7), a partner of unknown function that is not an Hsp70. The
+      generic &#34;protein binding&#34; term is uninformative about BAG-1&#39;s molecular
+      function; retained as a real but non-core experimental interaction.
+    action: KEEP_AS_NON_CORE
+    supported_by:
+    - reference_id: PMID:14704431
+      supporting_text: &gt;-
+        more than 4000 interactions were identified from high-throughput, yeast
+        two-hybrid (HT=Y2H) screens
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:19123269
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Second high-throughput yeast-two-hybrid report of the same Y43F8B.2
+      (Q9XWX7) interaction. As above, the generic &#34;protein binding&#34; term is
+      uninformative about function; retained as a non-core experimental
+      interaction rather than a core molecular function.
+    action: KEEP_AS_NON_CORE
+    supported_by:
+    - reference_id: PMID:19123269
+      supporting_text: &gt;-
+        We present an expanded C. elegans protein-protein interaction network, or
+        &#39;interactome&#39; map, derived from testing a matrix of approximately 10,000 x
+        approximately 10,000 proteins using a highly specific, high-throughput
+        yeast two-hybrid system.
+- term:
+    id: GO:0001671
+    label: ATPase activator activity
+  evidence_type: IDA
+  original_reference_id: PMID:25053410
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Experimentally supported for worm BAG-1: as a nucleotide-exchange factor it
+      accelerates the Hsc70 ATPase cycle. Papsdorf et al. measured ATPase
+      stimulation and folding regulation for the BAG cofactors and report that
+      BAG-1 acts with higher affinity than the paralog UNC-23. This mechanistically
+      complements the nucleotide-exchange-factor annotation and is a core function.
+    action: ACCEPT
+    supported_by:
+    - reference_id: PMID:25053410
+      supporting_text: &gt;-
+        C-terminal fragments of UNC-23 instead perform all Hsc70-related
+        functions, like ATPase stimulation and regulation of folding activity,
+        albeit with lower affinity than BAG-1
+- term:
+    id: GO:0006457
+    label: protein folding
+  evidence_type: ISS
+  original_reference_id: PMID:9873016
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      As an Hsp70/Hsc70 co-chaperone that regulates the ATP-driven folding cycle,
+      BAG-1 is legitimately involved in the protein-folding process; the
+      involved_in qualifier does not imply it is itself a foldase (indeed excess
+      BAG can inhibit chaperone activity). The specific regulatory mechanism is
+      captured by the nucleotide-exchange-factor and ATPase-activator annotations.
+    action: ACCEPT
+    supported_by:
+    - reference_id: PMID:9873016
+      supporting_text: &gt;-
+        The human BAG-1, BAG-2, and BAG-3 proteins bind with high affinity (KD
+        congruent with 1-10 nM) to the ATPase domain of Hsc70 and inhibit its
+        chaperone activity in a Hip-repressible manner
+- term:
+    id: GO:0051087
+    label: protein-folding chaperone binding
+  evidence_type: ISS
+  original_reference_id: PMID:15333932
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Sequence/structure-based inference of Hsp70 chaperone binding, supported by
+      the crystal structure of the worm BAG domain and its documented role in
+      Hsp70-dependent substrate release. An independent evidence line for the same
+      accepted chaperone-binding function.
+    action: ACCEPT
+    supported_by:
+    - reference_id: PMID:15333932
+      supporting_text: &gt;-
+        Binding of the BAG domain to the eukaryotic chaperone heat-shock protein
+        (Hsp70) promotes ATP-dependent release of the protein substrate from
+        Hsp70.
+core_functions:
+- description: &gt;-
+    BAG-1 is a BAG-domain co-chaperone that acts as a nucleotide-exchange factor
+    (NEF) for cytosolic Hsp70/Hsc70 (worm HSP-1). Its C-terminal BAG domain binds
+    the chaperone&#39;s nucleotide-binding (ATPase) domain and promotes ADP release,
+    accelerating the ATP-driven cycle and ATP-dependent discharge of client
+    substrates. Experimentally, worm BAG-1 stimulates the Hsc70 ATPase (with
+    higher affinity than the paralog UNC-23), and thereby tunes chaperone-assisted
+    folding; the same activity can antagonize the chaperone when the cofactor is in
+    excess.
+  molecular_function:
+    id: GO:0000774
+    label: adenyl-nucleotide exchange factor activity
+  directly_involved_in:
+  - id: GO:0006457
+    label: protein folding
+  locations:
+  - id: GO:0005829
+    label: cytosol
+  supported_by:
+  - reference_id: PMID:15333932
+    supporting_text: &gt;-
+      Binding of the BAG domain to the eukaryotic chaperone heat-shock protein
+      (Hsp70) promotes ATP-dependent release of the protein substrate from Hsp70.
+  - reference_id: PMID:9873016
+    supporting_text: &gt;-
+      BAG-1 binds the ATPase domains of Hsp70 and Hsc70, modulating their
+      chaperone activity and functioning as a competitive antagonist of the
+      co-chaperone Hip
+  - reference_id: PMID:25053410
+    supporting_text: &gt;-
+      C-terminal fragments of UNC-23 instead perform all Hsc70-related functions,
+      like ATPase stimulation and regulation of folding activity, albeit with
+      lower affinity than BAG-1
+knowledge_gaps:
+- gap_statement: &gt;-
+    No in-vivo client or substrate of C. elegans BAG-1 has been identified, and it
+    is untested whether worm BAG-1 biases Hsc70-bound clients toward productive
+    refolding or, via its ubiquitin-like domain, toward proteasomal degradation
+    (the folding-versus-degradation decision that mammalian BAG-1 helps make).
+  boundary: &gt;-
+    It is firmly established that BAG-1 is a BAG-domain nucleotide-exchange factor
+    that binds the Hsp70/Hsc70 ATPase domain, stimulates the Hsc70 ATPase, and
+    promotes ATP-dependent substrate release, and that it carries an N-terminal
+    ubiquitin-like domain. What clients pass through this activity in the worm, and
+    what fate BAG-1 directs them to, are unknown.
+  gap_kind:
+  - BIOLOGY
+  dark_aspect: BP_DARK
+  status: OPEN
+  significance: &gt;-
+    The functional output of an Hsp70 NEF depends entirely on which clients it
+    engages and whether it promotes their folding or clearance; without this, the
+    worm-specific biological role of BAG-1 cannot be assigned, and its relationship
+    to proteostasis-network aging phenotypes remains inferential.
+  resolution: &gt;-
+    Affinity-proteomics / co-immunoprecipitation of BAG-1 (and BAG-1-vs-UNC-23) from
+    C. elegans to define native clients, combined with degradation/refolding
+    reporter assays and tests of the ubiquitin-like-domain proteasome link, would
+    close the gap.
+  provenance:
+  - reference_id: PMID:9873016
+    supporting_text: &gt;-
+      The mechanisms by which Hsp70 family chaperones are regulated, however, are
+      only partly understood.
+  - reference_id: file:worm/bag-1/bag-1-notes.md
+    supporting_text: &gt;-
+      No in-vivo client or substrate has been identified for C. elegans BAG-1, and
+      it is untested whether worm BAG-1 channels Hsc70 clients toward productive
+      refolding or toward proteasomal degradation.
+- gap_statement: &gt;-
+    No loss-of-function phenotype has been reported for the bag-1 gene itself in C.
+    elegans, so it is unknown whether bag-1 is essential, is functionally redundant
+    with its paralog unc-23, or has a distinct tissue-restricted role.
+  boundary: &gt;-
+    In this cofactor system the characterized in-vivo phenotype (severe motility
+    dysfunction, muscle-attachment-site localization) belongs to the paralog
+    UNC-23/BAG2, whereas BAG-1 has only been characterized biochemically (higher
+    Hsc70 affinity than UNC-23). A bag-1 mutant or RNAi phenotype is not described in
+    the cached literature.
+  gap_kind:
+  - BIOLOGY
+  dark_aspect: BP_DARK
+  status: OPEN
+  significance: &gt;-
+    Whether bag-1 is dispensable, buffered by unc-23, or independently required in a
+    particular tissue determines its true biological role and its weight in the worm
+    proteostasis network.
+  resolution: &gt;-
+    Characterization of a bag-1 deletion/RNAi (alone and in a unc-23 background) for
+    viability, motility, stress resistance, and proteostasis reporters would define
+    the biological role and test redundancy with unc-23.
+  provenance:
+  - reference_id: PMID:25053410
+    supporting_text: &gt;-
+      one of them being UNC-23, whose mutation induces severe motility dysfunctions
+  - reference_id: file:worm/bag-1/bag-1-notes.md
+    supporting_text: &gt;-
+      No loss-of-function phenotype has been reported for the bag-1 gene itself in
+      C. elegans, so it is unknown whether bag-1 is essential, redundant with the
+      paralog unc-23, or has a tissue-restricted role.
+- gap_statement: &gt;-
+    A direct physical BAG-1-to-HSP-1/Hsc70 complex in C. elegans has not been
+    demonstrated, and the subcellular site of BAG-1 action in the worm is untested;
+    the only experimentally reported worm partner is the DUF727 protein Y43F8B.2,
+    whose functional relationship to BAG-1 is unexplained.
+  boundary: &gt;-
+    Family biology and the worm BAG-domain crystal structure predict binding to the
+    Hsp70/Hsc70 ATPase domain, and biochemistry shows worm BAG-1 stimulates Hsc70;
+    but the demonstrated worm two-hybrid partner is Y43F8B.2, not HSP-1, and no
+    localization data exist for endogenous BAG-1.
+  gap_kind:
+  - BIOLOGY
+  - CURATION
+  dark_aspect: CC_DARK
+  status: OPEN
+  significance: &gt;-
+    Establishing the physiological BAG-1/Hsc70 complex and where it forms would
+    convert the inferred co-chaperone role into a directly evidenced one and clarify
+    the meaning (if any) of the Y43F8B.2 interaction.
+  resolution: &gt;-
+    Co-immunoprecipitation or proximity labeling of endogenous BAG-1 with HSP-1, plus
+    a tagged-BAG-1 expression/localization reporter, would confirm the complex and its
+    site of action.
+  provenance:
+  - reference_id: PMID:15333932
+    supporting_text: &gt;-
+      The structure may represent a new folding type of the BAG domain.
+  - reference_id: file:worm/bag-1/bag-1-notes.md
+    supporting_text: &gt;-
+      The only experimentally demonstrated physical partner of worm BAG-1 is the
+      DUF727 protein Y43F8B.2, and a direct BAG-1 to HSP-1/Hsc70 complex in C.
+      elegans has not been shown; the subcellular site of BAG-1 action in the worm
+      is untested.
+suggested_questions:
+- question: &gt;-
+    Does C. elegans BAG-1 form a physiological complex with the constitutive Hsc70
+    HSP-1, and is this interaction functionally distinct from that of the paralog
+    UNC-23?
+- question: &gt;-
+    Does BAG-1 direct Hsc70 clients toward refolding or toward proteasomal
+    degradation, and does its ubiquitin-like domain mediate a proteasome link as in
+    mammalian BAG-1?
+suggested_experiments:
+- description: &gt;-
+    Generate and phenotype a bag-1 loss-of-function allele (CRISPR deletion or RNAi),
+    alone and combined with unc-23 loss, assaying viability, motility,
+    thermotolerance, and aggregation/proteostasis reporters to test whether bag-1 has
+    an independent role or is redundant with unc-23.
+- description: &gt;-
+    Affinity-purify tagged BAG-1 from worm lysates followed by mass spectrometry to
+    define the native BAG-1 interactome (HSP-1/Hsc70 and clients), and combine with
+    in-vitro Hsc70 ATPase and luciferase refolding assays to quantify BAG-1&#39;s effect
+    on the chaperone cycle.
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/genes/worm/bbs-4/bbs-4-ai-review.html
+++ b/genes/worm/bbs-4/bbs-4-ai-review.html
@@ -1,0 +1,3720 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>bbs-4 - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        .propagation-review {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f8fafc;
+            border-left: 3px solid #64748b;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .propagation-title {
+            font-weight: 600;
+            color: #334155;
+            margin-bottom: 0.25rem;
+        }
+
+        .propagation-row {
+            margin-top: 0.25rem;
+        }
+
+        .propagation-source {
+            margin-top: 0.5rem;
+            padding-top: 0.5rem;
+            border-top: 1px solid #e5e7eb;
+        }
+
+        .propagation-source-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #1d4ed8;
+        }
+
+        .propagation-comment {
+            color: #4b5563;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>bbs-4</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/Q5CZ52" target="_blank" class="term-link">
+                        Q5CZ52
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Caenorhabditis elegans</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-complete">
+                    COMPLETE
+                </span>
+            </div>
+
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "bbs-4";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="Q5CZ52" data-a="DESCRIPTION: BBS-4 is a tetratricopeptide-repeat (TPR) protein ..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>BBS-4 is a tetratricopeptide-repeat (TPR) protein that is a peripheral structural subunit of the BBSome, an octameric complex (BBS-1, BBS-2, BBS-4, BBS-5, OSM-12/BBS-7, BBS-8/TTC-8, BBS-9) that couples intraflagellar transport (IFT) to the trafficking of membrane cargo at sensory cilia. Like the COPI, COPII and clathrin coats it structurally resembles, the BBSome assembles IFT particles at the ciliary base, binds the anterograde IFT particle, and reaches the ciliary tip where it regulates IFT turnaround and recycling. Within the complex BBS-4 binds directly to BBS-5 through its C-terminal TPR region and localizes to the ciliary base/basal body and along cilia. In C. elegans, BBS-4 is functionally redundant with BBS-5: single mutants have essentially normal cilia, whereas bbs-4; bbs-5 double mutants phenocopy loss of the whole BBSome, showing IFT-A/IFT-B uncoupling, disrupted ciliogenesis, and defective polycystin-mediated cilia signaling. Beyond building cilia, BBS-4 (redundantly with BBS-5) is required for the removal of ciliary sensory receptors — including polycystin-2/PKD-2, the TRP channel OSM-9 and the GPCR ODR-10 — from cilia for lysosome-targeted degradation, acting upstream of the early endosome at the ciliary base. A conserved C-terminal residue (A388 in the worm protein, A364 in human BBS4) is required for the BBS-4–BBS-5 interaction and for ciliary targeting, and its mutation models human Bardet-Biedl syndrome.</p>
+    </div>
+
+
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0034464" target="_blank" class="term-link">
+                                    GO:0034464
+                                </a>
+                            </span>
+                            <span class="term-label">BBSome</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">NAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/22922713" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:22922713
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The BBSome controls IFT assembly and turnaround in cilia.
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q5CZ52" data-a="GO:0034464" data-r="PMID:22922713" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> BBS-4 is a bona fide subunit of the BBSome, the octameric complex containing BBS-1, BBS-2, BBS-4, BBS-5, OSM-12/BBS-7, BBS-8/TTC-8 and BBS-9. This is the core cellular-component assignment for bbs-4 and is supported experimentally in C. elegans, where BBS-4 co-behaves with the other BBSome subunits during IFT.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Complex membership is the defining property of bbs-4 and is strongly supported by both C. elegans experiments and cross-species orthology. This is a core annotation.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/22922713" target="_blank" class="term-link">
+                                        PMID:22922713
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">the in vivo function for the BBSome is to regulate the assembly of the IFT particles at the ciliary base</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/26150102" target="_blank" class="term-link">
+                                        PMID:26150102
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">during the assembly of the BBSome, BBS2, 7, and 9 form the core, then BBS1, 5, 8, and finally BBS4 are added in a stepwise manner</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:worm/bbs-4/bbs-4-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">model: Edison Scientific Literature</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030674" target="_blank" class="term-link">
+                                    GO:0030674
+                                </a>
+                            </span>
+                            <span class="term-label">protein-macromolecule adaptor activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ISS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000024
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q5CZ52" data-a="GO:0030674" data-r="GO_REF:0000024" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> This adaptor-activity term is transferred by sequence similarity from human BBS4 (UniProtKB:Q96RK4). It captures the fact that BBS-4, as a TPR-repeat subunit of the coat-like BBSome, acts as a scaffold/adaptor rather than an enzyme. It is far more informative than a generic &#39;protein binding&#39; term, and reflects the best current molecular-function description for a BBSome coat subunit.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Adaptor activity is the most defensible molecular function for a BBSome structural subunit and is preferable to uninformative protein binding. However, no experimental MF has been measured for BBS-4 itself, and no GO term specifically expresses the BBSome coat/cargo-adaptor role — see knowledge_gaps.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/22922713" target="_blank" class="term-link">
+                                        PMID:22922713
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">shares the common structural features with COPI, COPII, and clathrin coats, and can directly recognize IFT cargos</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0060271" target="_blank" class="term-link">
+                                    GO:0060271
+                                </a>
+                            </span>
+                            <span class="term-label">cilium assembly</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q5CZ52" data-a="GO:0060271" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> BBS-4 contributes to cilium assembly as part of the BBSome. In C. elegans this is genetically redundant with BBS-5: single mutants are normal, but bbs-4; bbs-5 double mutants show typical bbs-class cilia defects, confirming a real (if buffered) role in ciliogenesis.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Well supported by phylogenetic inference and by direct C. elegans genetics (redundancy with bbs-5). A core biological-process annotation.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/26150102" target="_blank" class="term-link">
+                                        PMID:26150102
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">bbs-4; bbs-5 double mutants show typical cilia defect as observed in other bbs mutants</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/22922713" target="_blank" class="term-link">
+                                        PMID:22922713
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">the in vivo function for the BBSome is to regulate the assembly of the IFT particles at the ciliary base</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0060271" target="_blank" class="term-link">
+                                    GO:0060271
+                                </a>
+                            </span>
+                            <span class="term-label">cilium assembly</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">NAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/22922713" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:22922713
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The BBSome controls IFT assembly and turnaround in cilia.
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q5CZ52" data-a="GO:0060271" data-r="PMID:22922713" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Author-stated (NAS) assignment of the cilium-assembly role, duplicating the IBA annotation. The BBSome assembles IFT particles required for ciliogenesis.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct and consistent with the IBA annotation and with C. elegans genetics; both are retained as complementary evidence for the same core role.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/22922713" target="_blank" class="term-link">
+                                        PMID:22922713
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">the in vivo function for the BBSome is to regulate the assembly of the IFT particles at the ciliary base</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0061512" target="_blank" class="term-link">
+                                    GO:0061512
+                                </a>
+                            </span>
+                            <span class="term-label">protein localization to cilium</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q5CZ52" data-a="GO:0061512" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> As a BBSome subunit, BBS-4 is required for correct localization of membrane and signaling proteins to/from cilia. In C. elegans the BBSome (redundantly requiring bbs-4/bbs-5) governs the ciliary homeostasis of sensory receptors such as PKD-2, OSM-9 and ODR-10, which mislocalize and accumulate when the complex is disrupted.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Central to BBSome function and supported by both phylogenetic inference and C. elegans experiments. Core biological-process annotation.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/26150102" target="_blank" class="term-link">
+                                        PMID:26150102
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">with ~6-fold increasing of protein levels in their native expressing cilia in bbs-4; bbs-5 mutants</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0036064" target="_blank" class="term-link">
+                                    GO:0036064
+                                </a>
+                            </span>
+                            <span class="term-label">ciliary basal body</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q5CZ52" data-a="GO:0036064" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> BBS-4 acts at the ciliary basal body / ciliary base, where the BBSome assembles IFT particles prior to anterograde transport. Supported phylogenetically and consistent with direct C. elegans localization data.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Basal-body localization is a core, well-supported cellular-component annotation and matches the site of BBSome-mediated IFT assembly.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/22922713" target="_blank" class="term-link">
+                                        PMID:22922713
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">the in vivo function for the BBSome is to regulate the assembly of the IFT particles at the ciliary base</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0036064" target="_blank" class="term-link">
+                                    GO:0036064
+                                </a>
+                            </span>
+                            <span class="term-label">ciliary basal body</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/22922713" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:22922713
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The BBSome controls IFT assembly and turnaround in cilia.
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q5CZ52" data-a="GO:0036064" data-r="PMID:22922713" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct experimental (IDA) localization of BBS-4 to the ciliary basal body/base in C. elegans, consistent with BBSome accumulation around the ciliary base when it is uncoupled from moving IFT.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Experimental localization; the strongest evidence class for the basal-body assignment. Core cellular-component annotation.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/22922713" target="_blank" class="term-link">
+                                        PMID:22922713
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Some of them (BBS-1, BBS-4) totally lost the ciliary localization</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005929" target="_blank" class="term-link">
+                                    GO:0005929
+                                </a>
+                            </span>
+                            <span class="term-label">cilium</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">NAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/22922713" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:22922713
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The BBSome controls IFT assembly and turnaround in cilia.
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q5CZ52" data-a="GO:0005929" data-r="PMID:22922713" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> BBS-4 localizes to cilia as a BBSome subunit that undergoes IFT along the ciliary axoneme. A correct, if general, cellular-component assignment (the basal-body and ciliary-base terms are more specific).
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Accurate general localization supported by the referenced work, but non-core relative to the more specific basal-body/ciliary-base terms which are the core CC annotations; retained as a valid non-core localization.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/22922713" target="_blank" class="term-link">
+                                        PMID:22922713
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Some of them (BBS-1, BBS-4) totally lost the ciliary localization</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0060170" target="_blank" class="term-link">
+                                    GO:0060170
+                                </a>
+                            </span>
+                            <span class="term-label">ciliary membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000044
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q5CZ52" data-a="GO:0060170" data-r="GO_REF:0000044" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Ciliary-membrane localization is inferred from the UniProt subcellular-location mapping (Cell projection, cilium membrane, By similarity). It is consistent with the BBSome&#39;s role as a membrane-associated coat that traffics and removes ciliary membrane receptors.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Consistent with BBSome coat function at the ciliary membrane and with the receptor trafficking/removal role demonstrated for bbs-4/bbs-5.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005813" target="_blank" class="term-link">
+                                    GO:0005813
+                                </a>
+                            </span>
+                            <span class="term-label">centrosome</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000044
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q5CZ52" data-a="GO:0005813" data-r="GO_REF:0000044" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Centrosome localization is an electronic UniProt subcellular-location mapping derived from the mammalian BBS4 annotation (Cytoplasm, cytoskeleton, MTOC, centrosome, By similarity). In C. elegans the relevant structure is the centriole-derived ciliary basal body, which is separately annotated; a distinct centrosomal pool has not been demonstrated for worm BBS-4.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The basal body is centriole-derived, so a centrosomal assignment is not wrong, but it is a non-specific/derived term for this organism where the experimentally supported site is the ciliary basal body/base. Kept as non-core rather than removed.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005856" target="_blank" class="term-link">
+                                    GO:0005856
+                                </a>
+                            </span>
+                            <span class="term-label">cytoskeleton</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000044
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q5CZ52" data-a="GO:0005856" data-r="GO_REF:0000044" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> High-level cytoskeleton localization from the UniProt subcellular-location mapping. This is a very general parent term encompassing the more specific ciliary/basal-body localizations.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Not incorrect but uninformative relative to the specific ciliary basal body and ciliary base terms. Retained as non-core.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000242" target="_blank" class="term-link">
+                                    GO:0000242
+                                </a>
+                            </span>
+                            <span class="term-label">pericentriolar material</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ISS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000024
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q5CZ52" data-a="GO:0000242" data-r="GO_REF:0000024" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Pericentriolar-material localization is transferred by similarity from human BBS4, which has a mammalian pericentriolar/centriolar-satellite role. C. elegans BBS-4 has been characterized only in the ciliary/BBSome context, and nematodes largely lack the mammalian centriolar-satellite system; no worm experiment supports a pericentriolar-material localization.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> This is a mammalian-derived ISS transfer with no experimental support in C. elegans and is not part of the conserved core BBSome/ciliary function assayed in this organism. Flagged as over-annotation for the worm rather than a core localization.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0007098" target="_blank" class="term-link">
+                                    GO:0007098
+                                </a>
+                            </span>
+                            <span class="term-label">centrosome cycle</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ISS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000024
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q5CZ52" data-a="GO:0007098" data-r="GO_REF:0000024" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> The centrosome-cycle process is transferred by similarity from mammalian BBS4, which has been implicated in microtubule anchoring and dynein-mediated pericentriolar transport. There is no C. elegans evidence that BBS-4 participates in the centrosome cycle; all worm phenotypes concern cilia and IFT.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Mammalian-derived ISS process transfer without worm support and outside the conserved core ciliary role. Flagged as over-annotation for this organism.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0097546" target="_blank" class="term-link">
+                                    GO:0097546
+                                </a>
+                            </span>
+                            <span class="term-label">ciliary base</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/22922713" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:22922713
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The BBSome controls IFT assembly and turnaround in cilia.
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-new">
+                            NEW
+                        </span>
+                        <span class="vote-buttons" data-g="Q5CZ52" data-a="GO:0097546" data-r="PMID:22922713" data-act="NEW">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> BBS-4 and the other BBSome subunits concentrate at the ciliary base, where the BBSome assembles IFT particles; when the BBSome is uncoupled from moving IFT the proteins strongly accumulate there. This is a more precise localization than the general &#39;cilium&#39; term and complements the ciliary basal body annotation.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Ciliary base is the experimentally supported site of BBSome-mediated IFT assembly in C. elegans and is included as a location in core_functions; added here as a specific cellular-component annotation.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/22922713" target="_blank" class="term-link">
+                                        PMID:22922713
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">all BBS proteins examined strongly accumulated around the ciliary base</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042073" target="_blank" class="term-link">
+                                    GO:0042073
+                                </a>
+                            </span>
+                            <span class="term-label">intraciliary transport</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/22922713" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:22922713
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The BBSome controls IFT assembly and turnaround in cilia.
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-new">
+                            NEW
+                        </span>
+                        <span class="vote-buttons" data-g="Q5CZ52" data-a="GO:0042073" data-r="PMID:22922713" data-act="NEW">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> BBS-4, as a BBSome subunit, itself undergoes IFT movement along the ciliary axoneme and is required for normal intraflagellar transport; loss of the BBSome (e.g. in bbs-4; bbs-5 double mutants) uncouples IFT-A from IFT-B and disrupts IFT integrity.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Intraciliary transport is a core biological process for the BBSome, captured in core_functions; added here as a specific process annotation supported by BBS-protein IFT movement and the IFT defects of bbs mutants.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/22922713" target="_blank" class="term-link">
+                                        PMID:22922713
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">all BBS proteins completely lost IFT movement</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/26150102" target="_blank" class="term-link">
+                                        PMID:26150102
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">bbs-4; bbs-5 and bbs-7 share similar mutant phenotypes in that CHE-11 is absent, but OSM-6 abnormally accumulates, in the distal segments of plasmid cilia</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>BBS-4 acts as a TPR-repeat structural/adaptor subunit of the coat-like BBSome. Through its C-terminal TPR region it binds BBS-5 and integrates into the complex, contributing to BBSome-mediated assembly of IFT particles at the ciliary base and to the IFT-coupled trafficking and degradative removal of ciliary membrane cargo. Its molecular activity is best described as a protein-macromolecule adaptor within the BBSome coat; no independent enzymatic activity is known.</h3>
+                <span class="vote-buttons" data-g="Q5CZ52" data-a="FUNCTION: BBS-4 acts as a TPR-repeat structural/adaptor subu..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030674" target="_blank" class="term-link">
+                            protein-macromolecule adaptor activity
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0061512" target="_blank" class="term-link">
+                                protein localization to cilium
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0060271" target="_blank" class="term-link">
+                                cilium assembly
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042073" target="_blank" class="term-link">
+                                intraciliary transport
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0036064" target="_blank" class="term-link">
+                                ciliary basal body
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0097546" target="_blank" class="term-link">
+                                ciliary base
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0060170" target="_blank" class="term-link">
+                                ciliary membrane
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">In Complex:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0034464" target="_blank" class="term-link">
+                            BBSome
+                        </a>
+                    </span>
+                </div>
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/22922713" target="_blank" class="term-link">
+                                PMID:22922713
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">the in vivo function for the BBSome is to regulate the assembly of the IFT particles at the ciliary base</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/26150102" target="_blank" class="term-link">
+                                PMID:26150102
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">mapped down the binding region in BBS-4 to the C-terminal 193 amino acids (a.a. 270–462)</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000024.md" target="_blank" class="term-link">
+                            GO_REF:0000024
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Manual transfer of experimentally-verified manual GO annotation data to orthologs by curator judgment of sequence similarity</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
+                            GO_REF:0000033
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Annotation inferences using phylogenetic trees</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
+                            GO_REF:0000044
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/22922713" target="_blank" class="term-link">
+                            PMID:22922713
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">The BBSome controls IFT assembly and turnaround in cilia.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">The BBSome assembles IFT particles at the ciliary base and regulates IFT turnaround/recycling at the ciliary tip.</div>
+
+                        <div class="finding-text">"the in vivo function for the BBSome is to regulate the assembly of the IFT particles at the ciliary base"</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <div class="finding-statement">The BBSome binds the IFT particle as a cargo, not as an integral structural component.</div>
+
+                        <div class="finding-text">"the BBSome binds to the IFT particle like a cargo but not a structural component"</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <div class="finding-statement">BBS-4 loses ciliary localization and accumulates at the ciliary base when the BBSome is uncoupled from moving IFT.</div>
+
+                        <div class="finding-text">"Some of them (BBS-1, BBS-4) totally lost the ciliary localization"</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <div class="finding-statement">The BBSome shares coat features with COPI/COPII/clathrin and can directly recognize IFT cargo.</div>
+
+                        <div class="finding-text">"shares the common structural features with COPI, COPII, and clathrin coats, and can directly recognize IFT cargos"</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/26150102" target="_blank" class="term-link">
+                            PMID:26150102
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">BBS4 and BBS5 show functional redundancy in the BBSome to regulate the degradative sorting of ciliary sensory receptors.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">BBS-4 directly interacts with BBS-5 through its C-terminal region (a.a. 270-462).</div>
+
+                        <div class="finding-text">"mapped down the binding region in BBS-4 to the C-terminal 193 amino acids (a.a. 270–462)"</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <div class="finding-statement">bbs-4 and bbs-5 single mutants have normal cilia; bbs-4; bbs-5 double mutants phenocopy whole-BBSome loss.</div>
+
+                        <div class="finding-text">"bbs-4 or bbs-5 single mutants are completely normal in dye-filling assay"</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <div class="finding-statement">BBS-4 and BBS-5 redundantly regulate lysosome-targeted degradation of ciliary sensory receptors.</div>
+
+                        <div class="finding-text">"BBS-4 and BBS-5 play redundant role in the BBSome to ubiquitously regulate the lysosome-targeted degradation of ciliary sensory receptors"</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <div class="finding-statement">The BBSome acts upstream of the early endosome at the ciliary base to direct receptors to lysosomal degradation.</div>
+
+                        <div class="finding-text">"the BBSome acts upstream of the early endosome, probably in endocytic stage at cilia base, to regulate the lysosomal sorting of ciliary receptors"</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        file:worm/bbs-4/bbs-4-deep-research-falcon.md
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Deep research report on bbs-4 (Edison/falcon)</div>
+
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Questions for Experts</h2>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Does BBS-4&#39;s TPR surface directly contact a specific ciliary membrane cargo within the BBSome, or does it act purely as a scaffold linking BBS-5 into the coat?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q5CZ52" data-a="Q: Does BBS-4&#39;s TPR surface directly contact a specif..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> What endocytic/ubiquitin effectors at the ciliary base connect the BBSome to lysosome-targeted degradation of sensory receptors?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q5CZ52" data-a="Q: What endocytic/ubiquitin effectors at the ciliary ..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Experiments</h2>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Proximity-dependent biotinylation (TurboID) or affinity proteomics of BBS-4 at the ciliary base in wild-type versus bbs-5 mutant worms to identify cargo and endocytic/ubiquitin effectors.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: BBS-4 within the BBSome physically links ciliary sensory receptors to the early-endosome/lysosome sorting machinery at the ciliary base.</em></p>
+
+
+                    <p style="margin-top: 0.5rem;">Type: proteomics</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q5CZ52" data-a="EXPERIMENT: Proximity-dependent biotinylation (TurboID) or aff..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Structure-guided separation-of-function alleles of bbs-4 that abolish BBS-5 binding (C-terminal TPR) while preserving BBSome incorporation, scored for ciliogenesis, IFT integrity, and receptor removal.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: The BBS-4–BBS-5 interaction is specifically required for receptor degradative sorting, separable from bulk IFT assembly.</em></p>
+
+
+                    <p style="margin-top: 0.5rem;">Type: genetics</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q5CZ52" data-a="EXPERIMENT: Structure-guided separation-of-function alleles of..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Knowledge Gaps</h2>
+        <p style="color: #555; font-size: 0.92rem; margin-top: -0.3rem;">
+            What is <em>not</em> known — curated, literature-grounded statements of the open
+            unknowns (the inverse of core functions).
+        </p>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> There is no GO molecular-function term that expresses the role of a BBSome coat/cargo- adaptor subunit, and the specific cargo(es) that BBS-4&#39;s TPR array directly recognizes within the BBSome are undefined. BBS-4 has no experimentally measured biochemical activity of its own; its sole MF annotation (protein-macromolecule adaptor activity) is a generic sequence-similarity transfer.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">ONTOLOGY</span><span class="badge">BIOLOGY</span>
+                <span class="badge">MF_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> BBS-4 is an established BBSome subunit built from tetratricopeptide repeats; the BBSome is explicitly coat-like (shares structural features with COPI, COPII and clathrin) and is proposed to polymerize and recognize ciliary membrane proteins, and it can directly recognize IFT cargo. What is missing is a molecular-function term (and the direct cargo identity) for the coat subunit rather than the complex-level process.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> BBSome subunits illustrate the structural-subunit ontology gap: their function is &#39;be part of the coat&#39;, which the GO molecular-function aspect cannot currently express, so the gene reads as MF-dark despite a well-defined cellular role central to Bardet-Biedl syndrome.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Ontology development of a BBSome coat/cargo-adaptor molecular-function term (analogous to a vesicle-coat adaptor), plus proximity/affinity proteomics and structural work to identify the membrane cargo directly contacted by the BBS-4 TPR surface.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"shares the common structural features with COPI, COPII, and clathrin coats, and can directly recognize IFT cargos"</em> — PMID:22922713</li>
+
+                <li><em>"has been proposed to polymerize and recognize the ciliary membrane proteins"</em> — PMID:26150102</li>
+
+            </ul>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Proposed term (ontology gap):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><strong>BBSome coat cargo-adaptor activity</strong> — BBSome subunits such as BBS-4 have no adequate GO molecular-function term; they are annotatable only with the generic &#39;protein-macromolecule adaptor activity&#39; or the uninformative &#39;protein binding&#39;, leaving them MF-dark despite a well-defined coat-subunit role.</li>
+
+            </ul>
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The molecular mechanism by which the BBSome triggers degradative (lysosome-targeted) removal of ciliary sensory receptors — the direct effectors linking the ciliary-base BBSome to the endocytic/ubiquitin machinery — and the molecular basis of the BBS-4/BBS-5 functional redundancy (two subunits with no shared domain, each dispensable alone) are undetermined.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">RESIDUAL_SUBGAP</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> bbs-4 and bbs-5 single mutants have normal cilia; bbs-4; bbs-5 double mutants phenocopy whole-BBSome loss, with IFT-A/IFT-B uncoupling and ~3–6-fold ciliary accumulation of PKD-2, OSM-9 and ODR-10. RAB-5 overexpression rescues, and STAM-1 epistasis places the BBSome upstream of the early endosome at the ciliary base for these non-IFT cargoes; BBS-4 binds BBS-5 directly via its C-terminal TPR region. What remains unknown is the biochemical output that couples the BBSome to receptor endocytosis/degradation.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> This receptor-downregulation activity is conserved to human BBS4/BBS5 and to polycystin-2, directly relevant to Bardet-Biedl syndrome and polycystic kidney disease; the missing effectors are the mechanistic link between the BBSome and ciliary signaling homeostasis.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Proximity/affinity proteomics of the ciliary-base BBSome to identify the endocytic/ ubiquitin effectors; separation-of-function bbs-4 alleles that uncouple BBS-5 binding from cargo removal; and structural definition of how BBS-4 and BBS-5 co-contribute to a shared coat surface.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"the definite molecular activity of the BBSome in regulating the homoeostasis of ciliary membrane proteins remain unclear"</em> — PMID:26150102</li>
+
+                <li><em>"two BBSome components that share no similar protein domains"</em> — PMID:26150102</li>
+
+            </ul>
+
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Tags</h2>
+        <div class="aliases">
+
+            <span class="badge">caeel-ciliopathy</span>
+
+        </div>
+    </div>
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Deep Research Sections -->
+
+    <div class="section">
+        <h2 class="section-title">Deep Research</h2>
+
+        <details class="deep-research-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; gap: 1rem;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Falcon</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(bbs-4-deep-research-falcon.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="Q5CZ52" data-a="DEEP_RESEARCH: Falcon" data-r="" data-act="DEEP_RESEARCH" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This deep research is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This deep research needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+
+                <div class="report-meta">
+
+                    <span class="report-meta-text">Comprehensive Research Report: *bbs-4* (BBS-4) in *Caenorhabditis elegans*</span>
+
+
+                    <span class="report-badge">Falcon</span>
+
+
+                    <span class="report-badge">Edison Scientific Literature</span>
+
+
+                    <span class="report-badge">36 citations</span>
+
+
+                    <span class="report-badge">1 artifacts</span>
+
+
+                    <span class="report-meta-text">2026-07-04T15:45:00.093261</span>
+
+
+
+                </div>
+
+
+                <div class="artifact-list">
+
+
+
+                    <div class="artifact-link">
+                        <a href="bbs-4-deep-research-falcon_artifacts/artifact-00.md" class="term-link">Edison artifact artifact-00</a>
+                        <span>(text/markdown)</span>
+                    </div>
+
+
+                </div>
+
+                <p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h1 id="comprehensive-research-report-bbs-4-bbs-4-in-caenorhabditis-elegans">Comprehensive Research Report: <em>bbs-4</em> (BBS-4) in <em>Caenorhabditis elegans</em></h1>
+<h2 id="geneprotein-identity-verification">Gene/Protein Identity Verification</h2>
+<p>The gene <em>bbs-4</em> (ORF name F58A4.14) in <em>C. elegans</em> encodes the BBSome complex member BBS-4 (UniProt: Q5CZ52), a homolog of the human Bardet-Biedl syndrome 4 protein (BBS4). The protein belongs to the BBS4 family and contains multiple tetratricopeptide repeat (TPR) domains (IPR019734, IPR011990), consistent with its characterized role as a structural adaptor protein within the BBSome complex. The gene symbol, organism, protein family, and domain architecture all align with the literature reviewed below.</p>
+<table>
+<thead>
+<tr>
+<th>Gene name</th>
+<th>Protein name</th>
+<th>Organism</th>
+<th>Protein family</th>
+<th>Key domains</th>
+<th>Primary function</th>
+<th>Subcellular localization</th>
+<th>Interacting partners / complex context</th>
+<th>Mutant phenotypes in <em>C. elegans</em></th>
+<th>Disease relevance / human ortholog</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><strong>bbs-4</strong></td>
+<td>BBS-4; BBSome complex member bbs-4; Bardet-Biedl syndrome 4 protein homolog</td>
+<td><em>Caenorhabditis elegans</em></td>
+<td>BBS4 family; BBSome subunit</td>
+<td>TPR-like helical domain superfamily; tetratricopeptide repeats (TPRs), consistent with a TPR α-solenoid/adaptor architecture (klink2020structureofthe pages 2-4, singh2020structureandactivation pages 5-8, klink2020structureofthe pages 4-6)</td>
+<td>Non-enzymatic trafficking adaptor subunit of the BBSome. Helps organize ciliary membrane protein trafficking, especially removal/degradative sorting of sensory receptors, and contributes to IFT particle assembly/turnaround through the BBSome rather than catalyzing a chemical reaction (xu2015bbs4andbbs5 pages 2-4, xu2015bbs4andbbs5 pages 6-7, wei2012thebbsomecontrols pages 1-2, tian2023organizationfunctionsand pages 16-18)</td>
+<td>Localizes to cilia and the ciliary base in worms; in dyf-2 mutants accumulates around the ciliary base and loses normal ciliary localization. In broader BBS literature, BBS4/BBSome also associates with basal body, centrosomal/pericentriolar regions and centriolar satellites (xu2015bbs4andbbs5 pages 6-7, novas2015bardet–biedlsyndromeis pages 4-4, wei2012thebbsomecontrols pages 2-4)</td>
+<td>Directly interacts with <strong>BBS-5</strong> in worms; structurally connected within the BBSome to BBS1, BBS8, BBS9, and BBS18; assembled late into the BBSome after the BBS2-BBS7-BBS9 core and after incorporation of BBS1/BBS5/BBS8 in assembly models (xu2015bbs4andbbs5 pages 6-7, klink2020structureofthe pages 4-6, tian2023organizationfunctionsand pages 7-9, zhang2012intrinsicproteinproteininteractionmediated pages 6-8, zhang2012intrinsicproteinproteininteractionmediated pages 8-10)</td>
+<td><strong>Single mutants:</strong> often normal in dye-filling/ciliogenesis assays but show defects in polycystin signaling. <strong>bbs-4;bbs-5 double mutants:</strong> strong ciliary dysfunction, IFT-A/IFT-B dissociation with altered velocities, receptor accumulation in cilia (e.g., PKD-2, OSM-9, ODR-10), and defective sensory/ciliary homeostasis (xu2015bbs4andbbs5 pages 2-4, wingfield2018traffickingofciliary pages 4-5)</td>
+<td>Human ortholog <strong>BBS4</strong> is a Bardet-Biedl syndrome gene. Disease associations include Bardet-Biedl syndrome / Bardet-Biedl syndrome 4, retinitis pigmentosa, and polydactyly, supporting evolutionary conservation of BBS4-dependent ciliary trafficking (OpenTargets Search: -BBS4)</td>
+</tr>
+</tbody>
+</table>
+<p><em>Table: This table summarizes the core molecular and functional properties of </em>C. elegans<em> bbs-4/BBS-4, emphasizing its role as a TPR-containing BBSome subunit involved in ciliary trafficking and IFT-related processes. It also links worm findings to conserved human BBS4 disease relevance.</em></p>
+<h2 id="1-primary-function-non-enzymatic-structural-adaptor-in-the-bbsome-complex">1. Primary Function: Non-Enzymatic Structural Adaptor in the BBSome Complex</h2>
+<p>BBS-4 is not an enzyme; it does not catalyze a chemical reaction. Rather, it functions as a <strong>structural adaptor subunit of the BBSome</strong>, an octameric protein complex that acts as a cargo adapter linking ciliary membrane proteins to the intraflagellar transport (IFT) machinery (xu2015bbs4andbbs5 pages 2-4, tian2023organizationfunctionsand pages 3-5). The BBSome was originally discovered through tandem affinity purification of BBS4, which identified six other BBS proteins (BBS1, BBS2, BBS5, BBS7, BBS8, and BBS9) associating with BBS4 in stoichiometric ratios (tian2023organizationfunctionsand pages 3-5). A later-identified eighth subunit, BBS18/BBIP10, completes the octameric complex (tian2023organizationfunctionsand pages 3-5).</p>
+<p>The primary molecular role of BBS-4 within the BBSome is to contribute to the complex's function as a <strong>planar coat complex</strong> that recognizes ciliary membrane proteins—particularly G protein-coupled receptors (GPCRs) and sensory receptors—and mediates their trafficking into and, predominantly, out of cilia via association with IFT trains (tian2023organizationfunctionsand pages 16-18, wingfield2018traffickingofciliary pages 5-7, wingfield2018traffickingofciliary pages 2-4). In <em>C. elegans</em>, BBS-4 is specifically implicated in regulating the <strong>degradative sorting of ciliary sensory receptors</strong>, directing ubiquitinated receptors toward lysosomal degradation rather than simply mediating retrograde IFT transport (xu2015bbs4andbbs5 pages 6-7).</p>
+<h2 id="2-functional-redundancy-with-bbs-5">2. Functional Redundancy with BBS-5</h2>
+<p>A key finding in <em>C. elegans</em> is that BBS-4 and BBS-5 exhibit <strong>unexpected functional redundancy</strong> within the BBSome. Single <em>bbs-4</em> mutants are largely normal in ciliogenesis and dye-filling assays, though they do show defective polycystin-mediated mechanosensory signaling (xu2015bbs4andbbs5 pages 2-4). However, <em>bbs-4; bbs-5</em> double mutants display severe ciliary defects, including abnormal cilia biogenesis, disrupted IFT velocities (with IFT-A and IFT-B complexes separating and moving at distinct speeds), and aberrant accumulation of ciliary sensory receptors such as PKD-2, OSM-9, and ODR-10 (xu2015bbs4andbbs5 pages 2-4, wingfield2018traffickingofciliary pages 4-5). BBS-4 directly interacts with BBS-5 through its carboxyl-terminus, and a conserved mutation (A388E) in BBS-4 can disrupt this interaction and impair ciliary targeting (xu2015bbs4andbbs5 pages 6-7).</p>
+<p>The double mutant phenotype reveals that BBS-4 and BBS-5 act redundantly within the BBSome to regulate the <strong>ciliary removal and lysosome-targeted degradative sorting</strong> of mono-ubiquitinated sensory receptors, rather than their ciliary entry or retrograde IFT transport per se (xu2015bbs4andbbs5 pages 6-7). This function is conserved in mammals, where BBS4 and BBS5 also interact directly and coordinate ciliary removal of polycystin 2 (xu2015bbs4andbbs5 pages 6-7).</p>
+<h2 id="3-protein-structure-and-domain-architecture">3. Protein Structure and Domain Architecture</h2>
+<p>BBS-4 contains multiple <strong>tetratricopeptide repeat (TPR) domains</strong> that fold into a characteristic α-solenoid (superhelical) structure (singh2020structureandactivation pages 5-8, klink2020structureofthe pages 4-6). High-resolution cryo-EM structures of the human and bovine BBSome have revealed the atomic-level architecture of BBS4 within the complex:</p>
+<ul>
+<li>BBS4 forms a conventional, uninterrupted α-solenoid that runs along the side of the BBSome "body" domain, which also includes BBS5, BBS8, and BBS18 (singh2020structureandactivation pages 5-8). These four subunits collectively comprise approximately one-third of the BBSome's molecular mass.</li>
+<li><strong>BBS18</strong> acts as a stabilizing "U-bolt," winding through the TPR domains of both BBS4 and BBS8 (klink2020structureofthe pages 4-6).</li>
+<li><strong>BBS1</strong> interacts with BBS4 through its N-terminal β-propeller domain binding to the N-terminus of BBS4's TPR superhelix, while the BBS1 C-terminal GAE domain binds to BBS8 (klink2020structureofthe pages 4-6).</li>
+<li>BBS4 also interacts with <strong>BBS9</strong> through BBS9's C-terminal domain (tian2023organizationfunctionsand pages 7-9).</li>
+<li>The TPR domains of BBS4 participate in extensive interactions with β-propeller domains through hydrophobic and ionic contacts (klink2020structureofthe pages 4-6).</li>
+</ul>
+<p>The BBSome contains a prominent <strong>negatively charged cleft</strong> at its center, with contributions from multiple subunits, that likely mediates recognition of positively charged ciliary targeting sequences on cargo proteins (klink2020structureofthe pages 2-4, klink2020structureofthe pages 11-12). A large positively charged patch on the complex surface strengthens membrane association (klink2020structureofthe pages 2-4).</p>
+<h2 id="4-bbsome-assembly-bbs-4-is-the-last-subunit-added">4. BBSome Assembly: BBS-4 is the Last Subunit Added</h2>
+<p>The BBSome assembles through a <strong>regulated, sequential pathway</strong>. Three non-core BBS proteins—BBS6, BBS10, and BBS12—form a chaperonin complex with CCT/TRiC proteins that first stabilizes BBS7 (zhang2012intrinsicproteinproteininteractionmediated pages 6-8, tian2023organizationfunctionsand pages 5-6). BBS7 then forms a ternary core complex with BBS2 and BBS9 (the "BBSome core complex"). Subsequently, BBS1, BBS5, and BBS8 are incorporated through intrinsic protein-protein interactions with BBS9, which serves as the organizational hub (tian2023organizationfunctionsand pages 6-7). <strong>BBS4 is the last subunit added</strong> to complete the BBSome, and its incorporation requires BBS1 (zhang2012intrinsicproteinproteininteractionmediated pages 6-8, zhang2012intrinsicproteinproteininteractionmediated pages 8-10, zhang2012intrinsicproteinproteininteractionmediated pages 2-4). This peripheral position in the assembly hierarchy is consistent with the observation that BBS4 localizes to the periphery of the complex and has a dispensable role in BBSome assembly per se (tian2023organizationfunctionsand pages 7-9).</p>
+<h2 id="5-subcellular-localization">5. Subcellular Localization</h2>
+<p>In <em>C. elegans</em>, BBS-4 localizes to the <strong>cilia of ciliated sensory neurons</strong> and to the <strong>ciliary base</strong> (xu2015bbs4andbbs5 pages 6-7, wei2012thebbsomecontrols pages 2-4). GFP-tagged BBS-4 can be observed along the length of cilia from base to tip. In <em>dyf-2</em> (WDR19 ortholog) mutants, BBS-4 loses ciliary localization and instead accumulates strongly around the ciliary base, indicating that DYF-2 is required for loading the BBSome onto anterograde IFT trains for ciliary entry (wei2012thebbsomecontrols pages 2-4). Despite this accumulation, the BBSome complex itself still forms but remains restricted to the base (wei2012thebbsomecontrols pages 2-4).</p>
+<p>In mammalian cells, BBS4 localizes to <strong>centriolar satellites</strong>, the <strong>centrosome/basal body</strong>, and the <strong>periciliary region</strong> (novas2015bardet–biedlsyndromeis pages 4-4, novas2015bardet–biedlsyndromeis pages 3-4). BBS4 interacts with <strong>PCM1</strong> (the main component of pericentriolar satellites) and <strong>AZI1</strong> (another centriolar satellite protein), and must properly relocalize from satellites to the cilium for recruitment of other BBSome components like BBS8 (novas2015bardet–biedlsyndromeis pages 3-4, novas2015bardet–biedlsyndromeis pages 4-4). In mammalian olfactory sensory neurons, BBS4 localizes to basal bodies and ciliary knobs and undergoes bidirectional IFT movement along the entire ciliary length (williams2014directevidencefor pages 7-8).</p>
+<h2 id="6-role-in-intraflagellar-transport-ift">6. Role in Intraflagellar Transport (IFT)</h2>
+<p>The BBSome, including BBS-4, plays critical roles in <strong>IFT complex organization and turnaround</strong> in <em>C. elegans</em> cilia:</p>
+<ul>
+<li>The BBSome <strong>assembles IFT complexes</strong> at the ciliary base, stabilizing the interaction between IFT-A and IFT-B subcomplexes (wei2012thebbsomecontrols pages 1-2, wingfield2018traffickingofciliary pages 4-5). In <em>bbs</em> mutants, IFT-A and IFT-B dissociate and move with distinct velocities corresponding to their associated motor proteins (OSM-3/kinesin for IFT-B, heterotrimeric kinesin-II for IFT-A) (wingfield2018traffickingofciliary pages 4-5).</li>
+<li>The BBSome binds to anterograde IFT particles in a <strong>DYF-2- and BBS-1-dependent manner</strong>, reaches the ciliary tip, and there <strong>regulates IFT turnaround</strong> from anterograde to retrograde transport (wei2012thebbsomecontrols pages 1-2, wei2012thebbsomecontrols pages 14-16). In <em>bbs-1</em> mutants, IFT-B components (OSM-6, DYF-1) accumulate at the ciliary tip with greatly reduced retrograde movement, while IFT-A maintains normal transport (wei2012thebbsomecontrols pages 8-14).</li>
+<li>Notably, <em>C. elegans</em> lacks certain mammalian mediators of BBSome-IFT interaction (IFT25, IFT27, LZTFL1), indicating that <strong>distinct BBSome-IFT coupling mechanisms</strong> have evolved in nematodes (wingfield2018traffickingofciliary pages 4-5).</li>
+</ul>
+<h2 id="7-cargo-trafficking-and-signaling-pathways">7. Cargo Trafficking and Signaling Pathways</h2>
+<p>The BBSome functions as a multivalent cargo adapter for ciliary membrane proteins. In <em>C. elegans</em>, BBS-4 (together with BBS-5) is required for proper homeostasis of several ciliary sensory receptors:</p>
+<ul>
+<li><strong>PKD-2</strong> (polycystin-2): a TRP channel involved in mechanosensory signaling in male-specific neurons (xu2015bbs4andbbs5 pages 6-7)</li>
+<li><strong>OSM-9</strong>: a TRPV channel involved in osmosensation and olfaction (xu2015bbs4andbbs5 pages 2-4)</li>
+<li><strong>ODR-10</strong>: an olfactory receptor for diacetyl chemotaxis (xu2015bbs4andbbs5 pages 2-4)</li>
+</ul>
+<p>In <em>bbs-4; bbs-5</em> double mutants, these receptors abnormally accumulate in cilia due to disrupted lysosome-targeted degradative sorting of ubiquitinated receptors (xu2015bbs4andbbs5 pages 6-7, wingfield2018traffickingofciliary pages 4-5). This demonstrates that BBS-4 functions in a <strong>post-ciliary export degradative sorting pathway</strong> rather than solely in retrograde IFT.</p>
+<p>In vertebrate systems, the BBSome (of which BBS4 is a subunit) mediates ciliary export of GPCRs including Smoothened (SMO), GPR161, SSTR3, and MCHR1 (yang2020nearatomicstructuresof pages 12-13, tian2023organizationfunctionsand pages 16-18, tian2023organizationfunctionsand pages 15-16). The BBSome recognizes specific motifs in cargo proteins, including the [W/F/Y][K/R] motif in GPCR helix 8, the Ax[S/A]xQ consensus in intracellular loops, and C-terminal VxP sequences (yang2020nearatomicstructuresof pages 12-13, tian2023organizationfunctionsand pages 15-16). BBSome-mediated GPCR removal is critical for <strong>Hedgehog signaling</strong> (via SMO and GPR161 trafficking) and other cilium-dependent signaling pathways (tian2023organizationfunctionsand pages 16-18, wingfield2018traffickingofciliary pages 5-7).</p>
+<h2 id="8-extra-ciliary-functions">8. Extra-Ciliary Functions</h2>
+<p>Beyond ciliary trafficking, BBS4/BBS-4 has been implicated in several non-ciliary processes:<br />
+- <strong>Actin cytoskeleton regulation</strong>: Bbs4-deficient mammalian cells show disrupted actin stress fibers, upregulated RhoA-GTP levels, impaired cell migration, adhesion, and division, and abnormal focal adhesion formation (tian2023organizationfunctionsand pages 9-11).<br />
+- <strong>Centriolar satellite organization</strong>: BBS4 recruits BBSome subunits to centriolar satellites and interacts with PCM1 and the dynein/dynactin motor complex via p150Glued (novas2015bardet–biedlsyndromeis pages 4-4).<br />
+- Additional reported roles include Notch recycling, transcriptional regulation of RNF2, and pericentriolar cargo targeting (novas2015bardet–biedlsyndromeis pages 3-4).</p>
+<h2 id="9-disease-relevance">9. Disease Relevance</h2>
+<p>The human ortholog BBS4 is causally associated with <strong>Bardet-Biedl syndrome type 4</strong> (OMIM), a ciliopathy characterized by retinal degeneration, obesity, polydactyly, renal abnormalities, and cognitive impairment (OpenTargets Search: -BBS4). BBS4 mutations are also associated with retinitis pigmentosa and polydactyly (OpenTargets Search: -BBS4). The conserved role of BBS-4 in ciliary sensory receptor trafficking in <em>C. elegans</em> provides a mechanistic basis for understanding the sensory and developmental deficits observed in BBS patients.</p>
+<h2 id="10-summary">10. Summary</h2>
+<p><em>C. elegans</em> BBS-4 is a TPR-containing structural adaptor protein that functions as a subunit of the octameric BBSome complex. It is the last subunit incorporated during BBSome assembly and localizes to cilia and the ciliary base in sensory neurons. BBS-4's primary molecular function is to contribute to the BBSome's role as a cargo adapter that couples ciliary membrane proteins (sensory receptors and GPCRs) to the IFT machinery for regulated ciliary export and degradative sorting. BBS-4 exhibits functional redundancy with BBS-5 in <em>C. elegans</em>, and their combined loss leads to severe defects in cilia structure, IFT organization, and sensory receptor homeostasis. The protein's TPR α-solenoid architecture mediates critical protein-protein interactions within the BBSome body domain, connecting to BBS1, BBS8, BBS9, and BBS18. These findings, derived from genetic, biochemical, and structural studies in <em>C. elegans</em> and mammalian systems, establish BBS-4 as an essential component of the ciliary trafficking machinery with conserved roles from nematodes to humans.</p>
+<p>References</p>
+<ol>
+<li>
+<p>(klink2020structureofthe pages 2-4): Björn Udo Klink, Christos Gatsogiannis, Oliver Hofnagel, Alfred Wittinghofer, and Stefan Raunser. Structure of the human bbsome core complex. Jan 2020. URL: https://doi.org/10.7554/elife.53910, doi:10.7554/elife.53910. This article has 97 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(singh2020structureandactivation pages 5-8): Sandeep K Singh, Miao Gui, Fujiet Koh, Matthew CJ Yip, and Alan Brown. Structure and activation mechanism of the bbsome membrane protein trafficking complex. eLife, Jan 2020. URL: https://doi.org/10.7554/elife.53322, doi:10.7554/elife.53322. This article has 106 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(klink2020structureofthe pages 4-6): Björn Udo Klink, Christos Gatsogiannis, Oliver Hofnagel, Alfred Wittinghofer, and Stefan Raunser. Structure of the human bbsome core complex. Jan 2020. URL: https://doi.org/10.7554/elife.53910, doi:10.7554/elife.53910. This article has 97 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(xu2015bbs4andbbs5 pages 2-4): Qingwen Xu, Yuxia Zhang, Qing Wei, Yan Huang, Yan Li, Kun Ling, and Jinghua Hu. Bbs4 and bbs5 show functional redundancy in the bbsome to regulate the degradative sorting of ciliary sensory receptors. Scientific Reports, Jul 2015. URL: https://doi.org/10.1038/srep11855, doi:10.1038/srep11855. This article has 93 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(xu2015bbs4andbbs5 pages 6-7): Qingwen Xu, Yuxia Zhang, Qing Wei, Yan Huang, Yan Li, Kun Ling, and Jinghua Hu. Bbs4 and bbs5 show functional redundancy in the bbsome to regulate the degradative sorting of ciliary sensory receptors. Scientific Reports, Jul 2015. URL: https://doi.org/10.1038/srep11855, doi:10.1038/srep11855. This article has 93 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(wei2012thebbsomecontrols pages 1-2): Qing Wei, Yuxia Zhang, Yujie Li, Qing Zhang, Kun Ling, and Jinghua Hu. The bbsome controls ift assembly and turnaround in cilia. Aug 2012. URL: https://doi.org/10.1038/ncb2560, doi:10.1038/ncb2560. This article has 273 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(tian2023organizationfunctionsand pages 16-18): Xiaoyu Tian, Huijie Zhao, and Jun Zhou. Organization, functions, and mechanisms of the bbsome in development, ciliopathies, and beyond. eLife, Jul 2023. URL: https://doi.org/10.7554/elife.87623, doi:10.7554/elife.87623. This article has 88 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(novas2015bardet–biedlsyndromeis pages 4-4): Rossina Novas, Magdalena Cardenas-Rodriguez, Florencia Irigoín, and Jose L. Badano. Bardet–biedl syndrome: is it only cilia dysfunction? FEBS Letters, 589:3479-3491, Nov 2015. URL: https://doi.org/10.1016/j.febslet.2015.07.031, doi:10.1016/j.febslet.2015.07.031. This article has 111 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(wei2012thebbsomecontrols pages 2-4): Qing Wei, Yuxia Zhang, Yujie Li, Qing Zhang, Kun Ling, and Jinghua Hu. The bbsome controls ift assembly and turnaround in cilia. Aug 2012. URL: https://doi.org/10.1038/ncb2560, doi:10.1038/ncb2560. This article has 273 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(tian2023organizationfunctionsand pages 7-9): Xiaoyu Tian, Huijie Zhao, and Jun Zhou. Organization, functions, and mechanisms of the bbsome in development, ciliopathies, and beyond. eLife, Jul 2023. URL: https://doi.org/10.7554/elife.87623, doi:10.7554/elife.87623. This article has 88 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(zhang2012intrinsicproteinproteininteractionmediated pages 6-8): Qihong Zhang, Dahai Yu, Seongjin Seo, Edwin M. Stone, and Val C. Sheffield. Intrinsic protein-protein interaction-mediated and chaperonin-assisted sequential assembly of stable bardet-biedl syndrome protein complex, the bbsome. Journal of Biological Chemistry, 287:20625-20635, Jun 2012. URL: https://doi.org/10.1074/jbc.m112.341487, doi:10.1074/jbc.m112.341487. This article has 206 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(zhang2012intrinsicproteinproteininteractionmediated pages 8-10): Qihong Zhang, Dahai Yu, Seongjin Seo, Edwin M. Stone, and Val C. Sheffield. Intrinsic protein-protein interaction-mediated and chaperonin-assisted sequential assembly of stable bardet-biedl syndrome protein complex, the bbsome. Journal of Biological Chemistry, 287:20625-20635, Jun 2012. URL: https://doi.org/10.1074/jbc.m112.341487, doi:10.1074/jbc.m112.341487. This article has 206 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(wingfield2018traffickingofciliary pages 4-5): Jenna L. Wingfield, Karl-Ferdinand Lechtreck, and Esben Lorentzen. Trafficking of ciliary membrane proteins by the intraflagellar transport/bbsome machinery. Essays in biochemistry, 62 6:753-763, Oct 2018. URL: https://doi.org/10.1042/ebc20180030, doi:10.1042/ebc20180030. This article has 186 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(OpenTargets Search: -BBS4): Open Targets Query (-BBS4, 5 results). Buniello, A. et al. (2025). Open Targets Platform: facilitating therapeutic hypotheses building in drug discovery. Nucleic Acids Research.</p>
+</li>
+<li>
+<p>(tian2023organizationfunctionsand pages 3-5): Xiaoyu Tian, Huijie Zhao, and Jun Zhou. Organization, functions, and mechanisms of the bbsome in development, ciliopathies, and beyond. eLife, Jul 2023. URL: https://doi.org/10.7554/elife.87623, doi:10.7554/elife.87623. This article has 88 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(wingfield2018traffickingofciliary pages 5-7): Jenna L. Wingfield, Karl-Ferdinand Lechtreck, and Esben Lorentzen. Trafficking of ciliary membrane proteins by the intraflagellar transport/bbsome machinery. Essays in biochemistry, 62 6:753-763, Oct 2018. URL: https://doi.org/10.1042/ebc20180030, doi:10.1042/ebc20180030. This article has 186 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(wingfield2018traffickingofciliary pages 2-4): Jenna L. Wingfield, Karl-Ferdinand Lechtreck, and Esben Lorentzen. Trafficking of ciliary membrane proteins by the intraflagellar transport/bbsome machinery. Essays in biochemistry, 62 6:753-763, Oct 2018. URL: https://doi.org/10.1042/ebc20180030, doi:10.1042/ebc20180030. This article has 186 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(klink2020structureofthe pages 11-12): Björn Udo Klink, Christos Gatsogiannis, Oliver Hofnagel, Alfred Wittinghofer, and Stefan Raunser. Structure of the human bbsome core complex. Jan 2020. URL: https://doi.org/10.7554/elife.53910, doi:10.7554/elife.53910. This article has 97 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(tian2023organizationfunctionsand pages 5-6): Xiaoyu Tian, Huijie Zhao, and Jun Zhou. Organization, functions, and mechanisms of the bbsome in development, ciliopathies, and beyond. eLife, Jul 2023. URL: https://doi.org/10.7554/elife.87623, doi:10.7554/elife.87623. This article has 88 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(tian2023organizationfunctionsand pages 6-7): Xiaoyu Tian, Huijie Zhao, and Jun Zhou. Organization, functions, and mechanisms of the bbsome in development, ciliopathies, and beyond. eLife, Jul 2023. URL: https://doi.org/10.7554/elife.87623, doi:10.7554/elife.87623. This article has 88 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(zhang2012intrinsicproteinproteininteractionmediated pages 2-4): Qihong Zhang, Dahai Yu, Seongjin Seo, Edwin M. Stone, and Val C. Sheffield. Intrinsic protein-protein interaction-mediated and chaperonin-assisted sequential assembly of stable bardet-biedl syndrome protein complex, the bbsome. Journal of Biological Chemistry, 287:20625-20635, Jun 2012. URL: https://doi.org/10.1074/jbc.m112.341487, doi:10.1074/jbc.m112.341487. This article has 206 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(novas2015bardet–biedlsyndromeis pages 3-4): Rossina Novas, Magdalena Cardenas-Rodriguez, Florencia Irigoín, and Jose L. Badano. Bardet–biedl syndrome: is it only cilia dysfunction? FEBS Letters, 589:3479-3491, Nov 2015. URL: https://doi.org/10.1016/j.febslet.2015.07.031, doi:10.1016/j.febslet.2015.07.031. This article has 111 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(williams2014directevidencefor pages 7-8): Corey L. Williams, Jeremy C. McIntyre, Stephen R. Norris, Paul M. Jenkins, Lian Zhang, Qinglin Pei, Kristen Verhey, and Jeffrey R. Martens. Direct evidence for bbsome-associated intraflagellar transport reveals distinct properties of native mammalian cilia. Nature Communications, Dec 2014. URL: https://doi.org/10.1038/ncomms6813, doi:10.1038/ncomms6813. This article has 187 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(wei2012thebbsomecontrols pages 14-16): Qing Wei, Yuxia Zhang, Yujie Li, Qing Zhang, Kun Ling, and Jinghua Hu. The bbsome controls ift assembly and turnaround in cilia. Aug 2012. URL: https://doi.org/10.1038/ncb2560, doi:10.1038/ncb2560. This article has 273 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(wei2012thebbsomecontrols pages 8-14): Qing Wei, Yuxia Zhang, Yujie Li, Qing Zhang, Kun Ling, and Jinghua Hu. The bbsome controls ift assembly and turnaround in cilia. Aug 2012. URL: https://doi.org/10.1038/ncb2560, doi:10.1038/ncb2560. This article has 273 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(yang2020nearatomicstructuresof pages 12-13): Shuang Yang, Kriti Bahl, Hui-Ting Chou, Jonathan Woodsmith, Ulrich Stelzl, Thomas Walz, and Maxence V Nachury. Near-atomic structures of the bbsome reveal the basis for bbsome activation and binding to gpcr cargoes. Jun 2020. URL: https://doi.org/10.7554/elife.55954, doi:10.7554/elife.55954. This article has 56 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(tian2023organizationfunctionsand pages 15-16): Xiaoyu Tian, Huijie Zhao, and Jun Zhou. Organization, functions, and mechanisms of the bbsome in development, ciliopathies, and beyond. eLife, Jul 2023. URL: https://doi.org/10.7554/elife.87623, doi:10.7554/elife.87623. This article has 88 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(tian2023organizationfunctionsand pages 9-11): Xiaoyu Tian, Huijie Zhao, and Jun Zhou. Organization, functions, and mechanisms of the bbsome in development, ciliopathies, and beyond. eLife, Jul 2023. URL: https://doi.org/10.7554/elife.87623, doi:10.7554/elife.87623. This article has 88 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+</ol>
+<h2 id="artifacts">Artifacts</h2>
+<ul>
+<li><a href="bbs-4-deep-research-falcon_artifacts/artifact-00.md">Edison artifact artifact-00</a></li>
+</ul>
+<h2 id="citations">Citations</h2>
+<ol>
+<li>tian2023organizationfunctionsand pages 3-5</li>
+<li>singh2020structureandactivation pages 5-8</li>
+<li>klink2020structureofthe pages 4-6</li>
+<li>tian2023organizationfunctionsand pages 7-9</li>
+<li>klink2020structureofthe pages 2-4</li>
+<li>tian2023organizationfunctionsand pages 6-7</li>
+<li>wei2012thebbsomecontrols pages 2-4</li>
+<li>williams2014directevidencefor pages 7-8</li>
+<li>wingfield2018traffickingofciliary pages 4-5</li>
+<li>wei2012thebbsomecontrols pages 8-14</li>
+<li>tian2023organizationfunctionsand pages 9-11</li>
+<li>wei2012thebbsomecontrols pages 1-2</li>
+<li>tian2023organizationfunctionsand pages 16-18</li>
+<li>zhang2012intrinsicproteinproteininteractionmediated pages 6-8</li>
+<li>zhang2012intrinsicproteinproteininteractionmediated pages 8-10</li>
+<li>wingfield2018traffickingofciliary pages 5-7</li>
+<li>wingfield2018traffickingofciliary pages 2-4</li>
+<li>klink2020structureofthe pages 11-12</li>
+<li>tian2023organizationfunctionsand pages 5-6</li>
+<li>zhang2012intrinsicproteinproteininteractionmediated pages 2-4</li>
+<li>wei2012thebbsomecontrols pages 14-16</li>
+<li>yang2020nearatomicstructuresof pages 12-13</li>
+<li>tian2023organizationfunctionsand pages 15-16</li>
+<li>W/F/Y</li>
+<li>K/R</li>
+<li>S/A</li>
+<li>https://doi.org/10.7554/elife.53910,</li>
+<li>https://doi.org/10.7554/elife.53322,</li>
+<li>https://doi.org/10.1038/srep11855,</li>
+<li>https://doi.org/10.1038/ncb2560,</li>
+<li>https://doi.org/10.7554/elife.87623,</li>
+<li>https://doi.org/10.1016/j.febslet.2015.07.031,</li>
+<li>https://doi.org/10.1074/jbc.m112.341487,</li>
+<li>https://doi.org/10.1042/ebc20180030,</li>
+<li>https://doi.org/10.1038/ncomms6813,</li>
+<li>https://doi.org/10.7554/elife.55954,</li>
+</ol>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(bbs-4-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="Q5CZ52" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="bbs-4-c-elegans-research-notes">bbs-4 (C. elegans) research notes</h1>
+<p>UniProt: Q5CZ52 (BBS4_CAEEL). WormBase: WBGene00043992 / F58A4.14. 462 aa.<br />
+Gene: bbs-4 (Bardet-Biedl syndrome 4 protein homolog / "BBSome complex member bbs-4").</p>
+<h2 id="summary-of-gene-identity">Summary of gene identity</h2>
+<p>BBS-4 is a <strong>core structural subunit of the BBSome</strong>, the octameric complex (bbs-1, bbs-2,<br />
+bbs-4, bbs-5, osm-12/bbs-7, bbs-8/ttc-8, bbs-9) that couples intraflagellar transport (IFT)<br />
+to ciliary membrane-cargo trafficking. BBS-4 is a tetratricopeptide-repeat (TPR) protein<br />
+(UniProt annotates 7 TPR repeats spanning ~89–402, with a disordered N-terminal region<br />
+1–46). The BBSome shares structural features with the COPI/COPII/clathrin vesicle coats and<br />
+is thought to act as a membrane coat/cargo adaptor at cilia.</p>
+<h2 id="known-with-provenance">KNOWN (with provenance)</h2>
+<h3 id="bbsome-membership-and-architecture">BBSome membership and architecture</h3>
+<ul>
+<li>BBS-4 is part of the BBSome: [UniProt SUBUNIT "Part of BBSome complex, that contains at<br />
+  least bbs-1, bbs-2, bbs-4, bbs-5, osm-12, bbs-8/ttc-8 and bbs-9 (By similarity)"].</li>
+<li>Assembly order places BBS4 peripherally, added last: <a href="https://pubmed.ncbi.nlm.nih.gov/26150102" title="during the assembly   of the BBSome, BBS2, 7, and 9 form the core, then BBS1, 5, 8, and finally BBS4 are added   in a stepwise manner">PMID:26150102</a>.</li>
+<li>BBS-4 is a TPR protein; BBS5 is a PH-domain protein — the two share no domains yet are<br />
+  functionally redundant: <a href="https://pubmed.ncbi.nlm.nih.gov/26150102" title="BBS4 is a multiple tetratricopeptide repeats (TPR)   containing protein, whereas BBS5 is a pleckstrin homology (PH) domain-containing protein   ... two BBSome components that share no similar protein domains ... can function redundantly   in the context of cilia">PMID:26150102</a>.</li>
+</ul>
+<h3 id="bbsome-function-in-ift-assembly-turnaround-the-core-ciliary-role">BBSome function in IFT assembly / turnaround (the core ciliary role)</h3>
+<ul>
+<li>The BBSome assembles IFT particles at the ciliary base and rides the anterograde IFT<br />
+  particle to the tip to regulate turnaround/recycling: <a href="https://pubmed.ncbi.nlm.nih.gov/22922713" title="the BBSome ...   assembles IFT complexes at the ciliary base, then binds to the anterograde IFT particle in   a DYF-2- ... and BBS-1-dependent manner, and lastly reaches the ciliary tip to regulate   proper IFT recycling">PMID:22922713</a>, <a href="https://pubmed.ncbi.nlm.nih.gov/22922713" title="the in vivo function for the BBSome is to regulate   the assembly of the IFT particles at the ciliary base">PMID:22922713</a>.</li>
+<li>The BBSome binds IFT like a cargo, not as an integral structural part of the IFT particle:<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/22922713" title="After IFT particles are assembled at the ciliary base, the BBSome binds to   the IFT particle like a cargo but not a structural component">PMID:22922713</a>.</li>
+<li>BBSome shares coat features and can recognize IFT cargo: <a href="https://pubmed.ncbi.nlm.nih.gov/22922713" title="The BBSome also   shares the common structural features with COPI, COPII, and clathrin coats, and can directly   recognize IFT cargos">PMID:22922713</a>.</li>
+</ul>
+<h3 id="bbs-4-ciliary-localization-experimental-worm">BBS-4 ciliary localization (experimental, worm)</h3>
+<ul>
+<li>BBS-4 localizes to cilia / ciliary basal body (GOA IDA GO:0036064, MGI, PMID:22922713).</li>
+<li>In dyf-2 or bbs-1 mutants that uncouple the BBSome from moving IFT, BBS-4 completely loses<br />
+  ciliary localization and accumulates at the ciliary base: <a href="https://pubmed.ncbi.nlm.nih.gov/22922713" title="Some of them   (BBS-1, BBS-4) totally lost the ciliary localization; the others (BBS-2, -5, -7, -8, -9)   only showed very dim ciliary staining">PMID:22922713</a>.</li>
+</ul>
+<h3 id="bbs-4bbs-5-direct-interaction-and-redundancy-pmid26150102">BBS-4–BBS-5 direct interaction and redundancy (PMID:26150102)</h3>
+<ul>
+<li>BBS-4 directly interacts with BBS-5, via its C-terminus: <a href="https://pubmed.ncbi.nlm.nih.gov/26150102" title="We further mapped   down the binding region in BBS-4 to the C-terminal 193 amino acids (a.a. 270–462)">PMID:26150102</a> and<br />
+  in vivo <a href="https://pubmed.ncbi.nlm.nih.gov/26150102" title="strong fluorescence complementation between BBS-4 and BBS-5 was   observed ... indicative of in vivo BBS-4-BBS-5 association">PMID:26150102</a>.</li>
+<li>Single mutants have no ciliogenesis defect; double bbs-4; bbs-5 mutants do:<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/26150102" title="bbs-4 or bbs-5 single mutants are completely normal in dye-filling assay,   indicating that BBS-4 or BBS-5 alone is dispensable for ciliogenesis">PMID:26150102</a>, <a href="https://pubmed.ncbi.nlm.nih.gov/26150102" title="bbs-4; bbs-5 double mutants show typical cilia defect as observed in other bbs mutants">PMID:26150102</a>.</li>
+<li>Double mutants disrupt IFT integrity (IFT-A/IFT-B uncoupling, CHE-11 absent distally,<br />
+  OSM-6 accumulates): <a href="https://pubmed.ncbi.nlm.nih.gov/26150102" title="bbs-4; bbs-5 and bbs-7 share similar mutant phenotypes   in that CHE-11 is absent, but OSM-6 abnormally accumulates, in the distal segments">PMID:26150102</a>.</li>
+</ul>
+<h3 id="bbs-4bbs-5-role-in-ciliary-sensory-receptor-removal-degradative-sorting">BBS-4/BBS-5 role in ciliary sensory-receptor removal / degradative sorting</h3>
+<ul>
+<li>Redundantly required for <strong>removal</strong> (not entry) of ciliary sensory receptors PKD-2,<br />
+  OSM-9, ODR-10 — receptors abnormally accumulate in double mutants: <a href="https://pubmed.ncbi.nlm.nih.gov/26150102" title="both   OSM-9 and ODR-10 show strong accumulations, with ~6-fold increasing of protein levels in   their native expressing cilia in bbs-4; bbs-5 mutants">PMID:26150102</a>, and the defect is degradative:<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/26150102" title="BBS-4 and BBS-5 play redundant role in the BBSome to ubiquitously regulate   the lysosome-targeted degradation of ciliary sensory receptors">PMID:26150102</a>.</li>
+<li>The BBSome acts upstream of the early endosome, at the ciliary base, not by retrograde IFT<br />
+  for these non-IFT cargoes: <a href="https://pubmed.ncbi.nlm.nih.gov/26150102" title="the BBSome acts upstream of the early endosome,   probably in endocytic stage at cilia base, to regulate the lysosomal sorting of ciliary   receptors">PMID:26150102</a>.</li>
+<li>Polycystin signaling (mating behavior) is defective in double but not single mutants:<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/26150102" title="bbs-4; bbs-5 double mutants, but not bbs-4 or bbs-5 single mutants, exhibit   defective polycystin signaling similar to that observed in bbs-7 mutants">PMID:26150102</a>.</li>
+</ul>
+<h3 id="disease-relevant-mutagenesis-worm-mimics-of-human-bbs4-alleles">Disease-relevant mutagenesis (worm mimics of human BBS4 alleles)</h3>
+<ul>
+<li>A388E (mimics human pathogenic BBS4 A364E): abolishes BBS-4–BBS-5 interaction and ciliary<br />
+  targeting: [UniProt MUTAGEN 388 "A-&gt;E: Abolishes interaction with bbs-5. Unable to target<br />
+  to cilia."], <a href="https://pubmed.ncbi.nlm.nih.gov/26150102" title="BBS-4A388E, but not BBS-4E107Q, lost ciliary targeting">PMID:26150102</a>.</li>
+<li>E107Q (mimics weak human BBS4 E85Q, LCA-like): no obvious phenotype; still rescues:<br />
+  [UniProt MUTAGEN 107 "E-&gt;Q: No obvious phenotype."], <a href="https://pubmed.ncbi.nlm.nih.gov/26150102" title="BBS-4E107Q, but not   BBS-4A388E, can rescue the ciliogenesis defect in bbs-4; bbs-5 mutants">PMID:26150102</a>.</li>
+<li>Conservation to mammals: human BBS4 and BBS5 also interact directly and redundantly<br />
+  downregulate ciliary polycystin-2 <a href="https://pubmed.ncbi.nlm.nih.gov/26150102" title="human BBS4 and BBS5 interact directly and   function redundantly in downregulating ciliary polycystin-2">PMID:26150102</a>.</li>
+</ul>
+<h2 id="not-known-knowledge-gaps">NOT known / knowledge gaps</h2>
+<ul>
+<li><strong>No experimentally demonstrated biochemical/molecular activity for BBS-4 itself.</strong> The only<br />
+  MF annotation (GO:0030674 protein-macromolecule adaptor activity) is an ISS transfer from<br />
+  human BBS4 (UniProtKB:Q96RK4). What cargo(s) BBS-4's TPR array directly recognizes within<br />
+  the BBSome coat is undefined.</li>
+<li><strong>Ontology gap:</strong> there is no GO molecular-function term expressing "membrane-coat / cargo-<br />
+  adaptor subunit of the BBSome" analogous to a COPI/COPII/clathrin coat subunit. The BBSome<br />
+  is explicitly described as coat-like <a href="https://pubmed.ncbi.nlm.nih.gov/22922713" title="shares the common structural features   with COPI, COPII, and clathrin coats">PMID:22922713</a>, but a subunit of it is annotatable only with the<br />
+  generic adaptor term or <code>protein binding</code>. This is the same structural-subunit pattern<br />
+  flagged as an ontology gap in projects/FUNCTION_KNOWLEDGE_GAPS.md.</li>
+<li><strong>Centrosome / pericentriolar-material role is mammalian-derived, not shown in worm.</strong> The<br />
+  ISS annotations GO:0000242 (pericentriolar material) and GO:0007098 (centrosome cycle), and<br />
+  the SubCell-mapped GO:0005813 centrosome / GO:0005856 cytoskeleton, all trace to the<br />
+  mammalian BBS4 pericentriolar/dynein role (By similarity, UniProtKB:Q96RK4). C. elegans<br />
+  BBS-4 has been characterized only in the ciliary/BBSome context; no worm experiment supports<br />
+  a pericentriolar-satellite function (and nematodes largely lack the mammalian centriolar-<br />
+  satellite system). Treated here as over-annotation for this organism.</li>
+<li>Structural position/stoichiometry of BBS-4 in the worm BBSome, and whether its redundancy<br />
+  with BBS-5 reflects a shared coat-surface, are not resolved.</li>
+</ul>
+<h2 id="annotation-review-plan-13-goa-rows">Annotation-review plan (13 GOA rows)</h2>
+<ul>
+<li>GO:0034464 BBSome (NAS, part_of) — ACCEPT (core; complex membership).</li>
+<li>GO:0030674 protein-macromolecule adaptor activity (ISS, enables) — ACCEPT as the best<br />
+  available (subunit-adaptor) MF; flag the ontology gap.</li>
+<li>GO:0060271 cilium assembly (IBA + NAS) — ACCEPT (core; redundant with bbs-5 experimentally).</li>
+<li>GO:0061512 protein localization to cilium (IBA) — ACCEPT (core; BBSome traffics membrane<br />
+  cargo to/from cilium).</li>
+<li>GO:0036064 ciliary basal body (IBA is_active_in + IDA located_in) — ACCEPT (IDA experimental).</li>
+<li>GO:0005929 cilium (NAS) — ACCEPT (general but correct).</li>
+<li>GO:0060170 ciliary membrane (IEA SubCell) — ACCEPT.</li>
+<li>GO:0005813 centrosome (IEA SubCell) — KEEP_AS_NON_CORE (basal body is centriole-derived;<br />
+  general).</li>
+<li>GO:0005856 cytoskeleton (IEA SubCell) — KEEP_AS_NON_CORE (general parent).</li>
+<li>GO:0000242 pericentriolar material (ISS) — MARK_AS_OVER_ANNOTATED (mammalian-derived, no<br />
+  worm support).</li>
+<li>GO:0007098 centrosome cycle (ISS) — MARK_AS_OVER_ANNOTATED (mammalian-derived, no worm<br />
+  support).</li>
+</ul>
+<h2 id="references-used">References used</h2>
+<ul>
+<li>PMID:22922713 Wei et al. 2012 Nat Cell Biol — BBSome controls IFT assembly &amp; turnaround (full text cached).</li>
+<li>PMID:26150102 Xu et al. 2015 Sci Rep — BBS4/BBS5 redundancy, direct interaction, receptor removal (full text cached).</li>
+<li>UniProt Q5CZ52 (BBS4_CAEEL).<br />
+</content><br />
+</invoke></li>
+</ul>
+<h2 id="deep-research-falcon-edison-scientific-literature">Deep research (falcon / Edison Scientific Literature)</h2>
+<p><code>bbs-4-deep-research-falcon.md</code> was generated by the falcon provider (Edison Scientific<br />
+Literature; 36 citations, ~29 min run; the just-recipe wrapper reported a 600s subprocess<br />
+timeout but the client completed and wrote real output). It corroborates every point above<br />
+and adds cross-species structural/assembly context (not in the two worm papers, cited by DOI<br />
+in that report, so used here only as background, not as annotation provenance):</p>
+<ul>
+<li>BBS-4 is a <strong>non-enzymatic TPR α-solenoid structural adaptor</strong>; cryo-EM places it in the<br />
+  BBSome "body" with BBS5/BBS8/BBS18, with BBS18 acting as a stabilizing "U-bolt" through the<br />
+  BBS4/BBS8 TPRs and BBS1's β-propeller binding the BBS4 TPR N-terminus (Klink 2020 eLife<br />
+  10.7554/elife.53910; Singh 2020 eLife 10.7554/elife.53322; Tian 2023 eLife 10.7554/elife.87623).</li>
+<li>BBS-4 is the <strong>last subunit added</strong> to the BBSome and its incorporation requires BBS1<br />
+  (Zhang 2012 JBC 10.1074/jbc.m112.341487) — consistent with PMID:26150102's stepwise-assembly<br />
+  statement used in the review.</li>
+<li>The BBSome recognizes cargo via a central negatively-charged cleft and specific GPCR motifs<br />
+  ([W/F/Y][K/R] in helix 8, VxP C-terminal) (Yang 2020 eLife 10.7554/elife.55954) — background<br />
+  for the ontology-gap framing (no GO MF term for a coat cargo-adaptor subunit).</li>
+<li>The centriolar-satellite / PCM1 / actin-cytoskeleton roles are reported for <strong>mammalian</strong><br />
+  BBS4 (Novas 2015 FEBS Lett 10.1016/j.febslet.2015.07.031; Tian 2023) — supporting the<br />
+  MARK_AS_OVER_ANNOTATED calls on the worm pericentriolar-material and centrosome-cycle ISS rows.</li>
+</ul>
+<p>These DOI-only sources are recorded here as background; the review's annotation provenance<br />
+uses only the two cached full-text worm papers (PMID:22922713, PMID:26150102) plus the falcon<br />
+file reference.</p>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: Q5CZ52
+gene_symbol: bbs-4
+product_type: PROTEIN
+status: COMPLETE
+taxon:
+  id: NCBITaxon:6239
+  label: Caenorhabditis elegans
+description: &gt;-
+  BBS-4 is a tetratricopeptide-repeat (TPR) protein that is a peripheral structural
+  subunit of the BBSome, an octameric complex (BBS-1, BBS-2, BBS-4, BBS-5, OSM-12/BBS-7,
+  BBS-8/TTC-8, BBS-9) that couples intraflagellar transport (IFT) to the trafficking of
+  membrane cargo at sensory cilia. Like the COPI, COPII and clathrin coats it structurally
+  resembles, the BBSome assembles IFT particles at the ciliary base, binds the anterograde
+  IFT particle, and reaches the ciliary tip where it regulates IFT turnaround and recycling.
+  Within the complex BBS-4 binds directly to BBS-5 through its C-terminal TPR region and
+  localizes to the ciliary base/basal body and along cilia. In C. elegans, BBS-4 is
+  functionally redundant with BBS-5: single mutants have essentially normal cilia, whereas
+  bbs-4; bbs-5 double mutants phenocopy loss of the whole BBSome, showing IFT-A/IFT-B
+  uncoupling, disrupted ciliogenesis, and defective polycystin-mediated cilia signaling.
+  Beyond building cilia, BBS-4 (redundantly with BBS-5) is required for the removal of
+  ciliary sensory receptors — including polycystin-2/PKD-2, the TRP channel OSM-9 and the
+  GPCR ODR-10 — from cilia for lysosome-targeted degradation, acting upstream of the early
+  endosome at the ciliary base. A conserved C-terminal residue (A388 in the worm protein,
+  A364 in human BBS4) is required for the BBS-4–BBS-5 interaction and for ciliary targeting,
+  and its mutation models human Bardet-Biedl syndrome.
+alternative_products:
+  - name: a
+    id: Q5CZ52-1
+  - name: b
+    id: Q5CZ52-2
+    sequence_note: VSP_044208
+references:
+  - id: GO_REF:0000024
+    title: Manual transfer of experimentally-verified manual GO annotation data to orthologs
+      by curator judgment of sequence similarity
+    findings: []
+  - id: GO_REF:0000033
+    title: Annotation inferences using phylogenetic trees
+    findings: []
+  - id: GO_REF:0000044
+    title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location
+      vocabulary mapping, accompanied by conservative changes to GO terms applied by
+      UniProt
+    findings: []
+  - id: PMID:22922713
+    title: The BBSome controls IFT assembly and turnaround in cilia.
+    findings:
+      - statement: The BBSome assembles IFT particles at the ciliary base and regulates
+          IFT turnaround/recycling at the ciliary tip.
+        supporting_text: the in vivo function for the BBSome is to regulate the assembly
+          of the IFT particles at the ciliary base
+      - statement: The BBSome binds the IFT particle as a cargo, not as an integral
+          structural component.
+        supporting_text: the BBSome binds to the IFT particle like a cargo but not a
+          structural component
+      - statement: BBS-4 loses ciliary localization and accumulates at the ciliary base
+          when the BBSome is uncoupled from moving IFT.
+        supporting_text: Some of them (BBS-1, BBS-4) totally lost the ciliary localization
+      - statement: The BBSome shares coat features with COPI/COPII/clathrin and can
+          directly recognize IFT cargo.
+        supporting_text: shares the common structural features with COPI, COPII, and
+          clathrin coats, and can directly recognize IFT cargos
+    reference_review:
+      relevance: HIGH
+      correctness: VERIFIED
+      review_notes: &gt;-
+        PubMed-verified (Wei et al. 2012, Nat Cell Biol; PMC3434251). Full text cached.
+        C. elegans forward-genetic study establishing the BBSome (including BBS-4) as the
+        regulator of IFT assembly and turnaround; directly supports the BBSome-membership,
+        cilium-assembly and ciliary-localization annotations for bbs-4.
+  - id: PMID:26150102
+    title: BBS4 and BBS5 show functional redundancy in the BBSome to regulate the
+      degradative sorting of ciliary sensory receptors.
+    findings:
+      - statement: BBS-4 directly interacts with BBS-5 through its C-terminal region
+          (a.a. 270-462).
+        supporting_text: mapped down the binding region in BBS-4 to the C-terminal 193
+          amino acids (a.a. 270–462)
+      - statement: bbs-4 and bbs-5 single mutants have normal cilia; bbs-4; bbs-5 double
+          mutants phenocopy whole-BBSome loss.
+        supporting_text: bbs-4 or bbs-5 single mutants are completely normal in dye-filling
+          assay
+      - statement: BBS-4 and BBS-5 redundantly regulate lysosome-targeted degradation of
+          ciliary sensory receptors.
+        supporting_text: BBS-4 and BBS-5 play redundant role in the BBSome to ubiquitously
+          regulate the lysosome-targeted degradation of ciliary sensory receptors
+      - statement: The BBSome acts upstream of the early endosome at the ciliary base to
+          direct receptors to lysosomal degradation.
+        supporting_text: the BBSome acts upstream of the early endosome, probably in
+          endocytic stage at cilia base, to regulate the lysosomal sorting of ciliary
+          receptors
+    reference_review:
+      relevance: HIGH
+      correctness: VERIFIED
+      review_notes: &gt;-
+        PubMed-verified (Xu et al. 2015, Sci Rep; PMC4493597). Full text cached. The
+        primary experimental paper for C. elegans bbs-4: GST pull-down + BiFC show direct
+        BBS-4–BBS-5 interaction via the BBS-4 C-terminus; genetic redundancy in
+        ciliogenesis, IFT integrity, polycystin signaling; and a conserved role in
+        degradative removal of ciliary receptors. Also cited by UniProt for the FUNCTION,
+        INTERACTION, DISRUPTION PHENOTYPE and MUTAGENESIS of E107 and A388.
+  - id: file:worm/bbs-4/bbs-4-deep-research-falcon.md
+    title: Deep research report on bbs-4 (Edison/falcon)
+    findings: []
+existing_annotations:
+  - term:
+      id: GO:0034464
+      label: BBSome
+    evidence_type: NAS
+    original_reference_id: PMID:22922713
+    qualifier: part_of
+    review:
+      summary: &gt;-
+        BBS-4 is a bona fide subunit of the BBSome, the octameric complex containing
+        BBS-1, BBS-2, BBS-4, BBS-5, OSM-12/BBS-7, BBS-8/TTC-8 and BBS-9. This is the core
+        cellular-component assignment for bbs-4 and is supported experimentally in
+        C. elegans, where BBS-4 co-behaves with the other BBSome subunits during IFT.
+      action: ACCEPT
+      reason: &gt;-
+        Complex membership is the defining property of bbs-4 and is strongly supported by
+        both C. elegans experiments and cross-species orthology. This is a core annotation.
+      supported_by:
+        - reference_id: PMID:22922713
+          supporting_text: the in vivo function for the BBSome is to regulate the assembly
+            of the IFT particles at the ciliary base
+        - reference_id: PMID:26150102
+          supporting_text: during the assembly of the BBSome, BBS2, 7, and 9 form the
+            core, then BBS1, 5, 8, and finally BBS4 are added in a stepwise manner
+        - reference_id: file:worm/bbs-4/bbs-4-deep-research-falcon.md
+          supporting_text: &#39;model: Edison Scientific Literature&#39;
+  - term:
+      id: GO:0030674
+      label: protein-macromolecule adaptor activity
+    evidence_type: ISS
+    original_reference_id: GO_REF:0000024
+    qualifier: enables
+    review:
+      summary: &gt;-
+        This adaptor-activity term is transferred by sequence similarity from human BBS4
+        (UniProtKB:Q96RK4). It captures the fact that BBS-4, as a TPR-repeat subunit of the
+        coat-like BBSome, acts as a scaffold/adaptor rather than an enzyme. It is far more
+        informative than a generic &#39;protein binding&#39; term, and reflects the best current
+        molecular-function description for a BBSome coat subunit.
+      action: ACCEPT
+      reason: &gt;-
+        Adaptor activity is the most defensible molecular function for a BBSome structural
+        subunit and is preferable to uninformative protein binding. However, no experimental
+        MF has been measured for BBS-4 itself, and no GO term specifically expresses the
+        BBSome coat/cargo-adaptor role — see knowledge_gaps.
+      supported_by:
+        - reference_id: PMID:22922713
+          supporting_text: shares the common structural features with COPI, COPII, and
+            clathrin coats, and can directly recognize IFT cargos
+  - term:
+      id: GO:0060271
+      label: cilium assembly
+    evidence_type: IBA
+    original_reference_id: GO_REF:0000033
+    qualifier: involved_in
+    review:
+      summary: &gt;-
+        BBS-4 contributes to cilium assembly as part of the BBSome. In C. elegans this is
+        genetically redundant with BBS-5: single mutants are normal, but bbs-4; bbs-5 double
+        mutants show typical bbs-class cilia defects, confirming a real (if buffered) role
+        in ciliogenesis.
+      action: ACCEPT
+      reason: &gt;-
+        Well supported by phylogenetic inference and by direct C. elegans genetics
+        (redundancy with bbs-5). A core biological-process annotation.
+      supported_by:
+        - reference_id: PMID:26150102
+          supporting_text: bbs-4; bbs-5 double mutants show typical cilia defect as
+            observed in other bbs mutants
+        - reference_id: PMID:22922713
+          supporting_text: the in vivo function for the BBSome is to regulate the assembly
+            of the IFT particles at the ciliary base
+  - term:
+      id: GO:0060271
+      label: cilium assembly
+    evidence_type: NAS
+    original_reference_id: PMID:22922713
+    qualifier: involved_in
+    review:
+      summary: &gt;-
+        Author-stated (NAS) assignment of the cilium-assembly role, duplicating the IBA
+        annotation. The BBSome assembles IFT particles required for ciliogenesis.
+      action: ACCEPT
+      reason: &gt;-
+        Correct and consistent with the IBA annotation and with C. elegans genetics; both
+        are retained as complementary evidence for the same core role.
+      supported_by:
+        - reference_id: PMID:22922713
+          supporting_text: the in vivo function for the BBSome is to regulate the assembly
+            of the IFT particles at the ciliary base
+  - term:
+      id: GO:0061512
+      label: protein localization to cilium
+    evidence_type: IBA
+    original_reference_id: GO_REF:0000033
+    qualifier: involved_in
+    review:
+      summary: &gt;-
+        As a BBSome subunit, BBS-4 is required for correct localization of membrane and
+        signaling proteins to/from cilia. In C. elegans the BBSome (redundantly requiring
+        bbs-4/bbs-5) governs the ciliary homeostasis of sensory receptors such as PKD-2,
+        OSM-9 and ODR-10, which mislocalize and accumulate when the complex is disrupted.
+      action: ACCEPT
+      reason: &gt;-
+        Central to BBSome function and supported by both phylogenetic inference and
+        C. elegans experiments. Core biological-process annotation.
+      supported_by:
+        - reference_id: PMID:26150102
+          supporting_text: with ~6-fold increasing of protein levels in their native
+            expressing cilia in bbs-4; bbs-5 mutants
+  - term:
+      id: GO:0036064
+      label: ciliary basal body
+    evidence_type: IBA
+    original_reference_id: GO_REF:0000033
+    qualifier: is_active_in
+    review:
+      summary: &gt;-
+        BBS-4 acts at the ciliary basal body / ciliary base, where the BBSome assembles IFT
+        particles prior to anterograde transport. Supported phylogenetically and consistent
+        with direct C. elegans localization data.
+      action: ACCEPT
+      reason: &gt;-
+        Basal-body localization is a core, well-supported cellular-component annotation and
+        matches the site of BBSome-mediated IFT assembly.
+      supported_by:
+        - reference_id: PMID:22922713
+          supporting_text: the in vivo function for the BBSome is to regulate the assembly
+            of the IFT particles at the ciliary base
+  - term:
+      id: GO:0036064
+      label: ciliary basal body
+    evidence_type: IDA
+    original_reference_id: PMID:22922713
+    qualifier: located_in
+    review:
+      summary: &gt;-
+        Direct experimental (IDA) localization of BBS-4 to the ciliary basal body/base in
+        C. elegans, consistent with BBSome accumulation around the ciliary base when it is
+        uncoupled from moving IFT.
+      action: ACCEPT
+      reason: &gt;-
+        Experimental localization; the strongest evidence class for the basal-body
+        assignment. Core cellular-component annotation.
+      supported_by:
+        - reference_id: PMID:22922713
+          supporting_text: Some of them (BBS-1, BBS-4) totally lost the ciliary localization
+  - term:
+      id: GO:0005929
+      label: cilium
+    evidence_type: NAS
+    original_reference_id: PMID:22922713
+    qualifier: located_in
+    review:
+      summary: &gt;-
+        BBS-4 localizes to cilia as a BBSome subunit that undergoes IFT along the ciliary
+        axoneme. A correct, if general, cellular-component assignment (the basal-body and
+        ciliary-base terms are more specific).
+      action: KEEP_AS_NON_CORE
+      reason: &gt;-
+        Accurate general localization supported by the referenced work, but non-core
+        relative to the more specific basal-body/ciliary-base terms which are the core CC
+        annotations; retained as a valid non-core localization.
+      supported_by:
+        - reference_id: PMID:22922713
+          supporting_text: Some of them (BBS-1, BBS-4) totally lost the ciliary localization
+  - term:
+      id: GO:0060170
+      label: ciliary membrane
+    evidence_type: IEA
+    original_reference_id: GO_REF:0000044
+    qualifier: located_in
+    review:
+      summary: &gt;-
+        Ciliary-membrane localization is inferred from the UniProt subcellular-location
+        mapping (Cell projection, cilium membrane, By similarity). It is consistent with the
+        BBSome&#39;s role as a membrane-associated coat that traffics and removes ciliary
+        membrane receptors.
+      action: ACCEPT
+      reason: &gt;-
+        Consistent with BBSome coat function at the ciliary membrane and with the receptor
+        trafficking/removal role demonstrated for bbs-4/bbs-5.
+  - term:
+      id: GO:0005813
+      label: centrosome
+    evidence_type: IEA
+    original_reference_id: GO_REF:0000044
+    qualifier: located_in
+    review:
+      summary: &gt;-
+        Centrosome localization is an electronic UniProt subcellular-location mapping
+        derived from the mammalian BBS4 annotation (Cytoplasm, cytoskeleton, MTOC,
+        centrosome, By similarity). In C. elegans the relevant structure is the
+        centriole-derived ciliary basal body, which is separately annotated; a distinct
+        centrosomal pool has not been demonstrated for worm BBS-4.
+      action: KEEP_AS_NON_CORE
+      reason: &gt;-
+        The basal body is centriole-derived, so a centrosomal assignment is not wrong, but
+        it is a non-specific/derived term for this organism where the experimentally
+        supported site is the ciliary basal body/base. Kept as non-core rather than removed.
+  - term:
+      id: GO:0005856
+      label: cytoskeleton
+    evidence_type: IEA
+    original_reference_id: GO_REF:0000044
+    qualifier: located_in
+    review:
+      summary: &gt;-
+        High-level cytoskeleton localization from the UniProt subcellular-location mapping.
+        This is a very general parent term encompassing the more specific ciliary/basal-body
+        localizations.
+      action: KEEP_AS_NON_CORE
+      reason: &gt;-
+        Not incorrect but uninformative relative to the specific ciliary basal body and
+        ciliary base terms. Retained as non-core.
+  - term:
+      id: GO:0000242
+      label: pericentriolar material
+    evidence_type: ISS
+    original_reference_id: GO_REF:0000024
+    qualifier: located_in
+    review:
+      summary: &gt;-
+        Pericentriolar-material localization is transferred by similarity from human BBS4,
+        which has a mammalian pericentriolar/centriolar-satellite role. C. elegans BBS-4 has
+        been characterized only in the ciliary/BBSome context, and nematodes largely lack
+        the mammalian centriolar-satellite system; no worm experiment supports a
+        pericentriolar-material localization.
+      action: MARK_AS_OVER_ANNOTATED
+      reason: &gt;-
+        This is a mammalian-derived ISS transfer with no experimental support in C. elegans
+        and is not part of the conserved core BBSome/ciliary function assayed in this
+        organism. Flagged as over-annotation for the worm rather than a core localization.
+  - term:
+      id: GO:0007098
+      label: centrosome cycle
+    evidence_type: ISS
+    original_reference_id: GO_REF:0000024
+    qualifier: involved_in
+    review:
+      summary: &gt;-
+        The centrosome-cycle process is transferred by similarity from mammalian BBS4,
+        which has been implicated in microtubule anchoring and dynein-mediated
+        pericentriolar transport. There is no C. elegans evidence that BBS-4 participates in
+        the centrosome cycle; all worm phenotypes concern cilia and IFT.
+      action: MARK_AS_OVER_ANNOTATED
+      reason: &gt;-
+        Mammalian-derived ISS process transfer without worm support and outside the
+        conserved core ciliary role. Flagged as over-annotation for this organism.
+  - term:
+      id: GO:0097546
+      label: ciliary base
+    evidence_type: IDA
+    original_reference_id: PMID:22922713
+    qualifier: located_in
+    review:
+      summary: &gt;-
+        BBS-4 and the other BBSome subunits concentrate at the ciliary base, where the
+        BBSome assembles IFT particles; when the BBSome is uncoupled from moving IFT the
+        proteins strongly accumulate there. This is a more precise localization than the
+        general &#39;cilium&#39; term and complements the ciliary basal body annotation.
+      action: NEW
+      reason: &gt;-
+        Ciliary base is the experimentally supported site of BBSome-mediated IFT assembly
+        in C. elegans and is included as a location in core_functions; added here as a
+        specific cellular-component annotation.
+      supported_by:
+        - reference_id: PMID:22922713
+          supporting_text: all BBS proteins examined strongly accumulated around the
+            ciliary base
+  - term:
+      id: GO:0042073
+      label: intraciliary transport
+    evidence_type: IMP
+    original_reference_id: PMID:22922713
+    qualifier: involved_in
+    review:
+      summary: &gt;-
+        BBS-4, as a BBSome subunit, itself undergoes IFT movement along the ciliary axoneme
+        and is required for normal intraflagellar transport; loss of the BBSome (e.g. in
+        bbs-4; bbs-5 double mutants) uncouples IFT-A from IFT-B and disrupts IFT integrity.
+      action: NEW
+      reason: &gt;-
+        Intraciliary transport is a core biological process for the BBSome, captured in
+        core_functions; added here as a specific process annotation supported by BBS-protein
+        IFT movement and the IFT defects of bbs mutants.
+      supported_by:
+        - reference_id: PMID:22922713
+          supporting_text: all BBS proteins completely lost IFT movement
+        - reference_id: PMID:26150102
+          supporting_text: bbs-4; bbs-5 and bbs-7 share similar mutant phenotypes in that
+            CHE-11 is absent, but OSM-6 abnormally accumulates, in the distal segments of
+            plasmid cilia
+core_functions:
+  - description: &gt;-
+      BBS-4 acts as a TPR-repeat structural/adaptor subunit of the coat-like BBSome. Through
+      its C-terminal TPR region it binds BBS-5 and integrates into the complex, contributing
+      to BBSome-mediated assembly of IFT particles at the ciliary base and to the
+      IFT-coupled trafficking and degradative removal of ciliary membrane cargo. Its
+      molecular activity is best described as a protein-macromolecule adaptor within the
+      BBSome coat; no independent enzymatic activity is known.
+    molecular_function:
+      id: GO:0030674
+      label: protein-macromolecule adaptor activity
+    directly_involved_in:
+      - id: GO:0061512
+        label: protein localization to cilium
+      - id: GO:0060271
+        label: cilium assembly
+      - id: GO:0042073
+        label: intraciliary transport
+    locations:
+      - id: GO:0036064
+        label: ciliary basal body
+      - id: GO:0097546
+        label: ciliary base
+      - id: GO:0060170
+        label: ciliary membrane
+    in_complex:
+      id: GO:0034464
+      label: BBSome
+    supported_by:
+      - reference_id: PMID:22922713
+        supporting_text: the in vivo function for the BBSome is to regulate the assembly
+          of the IFT particles at the ciliary base
+      - reference_id: PMID:26150102
+        supporting_text: mapped down the binding region in BBS-4 to the C-terminal 193
+          amino acids (a.a. 270–462)
+knowledge_gaps:
+  - gap_statement: &gt;-
+      There is no GO molecular-function term that expresses the role of a BBSome coat/cargo-
+      adaptor subunit, and the specific cargo(es) that BBS-4&#39;s TPR array directly recognizes
+      within the BBSome are undefined. BBS-4 has no experimentally measured biochemical
+      activity of its own; its sole MF annotation (protein-macromolecule adaptor activity)
+      is a generic sequence-similarity transfer.
+    boundary: &gt;-
+      BBS-4 is an established BBSome subunit built from tetratricopeptide repeats; the BBSome
+      is explicitly coat-like (shares structural features with COPI, COPII and clathrin) and
+      is proposed to polymerize and recognize ciliary membrane proteins, and it can directly
+      recognize IFT cargo. What is missing is a molecular-function term (and the direct
+      cargo identity) for the coat subunit rather than the complex-level process.
+    gap_kind:
+      - ONTOLOGY
+      - BIOLOGY
+    dark_aspect: MF_DARK
+    status: OPEN
+    significance: &gt;-
+      BBSome subunits illustrate the structural-subunit ontology gap: their function is &#39;be
+      part of the coat&#39;, which the GO molecular-function aspect cannot currently express, so
+      the gene reads as MF-dark despite a well-defined cellular role central to Bardet-Biedl
+      syndrome.
+    resolution: &gt;-
+      Ontology development of a BBSome coat/cargo-adaptor molecular-function term (analogous
+      to a vesicle-coat adaptor), plus proximity/affinity proteomics and structural work to
+      identify the membrane cargo directly contacted by the BBS-4 TPR surface.
+    provenance:
+      - reference_id: PMID:22922713
+        supporting_text: shares the common structural features with COPI, COPII, and
+          clathrin coats, and can directly recognize IFT cargos
+        reference_section_type: DISCUSSION
+      - reference_id: PMID:26150102
+        supporting_text: has been proposed to polymerize and recognize the ciliary membrane
+          proteins
+        reference_section_type: INTRODUCTION
+    proposed_terms:
+      - proposed_name: BBSome coat cargo-adaptor activity
+        proposed_definition: &gt;-
+          A protein-macromolecule adaptor activity of a subunit of the BBSome (a coat-like
+          complex structurally related to COPI/COPII/clathrin) that mediates recognition and
+          sorting of ciliary membrane cargo and its coupling to intraflagellar transport,
+          without the subunit independently catalyzing a biochemical reaction. Distinct from
+          the cellular component &#39;BBSome&#39; (GO:0034464) this term names the molecular
+          activity a coat subunit contributes to BBSome-mediated cargo sorting.
+        justification: &gt;-
+          BBSome subunits such as BBS-4 have no adequate GO molecular-function term; they are
+          annotatable only with the generic &#39;protein-macromolecule adaptor activity&#39; or the
+          uninformative &#39;protein binding&#39;, leaving them MF-dark despite a well-defined
+          coat-subunit role.
+        proposed_parent:
+          id: GO:0030674
+          label: protein-macromolecule adaptor activity
+  - gap_statement: &gt;-
+      The molecular mechanism by which the BBSome triggers degradative (lysosome-targeted)
+      removal of ciliary sensory receptors — the direct effectors linking the ciliary-base
+      BBSome to the endocytic/ubiquitin machinery — and the molecular basis of the
+      BBS-4/BBS-5 functional redundancy (two subunits with no shared domain, each dispensable
+      alone) are undetermined.
+    boundary: &gt;-
+      bbs-4 and bbs-5 single mutants have normal cilia; bbs-4; bbs-5 double mutants phenocopy
+      whole-BBSome loss, with IFT-A/IFT-B uncoupling and ~3–6-fold ciliary accumulation of
+      PKD-2, OSM-9 and ODR-10. RAB-5 overexpression rescues, and STAM-1 epistasis places the
+      BBSome upstream of the early endosome at the ciliary base for these non-IFT cargoes;
+      BBS-4 binds BBS-5 directly via its C-terminal TPR region. What remains unknown is the
+      biochemical output that couples the BBSome to receptor endocytosis/degradation.
+    gap_kind:
+      - BIOLOGY
+    dark_aspect: RESIDUAL_SUBGAP
+    status: OPEN
+    significance: &gt;-
+      This receptor-downregulation activity is conserved to human BBS4/BBS5 and to
+      polycystin-2, directly relevant to Bardet-Biedl syndrome and polycystic kidney disease;
+      the missing effectors are the mechanistic link between the BBSome and ciliary signaling
+      homeostasis.
+    resolution: &gt;-
+      Proximity/affinity proteomics of the ciliary-base BBSome to identify the endocytic/
+      ubiquitin effectors; separation-of-function bbs-4 alleles that uncouple BBS-5 binding
+      from cargo removal; and structural definition of how BBS-4 and BBS-5 co-contribute to a
+      shared coat surface.
+    provenance:
+      - reference_id: PMID:26150102
+        supporting_text: the definite molecular activity of the BBSome in regulating the
+          homoeostasis of ciliary membrane proteins remain unclear
+        reference_section_type: INTRODUCTION
+      - reference_id: PMID:26150102
+        supporting_text: two BBSome components that share no similar protein domains
+        reference_section_type: RESULTS
+proposed_new_terms: []
+suggested_questions:
+  - question: Does BBS-4&#39;s TPR surface directly contact a specific ciliary membrane cargo
+      within the BBSome, or does it act purely as a scaffold linking BBS-5 into the coat?
+  - question: What endocytic/ubiquitin effectors at the ciliary base connect the BBSome to
+      lysosome-targeted degradation of sensory receptors?
+suggested_experiments:
+  - description: Proximity-dependent biotinylation (TurboID) or affinity proteomics of BBS-4
+      at the ciliary base in wild-type versus bbs-5 mutant worms to identify cargo and
+      endocytic/ubiquitin effectors.
+    hypothesis: BBS-4 within the BBSome physically links ciliary sensory receptors to the
+      early-endosome/lysosome sorting machinery at the ciliary base.
+    experiment_type: proteomics
+  - description: Structure-guided separation-of-function alleles of bbs-4 that abolish BBS-5
+      binding (C-terminal TPR) while preserving BBSome incorporation, scored for ciliogenesis,
+      IFT integrity, and receptor removal.
+    hypothesis: The BBS-4–BBS-5 interaction is specifically required for receptor
+      degradative sorting, separable from bulk IFT assembly.
+    experiment_type: genetics
+tags:
+  - caeel-ciliopathy
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/genes/worm/che-11/che-11-ai-review.html
+++ b/genes/worm/che-11/che-11-ai-review.html
@@ -1,0 +1,4473 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>che-11 - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        .propagation-review {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f8fafc;
+            border-left: 3px solid #64748b;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .propagation-title {
+            font-weight: 600;
+            color: #334155;
+            margin-bottom: 0.25rem;
+        }
+
+        .propagation-row {
+            margin-top: 0.25rem;
+        }
+
+        .propagation-source {
+            margin-top: 0.5rem;
+            padding-top: 0.5rem;
+            border-top: 1px solid #e5e7eb;
+        }
+
+        .propagation-source-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #1d4ed8;
+        }
+
+        .propagation-comment {
+            color: #4b5563;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>che-11</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/P90757" target="_blank" class="term-link">
+                        P90757
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Caenorhabditis elegans</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-draft">
+                    DRAFT
+                </span>
+            </div>
+
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "che-11";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="P90757" data-a="DESCRIPTION: CHE-11 is the Caenorhabditis elegans ortholog of h..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>CHE-11 is the Caenorhabditis elegans ortholog of human IFT140, a core subunit of intraflagellar transport complex A (IFT-A). It is a large (1437 aa) scaffolding protein built from two N-terminal WD40 β-propellers followed by an extended tetratricopeptide-repeat (TPR)/α-solenoid, with no catalytic domain. CHE-11 is expressed in ciliated sensory neurons and localizes to the non-motile sensory cilium, where it moves along the axoneme as part of the IFT machinery and concentrates at the ciliary base/basal body. As an IFT-A subunit, CHE-11 is required for retrograde (tip-to-base) intraflagellar transport and, because retrograde return of IFT components sustains the whole transport cycle, for building and maintaining a normal-length ciliary axoneme. Loss of CHE-11 produces truncated sensory cilia with disrupted IFT and a dye-filling-defective (Dyf) phenotype; because these cilia mediate chemo- and osmosensation, che-11 mutants show impaired chemosensory behaviours, altered dauer formation, and a range of downstream sensory-dependent phenotypes (extended lifespan, resistance to paraquat/oxidative stress and heat). Human IFT140 mutations cause skeletal ciliopathies and retinal dystrophy, underscoring a conserved role in cilium biogenesis.</p>
+    </div>
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Proposed New Ontology Terms</h2>
+
+        <div class="proposed-term">
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>structural constituent of intraflagellar transport particle</h3>
+                <span class="vote-buttons" data-g="P90757" data-a="structural constituent of intraflagellar transport particle" data-r="" data-act="NEW">
+                    <button class="vote-btn" data-v="up" title="Agree this term should be created">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with creating this term">👎</button>
+                </span>
+            </div>
+
+
+            <p><strong>Definition:</strong> The action of a protein that contributes to the structural integrity of an intraflagellar transport (IFT) particle (IFT-A or IFT-B subcomplex), for example by acting as a WD40/TPR scaffold that holds core IFT subunits together and enables their bidirectional transport along the ciliary axoneme, without itself catalyzing a biochemical reaction.</p>
+
+
+
+
+
+            <p><strong>Parent term:</strong>
+                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005198" target="_blank" class="term-link">
+                    structural molecule activity
+                </a>
+            </p>
+
+
+
+
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0035721" target="_blank" class="term-link">
+                                    GO:0035721
+                                </a>
+                            </span>
+                            <span class="term-label">intraciliary retrograde transport</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P90757" data-a="GO:0035721" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> As a core IFT-A subunit (IFT140 ortholog), CHE-11 is required for retrograde (tip-to-base) intraflagellar transport, the defining function of the IFT-A complex.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Represents the core biological process of the gene. Phylogenetic inference agrees with direct evidence that CHE-11 is an IFT-A (&#34;Complex A&#34;) subunit essential for IFT.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/27930654" target="_blank" class="term-link">
+                                        PMID:27930654
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">which is a component of IFT-A essential for IFT</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0036064" target="_blank" class="term-link">
+                                    GO:0036064
+                                </a>
+                            </span>
+                            <span class="term-label">ciliary basal body</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P90757" data-a="GO:0036064" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IFT-A subunits, including the IFT140 ortholog CHE-11, concentrate at and act from the ciliary base/basal body where IFT trains are assembled and turned around.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Consistent core localization for an IFT-A subunit; phylogenetically inferred and in line with the ciliary/base localization of IFT proteins.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005930" target="_blank" class="term-link">
+                                    GO:0005930
+                                </a>
+                            </span>
+                            <span class="term-label">axoneme</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P90757" data-a="GO:0005930" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> CHE-11 moves along the ciliary axoneme as part of the IFT machinery.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Core localization; IFT-A subunits traffic along the axoneme. Corroborated by direct observation that CHE-11 moves along C. elegans sensory cilia.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/11301258" target="_blank" class="term-link">
+                                        PMID:11301258
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">move at the same rate</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030991" target="_blank" class="term-link">
+                                    GO:0030991
+                                </a>
+                            </span>
+                            <span class="term-label">intraciliary transport particle A</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P90757" data-a="GO:0030991" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> CHE-11 is a core subunit of the IFT-A complex, established by orthology to IFT140 and by direct identification as a Complex A polypeptide in the worm.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The defining cellular-component assignment for this gene; strongly supported by phylogeny and experiment.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/11301258" target="_blank" class="term-link">
+                                        PMID:11301258
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">two Complex A polypeptides</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005929" target="_blank" class="term-link">
+                                    GO:0005929
+                                </a>
+                            </span>
+                            <span class="term-label">cilium</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000120
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P90757" data-a="GO:0005929" data-r="GO_REF:0000120" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic annotation placing CHE-11 in the cilium; correct but less specific than the experimentally supported non-motile cilium term.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct ciliary localization. A more specific term (non-motile cilium) is also annotated by IDA; the general term is retained as consistent.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005929" target="_blank" class="term-link">
+                                    GO:0005929
+                                </a>
+                            </span>
+                            <span class="term-label">cilium</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">NAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/28479320" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:28479320
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Dynein-Driven Retrograde Intraflagellar Transport Is Triphas...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P90757" data-a="GO:0005929" data-r="PMID:28479320" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> ComplexPortal (CPX-1289) complex-based assertion that CHE-11, as an IFT-A subunit, localizes to the cilium.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct ciliary localization consistent with all other evidence; a more specific non-motile cilium term is also present.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030991" target="_blank" class="term-link">
+                                    GO:0030991
+                                </a>
+                            </span>
+                            <span class="term-label">intraciliary transport particle A</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">NAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/28479320" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:28479320
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Dynein-Driven Retrograde Intraflagellar Transport Is Triphas...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P90757" data-a="GO:0030991" data-r="PMID:28479320" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> ComplexPortal complex-membership assertion that CHE-11 is part of IFT-A; redundant with, and corroborated by, the IBA and ISS IFT-A annotations.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Core complex membership; consistent across ComplexPortal, phylogeny and experimental identification as a Complex A polypeptide.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0035721" target="_blank" class="term-link">
+                                    GO:0035721
+                                </a>
+                            </span>
+                            <span class="term-label">intraciliary retrograde transport</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">NAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/28479320" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:28479320
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Dynein-Driven Retrograde Intraflagellar Transport Is Triphas...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P90757" data-a="GO:0035721" data-r="PMID:28479320" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> ComplexPortal assertion that the IFT-A complex containing CHE-11 mediates retrograde intraflagellar transport.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Core biological process for an IFT-A subunit; redundant with the IBA retrograde-transport annotation.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0060271" target="_blank" class="term-link">
+                                    GO:0060271
+                                </a>
+                            </span>
+                            <span class="term-label">cilium assembly</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">NAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/28479320" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:28479320
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Dynein-Driven Retrograde Intraflagellar Transport Is Triphas...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P90757" data-a="GO:0060271" data-r="PMID:28479320" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IFT-A function (via CHE-11) is required to build and maintain the ciliary axoneme; ComplexPortal complex-based assertion.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Core process, downstream of the direct IFT transport activity; corroborated by the truncated-cilia phenotype of che-11 mutants.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/27930654" target="_blank" class="term-link">
+                                        PMID:27930654
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Although GFP::RAB-28 is observed within the truncated cilia of che-11 mutants, we could not detect processive movement of the GFP signals</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1905798" target="_blank" class="term-link">
+                                    GO:1905798
+                                </a>
+                            </span>
+                            <span class="term-label">positive regulation of intraciliary anterograde transport</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/27930654" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:27930654
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Whole-Organism Developmental Expression Profiling Identifies...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P90757" data-a="GO:1905798" data-r="PMID:27930654" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> In che-11 mutants, processive (anterograde and retrograde) movement of the ciliary cargo RAB-28 is abolished, so CHE-11 is required for anterograde IFT of cargo.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> CHE-11/IFT-A is mechanistically the retrograde module; the requirement for anterograde cargo transport is largely indirect (failure to recycle IFT components and truncated cilia). Real but peripheral to the core retrograde role, so retained as non-core.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/27930654" target="_blank" class="term-link">
+                                        PMID:27930654
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Although GFP::RAB-28 is observed within the truncated cilia of che-11 mutants, we could not detect processive movement of the GFP signals</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1905801" target="_blank" class="term-link">
+                                    GO:1905801
+                                </a>
+                            </span>
+                            <span class="term-label">positive regulation of intraciliary retrograde transport</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/27930654" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:27930654
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Whole-Organism Developmental Expression Profiling Identifies...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P90757" data-a="GO:1905801" data-r="PMID:27930654" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> CHE-11 is required for retrograde intraflagellar transport of ciliary cargo; loss abolishes processive movement in cilia.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> On-target with the core retrograde IFT function of IFT-A; CHE-11 is essential for IFT and its loss abolishes ciliary cargo transport.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/27930654" target="_blank" class="term-link">
+                                        PMID:27930654
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">which is a component of IFT-A essential for IFT</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0097730" target="_blank" class="term-link">
+                                    GO:0097730
+                                </a>
+                            </span>
+                            <span class="term-label">non-motile cilium</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/17420466" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:17420466
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Mutation of the MAP kinase DYF-5 affects docking and undocki...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P90757" data-a="GO:0097730" data-r="PMID:17420466" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct imaging localizes CHE-11 to the non-motile sensory cilium.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Core cellular-component localization, directly observed. C. elegans sensory cilia are non-motile.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0043053" target="_blank" class="term-link">
+                                    GO:0043053
+                                </a>
+                            </span>
+                            <span class="term-label">dauer entry</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IGI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/1732156" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:1732156
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Genetic analysis of chemosensory control of dauer formation ...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P90757" data-a="GO:0043053" data-r="PMID:1732156" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> che-11 is one of the cilium-structure genes whose mutations perturb the chemosensory control of dauer formation; genetic interactions with daf genes.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Dauer formation is a downstream, sensory-dependent behavioural output of cilium integrity, not a molecular/cellular function of CHE-11. Retained as a non-core pleiotropic phenotype.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/1732156" target="_blank" class="term-link">
+                                        PMID:1732156
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Dauer-defective mutations in nine genes cause structurally defective chemosensory cilia, thereby blocking chemosensation</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0060271" target="_blank" class="term-link">
+                                    GO:0060271
+                                </a>
+                            </span>
+                            <span class="term-label">cilium assembly</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IGI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/1732156" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:1732156
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Genetic analysis of chemosensory control of dauer formation ...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P90757" data-a="GO:0060271" data-r="PMID:1732156" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Loss of che-11 gives structurally defective chemosensory cilia, indicating a requirement in building the sensory cilium.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Core process for an IFT-A subunit; the structurally defective cilia of che-11 mutants support a role in cilium assembly/integrity.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/1732156" target="_blank" class="term-link">
+                                        PMID:1732156
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Dauer-defective mutations in nine genes cause structurally defective chemosensory cilia, thereby blocking chemosensation</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0097730" target="_blank" class="term-link">
+                                    GO:0097730
+                                </a>
+                            </span>
+                            <span class="term-label">non-motile cilium</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/11301258" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:11301258
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    An autosomal recessive polycystic kidney disease gene homolo...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P90757" data-a="GO:0097730" data-r="PMID:11301258" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> CHE-11 localizes to and moves within C. elegans sensory (non-motile) cilia.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Core cellular-component localization, directly observed as a Complex A polypeptide moving along sensory cilia.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/11301258" target="_blank" class="term-link">
+                                        PMID:11301258
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">two Complex A polypeptides</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008340" target="_blank" class="term-link">
+                                    GO:0008340
+                                </a>
+                            </span>
+                            <span class="term-label">determination of adult lifespan</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/14982934" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:14982934
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Mutations in chemosensory cilia cause resistance to paraquat...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P90757" data-a="GO:0008340" data-r="PMID:14982934" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> A che-11 nonsense mutant (mev-4) is long-lived; lifespan extension is a downstream consequence of impaired chemosensory (ciliary) signaling.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Adult-lifespan modulation is an indirect, sensory-dependent phenotype of losing ciliary function (the paper notes it is daf-16-dependent), not a molecular function of CHE-11. Retained as non-core.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/14982934" target="_blank" class="term-link">
+                                        PMID:14982934
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">One mutant named mev-4 was long-lived and showed cross-resistance to heat and Dyf phenotype</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008340" target="_blank" class="term-link">
+                                    GO:0008340
+                                </a>
+                            </span>
+                            <span class="term-label">determination of adult lifespan</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/19208769" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:19208769
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Functional interactions between the ciliopathy-associated Me...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P90757" data-a="GO:0008340" data-r="PMID:19208769" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Second IMP for determination of adult lifespan from a transition-zone (MKS) study, using a che-11 variant.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Same downstream, sensory-dependent lifespan phenotype as the PMID:14982934 annotation; a pleiotropic consequence of ciliary dysfunction, not a core function.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030991" target="_blank" class="term-link">
+                                    GO:0030991
+                                </a>
+                            </span>
+                            <span class="term-label">intraciliary transport particle A</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ISS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/14982934" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:14982934
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Mutations in chemosensory cilia cause resistance to paraquat...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P90757" data-a="GO:0030991" data-r="PMID:14982934" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Sequence-similarity annotation (from an IFT140 ortholog) placing CHE-11 in the IFT-A particle.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Core complex membership; consistent with the IBA and ComplexPortal IFT-A annotations and with experimental identification as a Complex A polypeptide.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042073" target="_blank" class="term-link">
+                                    GO:0042073
+                                </a>
+                            </span>
+                            <span class="term-label">intraciliary transport</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ISS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/14982934" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:14982934
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Mutations in chemosensory cilia cause resistance to paraquat...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P90757" data-a="GO:0042073" data-r="PMID:14982934" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> CHE-11 participates in intraflagellar transport, the general process subsuming its retrograde IFT-A role.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Core biological process; the more specific retrograde-transport term is also annotated. Corroborated by direct observation of CHE-11 IFT motility.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/11301258" target="_blank" class="term-link">
+                                        PMID:11301258
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">move at the same rate</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006972" target="_blank" class="term-link">
+                                    GO:0006972
+                                </a>
+                            </span>
+                            <span class="term-label">hyperosmotic response</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/14982934" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:14982934
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Mutations in chemosensory cilia cause resistance to paraquat...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P90757" data-a="GO:0006972" data-r="PMID:14982934" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> WB IMP annotation for hyperosmotic response, based on a che-11 mutant.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Osmotic-response phenotypes of che-11 mutants reflect loss of sensory (ciliary) function rather than a molecular role of CHE-11 in osmotic signaling. Retained as a non-core downstream phenotype.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006979" target="_blank" class="term-link">
+                                    GO:0006979
+                                </a>
+                            </span>
+                            <span class="term-label">response to oxidative stress</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/14982934" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:14982934
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Mutations in chemosensory cilia cause resistance to paraquat...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P90757" data-a="GO:0006979" data-r="PMID:14982934" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> che-11 (mev-4) mutants are resistant to paraquat, an oxidative-stress generator.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Paraquat/oxidative-stress resistance is a downstream, sensory-dependent consequence of ciliary dysfunction (the authors conclude chemosensory neurons are a target of oxidative stress influencing longevity), not a molecular function of CHE-11.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/14982934" target="_blank" class="term-link">
+                                        PMID:14982934
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">We isolated mutants resistant to paraquat from nematode</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0009408" target="_blank" class="term-link">
+                                    GO:0009408
+                                </a>
+                            </span>
+                            <span class="term-label">response to heat</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/14982934" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:14982934
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Mutations in chemosensory cilia cause resistance to paraquat...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P90757" data-a="GO:0009408" data-r="PMID:14982934" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> che-11 (mev-4) mutants show cross-resistance to heat.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Heat cross-resistance is a downstream, sensory-dependent phenotype of cilium loss, not a molecular function of CHE-11. Retained as non-core.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/14982934" target="_blank" class="term-link">
+                                        PMID:14982934
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">One mutant named mev-4 was long-lived and showed cross-resistance to heat and Dyf phenotype</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>Structural constituent of intraflagellar transport complex A (IFT-A) that drives retrograde (tip-to-base) intraflagellar transport along the sensory cilium. As the IFT140 ortholog, CHE-11 has no catalytic activity; it is a WD40 β-propeller + TPR/α-solenoid scaffold that helps hold the IFT-A particle together and is essential for IFT.</h3>
+                <span class="vote-buttons" data-g="P90757" data-a="FUNCTION: Structural constituent of intraflagellar transport..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005198" target="_blank" class="term-link">
+                            structural molecule activity
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0035721" target="_blank" class="term-link">
+                                intraciliary retrograde transport
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042073" target="_blank" class="term-link">
+                                intraciliary transport
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0097730" target="_blank" class="term-link">
+                                non-motile cilium
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">In Complex:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030991" target="_blank" class="term-link">
+                            intraciliary transport particle A
+                        </a>
+                    </span>
+                </div>
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/11301258" target="_blank" class="term-link">
+                                PMID:11301258
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">two Complex A polypeptides</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/27930654" target="_blank" class="term-link">
+                                PMID:27930654
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">which is a component of IFT-A essential for IFT</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>Required for assembly and structural integrity of the non-motile sensory cilium: IFT-A function via CHE-11 is needed to build and maintain the ciliary axoneme, and its loss produces truncated cilia with abolished processive ciliary transport.</h3>
+                <span class="vote-buttons" data-g="P90757" data-a="FUNCTION: Required for assembly and structural integrity of ..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0060271" target="_blank" class="term-link">
+                                cilium assembly
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0097730" target="_blank" class="term-link">
+                                non-motile cilium
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/27930654" target="_blank" class="term-link">
+                                PMID:27930654
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">Although GFP::RAB-28 is observed within the truncated cilia of che-11 mutants, we could not detect processive movement of the GFP signals</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/1732156" target="_blank" class="term-link">
+                                PMID:1732156
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">Dauer-defective mutations in nine genes cause structurally defective chemosensory cilia, thereby blocking chemosensation</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
+                            GO_REF:0000033
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Annotation inferences using phylogenetic trees</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000120.md" target="_blank" class="term-link">
+                            GO_REF:0000120
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Combined Automated Annotation using Multiple IEA Methods</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/11301258" target="_blank" class="term-link">
+                            PMID:11301258
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">An autosomal recessive polycystic kidney disease gene homolog is involved in intraflagellar transport in C. elegans ciliated sensory neurons.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/14982934" target="_blank" class="term-link">
+                            PMID:14982934
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Mutations in chemosensory cilia cause resistance to paraquat in nematode Caenorhabditis elegans.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/1732156" target="_blank" class="term-link">
+                            PMID:1732156
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Genetic analysis of chemosensory control of dauer formation in Caenorhabditis elegans.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/17420466" target="_blank" class="term-link">
+                            PMID:17420466
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Mutation of the MAP kinase DYF-5 affects docking and undocking of kinesin-2 motors and reduces their speed in the cilia of Caenorhabditis elegans.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/19208769" target="_blank" class="term-link">
+                            PMID:19208769
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Functional interactions between the ciliopathy-associated Meckel syndrome 1 (MKS1) protein and two novel MKS1-related (MKSR) proteins.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/27930654" target="_blank" class="term-link">
+                            PMID:27930654
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Whole-Organism Developmental Expression Profiling Identifies RAB-28 as a Novel Ciliary GTPase Associated with the BBSome and Intraflagellar Transport.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/28479320" target="_blank" class="term-link">
+                            PMID:28479320
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Dynein-Driven Retrograde Intraflagellar Transport Is Triphasic in C. elegans Sensory Cilia.</div>
+
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Questions for Experts</h2>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Does CHE-11/IFT140 make direct, separable contributions to anterograde IFT, or is the anterograde defect in che-11 mutants entirely secondary to failed retrograde recycling and cilium truncation?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P90757" data-a="Q: Does CHE-11/IFT140 make direct, separable contribu..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> What is the subunit-resolved architecture of the C. elegans IFT-A complex and the CHE-11 interface with dynein-2 during retrograde turnaround?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P90757" data-a="Q: What is the subunit-resolved architecture of the C..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Experiments</h2>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Cryo-EM of the intact worm IFT-A complex and of an IFT-A–dynein-2 assembly to map CHE-11 subunit contacts and the retrograde-turnaround interface.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: CHE-11/IFT140 occupies a defined structural position in IFT-A that mediates dynein-2 engagement for retrograde transport.</em></p>
+
+
+                </div>
+                <span class="vote-buttons" data-g="P90757" data-a="EXPERIMENT: Cryo-EM of the intact worm IFT-A complex and of an..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Allele-specific, time-resolved IFT imaging using separation-of-function CHE-11 alleles to measure anterograde train formation before secondary cilium truncation, separating direct from indirect anterograde requirements.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: The anterograde-transport defect in che-11 mutants is an indirect consequence of failed retrograde recycling rather than a direct CHE-11 anterograde role.</em></p>
+
+
+                </div>
+                <span class="vote-buttons" data-g="P90757" data-a="EXPERIMENT: Allele-specific, time-resolved IFT imaging using s..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Knowledge Gaps</h2>
+        <p style="color: #555; font-size: 0.92rem; margin-top: -0.3rem;">
+            What is <em>not</em> known — curated, literature-grounded statements of the open
+            unknowns (the inverse of core functions).
+        </p>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> CHE-11 has no molecular_function annotation and there is no adequate GO term to express one. Its role is to be a structural constituent of the IFT-A particle, but GO has no &#34;structural constituent of the intraflagellar transport particle&#34; molecular function term, so the gene reads as MF-dark despite a well-understood cellular and process-level role.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">ONTOLOGY</span><span class="badge">CURATION</span>
+                <span class="badge">MF_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> It is firmly established that CHE-11 = IFT140 is a WD40+TPR scaffolding subunit of IFT-A with no catalytic domain, required for retrograde IFT and cilium assembly. What is missing is a molecular-function representation: the worm GOA record carries only cellular-component and biological-process terms and no molecular_function annotation at all.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> This is the canonical &#34;structural subunit&#34; ontology gap shared across the IFT/ciliopathy gene set (e.g. its paralog dyf-2/WDR19): a mechanistically well-understood protein that cannot be annotated with an informative MF term, contributing to apparent molecular-function darkness.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Develop/adopt a molecular-function term for a structural constituent of the IFT particle (analogous to &#34;structural constituent of ribosome&#34;), then annotate CHE-11 (and other IFT-A/IFT-B core subunits) to it.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"which is a component of IFT-A essential for IFT"</em> — PMID:27930654</li>
+
+            </ul>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Proposed term (ontology gap):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><strong>structural constituent of intraflagellar transport particle</strong></li>
+
+            </ul>
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The subunit-resolved architecture of the worm IFT-A complex and the precise role of CHE-11 in the retrograde turnaround are not solved: how CHE-11 (IFT140) contacts the other IFT-A subunits (DAF-10/IFT122, DYF-2/WDR19, IFT-139, IFT-43, IFTA-1) and how IFT-A licenses dynein-2 for retrograde transport in C. elegans are inferred from orthology and proteomics, not from a worm structure.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">RESIDUAL_SUBGAP</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> IFT-A composition and the essentiality of CHE-11 for IFT are established genetically and biochemically, and the general IFT-A architecture (including the IFT140–IFT144/DYF-2 TPR heterodimer that forms the A1 core) has been solved by cryo-EM in other species. What remains incompletely understood is how the dynein-2 motor moves and is regulated within the cilium, how CHE-11/ IFT-A licenses retrograde turnaround in C. elegans, and the subunit-resolved arrangement of the worm complex specifically.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> The retrograde turnaround and dynein-2 engagement is the load-bearing, incompletely understood step of the IFT cycle; resolving it would explain how IFT-A subunits such as CHE-11/IFT140 organize retrograde transport and how ciliopathy-causing IFT140 mutations disrupt it.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Cryo-EM of the worm IFT-A complex (and of an IFT-A–dynein-2 assembly) plus structure-guided separation-of-function mutagenesis of CHE-11 with retrograde-IFT readouts.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"it remains unclear how the dynein-2 heavy chain moves in cilia"</em> — PMID:28479320</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> Whether CHE-11 has any direct role in anterograde intraflagellar transport, as opposed to an indirect requirement, is unresolved. che-11 mutants lose both anterograde and retrograde processive movement of ciliary cargo, but IFT-A is mechanistically the retrograde module, so the anterograde effect may be a secondary consequence of failed IFT-component recycling and truncated cilia.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span><span class="badge">CURATION</span>
+                <span class="badge">BP_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> It is established that loss of CHE-11 abolishes processive ciliary transport of cargo (e.g. RAB-28) in both directions and that IFT-A powers retrograde IFT; what is not separated is a direct CHE-11 contribution to anterograde train formation versus an indirect downstream effect.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Distinguishing direct from indirect anterograde requirement determines whether the &#34;positive regulation of intraciliary anterograde transport&#34; annotation reflects a genuine CHE-11 activity or a system-level consequence, affecting how IFT-A subunits are modelled in ciliary transport.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Time-resolved, allele-specific IFT imaging (separation-of-function CHE-11 alleles) that measures anterograde train formation before secondary cilium truncation, distinguishing a direct contribution from an indirect effect.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"Although GFP::RAB-28 is observed within the truncated cilia of che-11 mutants, we could not detect processive movement of the GFP signals"</em> — PMID:27930654</li>
+
+            </ul>
+
+
+        </div>
+
+    </div>
+
+
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Deep Research Sections -->
+
+    <div class="section">
+        <h2 class="section-title">Deep Research</h2>
+
+        <details class="deep-research-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; gap: 1rem;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Falcon</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(che-11-deep-research-falcon.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="P90757" data-a="DEEP_RESEARCH: Falcon" data-r="" data-act="DEEP_RESEARCH" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This deep research is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This deep research needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+
+                <div class="report-meta">
+
+                    <span class="report-meta-text">Comprehensive Functional Annotation of *C. elegans* CHE-11 (IFT140)</span>
+
+
+                    <span class="report-badge">Falcon</span>
+
+
+                    <span class="report-badge">Edison Scientific Literature</span>
+
+
+                    <span class="report-badge">30 citations</span>
+
+
+                    <span class="report-badge">2 artifacts</span>
+
+
+                    <span class="report-meta-text">2026-07-04T17:16:47.644627</span>
+
+
+
+                </div>
+
+
+                <div class="artifact-list">
+
+
+
+                    <div class="artifact-link">
+                        <a href="che-11-deep-research-falcon_artifacts/artifact-00.md" class="term-link">Edison artifact artifact-00</a>
+                        <span>(text/markdown)</span>
+                    </div>
+
+
+
+
+                    <div class="artifact-link">
+                        <a href="che-11-deep-research-falcon_artifacts/artifact-01.md" class="term-link">Edison artifact artifact-01</a>
+                        <span>(text/markdown)</span>
+                    </div>
+
+
+                </div>
+
+                <p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h1 id="comprehensive-functional-annotation-of-c-elegans-che-11-ift140">Comprehensive Functional Annotation of <em>C. elegans</em> CHE-11 (IFT140)</h1>
+<h2 id="1-gene-and-protein-identity">1. Gene and Protein Identity</h2>
+<p>The <em>che-11</em> gene (ORF name C27A7.4; UniProt P90757) of <em>Caenorhabditis elegans</em> encodes a WD-repeat- and TPR-domain-containing protein that is the ortholog of human intraflagellar transport protein 140 (IFT140). Multiple independent studies have confirmed this orthology based on sequence conservation, domain architecture, and functional complementation experiments (scheidel2018intraflagellartransportcomplex pages 1-3, blacque2006thewdrepeatcontaining pages 6-8, jensen2016wholeorganismdevelopmentalexpression pages 8-9). The gene was originally identified through forward genetic screens for chemotaxis-defective mutants in <em>C. elegans</em>, hence the "che" designation (scheidel2018intraflagellartransportcomplex pages 1-3).</p>
+<p>The following table summarizes the key properties of CHE-11/IFT140:</p>
+<table>
+<thead>
+<tr>
+<th>Property</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Gene name</td>
+<td><strong>che-11</strong>; the provided UniProt annotation and C. elegans literature align che-11 with the IFT140 ortholog in sensory cilia (scheidel2018intraflagellartransportcomplex pages 1-3, brocalruiz2023forkheadtranscriptionfactor pages 3-5)</td>
+</tr>
+<tr>
+<td>Protein name</td>
+<td><strong>CHE-11 / IFT-140</strong>; a WD-repeat/TPR-containing intraflagellar transport protein and core IFT-A subunit (blacque2006thewdrepeatcontaining pages 6-8, picariello2019aglobalanalysis pages 4-6)</td>
+</tr>
+<tr>
+<td>UniProt ID</td>
+<td><strong>P90757</strong> (provided target identity)</td>
+</tr>
+<tr>
+<td>Organism</td>
+<td><strong>Caenorhabditis elegans</strong> (worm) (scheidel2018intraflagellartransportcomplex pages 1-3, brocalruiz2023forkheadtranscriptionfactor pages 3-5)</td>
+</tr>
+<tr>
+<td>ORF name</td>
+<td><strong>C27A7.4</strong> (provided target identity)</td>
+</tr>
+<tr>
+<td>Human ortholog</td>
+<td><strong>IFT140</strong>; che-11 is identified as the C. elegans ortholog of mammalian/human IFT140 (scheidel2018intraflagellartransportcomplex pages 1-3, OpenTargets Search: -IFT140)</td>
+</tr>
+<tr>
+<td>Protein complex</td>
+<td><strong>IFT-A core complex</strong>; IFT140/CHE-11 belongs to the IFT-A core together with IFT122 and IFT144 (meleppattu2022mechanismofifta pages 3-5, nakayama2018ciliaryproteintrafficking pages 3-3)</td>
+</tr>
+<tr>
+<td>Key domains</td>
+<td><strong>N-terminal WD repeats / β-propeller domains</strong> plus <strong>C-terminal TPR domains</strong>; WD repeats contribute to membrane-associated cargo transport and retrograde transport performance, whereas TPR domains stabilize IFT-A assembly and mediate core subunit interactions (picariello2019aglobalanalysis pages 6-8, picariello2019aglobalanalysis pages 13-15, meleppattu2022mechanismofifta pages 3-5)</td>
+</tr>
+<tr>
+<td>Molecular function</td>
+<td><strong>Structural/adaptor subunit of the IFT-A complex required for retrograde intraflagellar transport</strong> and for proper assembly/stability of IFT-A; broader comparative work indicates IFT140-containing IFT-A also specializes in trafficking membrane-associated ciliary cargoes (blacque2006thewdrepeatcontaining pages 6-8, blacque2006thewdrepeatcontaining pages 8-9, picariello2019aglobalanalysis pages 6-8, picariello2019aglobalanalysis pages 1-4)</td>
+</tr>
+<tr>
+<td>Subcellular localization</td>
+<td>Localizes to <strong>sensory cilia</strong>, including the <strong>axoneme</strong> and ciliary region visualized in phasmid/amphid neurons; genetic evidence also places IFT-A/CHE-11 function at the <strong>transition zone/periciliary gating interface</strong>, and in some mutant contexts CHE-11 can become restricted near the <strong>transition zone</strong> (scheidel2018intraflagellartransportcomplex pages 3-4, efimenko2006caenorhabditiselegansdyf2an pages 6-8, scheidel2018intraflagellartransportcomplex pages 4-6)</td>
+</tr>
+<tr>
+<td>Expression pattern</td>
+<td>Expressed broadly in the <strong>ciliated sensory neuron system</strong>, with reporter activity in <strong>~30 or more ciliated neurons</strong> (brocalruiz2023forkheadtranscriptionfactor pages 3-5)</td>
+</tr>
+<tr>
+<td>Mutant phenotypes</td>
+<td><strong>Truncated/short cilia</strong>, defective retrograde IFT with accumulation of IFT material in cilia, <strong>dye-filling defects</strong>, and <strong>chemotaxis/sensory defects</strong>; cell-type-specific defects include collapsed AWC cilia and CEP abnormalities (blacque2006thewdrepeatcontaining pages 6-8, jensen2016wholeorganismdevelopmentalexpression pages 8-9, scheidel2018intraflagellartransportcomplex pages 1-3)</td>
+</tr>
+<tr>
+<td>Transcriptional regulation</td>
+<td>Regulated by <strong>DAF-19/RFX</strong>, with additional cooperative input from <strong>FKH-8</strong>; che-11 contains validated X-box regulatory elements and retains partial expression in daf-19 mutants, indicating combinatorial control (brocalruiz2023forkheadtranscriptionfactor pages 3-5, brocalruiz2023forkheadtranscriptionfactor pages 2-3)</td>
+</tr>
+<tr>
+<td>Human disease associations</td>
+<td>Human <strong>IFT140</strong> is associated with ciliopathies including <strong>Mainzer-Saldino syndrome</strong>, <strong>Jeune syndrome</strong>, <strong>short-rib thoracic dysplasia</strong>, <strong>retinitis pigmentosa</strong>, and <strong>cystic kidney disease / polycystic kidney disease</strong> (OpenTargets Search: -IFT140)</td>
+</tr>
+</tbody>
+</table>
+<p><em>Table: This table summarizes the core identifiers, molecular role, localization, regulation, mutant phenotypes, and human disease relevance of C. elegans che-11/CHE-11. It is useful as a quick reference for the full research report.</em></p>
+<h2 id="2-primary-molecular-function-core-subunit-of-the-ift-a-complex">2. Primary Molecular Function: Core Subunit of the IFT-A Complex</h2>
+<p>CHE-11 functions as a core structural and adaptor subunit of the intraflagellar transport complex A (IFT-A). It is not an enzyme; rather, it serves as a scaffold protein within the IFT-A macromolecular assembly that is essential for retrograde intraflagellar transport (IFT)—the directed movement of protein cargo from the ciliary tip back to the ciliary base (blacque2006thewdrepeatcontaining pages 6-8, blacque2006thewdrepeatcontaining pages 8-9).</p>
+<h3 id="21-ift-a-complex-architecture">2.1 IFT-A Complex Architecture</h3>
+<p>The IFT-A complex is a six-subunit assembly organized into two modules. CHE-11/IFT140 resides in the core (A1) subcomplex together with IFT144 (DYF-2 in <em>C. elegans</em>) and IFT122 (DAF-10). The peripheral (A2) module contains IFT139, IFT121, and IFT43 (meleppattu2022mechanismofifta pages 3-5, nakayama2018ciliaryproteintrafficking pages 3-3). Cryo-electron microscopy and integrative modeling studies have revealed that IFT140 and IFT144 form a heterodimer through antiparallel TPR-TPR interactions involving the first five helices of their respective TPR domains, creating a characteristic V-shaped architecture with their tandem β-propeller domains splayed approximately 50 Å apart (meleppattu2022mechanismofifta pages 3-5). IFT122 serves as a linker, bridging the A1 and A2 modules by extending its TPR domain to engage both IFT140 and IFT144 at the apex of the V-shape (meleppattu2022mechanismofifta pages 5-6).</p>
+<table>
+<thead>
+<tr>
+<th>Subunit Name</th>
+<th><em>C. elegans</em> Ortholog</th>
+<th>Subcomplex</th>
+<th>Domain Architecture</th>
+<th>Key Function</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>IFT140</td>
+<td>CHE-11</td>
+<td>Core / A1</td>
+<td>N-terminal WD repeats / β-propellers plus C-terminal TPR domains</td>
+<td>Stabilizes the IFT-A complex, contributes to retrograde IFT, and supports transport of membrane-associated ciliary cargoes (meleppattu2022mechanismofifta pages 3-5, picariello2019aglobalanalysis pages 6-8, picariello2019aglobalanalysis pages 13-15)</td>
+</tr>
+<tr>
+<td>IFT144</td>
+<td>DYF-2</td>
+<td>Core / A1</td>
+<td>WD repeats / β-propellers plus TPR domains</td>
+<td>Forms a heterodimeric core unit with IFT140 through TPR-mediated interactions and helps build the A1 V-shaped architecture (meleppattu2022mechanismofifta pages 3-5, meleppattu2022mechanismofifta pages 5-6)</td>
+</tr>
+<tr>
+<td>IFT122</td>
+<td>DAF-10 / IFT-122</td>
+<td>Core linker between A1 and A2</td>
+<td>WD repeats / β-propellers plus TPR domains</td>
+<td>Bridges the core and peripheral modules; its TPR region extends to contact IFT140 and IFT144, linking A1 and A2 (meleppattu2022mechanismofifta pages 3-5, meleppattu2022mechanismofifta pages 5-6, nakayama2018ciliaryproteintrafficking pages 3-3)</td>
+</tr>
+<tr>
+<td>IFT139</td>
+<td>IFT-139</td>
+<td>Peripheral / A2</td>
+<td>TPR domains throughout</td>
+<td>Peripheral IFT-A component important for peripheral module stability and retrograde IFT-related organization (picariello2019aglobalanalysis pages 4-6, scheidel2018intraflagellartransportcomplex pages 4-6)</td>
+</tr>
+<tr>
+<td>IFT121</td>
+<td>IFT-121</td>
+<td>Peripheral / A2</td>
+<td>WD repeats / β-propellers plus TPR domains</td>
+<td>Peripheral component of A2; interacts with IFT43 and contacts the core via IFT122 (meleppattu2022mechanismofifta pages 5-6, nakayama2018ciliaryproteintrafficking pages 3-3)</td>
+</tr>
+<tr>
+<td>IFT43</td>
+<td>IFT-43</td>
+<td>Peripheral / A2</td>
+<td>Coiled-coil domain</td>
+<td>Peripheral component that directly interacts with IFT121 and supports A2 integrity and localization (nakayama2018ciliaryproteintrafficking pages 3-3, zhu2017functionalexplorationof pages 9-12)</td>
+</tr>
+</tbody>
+</table>
+<p><em>Table: This table summarizes the six-subunit IFT-A complex with emphasis on the CHE-11/IFT140-containing core module, domain architecture, and inferred functional roles. It is useful for linking the worm che-11 gene to conserved IFT-A assembly and cargo-transport mechanisms.</em></p>
+<h3 id="22-domain-specific-functions">2.2 Domain-Specific Functions</h3>
+<p>The CHE-11/IFT140 protein contains two principal functional regions:</p>
+<p><strong>N-terminal WD-repeat (β-propeller) domains:</strong> Studies in <em>Chlamydomonas reinhardtii</em> using a truncated IFT140 lacking the N-terminal WD repeats demonstrated that these domains are required for proper retrograde IFT velocity, likely by affecting dynein-1b motor activation or IFT train–motor interaction (picariello2019aglobalanalysis pages 13-15). Critically, the WD repeats are also essential for proper trafficking of membrane-associated proteins—including small GTPases, lipid-anchored proteins (myristoylated and geranylgeranylated), and cell signaling components—into cilia (picariello2019aglobalanalysis pages 6-8, picariello2019aglobalanalysis pages 13-15). When the WD repeats are absent, the truncated protein still supports half-length flagella with normal axonemal ultrastructure, but these flagella show dramatic decreases in membrane-associated signaling proteins (picariello2019aglobalanalysis pages 1-4, picariello2019aglobalanalysis pages 17-19).</p>
+<p><strong>C-terminal TPR domains:</strong> These tetratricopeptide repeat domains are sufficient to stabilize IFT-A complex assembly. Expression of only the TPR region of IFT140 partially rescues IFT-A formation and supports partial flagellar assembly, indicating that the TPR domains mediate the essential protein–protein interactions within the IFT-A core (picariello2019aglobalanalysis pages 13-15, picariello2019aglobalanalysis pages 4-6).</p>
+<h3 id="23-functional-specialization-membrane-protein-cargo-transport">2.3 Functional Specialization: Membrane Protein Cargo Transport</h3>
+<p>A landmark study by Picariello et al. (2019) using <em>Chlamydomonas</em> IFT140 null mutants revealed a key functional specialization of IFT-A: it is specifically dedicated to importing membrane-associated proteins into cilia, while IFT-B handles the import of axonemal structural proteins (picariello2019aglobalanalysis pages 1-4, picariello2019aglobalanalysis pages 17-19). The IFT-A complex, via IFT140, transports G protein-coupled receptors (GPCRs), Smoothened, rhodopsin/opsin, Arl13b, and various lipid-modified signaling proteins into the ciliary compartment (picariello2019aglobalanalysis pages 17-19). This is accomplished in part through the adaptor protein TULP3, which bridges IFT-A core subunits (including IFT140) and membrane phosphoinositides (nakayama2018ciliaryproteintrafficking pages 3-3).</p>
+<h2 id="3-subcellular-localization">3. Subcellular Localization</h2>
+<p>CHE-11 protein localizes to the sensory cilia of <em>C. elegans</em> ciliated neurons. Using GFP-tagged CHE-11 constructs, the protein has been visualized in both amphid and phasmid sensory cilia, where it undergoes bidirectional IFT—moving anterogradely from the ciliary base to tip and retrogradely from tip to base (scheidel2018intraflagellartransportcomplex pages 3-4). In <em>C. elegans</em>, IFT-A (including CHE-11) travels at the slow speed characteristic of heterotrimeric kinesin-II (~0.5 μm/s) during anterograde transport, while IFT-B moves at faster speeds characteristic of the homodimeric kinesin OSM-3 (blacque2006thewdrepeatcontaining pages 6-8, taschner2016theintraflagellartransport pages 12-13). The BBSome is responsible for holding IFT-A and IFT-B subcomplexes together during transport; in BBS mutant backgrounds, CHE-11/IFT-A and IFT-B separate and move independently at their respective motor speeds (taschner2016theintraflagellartransport pages 12-13, bhogaraju2013intraflagellartransportcomplex pages 6-7).</p>
+<p>In <em>dyf-2</em> (IFT144) mutant backgrounds, CHE-11 protein becomes restricted to the transition zone and is unable to enter the ciliary axoneme, demonstrating the dependence of CHE-11 ciliary entry on other core IFT-A components (efimenko2006caenorhabditiselegansdyf2an pages 6-8).</p>
+<h2 id="4-biological-processes-and-pathway-involvement">4. Biological Processes and Pathway Involvement</h2>
+<h3 id="41-retrograde-intraflagellar-transport">4.1 Retrograde Intraflagellar Transport</h3>
+<p>The primary biological process in which CHE-11 participates is retrograde IFT. Loss of CHE-11 function phenocopies classic retrograde IFT defects: IFT machinery components accumulate within the ciliary axoneme, retrograde motility is severely abrogated, and cilia become truncated (blacque2006thewdrepeatcontaining pages 6-8, blacque2006thewdrepeatcontaining pages 8-9). CHE-11 is also required for proper incorporation of other IFT components—such as IFTA-1—into the IFT machinery. In <em>che-11</em> mutants, IFTA-1 fails to localize to ciliary structures (blacque2006thewdrepeatcontaining pages 6-8, blacque2006thewdrepeatcontaining pages 8-9).</p>
+<h3 id="42-transition-zone-gating">4.2 Transition Zone Gating</h3>
+<p>CHE-11/IFT-140 plays a cell-type-specific role in transition zone (TZ) function. The TZ is a specialized ciliary gate at the base of the cilium that regulates protein entry and exit. Scheidel and Blacque (2018) demonstrated that IFT-A genes differentially regulate TZ gating in <em>C. elegans</em>: while non-core IFT-A genes (IFT-43, IFT-121, IFT-139) control ciliary removal of MKS module proteins, IFT-140 controls the ciliary entry/accumulation of MKS module proteins into cilia in these non-core mutant backgrounds (scheidel2018intraflagellartransportcomplex pages 4-6). IFT-140 also targets the peripheral component IFT-121 to cilia and mediates IFT-139's association with IFT trains (scheidel2018intraflagellartransportcomplex pages 4-6). These findings reveal that IFT-A maintains, rather than initially establishes, TZ restriction of gating proteins.</p>
+<h3 id="43-cilium-formation-and-morphogenesis">4.3 Cilium Formation and Morphogenesis</h3>
+<p>CHE-11 is essential for cilium formation across all examined cilium types in <em>C. elegans</em>. Mutants display cell-type-specific structural defects: for example, <em>ift-140</em> mutants show collapsed wing-shaped AWC cilia and abnormal rod-shaped CEP cilia (scheidel2018intraflagellartransportcomplex pages 1-3). The interaction between IFT-A and MKS module components works synergistically to determine cilium structure (scheidel2018intraflagellartransportcomplex pages 1-3).</p>
+<h3 id="44-sensory-signaling">4.4 Sensory Signaling</h3>
+<p>Because CHE-11 is essential for proper ciliary structure and composition, its loss leads to defective sensory behaviors including chemotaxis defects (hence the gene name "che") and dye-filling defects—a hallmark phenotype of ciliary structural compromise in <em>C. elegans</em> sensory neurons (scheidel2018intraflagellartransportcomplex pages 1-3, blacque2006thewdrepeatcontaining pages 6-8). Additionally, IFT-A's role in transporting membrane-associated signaling receptors implies that CHE-11 is indirectly required for sensory signal transduction through its role in localizing receptors and signaling components to the ciliary membrane (picariello2019aglobalanalysis pages 17-19).</p>
+<h3 id="45-cytoplasmic-precursor-transport">4.5 Cytoplasmic Precursor Transport</h3>
+<p>Studies in <em>Chlamydomonas</em> have identified a novel role for IFT-A, including IFT140, in mobilizing ciliary precursors from the cytoplasmic pool to the peri-basal body region prior to their entry into the cilium. In <em>ift140</em> null mutants, the peri-basal body localization of IFT-A proteins is disrupted, and flagellar regeneration requiring recruitment of preexisting precursors is blocked (zhu2017functionalexplorationof pages 9-12).</p>
+<h2 id="5-transcriptional-regulation">5. Transcriptional Regulation</h2>
+<p>The <em>che-11</em> gene is expressed in essentially all ciliated sensory neurons in <em>C. elegans</em> (~30+ neurons), as shown by reporter gene analysis (brocalruiz2023forkheadtranscriptionfactor pages 3-5). Its expression is regulated in part by the DAF-19/RFX transcription factor, an evolutionarily conserved master regulator of ciliome genes, acting through X-box regulatory elements in the <em>che-11</em> promoter. Loss of DAF-19 dramatically reduces but does not eliminate <em>che-11</em> expression, indicating that additional transcription factors cooperate in its regulation (brocalruiz2023forkheadtranscriptionfactor pages 3-5). The Forkhead transcription factor FKH-8 has been identified as an additional direct co-regulator that works synergistically with DAF-19/RFX to control ciliome gene expression, including <em>che-11</em> (brocalruiz2023forkheadtranscriptionfactor pages 2-3, brocalruiz2023forkheadtranscriptionfactor pages 3-5).</p>
+<h2 id="6-evolutionary-conservation-and-human-disease-relevance">6. Evolutionary Conservation and Human Disease Relevance</h2>
+<p>IFT140 is highly conserved across eukaryotes. The human ortholog IFT140 is strongly associated with multiple ciliopathies, as documented by OpenTargets disease-target associations (OpenTargets Search: -IFT140). Mutations in human IFT140 cause Mainzer-Saldino syndrome (characterized by retinitis pigmentosa, cerebellar ataxia, and renal disease), Jeune asphyxiating thoracic dystrophy (short-rib thoracic dysplasia with or without polydactyly), retinitis pigmentosa, and autosomal dominant polycystic kidney disease (OpenTargets Search: -IFT140). The pleiotropic nature of these ciliopathies can be explained by IFT-A's specialized role in transporting membrane-associated signaling proteins into cilia: abnormal levels of these proteins would disrupt multiple ciliary signaling pathways across diverse tissues (picariello2019aglobalanalysis pages 1-4, picariello2019aglobalanalysis pages 17-19).</p>
+<h2 id="7-summary">7. Summary</h2>
+<p>CHE-11 (UniProt P90757) is the <em>C. elegans</em> ortholog of IFT140, a core structural subunit of the IFT-A complex essential for retrograde intraflagellar transport and ciliary membrane protein import. It is not an enzyme but rather serves as a multi-domain scaffold within the IFT-A core, using its C-terminal TPR domains for complex assembly and its N-terminal WD-repeat/β-propeller domains for cargo recognition and retrograde motor regulation. CHE-11 localizes to the axoneme and transition zone region of all sensory cilia in <em>C. elegans</em>, where it undergoes bidirectional IFT movement. Its loss results in truncated cilia, disrupted retrograde IFT, defective transition zone gating, dye-filling defects, and chemotaxis behavioral impairment. Transcriptional regulation of <em>che-11</em> involves the cooperative action of DAF-19/RFX and FKH-8 transcription factors. The deep conservation of IFT140 from worms to humans, and its association with multiple human ciliopathies, underscores the fundamental importance of this protein in ciliary biology.</p>
+<p>References</p>
+<ol>
+<li>
+<p>(scheidel2018intraflagellartransportcomplex pages 1-3): Noémie Scheidel and Oliver E. Blacque. Intraflagellar transport complex a genes differentially regulate cilium formation and transition zone gating. Current Biology, 28:3279-3287.e2, Oct 2018. URL: https://doi.org/10.1016/j.cub.2018.08.017, doi:10.1016/j.cub.2018.08.017. This article has 59 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(blacque2006thewdrepeatcontaining pages 6-8): Oliver E. Blacque, Chunmei Li, Peter N. Inglis, Muneer A. Esmail, Guangshuo Ou, Allan K. Mah, David L. Baillie, Jonathan M. Scholey, and Michel R. Leroux. The wd repeat-containing protein ifta-1 is required for retrograde intraflagellar transport. Molecular biology of the cell, 17 12:5053-62, Dec 2006. URL: https://doi.org/10.1091/mbc.e06-06-0571, doi:10.1091/mbc.e06-06-0571. This article has 123 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(jensen2016wholeorganismdevelopmentalexpression pages 8-9): Victor L. Jensen, Stephen Carter, Anna A. W. M. Sanders, Chunmei Li, Julie Kennedy, Tiffany A. Timbers, Jerry Cai, Noemie Scheidel, Breandán N. Kennedy, Ryan D. Morin, Michel R. Leroux, and Oliver E. Blacque. Whole-organism developmental expression profiling identifies rab-28 as a novel ciliary gtpase associated with the bbsome and intraflagellar transport. PLOS Genetics, 12:e1006469, Dec 2016. URL: https://doi.org/10.1371/journal.pgen.1006469, doi:10.1371/journal.pgen.1006469. This article has 81 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(brocalruiz2023forkheadtranscriptionfactor pages 3-5): Rebeca Brocal-Ruiz, Ainara Esteve-Serrano, Carlos Mora-Martínez, Maria Luisa Franco-Rivadeneira, Peter Swoboda, Juan J Tena, Marçal Vilar, and Nuria Flames. Forkhead transcription factor fkh-8 cooperates with rfx in the direct regulation of sensory cilia in caenorhabditis elegans. eLife, Jul 2023. URL: https://doi.org/10.7554/elife.89702, doi:10.7554/elife.89702. This article has 15 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(picariello2019aglobalanalysis pages 4-6): Tyler Picariello, Jason M. Brown, Yuqing Hou, Gregory Swank, Deborah A. Cochran, Oliver D. King, Karl Lechtreck, Gregory J. Pazour, and George B. Witman. A global analysis of ift-a function reveals specialization for transport of membrane-associated proteins into cilia. Journal of Cell Science, Feb 2019. URL: https://doi.org/10.1242/jcs.220749, doi:10.1242/jcs.220749. This article has 84 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(OpenTargets Search: -IFT140): Open Targets Query (-IFT140, 12 results). Buniello, A. et al. (2025). Open Targets Platform: facilitating therapeutic hypotheses building in drug discovery. Nucleic Acids Research.</p>
+</li>
+<li>
+<p>(meleppattu2022mechanismofifta pages 3-5): Shimi Meleppattu, Haixia Zhou, Jin Dai, Miao Gui, and Alan Brown. Mechanism of ift-a polymerization into trains for ciliary transport. Cell, 185:4986-4998.e12, Dec 2022. URL: https://doi.org/10.1016/j.cell.2022.11.033, doi:10.1016/j.cell.2022.11.033. This article has 50 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(nakayama2018ciliaryproteintrafficking pages 3-3): Kazuhisa Nakayama and Yohei Katoh. Ciliary protein trafficking mediated by ift and bbsome complexes with the aid of kinesin-2 and dynein-2 motors. Journal of biochemistry, 163 3:155-164, Mar 2018. URL: https://doi.org/10.1093/jb/mvx087, doi:10.1093/jb/mvx087. This article has 160 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(picariello2019aglobalanalysis pages 6-8): Tyler Picariello, Jason M. Brown, Yuqing Hou, Gregory Swank, Deborah A. Cochran, Oliver D. King, Karl Lechtreck, Gregory J. Pazour, and George B. Witman. A global analysis of ift-a function reveals specialization for transport of membrane-associated proteins into cilia. Journal of Cell Science, Feb 2019. URL: https://doi.org/10.1242/jcs.220749, doi:10.1242/jcs.220749. This article has 84 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(picariello2019aglobalanalysis pages 13-15): Tyler Picariello, Jason M. Brown, Yuqing Hou, Gregory Swank, Deborah A. Cochran, Oliver D. King, Karl Lechtreck, Gregory J. Pazour, and George B. Witman. A global analysis of ift-a function reveals specialization for transport of membrane-associated proteins into cilia. Journal of Cell Science, Feb 2019. URL: https://doi.org/10.1242/jcs.220749, doi:10.1242/jcs.220749. This article has 84 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(blacque2006thewdrepeatcontaining pages 8-9): Oliver E. Blacque, Chunmei Li, Peter N. Inglis, Muneer A. Esmail, Guangshuo Ou, Allan K. Mah, David L. Baillie, Jonathan M. Scholey, and Michel R. Leroux. The wd repeat-containing protein ifta-1 is required for retrograde intraflagellar transport. Molecular biology of the cell, 17 12:5053-62, Dec 2006. URL: https://doi.org/10.1091/mbc.e06-06-0571, doi:10.1091/mbc.e06-06-0571. This article has 123 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(picariello2019aglobalanalysis pages 1-4): Tyler Picariello, Jason M. Brown, Yuqing Hou, Gregory Swank, Deborah A. Cochran, Oliver D. King, Karl Lechtreck, Gregory J. Pazour, and George B. Witman. A global analysis of ift-a function reveals specialization for transport of membrane-associated proteins into cilia. Journal of Cell Science, Feb 2019. URL: https://doi.org/10.1242/jcs.220749, doi:10.1242/jcs.220749. This article has 84 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(scheidel2018intraflagellartransportcomplex pages 3-4): Noémie Scheidel and Oliver E. Blacque. Intraflagellar transport complex a genes differentially regulate cilium formation and transition zone gating. Current Biology, 28:3279-3287.e2, Oct 2018. URL: https://doi.org/10.1016/j.cub.2018.08.017, doi:10.1016/j.cub.2018.08.017. This article has 59 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(efimenko2006caenorhabditiselegansdyf2an pages 6-8): Evgeni Efimenko, Oliver E. Blacque, Guangshuo Ou, Courtney J. Haycraft, Bradley K. Yoder, Jonathan M. Scholey, Michel R. Leroux, and Peter Swoboda. <i>caenorhabditis elegans</i>dyf-2, an orthologue of human wdr19, is a component of the intraflagellar transport machinery in sensory cilia. Nov 2006. URL: https://doi.org/10.1091/mbc.e06-04-0260, doi:10.1091/mbc.e06-04-0260. This article has 98 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(scheidel2018intraflagellartransportcomplex pages 4-6): Noémie Scheidel and Oliver E. Blacque. Intraflagellar transport complex a genes differentially regulate cilium formation and transition zone gating. Current Biology, 28:3279-3287.e2, Oct 2018. URL: https://doi.org/10.1016/j.cub.2018.08.017, doi:10.1016/j.cub.2018.08.017. This article has 59 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(brocalruiz2023forkheadtranscriptionfactor pages 2-3): Rebeca Brocal-Ruiz, Ainara Esteve-Serrano, Carlos Mora-Martínez, Maria Luisa Franco-Rivadeneira, Peter Swoboda, Juan J Tena, Marçal Vilar, and Nuria Flames. Forkhead transcription factor fkh-8 cooperates with rfx in the direct regulation of sensory cilia in caenorhabditis elegans. eLife, Jul 2023. URL: https://doi.org/10.7554/elife.89702, doi:10.7554/elife.89702. This article has 15 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(meleppattu2022mechanismofifta pages 5-6): Shimi Meleppattu, Haixia Zhou, Jin Dai, Miao Gui, and Alan Brown. Mechanism of ift-a polymerization into trains for ciliary transport. Cell, 185:4986-4998.e12, Dec 2022. URL: https://doi.org/10.1016/j.cell.2022.11.033, doi:10.1016/j.cell.2022.11.033. This article has 50 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(zhu2017functionalexplorationof pages 9-12): Bing Zhu, Xin Zhu, Limei Wang, Yinwen Liang, Qianqian Feng, and Junmin Pan. Functional exploration of the ift-a complex in intraflagellar transport and ciliogenesis. PLOS Genetics, 13:e1006627, Feb 2017. URL: https://doi.org/10.1371/journal.pgen.1006627, doi:10.1371/journal.pgen.1006627. This article has 78 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(picariello2019aglobalanalysis pages 17-19): Tyler Picariello, Jason M. Brown, Yuqing Hou, Gregory Swank, Deborah A. Cochran, Oliver D. King, Karl Lechtreck, Gregory J. Pazour, and George B. Witman. A global analysis of ift-a function reveals specialization for transport of membrane-associated proteins into cilia. Journal of Cell Science, Feb 2019. URL: https://doi.org/10.1242/jcs.220749, doi:10.1242/jcs.220749. This article has 84 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(taschner2016theintraflagellartransport pages 12-13): Michael Taschner and Esben Lorentzen. The intraflagellar transport machinery. Cold Spring Harbor perspectives in biology, 8 10:a028092, Oct 2016. URL: https://doi.org/10.1101/cshperspect.a028092, doi:10.1101/cshperspect.a028092. This article has 419 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(bhogaraju2013intraflagellartransportcomplex pages 6-7): Sagar Bhogaraju, Benjamin D Engel, and Esben Lorentzen. Intraflagellar transport complex structure and cargo interactions. Cilia, 2:10-10, Aug 2013. URL: https://doi.org/10.1186/2046-2530-2-10, doi:10.1186/2046-2530-2-10. This article has 125 citations.</p>
+</li>
+</ol>
+<h2 id="artifacts">Artifacts</h2>
+<ul>
+<li><a href="che-11-deep-research-falcon_artifacts/artifact-00.md">Edison artifact artifact-00</a></li>
+<li><a href="che-11-deep-research-falcon_artifacts/artifact-01.md">Edison artifact artifact-01</a></li>
+</ul>
+<h2 id="citations">Citations</h2>
+<ol>
+<li>scheidel2018intraflagellartransportcomplex pages 1-3</li>
+<li>brocalruiz2023forkheadtranscriptionfactor pages 3-5</li>
+<li>meleppattu2022mechanismofifta pages 3-5</li>
+<li>meleppattu2022mechanismofifta pages 5-6</li>
+<li>picariello2019aglobalanalysis pages 13-15</li>
+<li>picariello2019aglobalanalysis pages 17-19</li>
+<li>nakayama2018ciliaryproteintrafficking pages 3-3</li>
+<li>scheidel2018intraflagellartransportcomplex pages 3-4</li>
+<li>scheidel2018intraflagellartransportcomplex pages 4-6</li>
+<li>zhu2017functionalexplorationof pages 9-12</li>
+<li>blacque2006thewdrepeatcontaining pages 6-8</li>
+<li>jensen2016wholeorganismdevelopmentalexpression pages 8-9</li>
+<li>picariello2019aglobalanalysis pages 4-6</li>
+<li>picariello2019aglobalanalysis pages 6-8</li>
+<li>blacque2006thewdrepeatcontaining pages 8-9</li>
+<li>picariello2019aglobalanalysis pages 1-4</li>
+<li>brocalruiz2023forkheadtranscriptionfactor pages 2-3</li>
+<li>taschner2016theintraflagellartransport pages 12-13</li>
+<li>bhogaraju2013intraflagellartransportcomplex pages 6-7</li>
+<li>https://doi.org/10.1016/j.cub.2018.08.017,</li>
+<li>https://doi.org/10.1091/mbc.e06-06-0571,</li>
+<li>https://doi.org/10.1371/journal.pgen.1006469,</li>
+<li>https://doi.org/10.7554/elife.89702,</li>
+<li>https://doi.org/10.1242/jcs.220749,</li>
+<li>https://doi.org/10.1016/j.cell.2022.11.033,</li>
+<li>https://doi.org/10.1093/jb/mvx087,</li>
+<li>https://doi.org/10.1091/mbc.e06-04-0260,</li>
+<li>https://doi.org/10.1371/journal.pgen.1006627,</li>
+<li>https://doi.org/10.1101/cshperspect.a028092,</li>
+<li>https://doi.org/10.1186/2046-2530-2-10,</li>
+</ol>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(che-11-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="P90757" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="che-11-c-elegans-research-notes">che-11 (C. elegans) — research notes</h1>
+<p>Gene: <strong>che-11</strong> / ORF <strong>C27A7.4</strong> / WormBase <strong>WBGene00000490</strong> / UniProt <strong>P90757</strong> (1437 aa).<br />
+Ortholog: <strong>IFT140</strong> (human IFT140; UniProt Q96RY7). PANTHER PTHR15722:SF7 "INTRAFLAGELLAR<br />
+TRANSPORT PROTEIN 140 HOMOLOG". Domain architecture (UniProt P90757): two N-terminal<br />
+WD40 β-propellers ("IFT140 first/second beta-propeller", Pfam PF23383/PF23385) followed by a<br />
+long TPR/α-solenoid ("IF140/IFT172/WDR19 TPR", PF24762; "IF140 C-terminal TPR", PF24760).<br />
+No catalytic domain. ComplexPortal CPX-1289 = Intraflagellar transport complex A. Reactome<br />
+R-CEL-5620924 (Intraflagellar transport), R-CEL-5610787 (Hedgehog 'off' state).</p>
+<p>Note on nomenclature: che-11 = <strong>IFT140</strong> (retrograde IFT-A core subunit). This is distinct<br />
+from the paralogous IFT-A subunit <strong>dyf-2 = WDR19/IFT144</strong> (already reviewed in this repo).<br />
+Both are IFT-A core subunits; do not conflate them.</p>
+<h2 id="known-well-supported">KNOWN (well supported)</h2>
+<h3 id="1-che-11-is-a-core-subunit-of-the-ift-a-complex-a-particle">1. CHE-11 is a core subunit of the IFT-A ("Complex A") particle</h3>
+<ul>
+<li><a href="https://pubmed.ncbi.nlm.nih.gov/11301258" title="DAF-10 and CHE-11 (two Complex A polypeptides)">PMID:11301258</a> — Qin, Rosenbaum &amp; Barr<br />
+  (2001) directly identified CHE-11 as one of the two Complex A (IFT-A) polypeptides assayed<br />
+  (with DAF-10), alongside OSM-5 (Complex B) and CHE-2.</li>
+<li>ComplexPortal CPX-1289 (IFT complex A) records CHE-11 as a subunit (NAS, GOA reference<br />
+  PMID:28479320).</li>
+<li><a href="https://pubmed.ncbi.nlm.nih.gov/27930654" title="disrupted CHE-11 (IFT140), which is a component of IFT-A essential for IFT">PMID:27930654</a><br />
+  — Jensen et al. (2016) describe CHE-11 as the IFT140 component of IFT-A that is essential<br />
+  for IFT.</li>
+</ul>
+<h3 id="2-che-11-undergoesdrives-intraflagellar-transport-in-sensory-cilia">2. CHE-11 undergoes/drives intraflagellar transport in sensory cilia</h3>
+<ul>
+<li><a href="https://pubmed.ncbi.nlm.nih.gov/11301258" title="move at the same rate">PMID:11301258</a> — OSM-5, DAF-10, CHE-11 and CHE-2 all move at the<br />
+  same rate along C. elegans sensory cilia (i.e. as part of the moving IFT machinery).</li>
+<li>The IFT-A complex is the retrograde (tip-to-base) module of IFT (driven by cytoplasmic<br />
+  dynein-2); the anterograde module is IFT-B + kinesin-2. As an IFT-A subunit CHE-11 is<br />
+  required for retrograde transport and, because retrograde return of IFT components is needed<br />
+  to sustain the whole cycle, for IFT/cilium assembly overall.</li>
+</ul>
+<h3 id="3-che-11-is-required-for-ciliary-ift-and-cilium-assembly-loss-of-function-phenotype">3. CHE-11 is required for ciliary IFT and cilium assembly (loss-of-function phenotype)</h3>
+<ul>
+<li><a href="https://pubmed.ncbi.nlm.nih.gov/27930654" title="Although GFP::RAB-28 is observed within the truncated cilia of che-11   mutants, we could not detect processive movement of the GFP signals">PMID:27930654</a> — che-11(e1810)<br />
+  mutants have <strong>truncated cilia</strong> and abolished processive ciliary transport of the IFT cargo<br />
+  RAB-28; this establishes CHE-11 as required for (a positive regulator of) IFT of ciliary<br />
+  cargo and for building a normal-length cilium.</li>
+<li>Localizes to the (non-motile) sensory cilium: CHE-11 moves within cilia (PMID:11301258) and<br />
+  CHE-11::GFP is imaged in cilia in IFT studies. GOA carries IDA "non-motile cilium"<br />
+  (PMID:11301258, PMID:17420466).</li>
+</ul>
+<h3 id="4-che-11-mutants-are-dyf-dye-filling-defective-with-structurally-defective-chemosensory-cilia">4. che-11 mutants are Dyf (dye-filling defective) with structurally defective chemosensory cilia</h3>
+<ul>
+<li><a href="https://pubmed.ncbi.nlm.nih.gov/1732156" title="Dauer-defective mutations in nine genes cause structurally defective   chemosensory cilia, thereby blocking chemosensation">PMID:1732156</a> — Vowels &amp; Thomas (1992): che-11 is<br />
+  one of the cilium-structure genes whose mutations block chemosensation and perturb<br />
+  chemosensory (dauer) decision-making.</li>
+<li><a href="https://pubmed.ncbi.nlm.nih.gov/14982934" title="mev-4 had a nonsense mutation on the che-11 gene">PMID:14982934</a> — the paraquat-resistance<br />
+  mutant mev-4 is a che-11 nonsense allele with a <strong>Dyf phenotype</strong> (dye-filling defective).</li>
+</ul>
+<h3 id="5-downstream-pleiotropic-sensory-consequences-of-losing-ciliary-function">5. Downstream / pleiotropic sensory consequences of losing ciliary function</h3>
+<p>These are phenotypes of the <em>cilium-defective animal</em>, not molecular activities of CHE-11.<br />
+- Extended adult lifespan: <a href="https://pubmed.ncbi.nlm.nih.gov/14982934" title="One mutant named mev-4 was long-lived and showed   cross-resistance to heat and Dyf phenotype">PMID:14982934</a>. (Also GOA IMP determination of adult lifespan<br />
+  from PMID:19208769.)<br />
+- Resistance to oxidative stress (paraquat): <a href="https://pubmed.ncbi.nlm.nih.gov/14982934" title="We isolated mutants resistant to   paraquat from nematode Caenorhabditis elegans">PMID:14982934</a>; paraquat is an oxidative-stress generator.<br />
+- Cross-resistance to heat (response to heat): PMID:14982934 (same quote as lifespan).<br />
+- Hyperosmotic response: GOA IMP (PMID:14982934) — WB curator annotation; not stated in the<br />
+  abstract but consistent with Dyf/osmotic-avoidance phenotypes of ciliary mutants.<br />
+- Dauer entry: GOA IGI (PMID:1732156) — genetic interactions with daf genes; cilium-structure<br />
+  gene acting in chemosensory control of the dauer decision.<br />
+These are best captured as KEEP_AS_NON_CORE (pleiotropic, downstream of the ciliary sensory<br />
+defect) rather than core molecular/cellular functions.</p>
+<h3 id="6-conserved-disease-relevance">6. Conserved disease relevance</h3>
+<p>Human IFT140 mutations cause skeletal ciliopathies and retinal dystrophy (short-rib thoracic<br />
+dysplasia / Mainzer–Saldino syndrome / non-syndromic retinitis pigmentosa). Not separately<br />
+cached here; used only as conserved-function context, not for any worm annotation.</p>
+<h2 id="not-known-gaps">NOT known / gaps</h2>
+<ul>
+<li><strong>No molecular_function annotation and no adequate MF term.</strong> CHE-11 is a structural IFT-A<br />
+  scaffold with no catalytic activity; GO has no "structural constituent of intraflagellar<br />
+  transport particle" term, so its MF is effectively dark (same ontology gap as its paralog<br />
+  dyf-2). The worm GOA record for che-11 carries only CC and BP terms.</li>
+<li><strong>Subunit-resolved IFT-A architecture in the worm is not solved.</strong> The precise CHE-11<br />
+  contacts within IFT-A (with DAF-10/IFT122, DYF-2/WDR19, IFT-139, IFT-43, IFTA-1) and how<br />
+  IFT-A engages dynein-2 for retrograde turnaround are inferred from orthology/proteomics, not<br />
+  from a worm structure.</li>
+<li><strong>Anterograde vs retrograde requirement.</strong> GOA carries both "positive regulation of<br />
+  intraciliary anterograde transport" and "...retrograde transport" (IMP, PMID:27930654) for<br />
+  che-11; mechanistically CHE-11/IFT-A is primarily the retrograde module, and the anterograde<br />
+  effect is largely an indirect consequence of failed IFT-component recycling. The direct vs<br />
+  indirect boundary for anterograde regulation is not resolved.</li>
+</ul>
+<h2 id="annotation-review-plan-summary">Annotation review plan (summary)</h2>
+<ul>
+<li>IFT-A membership (GO:0030991), retrograde IFT (GO:0035721), IFT (GO:0042073), cilium<br />
+  assembly (GO:0060271), ciliary localization (non-motile cilium GO:0097730, cilium<br />
+  GO:0005929, axoneme GO:0005930, ciliary basal body GO:0036064): ACCEPT (core / core CC).</li>
+<li>positive regulation of intraciliary retrograde/anterograde transport (PMID:27930654): KEEP —<br />
+  retrograde is on-target (near-core); anterograde is an indirect requirement, non-core.</li>
+<li>Stress/lifespan/dauer/hyperosmotic (PMID:14982934, PMID:1732156, PMID:19208769):<br />
+  KEEP_AS_NON_CORE — pleiotropic downstream sensory phenotypes.</li>
+<li>Core function: structural constituent of IFT-A (MF: structural molecule activity), in_complex<br />
+  IFT particle A, driving intraciliary retrograde transport and cilium assembly.</li>
+</ul>
+<h2 id="update-after-falcon-deep-research-edison-scientific-2026-07-04">Update after falcon deep research (Edison Scientific, 2026-07-04)</h2>
+<p>Genuine falcon report landed at 17:16 after the wrapper's 600s timeout (kept and<br />
+committed as che-11-deep-research-falcon.md; 30 citations to real papers). It<br />
+corroborates the PMID-grounded review above and adds context (citations here are to<br />
+the falcon report's sources, not cached in publications/, so used as context only):</p>
+<ul>
+<li><strong>IFT-A architecture is cryo-EM-solved (general/cross-species).</strong> CHE-11/IFT140 sits in<br />
+  the IFT-A core (A1) with DYF-2/IFT144 and DAF-10/IFT122; IFT140 and IFT144 form an<br />
+  antiparallel TPR–TPR heterodimer (V-shaped, β-propellers splayed ~50 Å), IFT122 bridges<br />
+  A1 to the peripheral A2 module (IFT139/IFT121/IFT43) [Meleppattu et al. 2022 Cell,<br />
+  10.1016/j.cell.2022.11.033]. This is why the review's gap #2 boundary now notes the<br />
+  general architecture is solved while the worm-specific/dynein-2 turnaround remains open.</li>
+<li><strong>Domain division of labour:</strong> N-terminal WD40 β-propellers → retrograde velocity +<br />
+  import of membrane-associated cargo (GPCRs, lipid-anchored signaling proteins); C-terminal<br />
+  TPR → IFT-A assembly [Picariello et al. 2019 J Cell Sci, 10.1242/jcs.220749].</li>
+<li><strong>CHE-11 is required to recruit other IFT-A subunits:</strong> in che-11 mutants IFTA-1 fails to<br />
+  localize to cilia [Blacque et al. 2006 Mol Biol Cell, 10.1091/mbc.e06-06-0571].</li>
+<li><strong>Transition-zone gating (worm-specific):</strong> IFT-140 controls ciliary entry/accumulation of<br />
+  MKS-module proteins and targets IFT-121/IFT-139 to trains [Scheidel &amp; Blacque 2018 Curr<br />
+  Biol, 10.1016/j.cub.2018.08.017] — a worm IFT-140 function not captured in current GOA.</li>
+<li><strong>Transcriptional regulation:</strong> che-11 is a DAF-19/RFX X-box target, co-regulated by FKH-8<br />
+  [Brocal-Ruiz et al. 2023 eLife, 10.7554/eLife.89702]. Consistent with expression in ~30+<br />
+  ciliated sensory neurons.</li>
+<li><strong>Nomenclature confirmed:</strong> CHE-11 = IFT140 (distinct from DYF-2 = WDR19/IFT144). No<br />
+  contradiction with any ACCEPT/KEEP decision in the review.</li>
+</ul>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: P90757
+gene_symbol: che-11
+product_type: PROTEIN
+status: DRAFT
+taxon:
+  id: NCBITaxon:6239
+  label: Caenorhabditis elegans
+description: &gt;-
+  CHE-11 is the Caenorhabditis elegans ortholog of human IFT140, a core subunit
+  of intraflagellar transport complex A (IFT-A). It is a large (1437 aa)
+  scaffolding protein built from two N-terminal WD40 β-propellers followed by an
+  extended tetratricopeptide-repeat (TPR)/α-solenoid, with no catalytic domain.
+  CHE-11 is expressed in ciliated sensory neurons and localizes to the non-motile
+  sensory cilium, where it moves along the axoneme as part of the IFT machinery
+  and concentrates at the ciliary base/basal body. As an IFT-A subunit, CHE-11 is
+  required for retrograde (tip-to-base) intraflagellar transport and, because
+  retrograde return of IFT components sustains the whole transport cycle, for
+  building and maintaining a normal-length ciliary axoneme. Loss of CHE-11
+  produces truncated sensory cilia with disrupted IFT and a dye-filling-defective
+  (Dyf) phenotype; because these cilia mediate chemo- and osmosensation, che-11
+  mutants show impaired chemosensory behaviours, altered dauer formation, and a
+  range of downstream sensory-dependent phenotypes (extended lifespan, resistance
+  to paraquat/oxidative stress and heat). Human IFT140 mutations cause skeletal
+  ciliopathies and retinal dystrophy, underscoring a conserved role in cilium
+  biogenesis.
+references:
+  - id: GO_REF:0000033
+    title: Annotation inferences using phylogenetic trees
+    findings: []
+  - id: GO_REF:0000120
+    title: Combined Automated Annotation using Multiple IEA Methods
+    findings: []
+  - id: PMID:11301258
+    title: An autosomal recessive polycystic kidney disease gene homolog is involved
+      in intraflagellar transport in C. elegans ciliated sensory neurons.
+    findings: []
+    reference_review:
+      relevance: HIGH
+      correctness: VERIFIED
+      review_notes: &gt;-
+        Primary paper directly identifying CHE-11 as one of two Complex A (IFT-A)
+        polypeptides that move along C. elegans sensory cilia at the IFT rate.
+        Note the title&#39;s &#34;ARPKD gene homolog&#34; refers to osm-5/IFT88, not che-11;
+        the che-11 evidence is in the body (Complex A subunit, IFT motility).
+  - id: PMID:14982934
+    title: Mutations in chemosensory cilia cause resistance to paraquat in nematode
+      Caenorhabditis elegans.
+    findings: []
+    reference_review:
+      relevance: MEDIUM
+      correctness: VERIFIED
+      review_notes: &gt;-
+        Identifies the paraquat-resistant, long-lived mutant mev-4 as a che-11
+        nonsense allele with a Dyf phenotype. Supports stress/lifespan phenotypes
+        that are downstream consequences of ciliary/sensory dysfunction rather than
+        molecular functions of CHE-11.
+  - id: PMID:1732156
+    title: Genetic analysis of chemosensory control of dauer formation in Caenorhabditis
+      elegans.
+    findings: []
+    reference_review:
+      relevance: MEDIUM
+      correctness: VERIFIED
+      review_notes: &gt;-
+        Classic genetic study placing che-11 among the cilium-structure genes whose
+        mutations give structurally defective chemosensory cilia and block
+        chemosensation; basis for the dauer-entry (IGI) and cilium-assembly (IGI)
+        annotations.
+  - id: PMID:17420466
+    title: Mutation of the MAP kinase DYF-5 affects docking and undocking of kinesin-2
+      motors and reduces their speed in the cilia of Caenorhabditis elegans.
+    findings: []
+    reference_review:
+      relevance: LOW
+      correctness: VERIFIED
+      review_notes: &gt;-
+        Study of the DYF-5 MAP kinase that also imaged IFT proteins in cilia;
+        source of the IDA non-motile cilium localization for CHE-11. Abstract-only
+        cache does not name che-11, but the curator read the full text.
+  - id: PMID:19208769
+    title: Functional interactions between the ciliopathy-associated Meckel syndrome
+      1 (MKS1) protein and two novel MKS1-related (MKSR) proteins.
+    findings: []
+    reference_review:
+      relevance: LOW
+      correctness: VERIFIED
+      review_notes: &gt;-
+        MKS1/MKSR transition-zone study; source of a WB IMP determination-of-adult-
+        lifespan annotation for a che-11 variant. Lifespan is a downstream sensory
+        consequence, not a core CHE-11 function.
+  - id: PMID:27930654
+    title: Whole-Organism Developmental Expression Profiling Identifies RAB-28 as a
+      Novel Ciliary GTPase Associated with the BBSome and Intraflagellar Transport.
+    findings: []
+    reference_review:
+      relevance: HIGH
+      correctness: VERIFIED
+      review_notes: &gt;-
+        Uses che-11(e1810) as an IFT-A loss-of-function background and describes
+        CHE-11 as the IFT140 component of IFT-A essential for IFT; RAB-28 IFT
+        movement is abolished in che-11 mutant truncated cilia. Basis for the
+        positive-regulation-of-IFT annotations.
+  - id: PMID:28479320
+    title: Dynein-Driven Retrograde Intraflagellar Transport Is Triphasic in C. elegans
+      Sensory Cilia.
+    findings: []
+    reference_review:
+      relevance: MEDIUM
+      correctness: VERIFIED
+      review_notes: &gt;-
+        Retrograde (dynein-2/IFT-A) transport study; cited by ComplexPortal (CPX-1289)
+        for the NAS IFT-A complex-membership and retrograde-transport annotations.
+        The abstract discusses IFT-A subunits IFT-139/IFT-43 and dynein-2, not che-11
+        by name.
+existing_annotations:
+  - term:
+      id: GO:0035721
+      label: intraciliary retrograde transport
+    evidence_type: IBA
+    original_reference_id: GO_REF:0000033
+    qualifier: involved_in
+    review:
+      summary: &gt;-
+        As a core IFT-A subunit (IFT140 ortholog), CHE-11 is required for
+        retrograde (tip-to-base) intraflagellar transport, the defining function
+        of the IFT-A complex.
+      action: ACCEPT
+      reason: &gt;-
+        Represents the core biological process of the gene. Phylogenetic inference
+        agrees with direct evidence that CHE-11 is an IFT-A (&#34;Complex A&#34;) subunit
+        essential for IFT.
+      supported_by:
+        - reference_id: PMID:27930654
+          supporting_text: which is a component of IFT-A essential for IFT
+  - term:
+      id: GO:0036064
+      label: ciliary basal body
+    evidence_type: IBA
+    original_reference_id: GO_REF:0000033
+    qualifier: is_active_in
+    review:
+      summary: &gt;-
+        IFT-A subunits, including the IFT140 ortholog CHE-11, concentrate at and
+        act from the ciliary base/basal body where IFT trains are assembled and
+        turned around.
+      action: ACCEPT
+      reason: &gt;-
+        Consistent core localization for an IFT-A subunit; phylogenetically
+        inferred and in line with the ciliary/base localization of IFT proteins.
+  - term:
+      id: GO:0005930
+      label: axoneme
+    evidence_type: IBA
+    original_reference_id: GO_REF:0000033
+    qualifier: is_active_in
+    review:
+      summary: &gt;-
+        CHE-11 moves along the ciliary axoneme as part of the IFT machinery.
+      action: ACCEPT
+      reason: &gt;-
+        Core localization; IFT-A subunits traffic along the axoneme. Corroborated
+        by direct observation that CHE-11 moves along C. elegans sensory cilia.
+      supported_by:
+        - reference_id: PMID:11301258
+          supporting_text: move at the same rate
+  - term:
+      id: GO:0030991
+      label: intraciliary transport particle A
+    evidence_type: IBA
+    original_reference_id: GO_REF:0000033
+    qualifier: part_of
+    review:
+      summary: &gt;-
+        CHE-11 is a core subunit of the IFT-A complex, established by orthology to
+        IFT140 and by direct identification as a Complex A polypeptide in the worm.
+      action: ACCEPT
+      reason: &gt;-
+        The defining cellular-component assignment for this gene; strongly
+        supported by phylogeny and experiment.
+      supported_by:
+        - reference_id: PMID:11301258
+          supporting_text: two Complex A polypeptides
+  - term:
+      id: GO:0005929
+      label: cilium
+    evidence_type: IEA
+    original_reference_id: GO_REF:0000120
+    qualifier: located_in
+    review:
+      summary: &gt;-
+        Electronic annotation placing CHE-11 in the cilium; correct but less
+        specific than the experimentally supported non-motile cilium term.
+      action: ACCEPT
+      reason: &gt;-
+        Correct ciliary localization. A more specific term (non-motile cilium) is
+        also annotated by IDA; the general term is retained as consistent.
+  - term:
+      id: GO:0005929
+      label: cilium
+    evidence_type: NAS
+    original_reference_id: PMID:28479320
+    qualifier: located_in
+    review:
+      summary: &gt;-
+        ComplexPortal (CPX-1289) complex-based assertion that CHE-11, as an IFT-A
+        subunit, localizes to the cilium.
+      action: ACCEPT
+      reason: &gt;-
+        Correct ciliary localization consistent with all other evidence; a more
+        specific non-motile cilium term is also present.
+  - term:
+      id: GO:0030991
+      label: intraciliary transport particle A
+    evidence_type: NAS
+    original_reference_id: PMID:28479320
+    qualifier: part_of
+    review:
+      summary: &gt;-
+        ComplexPortal complex-membership assertion that CHE-11 is part of IFT-A;
+        redundant with, and corroborated by, the IBA and ISS IFT-A annotations.
+      action: ACCEPT
+      reason: &gt;-
+        Core complex membership; consistent across ComplexPortal, phylogeny and
+        experimental identification as a Complex A polypeptide.
+  - term:
+      id: GO:0035721
+      label: intraciliary retrograde transport
+    evidence_type: NAS
+    original_reference_id: PMID:28479320
+    qualifier: involved_in
+    review:
+      summary: &gt;-
+        ComplexPortal assertion that the IFT-A complex containing CHE-11 mediates
+        retrograde intraflagellar transport.
+      action: ACCEPT
+      reason: &gt;-
+        Core biological process for an IFT-A subunit; redundant with the IBA
+        retrograde-transport annotation.
+  - term:
+      id: GO:0060271
+      label: cilium assembly
+    evidence_type: NAS
+    original_reference_id: PMID:28479320
+    qualifier: involved_in
+    review:
+      summary: &gt;-
+        IFT-A function (via CHE-11) is required to build and maintain the ciliary
+        axoneme; ComplexPortal complex-based assertion.
+      action: ACCEPT
+      reason: &gt;-
+        Core process, downstream of the direct IFT transport activity; corroborated
+        by the truncated-cilia phenotype of che-11 mutants.
+      supported_by:
+        - reference_id: PMID:27930654
+          supporting_text: Although GFP::RAB-28 is observed within the truncated cilia
+            of che-11 mutants, we could not detect processive movement of the GFP signals
+  - term:
+      id: GO:1905798
+      label: positive regulation of intraciliary anterograde transport
+    evidence_type: IMP
+    original_reference_id: PMID:27930654
+    qualifier: involved_in
+    review:
+      summary: &gt;-
+        In che-11 mutants, processive (anterograde and retrograde) movement of the
+        ciliary cargo RAB-28 is abolished, so CHE-11 is required for anterograde IFT
+        of cargo.
+      action: KEEP_AS_NON_CORE
+      reason: &gt;-
+        CHE-11/IFT-A is mechanistically the retrograde module; the requirement for
+        anterograde cargo transport is largely indirect (failure to recycle IFT
+        components and truncated cilia). Real but peripheral to the core retrograde
+        role, so retained as non-core.
+      supported_by:
+        - reference_id: PMID:27930654
+          supporting_text: Although GFP::RAB-28 is observed within the truncated cilia
+            of che-11 mutants, we could not detect processive movement of the GFP signals
+  - term:
+      id: GO:1905801
+      label: positive regulation of intraciliary retrograde transport
+    evidence_type: IMP
+    original_reference_id: PMID:27930654
+    qualifier: involved_in
+    review:
+      summary: &gt;-
+        CHE-11 is required for retrograde intraflagellar transport of ciliary cargo;
+        loss abolishes processive movement in cilia.
+      action: ACCEPT
+      reason: &gt;-
+        On-target with the core retrograde IFT function of IFT-A; CHE-11 is
+        essential for IFT and its loss abolishes ciliary cargo transport.
+      supported_by:
+        - reference_id: PMID:27930654
+          supporting_text: which is a component of IFT-A essential for IFT
+  - term:
+      id: GO:0097730
+      label: non-motile cilium
+    evidence_type: IDA
+    original_reference_id: PMID:17420466
+    qualifier: located_in
+    review:
+      summary: &gt;-
+        Direct imaging localizes CHE-11 to the non-motile sensory cilium.
+      action: ACCEPT
+      reason: &gt;-
+        Core cellular-component localization, directly observed. C. elegans sensory
+        cilia are non-motile.
+  - term:
+      id: GO:0043053
+      label: dauer entry
+    evidence_type: IGI
+    original_reference_id: PMID:1732156
+    qualifier: involved_in
+    review:
+      summary: &gt;-
+        che-11 is one of the cilium-structure genes whose mutations perturb the
+        chemosensory control of dauer formation; genetic interactions with daf
+        genes.
+      action: KEEP_AS_NON_CORE
+      reason: &gt;-
+        Dauer formation is a downstream, sensory-dependent behavioural output of
+        cilium integrity, not a molecular/cellular function of CHE-11. Retained as
+        a non-core pleiotropic phenotype.
+      supported_by:
+        - reference_id: PMID:1732156
+          supporting_text: Dauer-defective mutations in nine genes cause structurally
+            defective chemosensory cilia, thereby blocking chemosensation
+  - term:
+      id: GO:0060271
+      label: cilium assembly
+    evidence_type: IGI
+    original_reference_id: PMID:1732156
+    qualifier: involved_in
+    review:
+      summary: &gt;-
+        Loss of che-11 gives structurally defective chemosensory cilia, indicating
+        a requirement in building the sensory cilium.
+      action: ACCEPT
+      reason: &gt;-
+        Core process for an IFT-A subunit; the structurally defective cilia of
+        che-11 mutants support a role in cilium assembly/integrity.
+      supported_by:
+        - reference_id: PMID:1732156
+          supporting_text: Dauer-defective mutations in nine genes cause structurally
+            defective chemosensory cilia, thereby blocking chemosensation
+  - term:
+      id: GO:0097730
+      label: non-motile cilium
+    evidence_type: IDA
+    original_reference_id: PMID:11301258
+    qualifier: located_in
+    review:
+      summary: &gt;-
+        CHE-11 localizes to and moves within C. elegans sensory (non-motile) cilia.
+      action: ACCEPT
+      reason: &gt;-
+        Core cellular-component localization, directly observed as a Complex A
+        polypeptide moving along sensory cilia.
+      supported_by:
+        - reference_id: PMID:11301258
+          supporting_text: two Complex A polypeptides
+  - term:
+      id: GO:0008340
+      label: determination of adult lifespan
+    evidence_type: IMP
+    original_reference_id: PMID:14982934
+    qualifier: involved_in
+    review:
+      summary: &gt;-
+        A che-11 nonsense mutant (mev-4) is long-lived; lifespan extension is a
+        downstream consequence of impaired chemosensory (ciliary) signaling.
+      action: KEEP_AS_NON_CORE
+      reason: &gt;-
+        Adult-lifespan modulation is an indirect, sensory-dependent phenotype of
+        losing ciliary function (the paper notes it is daf-16-dependent), not a
+        molecular function of CHE-11. Retained as non-core.
+      supported_by:
+        - reference_id: PMID:14982934
+          supporting_text: One mutant named mev-4 was long-lived and showed cross-resistance
+            to heat and Dyf phenotype
+  - term:
+      id: GO:0008340
+      label: determination of adult lifespan
+    evidence_type: IMP
+    original_reference_id: PMID:19208769
+    qualifier: involved_in
+    review:
+      summary: &gt;-
+        Second IMP for determination of adult lifespan from a transition-zone
+        (MKS) study, using a che-11 variant.
+      action: KEEP_AS_NON_CORE
+      reason: &gt;-
+        Same downstream, sensory-dependent lifespan phenotype as the PMID:14982934
+        annotation; a pleiotropic consequence of ciliary dysfunction, not a core
+        function.
+  - term:
+      id: GO:0030991
+      label: intraciliary transport particle A
+    evidence_type: ISS
+    original_reference_id: PMID:14982934
+    qualifier: part_of
+    review:
+      summary: &gt;-
+        Sequence-similarity annotation (from an IFT140 ortholog) placing CHE-11 in
+        the IFT-A particle.
+      action: ACCEPT
+      reason: &gt;-
+        Core complex membership; consistent with the IBA and ComplexPortal IFT-A
+        annotations and with experimental identification as a Complex A polypeptide.
+  - term:
+      id: GO:0042073
+      label: intraciliary transport
+    evidence_type: ISS
+    original_reference_id: PMID:14982934
+    qualifier: involved_in
+    review:
+      summary: &gt;-
+        CHE-11 participates in intraflagellar transport, the general process
+        subsuming its retrograde IFT-A role.
+      action: ACCEPT
+      reason: &gt;-
+        Core biological process; the more specific retrograde-transport term is
+        also annotated. Corroborated by direct observation of CHE-11 IFT motility.
+      supported_by:
+        - reference_id: PMID:11301258
+          supporting_text: move at the same rate
+  - term:
+      id: GO:0006972
+      label: hyperosmotic response
+    evidence_type: IMP
+    original_reference_id: PMID:14982934
+    qualifier: involved_in
+    review:
+      summary: &gt;-
+        WB IMP annotation for hyperosmotic response, based on a che-11 mutant.
+      action: KEEP_AS_NON_CORE
+      reason: &gt;-
+        Osmotic-response phenotypes of che-11 mutants reflect loss of sensory
+        (ciliary) function rather than a molecular role of CHE-11 in osmotic
+        signaling. Retained as a non-core downstream phenotype.
+  - term:
+      id: GO:0006979
+      label: response to oxidative stress
+    evidence_type: IMP
+    original_reference_id: PMID:14982934
+    qualifier: involved_in
+    review:
+      summary: &gt;-
+        che-11 (mev-4) mutants are resistant to paraquat, an oxidative-stress
+        generator.
+      action: KEEP_AS_NON_CORE
+      reason: &gt;-
+        Paraquat/oxidative-stress resistance is a downstream, sensory-dependent
+        consequence of ciliary dysfunction (the authors conclude chemosensory
+        neurons are a target of oxidative stress influencing longevity), not a
+        molecular function of CHE-11.
+      supported_by:
+        - reference_id: PMID:14982934
+          supporting_text: We isolated mutants resistant to paraquat from nematode
+  - term:
+      id: GO:0009408
+      label: response to heat
+    evidence_type: IMP
+    original_reference_id: PMID:14982934
+    qualifier: involved_in
+    review:
+      summary: &gt;-
+        che-11 (mev-4) mutants show cross-resistance to heat.
+      action: KEEP_AS_NON_CORE
+      reason: &gt;-
+        Heat cross-resistance is a downstream, sensory-dependent phenotype of
+        cilium loss, not a molecular function of CHE-11. Retained as non-core.
+      supported_by:
+        - reference_id: PMID:14982934
+          supporting_text: One mutant named mev-4 was long-lived and showed cross-resistance
+            to heat and Dyf phenotype
+core_functions:
+  - description: &gt;-
+      Structural constituent of intraflagellar transport complex A (IFT-A) that
+      drives retrograde (tip-to-base) intraflagellar transport along the sensory
+      cilium. As the IFT140 ortholog, CHE-11 has no catalytic activity; it is a
+      WD40 β-propeller + TPR/α-solenoid scaffold that helps hold the IFT-A particle
+      together and is essential for IFT.
+    molecular_function:
+      id: GO:0005198
+      label: structural molecule activity
+    directly_involved_in:
+      - id: GO:0035721
+        label: intraciliary retrograde transport
+      - id: GO:0042073
+        label: intraciliary transport
+    locations:
+      - id: GO:0097730
+        label: non-motile cilium
+    in_complex:
+      id: GO:0030991
+      label: intraciliary transport particle A
+    supported_by:
+      - reference_id: PMID:11301258
+        supporting_text: two Complex A polypeptides
+      - reference_id: PMID:27930654
+        supporting_text: which is a component of IFT-A essential for IFT
+  - description: &gt;-
+      Required for assembly and structural integrity of the non-motile sensory
+      cilium: IFT-A function via CHE-11 is needed to build and maintain the ciliary
+      axoneme, and its loss produces truncated cilia with abolished processive
+      ciliary transport.
+    directly_involved_in:
+      - id: GO:0060271
+        label: cilium assembly
+    locations:
+      - id: GO:0097730
+        label: non-motile cilium
+    supported_by:
+      - reference_id: PMID:27930654
+        supporting_text: Although GFP::RAB-28 is observed within the truncated cilia
+          of che-11 mutants, we could not detect processive movement of the GFP signals
+      - reference_id: PMID:1732156
+        supporting_text: Dauer-defective mutations in nine genes cause structurally
+          defective chemosensory cilia, thereby blocking chemosensation
+knowledge_gaps:
+  - gap_statement: &gt;-
+      CHE-11 has no molecular_function annotation and there is no adequate GO term
+      to express one. Its role is to be a structural constituent of the IFT-A
+      particle, but GO has no &#34;structural constituent of the intraflagellar
+      transport particle&#34; molecular function term, so the gene reads as MF-dark
+      despite a well-understood cellular and process-level role.
+    boundary: &gt;-
+      It is firmly established that CHE-11 = IFT140 is a WD40+TPR scaffolding
+      subunit of IFT-A with no catalytic domain, required for retrograde IFT and
+      cilium assembly. What is missing is a molecular-function representation: the
+      worm GOA record carries only cellular-component and biological-process terms
+      and no molecular_function annotation at all.
+    gap_kind:
+      - ONTOLOGY
+      - CURATION
+    dark_aspect: MF_DARK
+    status: OPEN
+    significance: &gt;-
+      This is the canonical &#34;structural subunit&#34; ontology gap shared across the
+      IFT/ciliopathy gene set (e.g. its paralog dyf-2/WDR19): a mechanistically
+      well-understood protein that cannot be annotated with an informative MF term,
+      contributing to apparent molecular-function darkness.
+    resolution: &gt;-
+      Develop/adopt a molecular-function term for a structural constituent of the
+      IFT particle (analogous to &#34;structural constituent of ribosome&#34;), then
+      annotate CHE-11 (and other IFT-A/IFT-B core subunits) to it.
+    provenance:
+      - reference_id: PMID:27930654
+        supporting_text: which is a component of IFT-A essential for IFT
+        reference_section_type: RESULTS
+    proposed_terms:
+      - proposed_name: structural constituent of intraflagellar transport particle
+        proposed_definition: &gt;-
+          The action of a protein that contributes to the structural integrity of an
+          intraflagellar transport (IFT) particle (IFT-A or IFT-B subcomplex), for
+          example by acting as a WD40/TPR scaffold that holds core IFT subunits
+          together and enables their bidirectional transport along the ciliary
+          axoneme, without itself catalyzing a biochemical reaction.
+        proposed_parent:
+          id: GO:0005198
+          label: structural molecule activity
+  - gap_statement: &gt;-
+      The subunit-resolved architecture of the worm IFT-A complex and the precise
+      role of CHE-11 in the retrograde turnaround are not solved: how CHE-11 (IFT140)
+      contacts the other IFT-A subunits (DAF-10/IFT122, DYF-2/WDR19, IFT-139,
+      IFT-43, IFTA-1) and how IFT-A licenses dynein-2 for retrograde transport in
+      C. elegans are inferred from orthology and proteomics, not from a worm
+      structure.
+    boundary: &gt;-
+      IFT-A composition and the essentiality of CHE-11 for IFT are established
+      genetically and biochemically, and the general IFT-A architecture (including
+      the IFT140–IFT144/DYF-2 TPR heterodimer that forms the A1 core) has been
+      solved by cryo-EM in other species. What remains incompletely understood is
+      how the dynein-2 motor moves and is regulated within the cilium, how CHE-11/
+      IFT-A licenses retrograde turnaround in C. elegans, and the subunit-resolved
+      arrangement of the worm complex specifically.
+    gap_kind:
+      - BIOLOGY
+    dark_aspect: RESIDUAL_SUBGAP
+    status: OPEN
+    significance: &gt;-
+      The retrograde turnaround and dynein-2 engagement is the load-bearing,
+      incompletely understood step of the IFT cycle; resolving it would explain how
+      IFT-A subunits such as CHE-11/IFT140 organize retrograde transport and how
+      ciliopathy-causing IFT140 mutations disrupt it.
+    resolution: &gt;-
+      Cryo-EM of the worm IFT-A complex (and of an IFT-A–dynein-2 assembly) plus
+      structure-guided separation-of-function mutagenesis of CHE-11 with
+      retrograde-IFT readouts.
+    provenance:
+      - reference_id: PMID:28479320
+        supporting_text: it remains unclear how the dynein-2 heavy chain moves in cilia
+        reference_section_type: ABSTRACT
+  - gap_statement: &gt;-
+      Whether CHE-11 has any direct role in anterograde intraflagellar transport,
+      as opposed to an indirect requirement, is unresolved. che-11 mutants lose both
+      anterograde and retrograde processive movement of ciliary cargo, but IFT-A is
+      mechanistically the retrograde module, so the anterograde effect may be a
+      secondary consequence of failed IFT-component recycling and truncated cilia.
+    boundary: &gt;-
+      It is established that loss of CHE-11 abolishes processive ciliary transport
+      of cargo (e.g. RAB-28) in both directions and that IFT-A powers retrograde IFT;
+      what is not separated is a direct CHE-11 contribution to anterograde train
+      formation versus an indirect downstream effect.
+    gap_kind:
+      - BIOLOGY
+      - CURATION
+    dark_aspect: BP_DARK
+    status: OPEN
+    significance: &gt;-
+      Distinguishing direct from indirect anterograde requirement determines whether
+      the &#34;positive regulation of intraciliary anterograde transport&#34; annotation
+      reflects a genuine CHE-11 activity or a system-level consequence, affecting how
+      IFT-A subunits are modelled in ciliary transport.
+    resolution: &gt;-
+      Time-resolved, allele-specific IFT imaging (separation-of-function CHE-11
+      alleles) that measures anterograde train formation before secondary cilium
+      truncation, distinguishing a direct contribution from an indirect effect.
+    provenance:
+      - reference_id: PMID:27930654
+        supporting_text: Although GFP::RAB-28 is observed within the truncated cilia
+          of che-11 mutants, we could not detect processive movement of the GFP signals
+        reference_section_type: RESULTS
+proposed_new_terms:
+  - proposed_name: structural constituent of intraflagellar transport particle
+    proposed_definition: &gt;-
+      The action of a protein that contributes to the structural integrity of an
+      intraflagellar transport (IFT) particle (IFT-A or IFT-B subcomplex), for
+      example by acting as a WD40/TPR scaffold that holds core IFT subunits together
+      and enables their bidirectional transport along the ciliary axoneme, without
+      itself catalyzing a biochemical reaction.
+    proposed_parent:
+      id: GO:0005198
+      label: structural molecule activity
+suggested_questions:
+  - question: &gt;-
+      Does CHE-11/IFT140 make direct, separable contributions to anterograde IFT, or
+      is the anterograde defect in che-11 mutants entirely secondary to failed
+      retrograde recycling and cilium truncation?
+  - question: &gt;-
+      What is the subunit-resolved architecture of the C. elegans IFT-A complex and
+      the CHE-11 interface with dynein-2 during retrograde turnaround?
+suggested_experiments:
+  - description: &gt;-
+      Cryo-EM of the intact worm IFT-A complex and of an IFT-A–dynein-2 assembly to
+      map CHE-11 subunit contacts and the retrograde-turnaround interface.
+    hypothesis: &gt;-
+      CHE-11/IFT140 occupies a defined structural position in IFT-A that mediates
+      dynein-2 engagement for retrograde transport.
+  - description: &gt;-
+      Allele-specific, time-resolved IFT imaging using separation-of-function CHE-11
+      alleles to measure anterograde train formation before secondary cilium
+      truncation, separating direct from indirect anterograde requirements.
+    hypothesis: &gt;-
+      The anterograde-transport defect in che-11 mutants is an indirect consequence
+      of failed retrograde recycling rather than a direct CHE-11 anterograde role.
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/genes/worm/daf-10/daf-10-ai-review.html
+++ b/genes/worm/daf-10/daf-10-ai-review.html
@@ -1,0 +1,3919 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>daf-10 - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        .propagation-review {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f8fafc;
+            border-left: 3px solid #64748b;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .propagation-title {
+            font-weight: 600;
+            color: #334155;
+            margin-bottom: 0.25rem;
+        }
+
+        .propagation-row {
+            margin-top: 0.25rem;
+        }
+
+        .propagation-source {
+            margin-top: 0.5rem;
+            padding-top: 0.5rem;
+            border-top: 1px solid #e5e7eb;
+        }
+
+        .propagation-source-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #1d4ed8;
+        }
+
+        .propagation-comment {
+            color: #4b5563;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>daf-10</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/G5EFW7" target="_blank" class="term-link">
+                        G5EFW7
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Caenorhabditis elegans</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-complete">
+                    COMPLETE
+                </span>
+            </div>
+
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "daf-10";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="G5EFW7" data-a="DESCRIPTION: DAF-10 is the Caenorhabditis elegans ortholog of h..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>DAF-10 is the Caenorhabditis elegans ortholog of human IFT122, a core subunit of intraflagellar transport complex A (IFT-A). It is a large (1192 aa) WD40 β-propeller plus tetratricopeptide-repeat (TPR) solenoid scaffold with a C-terminal zinc-ribbon and no catalytic domain, expressed in ciliated sensory neurons and shuttling along the axoneme of the non-motile sensory cilium at the same rate as IFT-B proteins. As part of IFT-A, DAF-10 is required for retrograde (ciliary tip-to-base) intraflagellar transport powered by cytoplasmic dynein-2, and thereby for assembly and maintenance of the sensory-cilium axoneme and for import of ciliary membrane cargo such as G protein-coupled receptors. Loss of DAF-10 produces structurally defective, disorganized sensory cilia with the characteristic IFT-A retrograde-defect signature (accumulation of IFT-B/OSM-6 material in the ciliary endings), together with dye-filling and chemotaxis defects. Because worm sensory cilia detect environmental cues, daf-10 mutants are dauer-formation-defective (the origin of the gene name, abnormal DAuer Formation) and show altered sensory modulation of insulin/IGF and TGF-β signaling. IFT122 mutations cause human ciliopathies (cranioectodermal dysplasia / Sensenbrenner syndrome), underscoring a conserved role in cilium biogenesis.</p>
+    </div>
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Proposed New Ontology Terms</h2>
+
+        <div class="proposed-term">
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>structural constituent of intraflagellar transport particle</h3>
+                <span class="vote-buttons" data-g="G5EFW7" data-a="structural constituent of intraflagellar transport particle" data-r="" data-act="NEW">
+                    <button class="vote-btn" data-v="up" title="Agree this term should be created">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with creating this term">👎</button>
+                </span>
+            </div>
+
+
+            <p><strong>Definition:</strong> The action of a protein that contributes to the structural integrity of an intraflagellar transport (IFT) particle (IFT-A or IFT-B subcomplex), for example by acting as a WD40/TPR scaffold that holds core IFT subunits together and enables their bidirectional transport along the ciliary axoneme, without itself catalyzing a biochemical reaction.</p>
+
+
+
+
+
+            <p><strong>Parent term:</strong>
+                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005198" target="_blank" class="term-link">
+                    structural molecule activity
+                </a>
+            </p>
+
+
+
+
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0061512" target="_blank" class="term-link">
+                                    GO:0061512
+                                </a>
+                            </span>
+                            <span class="term-label">protein localization to cilium</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="G5EFW7" data-a="GO:0061512" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> As an IFT-A subunit, DAF-10 transports and localizes protein cargo along the ciliary axoneme; loss of daf-10 disrupts the distribution of IFT-B (OSM-6) material in the ciliary endings.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Core process. Phylogenetic inference agrees with the founding paper, which established daf-10 as an IFT gene mediating the bidirectional movement of particles along the ciliary axoneme (i.e. protein localization within the cilium).
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/16648645" target="_blank" class="term-link">
+                                        PMID:16648645
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Some genes in this category are known to be required for intraflagellar transport (IFT), which is the bidirectional movement of raft-like particles along the axonemes of cilia and flagella</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0035721" target="_blank" class="term-link">
+                                    GO:0035721
+                                </a>
+                            </span>
+                            <span class="term-label">intraciliary retrograde transport</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="G5EFW7" data-a="GO:0035721" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> As a core IFT-A subunit, DAF-10 is required for retrograde (tip-to-base) intraflagellar transport, the defining function of IFT-A.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Represents the core biological process of the gene. Phylogenetic inference is corroborated by the IFT-A/retrograde-defect phenotype of daf-10 mutants and by mass-spec placement of DAF-10 in the worm IFT-A complex.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/28479320" target="_blank" class="term-link">
+                                        PMID:28479320
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Cytoplasmic dynein-2 powers retrograde intraflagellar transport that is essential for cilium formation and maintenance</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0097730" target="_blank" class="term-link">
+                                    GO:0097730
+                                </a>
+                            </span>
+                            <span class="term-label">non-motile cilium</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="G5EFW7" data-a="GO:0097730" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> DAF-10 acts within the worm&#39;s non-motile sensory cilia, where it shuttles along the axoneme as part of IFT-A.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Core localization, accurately specific to the worm&#39;s non-motile sensory cilia. Phylogenetic inference agrees with the direct ciliary localization of DAF-10 (IFT shuttling in amphid/phasmid cilia) and with the mutant cilia phenotype.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1905515" target="_blank" class="term-link">
+                                    GO:1905515
+                                </a>
+                            </span>
+                            <span class="term-label">non-motile cilium assembly</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="G5EFW7" data-a="GO:1905515" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IFT-A/retrograde transport by DAF-10 is required to build and maintain the non-motile sensory-cilium axoneme; loss of daf-10 gives structurally defective cilia.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Core process, accurately specific for the worm&#39;s non-motile sensory cilia. Phylogenetic inference is corroborated by the ciliogenesis defect of daf-10 mutants.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/21124868" target="_blank" class="term-link">
+                                        PMID:21124868
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">daf-10/IFT122 mutations (which disrupt ciliogenesis)</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030991" target="_blank" class="term-link">
+                                    GO:0030991
+                                </a>
+                            </span>
+                            <span class="term-label">intraciliary transport particle A</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="G5EFW7" data-a="GO:0030991" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> DAF-10 is a core subunit of the IFT-A complex, established by orthology to IFT122 and by direct mass-spec identification in the worm IFT-A complex.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Core complex membership. Phylogenetic inference agrees with the experimental (NAS/mass-spec, ISS) IFT-A assignments; the founding paper notes that the WAA-repeat architecture shared by daf-10 is characteristic of IFT particle components.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/16648645" target="_blank" class="term-link">
+                                        PMID:16648645
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The daf-10 and osm-1 gene products resemble each other and contain WD and WAA repeats</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005929" target="_blank" class="term-link">
+                                    GO:0005929
+                                </a>
+                            </span>
+                            <span class="term-label">cilium</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000044
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="G5EFW7" data-a="GO:0005929" data-r="GO_REF:0000044" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic (UniProt SubCell) assertion of ciliary localization, redundant with the more specific non-motile cilium annotation.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct location; consistent with the direct evidence that DAF-10 shuttles along sensory cilia, albeit less specific than the non-motile cilium term.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0060271" target="_blank" class="term-link">
+                                    GO:0060271
+                                </a>
+                            </span>
+                            <span class="term-label">cilium assembly</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000120
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="G5EFW7" data-a="GO:0060271" data-r="GO_REF:0000120" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic (ARBA/InterPro) annotation of the IFT-A cilium-assembly role, redundant with the experimental IGI/IMP and phylogenetic annotations.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct core process; consistent with the ciliogenesis defect of daf-10 mutants, though less specific than the non-motile cilium assembly term.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005929" target="_blank" class="term-link">
+                                    GO:0005929
+                                </a>
+                            </span>
+                            <span class="term-label">cilium</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">NAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/28479320" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:28479320
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Dynein-Driven Retrograde Intraflagellar Transport Is Triphas...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="G5EFW7" data-a="GO:0005929" data-r="PMID:28479320" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> ComplexPortal (CPX-1289) NAS assertion of ciliary localization for the IFT-A complex, based on the mass-spec study of worm retrograde IFT.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct core localization, consistent with the direct ciliary shuttling of DAF-10.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030991" target="_blank" class="term-link">
+                                    GO:0030991
+                                </a>
+                            </span>
+                            <span class="term-label">intraciliary transport particle A</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">NAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/28479320" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:28479320
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Dynein-Driven Retrograde Intraflagellar Transport Is Triphas...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="G5EFW7" data-a="GO:0030991" data-r="PMID:28479320" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> ComplexPortal NAS annotation placing DAF-10 in the IFT-A complex, based on affinity purification / mass spectrometry of the worm IFT-A complex (che-11, daf-10, dyf-2, ift-139, ift-43, ifta-1).
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Core complex membership, experimentally grounded (mass-spec definition of the worm IFT-A complex, which includes DAF-10).
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/28479320" target="_blank" class="term-link">
+                                        PMID:28479320
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">our affinity purification and genetic analyses show that IFT-A</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0035721" target="_blank" class="term-link">
+                                    GO:0035721
+                                </a>
+                            </span>
+                            <span class="term-label">intraciliary retrograde transport</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">NAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/28479320" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:28479320
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Dynein-Driven Retrograde Intraflagellar Transport Is Triphas...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="G5EFW7" data-a="GO:0035721" data-r="PMID:28479320" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> ComplexPortal NAS annotation of the IFT-A retrograde-transport role.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Core process, consistent with the experimental and phylogenetic evidence for DAF-10 as a retrograde IFT-A subunit.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/28479320" target="_blank" class="term-link">
+                                        PMID:28479320
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Cytoplasmic dynein-2 powers retrograde intraflagellar transport that is essential for cilium formation and maintenance</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0060271" target="_blank" class="term-link">
+                                    GO:0060271
+                                </a>
+                            </span>
+                            <span class="term-label">cilium assembly</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">NAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/28479320" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:28479320
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Dynein-Driven Retrograde Intraflagellar Transport Is Triphas...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="G5EFW7" data-a="GO:0060271" data-r="PMID:28479320" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> ComplexPortal NAS annotation of the cilium-assembly role of IFT-A.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct; downstream outcome of the IFT-A transport function and consistent with the ciliogenesis defect of daf-10 mutants.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030991" target="_blank" class="term-link">
+                                    GO:0030991
+                                </a>
+                            </span>
+                            <span class="term-label">intraciliary transport particle A</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ISS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000024
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="G5EFW7" data-a="GO:0030991" data-r="GO_REF:0000024" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Sequence-similarity (ISS) transfer of IFT-A membership from the human ortholog IFT122 (Q9HBG6).
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Core complex membership; the ISS to human IFT122 agrees with the direct mass-spec IFT-A assignment in the worm.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0036064" target="_blank" class="term-link">
+                                    GO:0036064
+                                </a>
+                            </span>
+                            <span class="term-label">ciliary basal body</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/27623382" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:27623382
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    A Conserved Role for Girdin in Basal Body Positioning and Ci...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="G5EFW7" data-a="GO:0036064" data-r="PMID:27623382" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct-assay assertion of DAF-10 at the ciliary basal body, from a study of Girdin-dependent basal-body positioning and ciliogenesis.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Biologically consistent location: IFT-A proteins concentrate at the ciliary base / transition-fibre region before axonemal entry. Retained as a genuine location per repo guidance not to overrule an experimental IDA; the cached record is abstract-only and does not name daf-10, so the datum is deferred to the curator&#39;s full-text reading (see reference_review). A secondary/base localization rather than the core axonemal-transport function.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0061065" target="_blank" class="term-link">
+                                    GO:0061065
+                                </a>
+                            </span>
+                            <span class="term-label">regulation of dauer larval development</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IGI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/21124868" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:21124868
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Localization of a guanylyl cyclase to chemosensory cilia req...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="G5EFW7" data-a="GO:0061065" data-r="PMID:21124868" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Genetic interaction with daf-25/Ankmy2: daf-10 loss (disrupting ciliogenesis) suppresses the daf-25 dauer-constitutive phenotype, implicating daf-10 in the chemosensory control of dauer formation.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Valid genetic-interaction phenotype, but a downstream consequence of the ciliary/IFT defect (functional chemosensory cilia are required to sense the dauer cues), not a core molecular function of an IFT-A structural subunit.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/21124868" target="_blank" class="term-link">
+                                        PMID:21124868
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">daf-10/IFT122 mutations (which disrupt ciliogenesis)</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0060271" target="_blank" class="term-link">
+                                    GO:0060271
+                                </a>
+                            </span>
+                            <span class="term-label">cilium assembly</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IGI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/1732156" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:1732156
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Genetic analysis of chemosensory control of dauer formation ...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="G5EFW7" data-a="GO:0060271" data-r="PMID:1732156" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> daf-10 is among the dauer-defective genes whose mutations cause structurally defective chemosensory cilia, implicating it in building the sensory cilium.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Core process; the cilium-structure defect of daf-10 mutants directly supports a requirement in ciliary assembly/maintenance.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/1732156" target="_blank" class="term-link">
+                                        PMID:1732156
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">structurally defective chemosensory cilia</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0061066" target="_blank" class="term-link">
+                                    GO:0061066
+                                </a>
+                            </span>
+                            <span class="term-label">positive regulation of dauer larval development</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/6583682" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:6583682
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    A pheromone-induced developmental switch in Caenorhabditis e...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="G5EFW7" data-a="GO:0061066" data-r="PMID:6583682" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> daf-10 is required for dauer formation (loss-of-function is dauer-defective), so it positively regulates entry into the dauer larval stage; the classic dauer-pheromone-switch study frames dauer-defective mutants as unresponsive to pheromone.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Well-established phenotype (the gene is named for abnormal DAuer Formation), but a downstream sensory consequence of the ciliary defect rather than a core molecular function. The cached record is abstract-only and does not name daf-10; retained per guidance not to overrule the WormBase IMP.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/6583682" target="_blank" class="term-link">
+                                        PMID:6583682
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Dauer-defective mutants fail to respond to added pheromone</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0097500" target="_blank" class="term-link">
+                                    GO:0097500
+                                </a>
+                            </span>
+                            <span class="term-label">receptor localization to non-motile cilium</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/24646679" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:24646679
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Diverse cell type-specific mechanisms localize G protein-cou...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="G5EFW7" data-a="GO:0097500" data-r="PMID:24646679" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> daf-10 is required for correct ciliary localization of G protein-coupled receptors in sensory neurons, reflecting the IFT-A role in ciliary import of membrane cargo.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> A specific, well-grounded manifestation of IFT-A function: import/retention of ciliary membrane GPCRs depends on intact IFT. The cached record is abstract-only and does not name daf-10; retained per guidance not to overrule the WormBase IMP and because the requirement is consistent with the established IFT-A role in ciliary GPCR trafficking.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/24646679" target="_blank" class="term-link">
+                                        PMID:24646679
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">localize GPCRs to the cilia of the AWB and ASK sensory neuron types</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1905515" target="_blank" class="term-link">
+                                    GO:1905515
+                                </a>
+                            </span>
+                            <span class="term-label">non-motile cilium assembly</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/16648645" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:16648645
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The molecular identities of the Caenorhabditis elegans intra...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="G5EFW7" data-a="GO:1905515" data-r="PMID:16648645" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Mutant analysis in the founding paper: daf-10 (complex A) is required for proper sensory-cilium structure; loss abnormally redistributes OSM-6::GFP in the ciliary endings.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Core process, accurately specific for the worm&#39;s non-motile sensory cilia and supported by the mutant phenotype. daf-10 is one of the IFT genes cloned in this paper whose loss perturbs sensory-cilium structure.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/16648645" target="_blank" class="term-link">
+                                        PMID:16648645
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The daf-10 and osm-1 gene products resemble each other and contain WD and WAA repeats</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0046626" target="_blank" class="term-link">
+                                    GO:0046626
+                                </a>
+                            </span>
+                            <span class="term-label">regulation of insulin receptor signaling pathway</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IGI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/11381260" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:11381260
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Regulation of the Caenorhabditis elegans longevity protein D...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="G5EFW7" data-a="GO:0046626" data-r="PMID:11381260" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Sensory (ciliated) neurons modulate DAF-16/insulin-IGF signaling systemically; daf-10 contributes to this via a genetic interaction, reflecting the sensory input of the ciliary system into insulin signaling.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Indirect, whole-organism sensory-modulation effect (ciliary sensory neurons influence DAF-16 nuclear localization), not a molecular function of an IFT-A structural subunit. Retained as a legitimate genetic-interaction phenotype but marked non-core/downstream.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/11381260" target="_blank" class="term-link">
+                                        PMID:11381260
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">both sensory neurons and germline activity regulate DAF-16 accumulation in nuclei</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>Structural constituent of intraflagellar transport complex A (IFT-A) that drives retrograde (ciliary tip-to-base) intraflagellar transport along the non-motile sensory cilium. As the IFT122 ortholog, DAF-10 has no catalytic activity; it acts as a WD40/TPR/Zn-ribbon scaffold within IFT-A that, with cytoplasmic dynein-2, returns IFT particles and turnover products from the ciliary tip to the base.</h3>
+                <span class="vote-buttons" data-g="G5EFW7" data-a="FUNCTION: Structural constituent of intraflagellar transport..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005198" target="_blank" class="term-link">
+                            structural molecule activity
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0035721" target="_blank" class="term-link">
+                                intraciliary retrograde transport
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042073" target="_blank" class="term-link">
+                                intraciliary transport
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0097730" target="_blank" class="term-link">
+                                non-motile cilium
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">In Complex:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030991" target="_blank" class="term-link">
+                            intraciliary transport particle A
+                        </a>
+                    </span>
+                </div>
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/16648645" target="_blank" class="term-link">
+                                PMID:16648645
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">The daf-10 and osm-1 gene products resemble each other and contain WD and WAA repeats</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/28479320" target="_blank" class="term-link">
+                                PMID:28479320
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">IFT-139 and IFT-43 function redundantly to promote dynein-2 motility</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>Required for assembly and maintenance of the non-motile sensory cilium and for ciliary import of membrane cargo. IFT-A function via DAF-10 is needed to build and maintain the ciliary axoneme, to keep IFT-B/ciliary proteins correctly distributed, and to localize signaling receptors (GPCRs) to the ciliary compartment; loss of DAF-10 disrupts ciliogenesis.</h3>
+                <span class="vote-buttons" data-g="G5EFW7" data-a="FUNCTION: Required for assembly and maintenance of the non-m..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0060271" target="_blank" class="term-link">
+                                cilium assembly
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1905515" target="_blank" class="term-link">
+                                non-motile cilium assembly
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0061512" target="_blank" class="term-link">
+                                protein localization to cilium
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0097730" target="_blank" class="term-link">
+                                non-motile cilium
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/21124868" target="_blank" class="term-link">
+                                PMID:21124868
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">daf-10/IFT122 mutations (which disrupt ciliogenesis)</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/1732156" target="_blank" class="term-link">
+                                PMID:1732156
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">structurally defective chemosensory cilia</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000024.md" target="_blank" class="term-link">
+                            GO_REF:0000024
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Manual transfer of experimentally-verified manual GO annotation data to orthologs by curator judgment of sequence similarity</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
+                            GO_REF:0000033
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Annotation inferences using phylogenetic trees</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
+                            GO_REF:0000044
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000120.md" target="_blank" class="term-link">
+                            GO_REF:0000120
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Combined Automated Annotation using Multiple IEA Methods</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/16648645" target="_blank" class="term-link">
+                            PMID:16648645
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">The molecular identities of the Caenorhabditis elegans intraflagellar transport genes dyf-6, daf-10 and osm-1.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/28479320" target="_blank" class="term-link">
+                            PMID:28479320
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Dynein-Driven Retrograde Intraflagellar Transport Is Triphasic in C. elegans Sensory Cilia.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/21124868" target="_blank" class="term-link">
+                            PMID:21124868
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Localization of a guanylyl cyclase to chemosensory cilia requires the novel ciliary MYND domain protein DAF-25.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/1732156" target="_blank" class="term-link">
+                            PMID:1732156
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Genetic analysis of chemosensory control of dauer formation in Caenorhabditis elegans.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/6583682" target="_blank" class="term-link">
+                            PMID:6583682
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">A pheromone-induced developmental switch in Caenorhabditis elegans: Temperature-sensitive mutants reveal a wild-type temperature-dependent process.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/24646679" target="_blank" class="term-link">
+                            PMID:24646679
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Diverse cell type-specific mechanisms localize G protein-coupled receptors to Caenorhabditis elegans sensory cilia.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/27623382" target="_blank" class="term-link">
+                            PMID:27623382
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">A Conserved Role for Girdin in Basal Body Positioning and Ciliogenesis.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/11381260" target="_blank" class="term-link">
+                            PMID:11381260
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Regulation of the Caenorhabditis elegans longevity protein DAF-16 by insulin/IGF-1 and germline signaling.</div>
+
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Questions for Experts</h2>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> What is the subunit-resolved architecture of the C. elegans IFT-A complex, and which IFT-A subunits does DAF-10/IFT122 directly contact?</p>
+
+                    <p style="margin-top: 0.5rem;"><em>Suggested experts: Ou G</em></p>
+
+                </div>
+                <span class="vote-buttons" data-g="G5EFW7" data-a="Q: What is the subunit-resolved architecture of the C..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Which ciliary phenotypes (retrograde IFT, axoneme assembly, ciliary GPCR import) are specifically attributable to DAF-10 versus the IFT-A complex as a whole?</p>
+
+                    <p style="margin-top: 0.5rem;"><em>Suggested experts: Sengupta P</em></p>
+
+                </div>
+                <span class="vote-buttons" data-g="G5EFW7" data-a="Q: Which ciliary phenotypes (retrograde IFT, axoneme ..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Experiments</h2>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Affinity-purify or reconstitute the worm IFT-A complex and determine its architecture by cryo-EM, assigning DAF-10/IFT122 and its direct neighbors and testing whether ciliopathy-mimicking substitutions perturb specific interfaces.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: DAF-10/IFT122 occupies a defined position within an IFT-A scaffold that can be resolved structurally.</em></p>
+
+
+                    <p style="margin-top: 0.5rem;">Type: structural biology</p>
+
+                </div>
+                <span class="vote-buttons" data-g="G5EFW7" data-a="EXPERIMENT: Affinity-purify or reconstitute the worm IFT-A com..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Generate structure-guided separation-of-function alleles of daf-10 and score, in vivo, retrograde IFT (kymography of IFT-B markers), cilium length, and ciliary localization of tagged GPCRs in AWB/ASK neurons, to test whether cargo-import and transport functions can be genetically uncoupled.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: DAF-10 makes a separable contribution to ciliary GPCR import distinct from its role in bulk retrograde IFT.</em></p>
+
+
+                    <p style="margin-top: 0.5rem;">Type: structure-function mutagenesis</p>
+
+                </div>
+                <span class="vote-buttons" data-g="G5EFW7" data-a="EXPERIMENT: Generate structure-guided separation-of-function a..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Knowledge Gaps</h2>
+        <p style="color: #555; font-size: 0.92rem; margin-top: -0.3rem;">
+            What is <em>not</em> known — curated, literature-grounded statements of the open
+            unknowns (the inverse of core functions).
+        </p>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> DAF-10 has no molecular-function annotation and no GO term that can express one. Its role is to be a structural constituent of the IFT-A particle, but GO has no &#34;structural constituent of the intraflagellar transport particle&#34; molecular-function term, so the gene reads as MF-dark despite a well-understood cellular and process-level role.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">ONTOLOGY</span><span class="badge">CURATION</span>
+                <span class="badge">MF_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> It is firmly established that DAF-10 = IFT122 is a WD40+TPR+Zn-ribbon scaffolding subunit of IFT-A with no catalytic domain, required for retrograde IFT and cilium assembly. What is missing is a molecular-function representation: the worm GOA record carries only cellular-component and biological-process terms and no molecular_function annotation at all.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> This is the canonical &#34;structural subunit&#34; ontology gap: a mechanistically well-understood protein that cannot be annotated with an informative MF term, contributing to apparent molecular-function darkness across the IFT/ciliopathy gene set (the same gap affects dyf-2/WDR19 and other IFT-A/IFT-B subunits).</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Develop/adopt a molecular-function term for a structural constituent of the IFT particle (analogous to &#34;structural constituent of ribosome&#34;), then annotate DAF-10 (and other IFT-A/IFT-B core subunits) to it.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"The daf-10 and osm-1 gene products resemble each other and contain WD and WAA repeats"</em> — PMID:16648645</li>
+
+            </ul>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Proposed term (ontology gap):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><strong>structural constituent of intraflagellar transport particle</strong></li>
+
+            </ul>
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The subunit-resolved architecture of the C. elegans IFT-A complex, and which of DAF-10&#39;s ciliary functions (retrograde transport, axoneme assembly, GPCR import) are directly and specifically mediated by DAF-10 versus emerging from IFT-A as a whole, are not dissected. DAF-10&#39;s direct IFT-A neighbor contacts are inferred from cross-species orthology and worm mass-spec composition, not resolved structurally.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">RESIDUAL_SUBGAP</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> The worm IFT-A composition (che-11, daf-10, dyf-2, ift-139, ift-43, ifta-1) is known from affinity purification / mass spectrometry, and daf-10 loss produces the IFT-A retrograde-defect signature (IFT-B accumulation in ciliary endings). What is not known is the position of DAF-10/IFT122 within a solved IFT-A structure, its direct binding partners in the worm, and any DAF-10-specific (as opposed to complex-level) contribution to cargo selection.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> IFT-A subunit architecture determines how retrograde IFT is organized and how ciliopathy-causing IFT122 mutations perturb it; a DAF-10-resolved structure and separation-of-function alleles would explain which ciliary phenotypes are directly attributable to DAF-10.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Cryo-EM of the worm IFT-A complex with DAF-10/IFT122 assigned, plus structure-guided separation-of-function alleles scored in vivo for retrograde IFT (kymography of IFT-B markers), cilium length, and ciliary GPCR localization.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"IFT-139 and IFT-43 function redundantly to promote dynein-2 motility"</em> — PMID:28479320</li>
+
+            </ul>
+
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Tags</h2>
+        <div class="aliases">
+
+            <span class="badge">caeel-ciliopathy</span>
+
+        </div>
+    </div>
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Deep Research Sections -->
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(daf-10-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="G5EFW7" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="daf-10-c-elegans-research-notes">daf-10 (C. elegans) research notes</h1>
+<p>UniProt: G5EFW7 (IF122_CAEEL). WormBase: WBGene00000906 / F23B2.4. Chromosome IV.<br />
+Human ortholog: IFT122 (Q9HBG6). 1192 aa; WD40 β-propeller + TPR solenoid + C-terminal<br />
+Zn-ribbon. No catalytic domain.</p>
+<h2 id="summary-of-identity-and-role-known">Summary of identity and role (KNOWN)</h2>
+<p>daf-10 encodes the <em>C. elegans</em> ortholog of <strong>IFT122</strong> (Chlamydomonas IFT122), a core<br />
+subunit of the <strong>intraflagellar transport complex A (IFT-A)</strong>. IFT-A is the retrograde<br />
+(ciliary tip -&gt; base) IFT subcomplex, moved by cytoplasmic dynein-2. daf-10 is required<br />
+for building/maintaining the non-motile sensory cilia of the worm's ciliated sensory<br />
+neurons, and — as a downstream sensory consequence — for chemosensation, dauer larva<br />
+formation, and modulation of insulin/IGF and TGF-β signaling.</p>
+<p>The gene was named for its mutant phenotype: <strong>abnormal DAuer Formation</strong> (daf). daf-10<br />
+mutants are <em>dauer-defective</em> (Daf-d): they fail to form dauers because their chemosensory<br />
+cilia are structurally defective and cannot detect the dauer pheromone / environmental cues.</p>
+<h3 id="ift-a-membership-known">IFT-A membership (KNOWN)</h3>
+<ul>
+<li>UniProt SUBUNIT: "Component of the IFT complex A (IFT-A) composed of at least che-11,<br />
+  daf-10, dyf-2, ift-139, ift-43 and ifta-1" [ECO:0000269|PubMed:28479320]. The worm IFT-A<br />
+  composition was defined by affinity purification / mass spectrometry<br />
+  [PMID:28479320 "our affinity purification and genetic analyses show that IFT-A" ...<br />
+  "IFT-139 and IFT-43 function redundantly to promote dynein-2 motility"].</li>
+<li>ComplexPortal CPX-1289 = Intraflagellar transport complex A (worm).</li>
+<li>Founding molecular-identity paper: daf-10 and osm-1 gene products contain WD and WAA<br />
+  repeats, and daf-10 (with che-11) encodes an <strong>IFT complex A</strong> component<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/16648645" title="The daf-10 and osm-1 gene products resemble each other and contain WD and WAA repeats">PMID:16648645</a><br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/16648645" title="mutation in daf-10 or che-11 , which encode complex A components">PMID:16648645</a>.<br />
+  Loss of daf-10/che-11 (complex A) gives <em>thicker-than-wild-type</em> patches of OSM-6::GFP in<br />
+  the dendritic endings (IFT-B accumulation), the classic IFT-A retrograde-defect signature,<br />
+  distinct from the <em>foreshortened/reduced</em> OSM-6::GFP of IFT-B (osm-1/osm-5/che-2/che-13)<br />
+  mutants.</li>
+</ul>
+<h3 id="subcellular-localization-known">Subcellular localization (KNOWN)</h3>
+<ul>
+<li>Cell projection, cilium [ECO:0000305|PubMed:11301258]. DAF-10 shuttles along the amphid<br />
+  and phasmid sensory cilia at the same rate as IFT-B proteins (osm-1, osm-5, osm-6)<br />
+  (Qin, Rosenbaum &amp; Barr 2001, PubMed:11301258 — the paper that first showed a worm IFT-A/PKD<br />
+  homolog undergoing IFT).</li>
+<li>Ciliary basal body: GO:0036064 IDA from PMID:27623382 (Girdin/basal-body-positioning study;<br />
+  consistent with IFT proteins concentrating at the ciliary base/transition-fibre region<br />
+  before axonemal entry). Abstract-only cache; daf-10 not named in the abstract.</li>
+</ul>
+<h3 id="cilium-assembly-ift-function-known">Cilium assembly / IFT function (KNOWN)</h3>
+<ul>
+<li>daf-10 is one of the classic dauer-defective genes whose mutations cause <em>structurally<br />
+  defective chemosensory cilia</em> <a href="https://pubmed.ncbi.nlm.nih.gov/1732156" title="structurally defective chemosensory cilia">PMID:1732156</a>.</li>
+<li>daf-10/IFT122 mutations disrupt ciliogenesis <a href="https://pubmed.ncbi.nlm.nih.gov/21124868" title="daf-10/IFT122 mutations (which disrupt ciliogenesis)">PMID:21124868</a>.</li>
+<li>IFT-A/retrograde IFT is required for cilium assembly &amp; maintenance and for ciliary import<br />
+  of membrane cargo, including GPCRs (UniProt FUNCTION: "entry into cilia of G protein-coupled<br />
+  receptors (GPCRs)"). GPCR ciliary-localization requirement scored by IMP in PMID:24646679<br />
+  (abstract-only; daf-10 not named in abstract, but IFT-A is a known requirement for ciliary<br />
+  GPCR import).</li>
+</ul>
+<h3 id="dauer-sensory-signaling-roles-known-but-non-core-downstream">Dauer / sensory / signaling roles (KNOWN but non-core / downstream)</h3>
+<ul>
+<li>Positive regulation of dauer larval development (daf-10 loss -&gt; dauer-defective) — IMP,<br />
+  PMID:6583682 (Golden &amp; Riddle 1984 pheromone switch; "Dauer-defective mutants fail to<br />
+  respond to added pheromone").</li>
+<li>Regulation of dauer larval development via genetic interaction with daf-25/Ankmy2<br />
+  (daf-25 dauer-constitutive phenotype is suppressed by daf-10 ciliogenesis loss) — IGI,<br />
+  PMID:21124868.</li>
+<li>Regulation of insulin receptor signaling pathway — IGI, PMID:11381260 (Lin et al. 2001).<br />
+  Sensory-neuron cilia modulate DAF-16/insulin nuclear localization systemically<br />
+  ("sensory neurons and germline activity regulate DAF-16 accumulation in nuclei"). This is<br />
+  an indirect, whole-organism, sensory-input effect, not a molecular function of an IFT-A<br />
+  structural subunit.</li>
+<li>Chemotaxis / chemosensation defects (UniProt KW Chemotaxis; disruption phenotype: defective<br />
+  chemotaxis, 86% reduced tracking to NH4Cl; sterile) — downstream of the ciliary defect.</li>
+</ul>
+<h2 id="what-is-not-known-gaps">What is NOT known / gaps</h2>
+<ul>
+<li><strong>No molecular-function annotation.</strong> GOA carries only CC and BP terms; daf-10 reads as<br />
+  MF-dark. There is no GO MF term for "structural constituent of the IFT particle" (cf.<br />
+  structural constituent of ribosome). Its role is a WD40/TPR/Zn-ribbon scaffold within IFT-A.</li>
+<li><strong>Subunit-resolved architecture of the worm IFT-A</strong> and daf-10's direct neighbor contacts<br />
+  are not solved structurally (composition known from mass-spec; no cryo-EM of the worm complex).</li>
+<li><strong>Which cilium-assembly / cargo-import functions are daf-10-specific vs generic IFT-A</strong> is<br />
+  not separately dissected in the worm (most readouts are complex-level).</li>
+</ul>
+<h2 id="deep-research-status">Deep research status</h2>
+<p>Falcon deep research (<code>just deep-research-falcon worm daf-10 --fallback perplexity-lite</code>)<br />
+was run twice in the foreground; both the falcon primary attempt and the perplexity-lite<br />
+fallback timed out at the 600s wrapper limit on each run (~40 min total), producing no<br />
+deep-research file. No <code>-deep-research-*.md</code> file was fabricated. This review is grounded<br />
+directly in UniProt (G5EFW7), the QuickGO GOA record, and the cached primary literature<br />
+(PMIDs below), with every supporting_text a verified verbatim substring of the cited<br />
+PubMed abstract.</p>
+<h2 id="provenance-cache-status">Provenance / cache status</h2>
+<ul>
+<li>Full text available: PMID:16648645 (founding daf-10 IFT paper), PMID:21124868 (DAF-25).</li>
+<li>Abstract-only cache: PMID:28479320, 27623382, 24646679, 1732156, 6583682, 11381260.<br />
+  For experimental annotations from abstract-only papers I defer to the WormBase/UniProt<br />
+  curator (full text read by them) per repo guidance; I do not REMOVE on absence-from-abstract<br />
+  grounds.</li>
+</ul>
+<h2 id="annotation-review-plan-see-ai-reviewyaml">Annotation review plan (see -ai-review.yaml)</h2>
+<p>Core: IFT-A membership (GO:0030991), retrograde IFT (GO:0035721) / intraciliary transport,<br />
+non-motile cilium localization (GO:0097730 / GO:0005929), cilium assembly (GO:0060271 /<br />
+GO:1905515), protein localization to cilium (GO:0061512).<br />
+Non-core downstream: dauer regulation (GO:0061065/0061066), receptor localization to cilium<br />
+(GO:0097500), regulation of insulin receptor signaling (GO:0046626), basal body (GO:0036064<br />
+kept as location).</p>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: G5EFW7
+gene_symbol: daf-10
+product_type: PROTEIN
+status: COMPLETE
+taxon:
+  id: NCBITaxon:6239
+  label: Caenorhabditis elegans
+description: &gt;-
+  DAF-10 is the Caenorhabditis elegans ortholog of human IFT122, a core subunit
+  of intraflagellar transport complex A (IFT-A). It is a large (1192 aa) WD40
+  β-propeller plus tetratricopeptide-repeat (TPR) solenoid scaffold with a
+  C-terminal zinc-ribbon and no catalytic domain, expressed in ciliated sensory
+  neurons and shuttling along the axoneme of the non-motile sensory cilium at the
+  same rate as IFT-B proteins. As part of IFT-A, DAF-10 is required for retrograde
+  (ciliary tip-to-base) intraflagellar transport powered by cytoplasmic dynein-2,
+  and thereby for assembly and maintenance of the sensory-cilium axoneme and for
+  import of ciliary membrane cargo such as G protein-coupled receptors. Loss of
+  DAF-10 produces structurally defective, disorganized sensory cilia with the
+  characteristic IFT-A retrograde-defect signature (accumulation of IFT-B/OSM-6
+  material in the ciliary endings), together with dye-filling and chemotaxis
+  defects. Because worm sensory cilia detect environmental cues, daf-10 mutants
+  are dauer-formation-defective (the origin of the gene name, abnormal DAuer
+  Formation) and show altered sensory modulation of insulin/IGF and TGF-β
+  signaling. IFT122 mutations cause human ciliopathies (cranioectodermal dysplasia
+  / Sensenbrenner syndrome), underscoring a conserved role in cilium biogenesis.
+references:
+  - id: GO_REF:0000024
+    title: Manual transfer of experimentally-verified manual GO annotation data to orthologs
+      by curator judgment of sequence similarity
+    findings: []
+  - id: GO_REF:0000033
+    title: Annotation inferences using phylogenetic trees
+    findings: []
+  - id: GO_REF:0000044
+    title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location
+      vocabulary mapping, accompanied by conservative changes to GO terms applied by
+      UniProt
+    findings: []
+  - id: GO_REF:0000120
+    title: Combined Automated Annotation using Multiple IEA Methods
+    findings: []
+  - id: PMID:16648645
+    title: The molecular identities of the Caenorhabditis elegans intraflagellar transport
+      genes dyf-6, daf-10 and osm-1.
+    findings: []
+    reference_review:
+      relevance: HIGH
+      correctness: VERIFIED
+      review_notes: &gt;-
+        Founding molecular-identity paper for daf-10: the daf-10 product contains WD
+        and WAA repeats and (per the full text, which the automated validator can only
+        access as the PubMed abstract) is classified with che-11 as an IFT complex A
+        component. Loss of daf-10/che-11 gives thicker-than-wild-type OSM-6::GFP
+        patches in the ciliary endings (IFT-B accumulation), the classic IFT-A
+        retrograde-defect signature. Supports the IFT-A membership and non-motile
+        cilium assembly annotations.
+  - id: PMID:28479320
+    title: Dynein-Driven Retrograde Intraflagellar Transport Is Triphasic in C. elegans
+      Sensory Cilia.
+    findings: []
+    reference_review:
+      relevance: HIGH
+      correctness: VERIFIED
+      review_notes: &gt;-
+        Affinity purification / mass spectrometry defined the worm IFT-A complex
+        (che-11, daf-10, dyf-2, ift-139, ift-43, ifta-1); basis for the ComplexPortal
+        (CPX-1289) NAS annotations placing DAF-10 in IFT-A and in retrograde
+        transport. Cached record is abstract-only (full_text_available: false); the
+        abstract confirms the affinity-purification definition of IFT-A subunits but
+        does not name daf-10, so the daf-10 datum rests on the full text / UniProt
+        SUBUNIT curation.
+  - id: PMID:21124868
+    title: Localization of a guanylyl cyclase to chemosensory cilia requires the novel
+      ciliary MYND domain protein DAF-25.
+    findings: []
+    reference_review:
+      relevance: HIGH
+      correctness: VERIFIED
+      review_notes: &gt;-
+        Full text available and read. States that daf-10/IFT122 mutations disrupt
+        ciliogenesis and genetically suppress the daf-25 dauer-constitutive
+        phenotype, confirming daf-10 = IFT122 and its ciliogenesis role, and grounding
+        the IGI regulation-of-dauer annotation (genetic interaction with daf-25).
+  - id: PMID:1732156
+    title: Genetic analysis of chemosensory control of dauer formation in Caenorhabditis
+      elegans.
+    findings: []
+    reference_review:
+      relevance: HIGH
+      correctness: VERIFIED
+      review_notes: &gt;-
+        Cached record is abstract-only. Classic epistasis study placing daf-10 among
+        the dauer-defective genes whose mutations cause structurally defective
+        chemosensory cilia; supports both the cilium-assembly (structural) role and
+        the downstream dauer-formation role.
+  - id: PMID:6583682
+    title: &#39;A pheromone-induced developmental switch in Caenorhabditis elegans: Temperature-sensitive
+      mutants reveal a wild-type temperature-dependent process.&#39;
+    findings: []
+    reference_review:
+      relevance: MEDIUM
+      correctness: VERIFIED
+      review_notes: &gt;-
+        Cached record is abstract-only; the abstract foregrounds daf-4/daf-7
+        dauer-constitutive genes and states that dauer-defective mutants fail to
+        respond to added pheromone. WormBase attaches a specific daf-10 allele
+        (WBVar00143964) IMP for positive regulation of dauer larval development; the
+        dauer role is well-established (gene name = abnormal DAuer Formation) but is a
+        downstream sensory consequence of the ciliary defect, not a core molecular
+        function.
+  - id: PMID:24646679
+    title: Diverse cell type-specific mechanisms localize G protein-coupled receptors
+      to Caenorhabditis elegans sensory cilia.
+    findings: []
+    reference_review:
+      relevance: MEDIUM
+      correctness: VERIFIED
+      review_notes: &gt;-
+        Cached record is abstract-only; describes the proteins required to localize
+        GPCRs to AWB/ASK sensory cilia. daf-10 is not named in the abstract, but the
+        WormBase IMP (receptor localization to non-motile cilium) reflects the
+        full-text result; consistent with the established IFT-A requirement for
+        ciliary import of membrane GPCRs.
+  - id: PMID:27623382
+    title: A Conserved Role for Girdin in Basal Body Positioning and Ciliogenesis.
+    findings: []
+    reference_review:
+      relevance: LOW
+      correctness: UNVERIFIED
+      review_notes: &gt;-
+        Cached record is abstract-only; the abstract is about Girdin and basal-body
+        positioning and does not name daf-10. The UniProt IDA (ciliary basal body)
+        rests on the full text (DAF-10 likely used/scored as a ciliary-base marker).
+        Basal-body/ciliary-base localization is biologically consistent with an IFT-A
+        subunit (IFT proteins dock at transition fibres before axonemal entry), so
+        the annotation is retained, but the daf-10-specific datum could not be
+        independently verified from the cached abstract.
+  - id: PMID:11381260
+    title: Regulation of the Caenorhabditis elegans longevity protein DAF-16 by insulin/IGF-1
+      and germline signaling.
+    findings: []
+    reference_review:
+      relevance: LOW
+      correctness: VERIFIED
+      review_notes: &gt;-
+        Cached record is abstract-only. Establishes that sensory neurons and germline
+        activity regulate DAF-16 nuclear accumulation systemically. Grounds the IGI
+        regulation-of-insulin-receptor-signaling annotation, but the effect of daf-10
+        is an indirect, whole-organism sensory input into insulin/IGF signaling, not a
+        molecular function of an IFT-A structural subunit.
+existing_annotations:
+  - term:
+      id: GO:0061512
+      label: protein localization to cilium
+    evidence_type: IBA
+    original_reference_id: GO_REF:0000033
+    qualifier: involved_in
+    review:
+      summary: &gt;-
+        As an IFT-A subunit, DAF-10 transports and localizes protein cargo along the
+        ciliary axoneme; loss of daf-10 disrupts the distribution of IFT-B (OSM-6)
+        material in the ciliary endings.
+      action: ACCEPT
+      reason: &gt;-
+        Core process. Phylogenetic inference agrees with the founding paper, which
+        established daf-10 as an IFT gene mediating the bidirectional movement of
+        particles along the ciliary axoneme (i.e. protein localization within the
+        cilium).
+      supported_by:
+        - reference_id: PMID:16648645
+          supporting_text: Some genes in this category are known to be required for intraflagellar
+            transport (IFT), which is the bidirectional movement of raft-like particles
+            along the axonemes of cilia and flagella
+  - term:
+      id: GO:0035721
+      label: intraciliary retrograde transport
+    evidence_type: IBA
+    original_reference_id: GO_REF:0000033
+    qualifier: involved_in
+    review:
+      summary: &gt;-
+        As a core IFT-A subunit, DAF-10 is required for retrograde (tip-to-base)
+        intraflagellar transport, the defining function of IFT-A.
+      action: ACCEPT
+      reason: &gt;-
+        Represents the core biological process of the gene. Phylogenetic inference is
+        corroborated by the IFT-A/retrograde-defect phenotype of daf-10 mutants and by
+        mass-spec placement of DAF-10 in the worm IFT-A complex.
+      supported_by:
+        - reference_id: PMID:28479320
+          supporting_text: Cytoplasmic dynein-2 powers retrograde intraflagellar transport
+            that is essential for cilium formation and maintenance
+  - term:
+      id: GO:0097730
+      label: non-motile cilium
+    evidence_type: IBA
+    original_reference_id: GO_REF:0000033
+    qualifier: is_active_in
+    review:
+      summary: &gt;-
+        DAF-10 acts within the worm&#39;s non-motile sensory cilia, where it shuttles
+        along the axoneme as part of IFT-A.
+      action: ACCEPT
+      reason: &gt;-
+        Core localization, accurately specific to the worm&#39;s non-motile sensory cilia.
+        Phylogenetic inference agrees with the direct ciliary localization of DAF-10
+        (IFT shuttling in amphid/phasmid cilia) and with the mutant cilia phenotype.
+  - term:
+      id: GO:1905515
+      label: non-motile cilium assembly
+    evidence_type: IBA
+    original_reference_id: GO_REF:0000033
+    qualifier: involved_in
+    review:
+      summary: &gt;-
+        IFT-A/retrograde transport by DAF-10 is required to build and maintain the
+        non-motile sensory-cilium axoneme; loss of daf-10 gives structurally defective
+        cilia.
+      action: ACCEPT
+      reason: &gt;-
+        Core process, accurately specific for the worm&#39;s non-motile sensory cilia.
+        Phylogenetic inference is corroborated by the ciliogenesis defect of daf-10
+        mutants.
+      supported_by:
+        - reference_id: PMID:21124868
+          supporting_text: daf-10/IFT122 mutations (which disrupt ciliogenesis)
+  - term:
+      id: GO:0030991
+      label: intraciliary transport particle A
+    evidence_type: IBA
+    original_reference_id: GO_REF:0000033
+    qualifier: part_of
+    review:
+      summary: &gt;-
+        DAF-10 is a core subunit of the IFT-A complex, established by orthology to
+        IFT122 and by direct mass-spec identification in the worm IFT-A complex.
+      action: ACCEPT
+      reason: &gt;-
+        Core complex membership. Phylogenetic inference agrees with the experimental
+        (NAS/mass-spec, ISS) IFT-A assignments; the founding paper notes that the
+        WAA-repeat architecture shared by daf-10 is characteristic of IFT particle
+        components.
+      supported_by:
+        - reference_id: PMID:16648645
+          supporting_text: The daf-10 and osm-1 gene products resemble each other and
+            contain WD and WAA repeats
+  - term:
+      id: GO:0005929
+      label: cilium
+    evidence_type: IEA
+    original_reference_id: GO_REF:0000044
+    qualifier: located_in
+    review:
+      summary: &gt;-
+        Electronic (UniProt SubCell) assertion of ciliary localization, redundant
+        with the more specific non-motile cilium annotation.
+      action: ACCEPT
+      reason: &gt;-
+        Correct location; consistent with the direct evidence that DAF-10 shuttles
+        along sensory cilia, albeit less specific than the non-motile cilium term.
+  - term:
+      id: GO:0060271
+      label: cilium assembly
+    evidence_type: IEA
+    original_reference_id: GO_REF:0000120
+    qualifier: involved_in
+    review:
+      summary: &gt;-
+        Electronic (ARBA/InterPro) annotation of the IFT-A cilium-assembly role,
+        redundant with the experimental IGI/IMP and phylogenetic annotations.
+      action: ACCEPT
+      reason: &gt;-
+        Correct core process; consistent with the ciliogenesis defect of daf-10
+        mutants, though less specific than the non-motile cilium assembly term.
+  - term:
+      id: GO:0005929
+      label: cilium
+    evidence_type: NAS
+    original_reference_id: PMID:28479320
+    qualifier: located_in
+    review:
+      summary: &gt;-
+        ComplexPortal (CPX-1289) NAS assertion of ciliary localization for the IFT-A
+        complex, based on the mass-spec study of worm retrograde IFT.
+      action: ACCEPT
+      reason: &gt;-
+        Correct core localization, consistent with the direct ciliary shuttling of
+        DAF-10.
+  - term:
+      id: GO:0030991
+      label: intraciliary transport particle A
+    evidence_type: NAS
+    original_reference_id: PMID:28479320
+    qualifier: part_of
+    review:
+      summary: &gt;-
+        ComplexPortal NAS annotation placing DAF-10 in the IFT-A complex, based on
+        affinity purification / mass spectrometry of the worm IFT-A complex (che-11,
+        daf-10, dyf-2, ift-139, ift-43, ifta-1).
+      action: ACCEPT
+      reason: &gt;-
+        Core complex membership, experimentally grounded (mass-spec definition of the
+        worm IFT-A complex, which includes DAF-10).
+      supported_by:
+        - reference_id: PMID:28479320
+          supporting_text: our affinity purification and genetic analyses show that IFT-A
+  - term:
+      id: GO:0035721
+      label: intraciliary retrograde transport
+    evidence_type: NAS
+    original_reference_id: PMID:28479320
+    qualifier: involved_in
+    review:
+      summary: &gt;-
+        ComplexPortal NAS annotation of the IFT-A retrograde-transport role.
+      action: ACCEPT
+      reason: &gt;-
+        Core process, consistent with the experimental and phylogenetic evidence for
+        DAF-10 as a retrograde IFT-A subunit.
+      supported_by:
+        - reference_id: PMID:28479320
+          supporting_text: Cytoplasmic dynein-2 powers retrograde intraflagellar transport
+            that is essential for cilium formation and maintenance
+  - term:
+      id: GO:0060271
+      label: cilium assembly
+    evidence_type: NAS
+    original_reference_id: PMID:28479320
+    qualifier: involved_in
+    review:
+      summary: &gt;-
+        ComplexPortal NAS annotation of the cilium-assembly role of IFT-A.
+      action: ACCEPT
+      reason: &gt;-
+        Correct; downstream outcome of the IFT-A transport function and consistent
+        with the ciliogenesis defect of daf-10 mutants.
+  - term:
+      id: GO:0030991
+      label: intraciliary transport particle A
+    evidence_type: ISS
+    original_reference_id: GO_REF:0000024
+    qualifier: part_of
+    review:
+      summary: &gt;-
+        Sequence-similarity (ISS) transfer of IFT-A membership from the human ortholog
+        IFT122 (Q9HBG6).
+      action: ACCEPT
+      reason: &gt;-
+        Core complex membership; the ISS to human IFT122 agrees with the direct
+        mass-spec IFT-A assignment in the worm.
+  - term:
+      id: GO:0036064
+      label: ciliary basal body
+    evidence_type: IDA
+    original_reference_id: PMID:27623382
+    qualifier: located_in
+    review:
+      summary: &gt;-
+        Direct-assay assertion of DAF-10 at the ciliary basal body, from a study of
+        Girdin-dependent basal-body positioning and ciliogenesis.
+      action: ACCEPT
+      reason: &gt;-
+        Biologically consistent location: IFT-A proteins concentrate at the ciliary
+        base / transition-fibre region before axonemal entry. Retained as a genuine
+        location per repo guidance not to overrule an experimental IDA; the cached
+        record is abstract-only and does not name daf-10, so the datum is deferred to
+        the curator&#39;s full-text reading (see reference_review). A secondary/base
+        localization rather than the core axonemal-transport function.
+  - term:
+      id: GO:0061065
+      label: regulation of dauer larval development
+    evidence_type: IGI
+    original_reference_id: PMID:21124868
+    qualifier: involved_in
+    review:
+      summary: &gt;-
+        Genetic interaction with daf-25/Ankmy2: daf-10 loss (disrupting ciliogenesis)
+        suppresses the daf-25 dauer-constitutive phenotype, implicating daf-10 in the
+        chemosensory control of dauer formation.
+      action: KEEP_AS_NON_CORE
+      reason: &gt;-
+        Valid genetic-interaction phenotype, but a downstream consequence of the
+        ciliary/IFT defect (functional chemosensory cilia are required to sense the
+        dauer cues), not a core molecular function of an IFT-A structural subunit.
+      supported_by:
+        - reference_id: PMID:21124868
+          supporting_text: daf-10/IFT122 mutations (which disrupt ciliogenesis)
+  - term:
+      id: GO:0060271
+      label: cilium assembly
+    evidence_type: IGI
+    original_reference_id: PMID:1732156
+    qualifier: involved_in
+    review:
+      summary: &gt;-
+        daf-10 is among the dauer-defective genes whose mutations cause structurally
+        defective chemosensory cilia, implicating it in building the sensory cilium.
+      action: ACCEPT
+      reason: &gt;-
+        Core process; the cilium-structure defect of daf-10 mutants directly supports
+        a requirement in ciliary assembly/maintenance.
+      supported_by:
+        - reference_id: PMID:1732156
+          supporting_text: structurally defective chemosensory cilia
+  - term:
+      id: GO:0061066
+      label: positive regulation of dauer larval development
+    evidence_type: IMP
+    original_reference_id: PMID:6583682
+    qualifier: involved_in
+    review:
+      summary: &gt;-
+        daf-10 is required for dauer formation (loss-of-function is dauer-defective),
+        so it positively regulates entry into the dauer larval stage; the classic
+        dauer-pheromone-switch study frames dauer-defective mutants as unresponsive to
+        pheromone.
+      action: KEEP_AS_NON_CORE
+      reason: &gt;-
+        Well-established phenotype (the gene is named for abnormal DAuer Formation),
+        but a downstream sensory consequence of the ciliary defect rather than a core
+        molecular function. The cached record is abstract-only and does not name
+        daf-10; retained per guidance not to overrule the WormBase IMP.
+      supported_by:
+        - reference_id: PMID:6583682
+          supporting_text: Dauer-defective mutants fail to respond to added pheromone
+  - term:
+      id: GO:0097500
+      label: receptor localization to non-motile cilium
+    evidence_type: IMP
+    original_reference_id: PMID:24646679
+    qualifier: involved_in
+    review:
+      summary: &gt;-
+        daf-10 is required for correct ciliary localization of G protein-coupled
+        receptors in sensory neurons, reflecting the IFT-A role in ciliary import of
+        membrane cargo.
+      action: ACCEPT
+      reason: &gt;-
+        A specific, well-grounded manifestation of IFT-A function: import/retention of
+        ciliary membrane GPCRs depends on intact IFT. The cached record is
+        abstract-only and does not name daf-10; retained per guidance not to overrule
+        the WormBase IMP and because the requirement is consistent with the
+        established IFT-A role in ciliary GPCR trafficking.
+      supported_by:
+        - reference_id: PMID:24646679
+          supporting_text: localize GPCRs to the cilia of the AWB and ASK sensory neuron types
+  - term:
+      id: GO:1905515
+      label: non-motile cilium assembly
+    evidence_type: IMP
+    original_reference_id: PMID:16648645
+    qualifier: involved_in
+    review:
+      summary: &gt;-
+        Mutant analysis in the founding paper: daf-10 (complex A) is required for
+        proper sensory-cilium structure; loss abnormally redistributes OSM-6::GFP in
+        the ciliary endings.
+      action: ACCEPT
+      reason: &gt;-
+        Core process, accurately specific for the worm&#39;s non-motile sensory cilia and
+        supported by the mutant phenotype. daf-10 is one of the IFT genes cloned in
+        this paper whose loss perturbs sensory-cilium structure.
+      supported_by:
+        - reference_id: PMID:16648645
+          supporting_text: The daf-10 and osm-1 gene products resemble each other and
+            contain WD and WAA repeats
+  - term:
+      id: GO:0046626
+      label: regulation of insulin receptor signaling pathway
+    evidence_type: IGI
+    original_reference_id: PMID:11381260
+    qualifier: involved_in
+    review:
+      summary: &gt;-
+        Sensory (ciliated) neurons modulate DAF-16/insulin-IGF signaling
+        systemically; daf-10 contributes to this via a genetic interaction, reflecting
+        the sensory input of the ciliary system into insulin signaling.
+      action: KEEP_AS_NON_CORE
+      reason: &gt;-
+        Indirect, whole-organism sensory-modulation effect (ciliary sensory neurons
+        influence DAF-16 nuclear localization), not a molecular function of an IFT-A
+        structural subunit. Retained as a legitimate genetic-interaction phenotype but
+        marked non-core/downstream.
+      supported_by:
+        - reference_id: PMID:11381260
+          supporting_text: both sensory neurons and germline activity regulate DAF-16
+            accumulation in nuclei
+core_functions:
+  - description: &gt;-
+      Structural constituent of intraflagellar transport complex A (IFT-A) that
+      drives retrograde (ciliary tip-to-base) intraflagellar transport along the
+      non-motile sensory cilium. As the IFT122 ortholog, DAF-10 has no catalytic
+      activity; it acts as a WD40/TPR/Zn-ribbon scaffold within IFT-A that, with
+      cytoplasmic dynein-2, returns IFT particles and turnover products from the
+      ciliary tip to the base.
+    molecular_function:
+      id: GO:0005198
+      label: structural molecule activity
+    directly_involved_in:
+      - id: GO:0035721
+        label: intraciliary retrograde transport
+      - id: GO:0042073
+        label: intraciliary transport
+    locations:
+      - id: GO:0097730
+        label: non-motile cilium
+    in_complex:
+      id: GO:0030991
+      label: intraciliary transport particle A
+    supported_by:
+      - reference_id: PMID:16648645
+        supporting_text: The daf-10 and osm-1 gene products resemble each other and
+          contain WD and WAA repeats
+      - reference_id: PMID:28479320
+        supporting_text: IFT-139 and IFT-43 function redundantly to promote dynein-2 motility
+  - description: &gt;-
+      Required for assembly and maintenance of the non-motile sensory cilium and for
+      ciliary import of membrane cargo. IFT-A function via DAF-10 is needed to build
+      and maintain the ciliary axoneme, to keep IFT-B/ciliary proteins correctly
+      distributed, and to localize signaling receptors (GPCRs) to the ciliary
+      compartment; loss of DAF-10 disrupts ciliogenesis.
+    directly_involved_in:
+      - id: GO:0060271
+        label: cilium assembly
+      - id: GO:1905515
+        label: non-motile cilium assembly
+      - id: GO:0061512
+        label: protein localization to cilium
+    locations:
+      - id: GO:0097730
+        label: non-motile cilium
+    supported_by:
+      - reference_id: PMID:21124868
+        supporting_text: daf-10/IFT122 mutations (which disrupt ciliogenesis)
+      - reference_id: PMID:1732156
+        supporting_text: structurally defective chemosensory cilia
+knowledge_gaps:
+  - gap_statement: &gt;-
+      DAF-10 has no molecular-function annotation and no GO term that can express
+      one. Its role is to be a structural constituent of the IFT-A particle, but GO
+      has no &#34;structural constituent of the intraflagellar transport particle&#34;
+      molecular-function term, so the gene reads as MF-dark despite a well-understood
+      cellular and process-level role.
+    boundary: &gt;-
+      It is firmly established that DAF-10 = IFT122 is a WD40+TPR+Zn-ribbon
+      scaffolding subunit of IFT-A with no catalytic domain, required for retrograde
+      IFT and cilium assembly. What is missing is a molecular-function
+      representation: the worm GOA record carries only cellular-component and
+      biological-process terms and no molecular_function annotation at all.
+    gap_kind:
+      - ONTOLOGY
+      - CURATION
+    dark_aspect: MF_DARK
+    status: OPEN
+    significance: &gt;-
+      This is the canonical &#34;structural subunit&#34; ontology gap: a mechanistically
+      well-understood protein that cannot be annotated with an informative MF term,
+      contributing to apparent molecular-function darkness across the IFT/ciliopathy
+      gene set (the same gap affects dyf-2/WDR19 and other IFT-A/IFT-B subunits).
+    resolution: &gt;-
+      Develop/adopt a molecular-function term for a structural constituent of the IFT
+      particle (analogous to &#34;structural constituent of ribosome&#34;), then annotate
+      DAF-10 (and other IFT-A/IFT-B core subunits) to it.
+    provenance:
+      - reference_id: PMID:16648645
+        supporting_text: The daf-10 and osm-1 gene products resemble each other and
+          contain WD and WAA repeats
+        reference_section_type: ABSTRACT
+    proposed_terms:
+      - proposed_name: structural constituent of intraflagellar transport particle
+        proposed_definition: &gt;-
+          The action of a protein that contributes to the structural integrity of an
+          intraflagellar transport (IFT) particle (IFT-A or IFT-B subcomplex), for
+          example by acting as a WD40/TPR scaffold that holds core IFT subunits
+          together and enables their bidirectional transport along the ciliary
+          axoneme, without itself catalyzing a biochemical reaction.
+        proposed_parent:
+          id: GO:0005198
+          label: structural molecule activity
+  - gap_statement: &gt;-
+      The subunit-resolved architecture of the C. elegans IFT-A complex, and which
+      of DAF-10&#39;s ciliary functions (retrograde transport, axoneme assembly, GPCR
+      import) are directly and specifically mediated by DAF-10 versus emerging from
+      IFT-A as a whole, are not dissected. DAF-10&#39;s direct IFT-A neighbor contacts
+      are inferred from cross-species orthology and worm mass-spec composition, not
+      resolved structurally.
+    boundary: &gt;-
+      The worm IFT-A composition (che-11, daf-10, dyf-2, ift-139, ift-43, ifta-1) is
+      known from affinity purification / mass spectrometry, and daf-10 loss produces
+      the IFT-A retrograde-defect signature (IFT-B accumulation in ciliary endings).
+      What is not known is the position of DAF-10/IFT122 within a solved IFT-A
+      structure, its direct binding partners in the worm, and any DAF-10-specific
+      (as opposed to complex-level) contribution to cargo selection.
+    gap_kind:
+      - BIOLOGY
+    dark_aspect: RESIDUAL_SUBGAP
+    status: OPEN
+    significance: &gt;-
+      IFT-A subunit architecture determines how retrograde IFT is organized and how
+      ciliopathy-causing IFT122 mutations perturb it; a DAF-10-resolved structure and
+      separation-of-function alleles would explain which ciliary phenotypes are
+      directly attributable to DAF-10.
+    resolution: &gt;-
+      Cryo-EM of the worm IFT-A complex with DAF-10/IFT122 assigned, plus
+      structure-guided separation-of-function alleles scored in vivo for retrograde
+      IFT (kymography of IFT-B markers), cilium length, and ciliary GPCR localization.
+    provenance:
+      - reference_id: PMID:28479320
+        supporting_text: IFT-139 and IFT-43 function redundantly to promote dynein-2 motility
+        reference_section_type: ABSTRACT
+proposed_new_terms:
+  - proposed_name: structural constituent of intraflagellar transport particle
+    proposed_definition: &gt;-
+      The action of a protein that contributes to the structural integrity of an
+      intraflagellar transport (IFT) particle (IFT-A or IFT-B subcomplex), for
+      example by acting as a WD40/TPR scaffold that holds core IFT subunits together
+      and enables their bidirectional transport along the ciliary axoneme, without
+      itself catalyzing a biochemical reaction.
+    proposed_parent:
+      id: GO:0005198
+      label: structural molecule activity
+suggested_questions:
+  - question: What is the subunit-resolved architecture of the C. elegans IFT-A
+      complex, and which IFT-A subunits does DAF-10/IFT122 directly contact?
+    experts:
+      - Ou G
+  - question: Which ciliary phenotypes (retrograde IFT, axoneme assembly, ciliary GPCR
+      import) are specifically attributable to DAF-10 versus the IFT-A complex as a whole?
+    experts:
+      - Sengupta P
+suggested_experiments:
+  - hypothesis: DAF-10/IFT122 occupies a defined position within an IFT-A scaffold that
+      can be resolved structurally.
+    description: &gt;-
+      Affinity-purify or reconstitute the worm IFT-A complex and determine its
+      architecture by cryo-EM, assigning DAF-10/IFT122 and its direct neighbors and
+      testing whether ciliopathy-mimicking substitutions perturb specific interfaces.
+    experiment_type: structural biology
+  - hypothesis: DAF-10 makes a separable contribution to ciliary GPCR import distinct
+      from its role in bulk retrograde IFT.
+    description: &gt;-
+      Generate structure-guided separation-of-function alleles of daf-10 and score, in
+      vivo, retrograde IFT (kymography of IFT-B markers), cilium length, and ciliary
+      localization of tagged GPCRs in AWB/ASK neurons, to test whether cargo-import and
+      transport functions can be genetically uncoupled.
+    experiment_type: structure-function mutagenesis
+tags:
+  - caeel-ciliopathy
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/genes/worm/dcar-1/dcar-1-ai-review.html
+++ b/genes/worm/dcar-1/dcar-1-ai-review.html
@@ -1,0 +1,4005 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>dcar-1 - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        .propagation-review {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f8fafc;
+            border-left: 3px solid #64748b;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .propagation-title {
+            font-weight: 600;
+            color: #334155;
+            margin-bottom: 0.25rem;
+        }
+
+        .propagation-row {
+            margin-top: 0.25rem;
+        }
+
+        .propagation-source {
+            margin-top: 0.5rem;
+            padding-top: 0.5rem;
+            border-top: 1px solid #e5e7eb;
+        }
+
+        .propagation-source-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #1d4ed8;
+        }
+
+        .propagation-comment {
+            color: #4b5563;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>dcar-1</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/G5EDI0" target="_blank" class="term-link">
+                        G5EDI0
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Caenorhabditis elegans</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-complete">
+                    COMPLETE
+                </span>
+            </div>
+
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "dcar-1";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="G5EDI0" data-a="DESCRIPTION: DCAR-1 (DihydroCaffeic Acid Receptor 1) is a seven..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>DCAR-1 (DihydroCaffeic Acid Receptor 1) is a seven-transmembrane, class A (rhodopsin-like) G protein-coupled receptor of Caenorhabditis elegans that acts in two distinct tissues. In the epidermis it is a plasma-membrane receptor, localized to the apical surface of the hyp7 syncytium, that senses the endogenous tyrosine-derived metabolite 4-hydroxyphenyllactic acid (HPLA), a damage-associated molecular pattern produced upon fungal infection and wounding, and triggers antimicrobial peptide (nlp-29 cluster) gene expression through a Galpha (GPA-12) / p38 MAP kinase (TIR-1, NSY-1, SEK-1, PMK-1) / STA-2 signalling cassette, conferring resistance to the natural fungal pathogen Drechmeria coniospora. In sensory neurons (ASH, ASI, PVQ) the same receptor detects the exogenous water-soluble repellent dihydrocaffeic acid (DHCA) and mediates an avoidance response, acting with the TRPV channel subunits OCR-2 and OSM-9. DCAR-1 thus couples small-molecule (catecholic/phenolic acid) ligand detection to Galpha signalling, with clearly recognizable homologs restricted to nematode genomes.</p>
+    </div>
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Proposed New Ontology Terms</h2>
+
+        <div class="proposed-term">
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>4-hydroxyphenyllactate (HPLA) receptor activity</h3>
+                <span class="vote-buttons" data-g="G5EDI0" data-a="4-hydroxyphenyllactate (HPLA) receptor activity" data-r="" data-act="NEW">
+                    <button class="vote-btn" data-v="up" title="Agree this term should be created">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with creating this term">👎</button>
+                </span>
+            </div>
+
+
+            <p><strong>Definition:</strong> Combining with the tyrosine-derived metabolite 4-hydroxyphenyllactic acid (HPLA), a damage-associated molecular pattern, to initiate a change in cell activity, typically via coupling to a heterotrimeric G protein. Applies to GPCRs, such as nematode DCAR-1, that detect HPLA (and structurally related catecholic/phenolic acids) to trigger downstream signalling.</p>
+
+
+
+            <p><strong>Justification:</strong> DCAR-1&#39;s specific molecular function - detection of the small-molecule DAMP HPLA - can currently only be annotated with the generic parent G protein-coupled receptor activity (GO:0004930). No ontology term expresses the ligand-specific activity, leaving the receptor&#39;s most distinctive feature un-annotatable (an ontology gap).</p>
+
+
+
+            <p><strong>Parent term:</strong>
+                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004930" target="_blank" class="term-link">
+                    G protein-coupled receptor activity
+                </a>
+            </p>
+
+
+
+
+
+            <p><strong>Supporting Evidence:</strong></p>
+            <ul style="margin-left: 1rem;">
+
+                <li>
+
+                    <a href="https://pubmed.ncbi.nlm.nih.gov/25086774" target="_blank" class="term-link">
+                        PMID:25086774
+                    </a>
+
+
+                    : the tyrosine derivative 4-hydroxyphenyllactic acid (HPLA) as an endogenous ligand
+
+                </li>
+
+            </ul>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004930" target="_blank" class="term-link">
+                                    GO:0004930
+                                </a>
+                            </span>
+                            <span class="term-label">G protein-coupled receptor activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000104
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="G5EDI0" data-a="GO:0004930" data-r="GO_REF:0000104" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> DCAR-1 is a bona fide seven-transmembrane class A GPCR (7 predicted TM helices; PROSITE G_PROTEIN_RECEP_F1_2; PANTHER PTHR24243) that functions as a receptor for small-molecule ligands: HPLA in the epidermis and DHCA in sensory neurons, in both cases coupling to Galpha signalling.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The GPCR activity is directly supported experimentally. DCAR-1 was identified as a heterologously expressible receptor for DHCA and shown to respond to HPLA, and it signals via the Galpha protein GPA-12. This is a core molecular function of the gene.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/22090488" target="_blank" class="term-link">
+                                        PMID:22090488
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">we identified a candidate dihydrocaffeic acid receptor (DCAR), DCAR-1. DCAR-1 is a novel seven-transmembrane protein that is expressed in the ASH avoidance sensory neurons of C. elegans.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/25086774" target="_blank" class="term-link">
+                                        PMID:25086774
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Dihydrocaffeic acid (DHCA) has been described as a potent ligand for DCAR-1 in both in vivo and in heterologous Xenopus oocyte assays</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0007186" target="_blank" class="term-link">
+                                    GO:0007186
+                                </a>
+                            </span>
+                            <span class="term-label">G protein-coupled receptor signaling pathway</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000104
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="G5EDI0" data-a="GO:0007186" data-r="GO_REF:0000104" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> DCAR-1 initiates GPCR signalling: in the epidermis it acts upstream of (or in parallel to) the Galpha protein GPA-12 to control downstream p38 MAPK (PMK-1) signalling.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Core biological process. Genetic epistasis places DCAR-1 at the top of a Galpha (GPA-12) -&gt; p38 MAPK cascade, consistent with canonical GPCR signalling.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/25086774" target="_blank" class="term-link">
+                                        PMID:25086774
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">dcar-1 alone acts upstream or in parallel to GPA-12</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0007165" target="_blank" class="term-link">
+                                    GO:0007165
+                                </a>
+                            </span>
+                            <span class="term-label">signal transduction</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000104
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="G5EDI0" data-a="GO:0007165" data-r="GO_REF:0000104" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct but generic. Signal transduction is a high-level parent of the more specific G protein-coupled receptor signaling pathway (GO:0007186) that is also annotated and better captures DCAR-1&#39;s activity.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The term is not wrong - DCAR-1 does transduce signals - but it is subsumed by the more informative GPCR signaling pathway annotation, so it is retained as non-core rather than treated as a distinct core function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/25086774" target="_blank" class="term-link">
+                                        PMID:25086774
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">multiple elements of the downstream signal transduction cascade</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0050832" target="_blank" class="term-link">
+                                    GO:0050832
+                                </a>
+                            </span>
+                            <span class="term-label">defense response to fungus</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/25086774" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:25086774
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Activation of a G protein-coupled receptor by its endogenous...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="G5EDI0" data-a="GO:0050832" data-r="PMID:25086774" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Loss of dcar-1 (RNAi and two null alleles, tm2484 and nj66) abolishes infection-induced antimicrobial peptide expression and markedly increases susceptibility to the fungus Drechmeria coniospora; DCAR-1 was the sole GPCR hit from a screen of 1,150 GPCR genes.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Strong IMP evidence for a core function. DCAR-1 is required in the epidermis for the innate immune response to fungal infection.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/25086774" target="_blank" class="term-link">
+                                        PMID:25086774
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">dcar-1 emerged alone as an innate immune receptor gene acting upstream of (or in parallel to) gpa-12</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/25086774" target="_blank" class="term-link">
+                                        PMID:25086774
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">dcar-1 mutants exhibited a markedly heightened susceptibility to D. coniospora infection</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0009611" target="_blank" class="term-link">
+                                    GO:0009611
+                                </a>
+                            </span>
+                            <span class="term-label">response to wounding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/25086774" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:25086774
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Activation of a G protein-coupled receptor by its endogenous...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="G5EDI0" data-a="GO:0009611" data-r="PMID:25086774" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> dcar-1 mutants show an almost complete block of antimicrobial peptide (nlp-29p::gfp) induction after sterile physical injury, showing that DCAR-1 mediates the response to wounding/damage independently of a pathogen - consistent with detection of an endogenous damage signal (HPLA/DAMP).
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Well-supported IMP for a core damage-sensing function; wounding and infection converge on the same DCAR-1-dependent, HPLA-driven pathway.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/25086774" target="_blank" class="term-link">
+                                        PMID:25086774
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">an almost complete block of nlp-29p::gfp induction following physical injury</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/25086774" target="_blank" class="term-link">
+                                        PMID:25086774
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">demonstrating that dcar-1 can be activated in the absence of a pathogen</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016324" target="_blank" class="term-link">
+                                    GO:0016324
+                                </a>
+                            </span>
+                            <span class="term-label">apical plasma membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/25086774" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:25086774
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Activation of a G protein-coupled receptor by its endogenous...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="G5EDI0" data-a="GO:0016324" data-r="PMID:25086774" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> A rescuing dcar-1p::dcar-1::gfp translational reporter localized DCAR-1 to the apical surface of the major epidermal syncytium hyp7, the site where it acts to drive antimicrobial peptide expression.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Direct IDA localization to the apical plasma membrane; a core cellular location for the receptor&#39;s immune function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/25086774" target="_blank" class="term-link">
+                                        PMID:25086774
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">dcar-1 was expressed on the apical surface in the major epidermal syncytium, hyp7</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005886" target="_blank" class="term-link">
+                                    GO:0005886
+                                </a>
+                            </span>
+                            <span class="term-label">plasma membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="G5EDI0" data-a="GO:0005886" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Plasma membrane localization inferred from phylogeny is consistent with DCAR-1 being a cell-surface 7-TM GPCR and with the direct (IDA) apical plasma membrane localization in the epidermis.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct and corroborated by experimental data; a parent of the more specific apical plasma membrane annotation.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/25086774" target="_blank" class="term-link">
+                                        PMID:25086774
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">dcar-1 was expressed on the apical surface in the major epidermal syncytium, hyp7</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016020" target="_blank" class="term-link">
+                                    GO:0016020
+                                </a>
+                            </span>
+                            <span class="term-label">membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000120
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="G5EDI0" data-a="GO:0016020" data-r="GO_REF:0000120" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Generic membrane localization from InterPro/UniProt subcellular-location pipelines; correct for a multi-pass membrane protein but uninformative relative to the plasma membrane / apical plasma membrane annotations.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Not wrong, but subsumed by the more specific and experimentally supported plasma membrane and apical plasma membrane terms.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0097730" target="_blank" class="term-link">
+                                    GO:0097730
+                                </a>
+                            </span>
+                            <span class="term-label">non-motile cilium</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/22090488" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:22090488
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    A seven-transmembrane receptor that mediates avoidance respo...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="G5EDI0" data-a="GO:0097730" data-r="PMID:22090488" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> WormBase IDA localization associated with DCAR-1&#39;s expression in the ciliated ASH (and ASI, PVQ) sensory neurons, where it detects the repellent DHCA. This reflects the neuronal chemosensory role, distinct from the epidermal immune role.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The cached copy of PMID:22090488 is abstract-only, so the specific cilium sub-localization cannot be re-verified from the cached text; per curation policy the WormBase curator&#39;s experimental (IDA) call is trusted and not overruled. It is retained as a non-core location because it belongs to the neuronal chemosensory context rather than the flagship epidermal immune function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/22090488" target="_blank" class="term-link">
+                                        PMID:22090488
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">expressed in the ASH avoidance sensory neurons of C. elegans</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008188" target="_blank" class="term-link">
+                                    GO:0008188
+                                </a>
+                            </span>
+                            <span class="term-label">neuropeptide receptor activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-remove">
+                            REMOVE
+                        </span>
+                        <span class="vote-buttons" data-g="G5EDI0" data-a="GO:0008188" data-r="GO_REF:0000033" data-act="REMOVE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> This activity was propagated by phylogenetic (IBA) inference from the broad class A GPCR family (PTHR24243), some of whose members are neuropeptide receptors. However, the two experimentally characterized ligands of DCAR-1 are small-molecule catecholic/phenolic acids - HPLA (a tyrosine-derived metabolite/DAMP) in the epidermis and DHCA in neurons - not neuropeptides.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Over-propagated family-level IBA that is contradicted by the direct experimental characterization of DCAR-1&#39;s ligands. DCAR-1 is not a neuropeptide receptor; its molecular function is adequately and correctly captured by G protein-coupled receptor activity (GO:0004930). Removing this avoids an unsupported and misleading molecular-function assertion.
+                        </div>
+
+
+
+                        <div class="propagation-review">
+                            <div class="propagation-title">Propagation Review</div>
+                            <div class="propagation-row">
+                                <strong>Root cause:</strong>
+                                <span class="badge">PROPAGATION BAD</span>
+                            </div>
+
+                            <div class="propagation-row">
+                                <strong>Failure modes:</strong>
+
+                                <span class="badge">WRONG ORTHOLOG OR PARALOG</span>
+
+                                <span class="badge">FUNCTIONAL DIVERGENCE</span>
+
+                            </div>
+
+
+                            <div class="propagation-source">
+                                <strong>Sources checked:</strong>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">PANTHER:PTN002797693</span>
+
+                                    &middot; PTHR24243 class A GPCR IBA seed node
+
+
+                                    <span class="badge">SUPPORTS SOURCE BUT NOT TARGET</span>
+
+
+                                    <div class="propagation-comment">Neuropeptide-receptor activity is valid for genuine peptide-receptor members of this large class A GPCR family, but DCAR-1&#39;s characterized ligands are small-molecule metabolites (HPLA, DHCA), not neuropeptides.</div>
+
+                                </div>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">WB:WBGene00019616</span>
+
+                                    &middot; C. elegans family member in the IBA with/from set
+
+
+                                    <span class="badge">SUPPORTS SOURCE BUT NOT TARGET</span>
+
+
+                                    <div class="propagation-comment">Co-annotated family member; it does not establish a neuropeptide ligand for DCAR-1.</div>
+
+                                </div>
+
+                            </div>
+
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/25086774" target="_blank" class="term-link">
+                                        PMID:25086774
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">the tyrosine derivative 4-hydroxyphenyllactic acid (HPLA) as an endogenous ligand</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/25086774" target="_blank" class="term-link">
+                                        PMID:25086774
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Dihydrocaffeic acid (DHCA) has been described as a potent ligand for DCAR-1 in both in vivo and in heterologous Xenopus oocyte assays</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0007218" target="_blank" class="term-link">
+                                    GO:0007218
+                                </a>
+                            </span>
+                            <span class="term-label">neuropeptide signaling pathway</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-remove">
+                            REMOVE
+                        </span>
+                        <span class="vote-buttons" data-g="G5EDI0" data-a="GO:0007218" data-r="GO_REF:0000033" data-act="REMOVE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Companion IBA propagation to the neuropeptide receptor activity call, inferred from the GPCR family rather than from DCAR-1&#39;s own biology. DCAR-1 signalling is driven by small-molecule ligands (HPLA, DHCA), not by neuropeptides.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Over-propagated family-level IBA not supported by any evidence specific to DCAR-1 and contradicted by its characterized small-molecule ligands. The gene&#39;s signalling role is correctly captured by G protein-coupled receptor signaling pathway (GO:0007186) and the defense/wounding process terms.
+                        </div>
+
+
+
+                        <div class="propagation-review">
+                            <div class="propagation-title">Propagation Review</div>
+                            <div class="propagation-row">
+                                <strong>Root cause:</strong>
+                                <span class="badge">PROPAGATION BAD</span>
+                            </div>
+
+                            <div class="propagation-row">
+                                <strong>Failure modes:</strong>
+
+                                <span class="badge">WRONG ORTHOLOG OR PARALOG</span>
+
+                                <span class="badge">FUNCTIONAL DIVERGENCE</span>
+
+                            </div>
+
+
+                            <div class="propagation-source">
+                                <strong>Sources checked:</strong>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">PANTHER:PTN002797693</span>
+
+                                    &middot; PTHR24243 class A GPCR IBA seed node
+
+
+                                    <span class="badge">SUPPORTS SOURCE BUT NOT TARGET</span>
+
+
+                                    <div class="propagation-comment">Neuropeptide signalling is valid for genuine peptide-receptor members of this family, but DCAR-1 signals in response to small-molecule metabolites (HPLA, DHCA), not neuropeptides.</div>
+
+                                </div>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">WB:WBGene00019616</span>
+
+                                    &middot; C. elegans family member in the IBA with/from set
+
+
+                                    <span class="badge">SUPPORTS SOURCE BUT NOT TARGET</span>
+
+
+                                    <div class="propagation-comment">Co-annotated family member; it does not establish neuropeptide signalling for DCAR-1.</div>
+
+                                </div>
+
+                            </div>
+
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/25086774" target="_blank" class="term-link">
+                                        PMID:25086774
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">HPLA can act through DCAR-1 to regulate the epidermal innate immune response</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0007635" target="_blank" class="term-link">
+                                    GO:0007635
+                                </a>
+                            </span>
+                            <span class="term-label">chemosensory behavior</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/22090488" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:22090488
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    A seven-transmembrane receptor that mediates avoidance respo...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-new">
+                            NEW
+                        </span>
+                        <span class="vote-buttons" data-g="G5EDI0" data-a="GO:0007635" data-r="PMID:22090488" data-act="NEW">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> In ASH sensory neurons DCAR-1 is required for avoidance of the water- soluble repellent dihydrocaffeic acid (DHCA): dcar-1 null mutants are defective in DHCA avoidance and ASH-specific expression rescues the defect (Aoki et al. 2011), a role corroborated in Zugasti et al. 2014.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Not present in GOA, but the neuronal chemosensory (repellent-avoidance) function is directly established by IMP evidence and is genetically separable from the epidermal immune role. Added so that the receptor&#39;s second, well-supported evolved function is captured in the structured annotations (mirrors the neuronal core_function).
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/22090488" target="_blank" class="term-link">
+                                        PMID:22090488
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">dcar-1 mutant animals are defective in avoidance response to DHCA, and cell-specific expression of dcar-1 in the ASH neurons</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/25086774" target="_blank" class="term-link">
+                                        PMID:25086774
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">In neurons, dcar-1 mediates an avoidance response to specific repellents, acting in concert with ocr-2 and osm-9</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>DCAR-1 acts as an epidermal innate-immune GPCR: it is a plasma-membrane (apical hyp7) receptor that detects the endogenous damage-associated metabolite HPLA (and, exogenously, DHCA) generated upon fungal infection or wounding, and transduces this via Galpha (GPA-12) and the p38 MAPK cascade to induce antimicrobial peptide genes and confer resistance to Drechmeria coniospora.</h3>
+                <span class="vote-buttons" data-g="G5EDI0" data-a="FUNCTION: DCAR-1 acts as an epidermal innate-immune GPCR: it..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004930" target="_blank" class="term-link">
+                            G protein-coupled receptor activity
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0050832" target="_blank" class="term-link">
+                                defense response to fungus
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0009611" target="_blank" class="term-link">
+                                response to wounding
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0007186" target="_blank" class="term-link">
+                                G protein-coupled receptor signaling pathway
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016324" target="_blank" class="term-link">
+                                apical plasma membrane
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005886" target="_blank" class="term-link">
+                                plasma membrane
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/25086774" target="_blank" class="term-link">
+                                PMID:25086774
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">DCAR-1 acted in the epidermis to regulate the expression of antimicrobial peptides via a conserved p38 mitogen-activated protein kinase pathway.</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/25086774" target="_blank" class="term-link">
+                                PMID:25086774
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">Our findings reveal DCAR-1 and its cognate ligand HPLA to be triggers of the epidermal innate immune response</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/25086774" target="_blank" class="term-link">
+                                PMID:25086774
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">dcar-1 was expressed on the apical surface in the major epidermal syncytium, hyp7</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:worm/dcar-1/dcar-1-deep-research-falcon.md
+
+                        </span>
+
+                        <div class="finding-text">DAMP-sensing GPCR that activates epidermal innate immunity in response to fungal infection and wounding</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>In ciliated ASH (and ASI, PVQ) sensory neurons DCAR-1 acts as a chemoreceptor for the exogenous water-soluble repellent dihydrocaffeic acid (DHCA), driving an avoidance response together with the TRPV channel subunits OCR-2 and OSM-9. This neuronal chemosensory role is genetically and functionally separable from the epidermal immune role (neuronal expression rescues avoidance but not antimicrobial peptide induction).</h3>
+                <span class="vote-buttons" data-g="G5EDI0" data-a="FUNCTION: In ciliated ASH (and ASI, PVQ) sensory neurons DCA..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004930" target="_blank" class="term-link">
+                            G protein-coupled receptor activity
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0007635" target="_blank" class="term-link">
+                                chemosensory behavior
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0007186" target="_blank" class="term-link">
+                                G protein-coupled receptor signaling pathway
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005886" target="_blank" class="term-link">
+                                plasma membrane
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/22090488" target="_blank" class="term-link">
+                                PMID:22090488
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">DCAR-1 as the first seven-transmembrane receptor required for avoidance of a water-soluble repellent, DHCA, in C. elegans</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/25086774" target="_blank" class="term-link">
+                                PMID:25086774
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">In neurons, dcar-1 mediates an avoidance response to specific repellents, acting in concert with ocr-2 and osm-9</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
+                            GO_REF:0000033
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Annotation inferences using phylogenetic trees</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000104.md" target="_blank" class="term-link">
+                            GO_REF:0000104
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Electronic Gene Ontology annotations created by transferring manual GO annotations between related proteins based on shared sequence features</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000120.md" target="_blank" class="term-link">
+                            GO_REF:0000120
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Combined Automated Annotation using Multiple IEA Methods</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/22090488" target="_blank" class="term-link">
+                            PMID:22090488
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">A seven-transmembrane receptor that mediates avoidance response to dihydrocaffeic acid, a water-soluble repellent in Caenorhabditis elegans.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">DCAR-1 is a novel seven-transmembrane receptor for the water-soluble repellent dihydrocaffeic acid (DHCA), expressed in the ASH avoidance sensory neurons; dcar-1 mutants are defective in DHCA avoidance and ASH-specific expression rescues the defect.</div>
+
+                        <div class="finding-text">"we identified a candidate dihydrocaffeic acid receptor (DCAR), DCAR-1. DCAR-1 is a novel seven-transmembrane protein that is expressed in the ASH avoidance sensory neurons of C. elegans."</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/25086774" target="_blank" class="term-link">
+                            PMID:25086774
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Activation of a G protein-coupled receptor by its endogenous ligand triggers the innate immune response of Caenorhabditis elegans.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">DCAR-1 was the sole hit from an RNAi screen of 1,150 GPCR genes required for infection- and wounding-induced antimicrobial peptide expression, acting upstream of (or in parallel to) the Galpha protein GPA-12 in the epidermal p38 MAPK pathway.</div>
+
+                        <div class="finding-text">"dcar-1 emerged alone as an innate immune receptor gene acting upstream of (or in parallel to) gpa-12"</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <div class="finding-statement">The tyrosine-derived metabolite HPLA is an endogenous damage-associated ligand for DCAR-1 that increases upon infection and cuticle damage and drives DCAR-1-dependent antimicrobial peptide expression in the epidermis.</div>
+
+                        <div class="finding-text">"the tyrosine derivative 4-hydroxyphenyllactic acid (HPLA) as an endogenous ligand"</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        file:worm/dcar-1/dcar-1-deep-research-falcon.md
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Deep research report (Edison/falcon) for C. elegans dcar-1</div>
+
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Questions for Experts</h2>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Does DCAR-1 bind HPLA directly, and which extracellular/transmembrane residues form the ligand-binding pocket?</p>
+
+                    <p style="margin-top: 0.5rem;"><em>Suggested experts: Jonathan J Ewbank, Nathalie Pujol</em></p>
+
+                </div>
+                <span class="vote-buttons" data-g="G5EDI0" data-a="Q: Does DCAR-1 bind HPLA directly, and which extracel..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Do HPLA-sensing receptors functionally analogous to DCAR-1 exist outside the nematode phylum, given that HPLA is a conserved tyrosine metabolite?</p>
+
+                    <p style="margin-top: 0.5rem;"><em>Suggested experts: Jonathan J Ewbank</em></p>
+
+                </div>
+                <span class="vote-buttons" data-g="G5EDI0" data-a="Q: Do HPLA-sensing receptors functionally analogous t..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Experiments</h2>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Express DCAR-1 in a heterologous GPCR-activation system (as previously done with DHCA in Xenopus oocytes) and measure dose-dependent activation by HPLA and structurally related phenolic acids; test coupling specificity against GPA-12 versus other Galpha subunits.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: DCAR-1 is the direct receptor for HPLA and couples to GPA-12.</em></p>
+
+
+                    <p style="margin-top: 0.5rem;">Type: heterologous receptor activation / ligand-response assay</p>
+
+                </div>
+                <span class="vote-buttons" data-g="G5EDI0" data-a="EXPERIMENT: Express DCAR-1 in a heterologous GPCR-activation s..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Use targeted metabolomics with isotope-labelled tyrosine to trace HPLA production before and after infection/wounding, combined with epidermis- specific RNAi/overexpression of candidate aminotransferases and reductases (e.g. tatn-1) to identify the biosynthetic enzymes.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: HPLA is generated in the epidermis by a defined tyrosine-catabolic route whose flux increases with damage.</em></p>
+
+
+                    <p style="margin-top: 0.5rem;">Type: stable-isotope metabolomics + tissue-specific genetics</p>
+
+                </div>
+                <span class="vote-buttons" data-g="G5EDI0" data-a="EXPERIMENT: Use targeted metabolomics with isotope-labelled ty..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Knowledge Gaps</h2>
+        <p style="color: #555; font-size: 0.92rem; margin-top: -0.3rem;">
+            What is <em>not</em> known — curated, literature-grounded statements of the open
+            unknowns (the inverse of core functions).
+        </p>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The structural and biochemical basis of ligand recognition by DCAR-1 is unknown: there is no direct binding assay, no structure, and no defined ligand-binding pocket or residues. Whether DCAR-1 is the direct receptor for HPLA (versus an upstream/indirect sensor) has not been demonstrated biochemically.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">RESIDUAL_SUBGAP</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> It is firmly established that DCAR-1 is a 7-TM class A GPCR required in the epidermis for HPLA/DHCA-triggered antimicrobial peptide induction and anti-fungal defense, and that it can respond to DHCA in a heterologous Xenopus oocyte system. The evidence that HPLA is the endogenous ligand is genetic and metabolomic (correlative), not a direct receptor-binding measurement.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> HPLA is the first described damage-associated molecular pattern (DAMP) in C. elegans; defining how DCAR-1 binds it would establish the molecular logic of DAMP sensing by a metazoan GPCR and enable rational tests of whether analogous receptors exist beyond nematodes.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Direct ligand-binding/activation assays (e.g. purified receptor or cell-based GPCR activation with HPLA titration), mutagenesis of predicted binding-pocket residues, and structural determination of the DCAR-1-HPLA complex.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"We provide strong correlative evidence that HPLA is an endogenous ligand for DCAR-1. Proving this definitively is not straightforward"</em> — PMID:25086774</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> It is unknown whether DCAR-1 has ligands or roles beyond HPLA/DHCA - including its natural neuronal ligand, whether it recognizes any microbe-associated molecular pattern, and whether it contributes to pathogen-avoidance behaviour as a second host-defense role.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">MF_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> DCAR-1 is known to detect the endogenous metabolite HPLA (epidermal immunity) and the exogenous repellent DHCA (neuronal avoidance via ASH/ASI/ PVQ with OCR-2/OSM-9). Beyond these, its ligand spectrum and the physiological relevance of its neuronal signalling to host defense are not established.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> GPCRs are proposed to be an under-explored class of immunomodulatory receptors; clarifying whether DCAR-1 senses microbial patterns or only host damage signals would sharpen models of how nematodes discriminate infection from sterile injury.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Systematic ligand/deorphanization screens, tests for direct microbe-derived agonists, and behavioural/immune assays separating DCAR-1&#39;s neuronal and epidermal contributions to defense.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"It is not known whether any GPCR recognizes specific microbe-associated molecular patterns."</em> — PMID:25086774</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The biosynthetic origin of the DAMP ligand HPLA, and the mechanism by which infection and cuticle damage raise its levels, are uncharacterized - including whether the invading fungus contributes to HPLA production or the increase is entirely host-derived.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">BP_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> HPLA is a tyrosine-derived metabolite that increases upon infection and in cuticle-defective dpy-10 mutants, and epidermal overexpression of the candidate aminotransferase tatn-1 raises dcar-1-dependent antimicrobial peptide expression. The enzymes and regulatory logic of HPLA production remain undefined and were only partially probed (candidate aminotransferase knockdowns were inconclusive, likely due to redundancy).</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Understanding how HPLA is generated would reveal how damage and infection are converted into a diffusible immune-activating signal, and whether the pathway is a host stress response or a pathogen-influenced process.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Genetic and biochemical dissection of tyrosine catabolism/HPLA synthesis in the epidermis, isotope-tracing of HPLA under infection, and host-versus- pathogen source discrimination.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"Although its biosynthetic pathway has not been characterized in any eukaryote, HPLA is likely derived from tyrosine"</em> — PMID:25086774</li>
+
+            </ul>
+
+
+        </div>
+
+    </div>
+
+
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Deep Research Sections -->
+
+    <div class="section">
+        <h2 class="section-title">Deep Research</h2>
+
+        <details class="deep-research-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; gap: 1rem;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Falcon</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(dcar-1-deep-research-falcon.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="G5EDI0" data-a="DEEP_RESEARCH: Falcon" data-r="" data-act="DEEP_RESEARCH" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This deep research is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This deep research needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+
+                <div class="report-meta">
+
+                    <span class="report-meta-text">Comprehensive Research Report: DCAR-1 (C06H5.7) in *Caenorhabditis elegans*</span>
+
+
+                    <span class="report-badge">Falcon</span>
+
+
+                    <span class="report-badge">Edison Scientific Literature</span>
+
+
+                    <span class="report-badge">19 citations</span>
+
+
+                    <span class="report-badge">2 artifacts</span>
+
+
+                    <span class="report-meta-text">2026-07-04T16:36:23.457277</span>
+
+
+
+                </div>
+
+
+                <div class="artifact-list">
+
+
+
+                    <div class="artifact-link">
+                        <a href="dcar-1-deep-research-falcon_artifacts/artifact-00.md" class="term-link">Edison artifact artifact-00</a>
+                        <span>(text/markdown)</span>
+                    </div>
+
+
+
+
+                    <div class="artifact-link">
+                        <a href="dcar-1-deep-research-falcon_artifacts/artifact-01.md" class="term-link">Edison artifact artifact-01</a>
+                        <span>(text/markdown)</span>
+                    </div>
+
+
+                </div>
+
+                <p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h1 id="comprehensive-research-report-dcar-1-c06h57-in-caenorhabditis-elegans">Comprehensive Research Report: DCAR-1 (C06H5.7) in <em>Caenorhabditis elegans</em></h1>
+<h2 id="1-gene-and-protein-identity">1. Gene and Protein Identity</h2>
+<p>DCAR-1 (DihydroCaffeic Acid Receptor-1) is a G-protein coupled receptor (GPCR) encoded by the gene <em>dcar-1</em> (systematic name C06H5.7) in <em>Caenorhabditis elegans</em> (UniProt accession G5EDI0). The protein belongs to the rhodopsin-like family of seven-transmembrane receptors (domain: GPCR_Rhodpsn_7TM, InterPro IPR017452) (venkatesh2021gproteincoupledreceptors pages 2-4, taffoni2015mechanismsofinnate pages 5-6). DCAR-1 is notable as the only GPCR identified to date that functions as a damage-associated molecular pattern (DAMP) sensor in <em>C. elegans</em> (venkatesh2021gproteincoupledreceptors pages 2-4, garciasanchez2021ubiquitinrelatedprocessesand pages 9-10).</p>
+<p>The following table summarizes the key identity and functional features of DCAR-1:</p>
+<table>
+<thead>
+<tr>
+<th>Feature</th>
+<th>Value</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Gene Symbol</td>
+<td>dcar-1</td>
+</tr>
+<tr>
+<td>Full Name</td>
+<td>DihydroCaffeic Acid Receptor-1</td>
+</tr>
+<tr>
+<td>Systematic Name</td>
+<td>C06H5.7</td>
+</tr>
+<tr>
+<td>UniProt ID</td>
+<td>G5EDI0</td>
+</tr>
+<tr>
+<td>Organism</td>
+<td><em>Caenorhabditis elegans</em></td>
+</tr>
+<tr>
+<td>Protein Type</td>
+<td>G-protein coupled receptor (GPCR), predicted 7-transmembrane receptor; consistent with rhodopsin-like 7TM annotation in UniProt (venkatesh2021gproteincoupledreceptors pages 2-4)</td>
+</tr>
+<tr>
+<td>Domain</td>
+<td>GPCR_Rhodpsn_7TM / IPR017452; literature describes DCAR-1 as a GPCR/7TM receptor (venkatesh2021gproteincoupledreceptors pages 2-4, taffoni2015mechanismsofinnate pages 5-6)</td>
+</tr>
+<tr>
+<td>Endogenous Ligand</td>
+<td>4-hydroxyphenyllactic acid (HPLA), a tyrosine-derived damage-associated molecular pattern (DAMP) that accumulates after infection or injury (venkatesh2021gproteincoupledreceptors pages 2-4, taffoni2015mechanismsofinnate pages 5-6)</td>
+</tr>
+<tr>
+<td>Tissue Expression</td>
+<td>Epidermis/hypodermis, especially the apical epidermal syncytium; also reported in sensory neurons, although immune function is epidermis-specific (taffoni2015mechanismsofinnate pages 5-6, venkatesh2021gproteincoupledreceptors pages 2-4)</td>
+</tr>
+<tr>
+<td>Functional Localization</td>
+<td>Cell surface receptor localized to the apical part of the epidermal syncytium hyp7 (taffoni2015mechanismsofinnate pages 5-6, taffoni2015mechanismsofinnate pages 4-5)</td>
+</tr>
+<tr>
+<td>Primary Function</td>
+<td>DAMP-sensing GPCR that activates epidermal innate immunity in response to fungal infection and wounding (venkatesh2021gproteincoupledreceptors pages 2-4, garciasanchez2021ubiquitinrelatedprocessesand pages 9-10, kim2018signalinginthe pages 14-16)</td>
+</tr>
+<tr>
+<td>Key Biological Processes</td>
+<td>Antifungal defense against <em>Drechmeria coniospora</em>, wound response, and induction of antimicrobial peptide genes including <em>nlp</em> family targets such as <em>nlp-29</em> (venkatesh2021gproteincoupledreceptors pages 2-4, taffoni2015mechanismsofinnate pages 5-6)</td>
+</tr>
+<tr>
+<td>Initial Characterization</td>
+<td>Initially characterized behaviorally as a seven-transmembrane receptor mediating avoidance to dihydrocaffeic acid (Aoki et al. 2011; identified in retrieved literature but full text unavailable in tool search). Subsequently established as an innate immune receptor activated by endogenous HPLA to trigger AMP expression during epidermal damage/infection (summarized in later reviews citing the 2014 primary work) (taffoni2015mechanismsofinnate pages 5-6, kim2018signalinginthe pages 14-16)</td>
+</tr>
+</tbody>
+</table>
+<p><em>Table: This table summarizes the verified identity, ligand, localization, and core biological role of the C. elegans GPCR DCAR-1. It is useful as a quick reference to distinguish this receptor from similarly named genes and to anchor interpretation of the downstream immune signaling literature.</em></p>
+<h2 id="2-primary-function-damp-sensing-receptor-for-epidermal-innate-immunity">2. Primary Function: DAMP-Sensing Receptor for Epidermal Innate Immunity</h2>
+<p>DCAR-1 serves as a pattern recognition receptor that detects tissue damage in the <em>C. elegans</em> epidermis (hypodermis) and activates innate immune defenses. Unlike mammalian Toll-like receptors that primarily detect pathogen-associated molecular patterns (PAMPs), DCAR-1 functions by sensing a host-derived endogenous ligand that accumulates when epidermal integrity is compromised (venkatesh2021gproteincoupledreceptors pages 2-4, kim2018signalinginthe pages 14-16).</p>
+<h3 id="21-endogenous-ligand-4-hydroxyphenyllactic-acid-hpla">2.1 Endogenous Ligand: 4-Hydroxyphenyllactic Acid (HPLA)</h3>
+<p>The endogenous ligand of DCAR-1 is 4-hydroxyphenyllactic acid (HPLA), a product of tyrosine degradation in the hypodermis (taffoni2015mechanismsofinnate pages 5-6, venkatesh2021gproteincoupledreceptors pages 2-4). HPLA levels increase under conditions of epidermal damage, including physical wounding, infection by the natural fungal pathogen <em>Drechmeria coniospora</em>, and in cuticle-defective mutants such as <em>dpy-9</em> and <em>dpy-10</em> (kim2018signalinginthe pages 14-16). The accumulation of HPLA thus functions as a danger signal, providing a mechanism by which the epidermis can detect tissue disruption and mount a defensive response. This identification of HPLA as the cognate ligand was a landmark finding that established DCAR-1 as the first deorphanized GPCR in the <em>C. elegans</em> innate immune system (venkatesh2021gproteincoupledreceptors pages 2-4, zhang2021antagonisticfungalenterotoxins pages 10-12).</p>
+<p>The gene was initially named for its response to dihydrocaffeic acid, a water-soluble repellent that elicits avoidance behavior in <em>C. elegans</em> via sensory neurons (Aoki et al., 2011, as cited in multiple reviews) (venkatesh2021gproteincoupledreceptors pages 2-4). However, the immune-regulatory function of DCAR-1 is distinct from and independent of this neuronal chemosensory role.</p>
+<h3 id="22-biological-roles">2.2 Biological Roles</h3>
+<p>DCAR-1 plays critical roles in two primary contexts of epidermal defense:</p>
+<p><strong>Antifungal immunity:</strong> During infection by <em>D. coniospora</em>, a natural endoparasitic fungal pathogen of <em>C. elegans</em> that adheres to the cuticle via specialized adhesive knobs and can kill worms within 48 hours, DCAR-1 is essential for the rapid transcriptional upregulation of antimicrobial peptide (AMP) genes in the epidermis (taffoni2015mechanismsofinnate pages 5-6, taffoni2015mechanismsofinnate pages 4-5). The primary transcriptional targets include neuropeptide-like protein genes, particularly <em>nlp-29</em>, as well as caenacin (<em>cnc</em>) genes (taffoni2015mechanismsofinnate pages 5-6, dierking2016antimicrobialeffectorsin pages 4-5).</p>
+<p><strong>Wound response:</strong> Physical injury to the epidermis similarly triggers DCAR-1-dependent AMP gene induction, demonstrating that this receptor integrates signals from both pathogenic and sterile damage (taffoni2015mechanismsofinnate pages 4-5, taffoni2015mechanismsofinnate pages 5-6).</p>
+<h2 id="3-tissue-and-subcellular-localization">3. Tissue and Subcellular Localization</h2>
+<p>DCAR-1 is expressed in the epidermis (hypodermis) and in sensory neurons. However, its immune-regulatory function is epidermis-specific and cell-autonomous (taffoni2015mechanismsofinnate pages 5-6, venkatesh2021gproteincoupledreceptors pages 2-4). Within the epidermis, DCAR-1 localizes to the apical part of the epidermal syncytium hyp7, positioning it at the cell surface facing the cuticle—the barrier tissue most directly exposed to environmental pathogens and physical insults (taffoni2015mechanismsofinnate pages 5-6, taffoni2015mechanismsofinnate pages 4-5). This apical localization is functionally significant because it places the receptor at the interface where damage signals (HPLA) would first accumulate following cuticle compromise or pathogen attachment.</p>
+<h2 id="4-signaling-pathway">4. Signaling Pathway</h2>
+<p>The DCAR-1 signaling pathway in the epidermis has been extensively characterized through forward genetic screens, genome-wide RNAi screens, and epistasis analysis. The pathway proceeds as follows:</p>
+<table>
+<thead>
+<tr>
+<th>Component</th>
+<th>Type/Function</th>
+<th>Position in Pathway</th>
+<th>Role</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>DCAR-1</td>
+<td>GPCR; DAMP receptor activated by HPLA</td>
+<td>Receptor / pathway entry point</td>
+<td>Binds the endogenous tyrosine-metabolite ligand 4-hydroxyphenyllactic acid (HPLA) generated during epidermal damage, fungal infection, or wounding; initiates epidermal innate immune signaling to AMP genes (venkatesh2021gproteincoupledreceptors pages 2-4, taffoni2015mechanismsofinnate pages 5-6)</td>
+</tr>
+<tr>
+<td>GPA-12</td>
+<td>Gα signaling subunit</td>
+<td>Immediately downstream of DCAR-1</td>
+<td>Transduces the activated GPCR signal toward PKC-dependent immune signaling required for AMP induction after fungal infection or wounding (taffoni2015mechanismsofinnate pages 5-6, dierking2016antimicrobialeffectorsin pages 4-5, zhang2021antagonisticfungalenterotoxins pages 10-12)</td>
+</tr>
+<tr>
+<td>RACK-1</td>
+<td>Gβ-associated signaling component / scaffold</td>
+<td>Parallel to GPA-12 downstream of DCAR-1</td>
+<td>Cooperates with GPA-12 in GPCR signaling upstream of TPA-1 to promote epidermal antimicrobial gene expression (taffoni2015mechanismsofinnate pages 5-6)</td>
+</tr>
+<tr>
+<td>EGL-8/PLC-3</td>
+<td>Phospholipase C enzymes</td>
+<td>Upstream of DAG production</td>
+<td>Convert PIP2 into DAG, providing the second messenger input needed to activate TPA-1/PKC in the epidermal immune pathway (taffoni2015mechanismsofinnate pages 5-6)</td>
+</tr>
+<tr>
+<td>DAG</td>
+<td>Lipid second messenger</td>
+<td>Between PLCs and TPA-1</td>
+<td>Activates TPA-1, coupling upstream GPCR/G-protein signaling to the kinase cascade that drives AMP expression (taffoni2015mechanismsofinnate pages 5-6, kim2018signalinginthe pages 9-12)</td>
+</tr>
+<tr>
+<td>TPA-1</td>
+<td>Protein kinase C (PKC)</td>
+<td>Downstream of GPA-12/RACK-1 and DAG</td>
+<td>Central kinase transmitting the DCAR-1 signal toward TIR-1 and the p38 MAPK cascade in response to epidermal infection or injury (taffoni2015mechanismsofinnate pages 5-6, kim2018signalinginthe pages 9-12)</td>
+</tr>
+<tr>
+<td>TIR-1</td>
+<td>TIR-domain adaptor / scaffold</td>
+<td>Upstream of MAP3K NSY-1</td>
+<td>Links PKC-dependent signaling to the conserved p38 MAPK module that controls antimicrobial peptide induction (taffoni2015mechanismsofinnate pages 5-6, dierking2016antimicrobialeffectorsin pages 4-5, kim2018signalinginthe pages 14-16)</td>
+</tr>
+<tr>
+<td>NSY-1</td>
+<td>MAP kinase kinase kinase (MAP3K)</td>
+<td>First kinase in p38 MAPK cascade</td>
+<td>Receives input from TIR-1 and activates downstream SEK-1 as part of the canonical epidermal innate immune cascade (taffoni2015mechanismsofinnate pages 5-6)</td>
+</tr>
+<tr>
+<td>SEK-1</td>
+<td>MAP kinase kinase (MAP2K)</td>
+<td>Middle kinase in p38 MAPK cascade</td>
+<td>Relays the signal from NSY-1 to PMK-1 to support transcriptional activation of AMP genes (taffoni2015mechanismsofinnate pages 5-6)</td>
+</tr>
+<tr>
+<td>PMK-1</td>
+<td>p38 MAP kinase</td>
+<td>Terminal kinase in core MAPK cascade</td>
+<td>Executes the p38 MAPK immune response downstream of DCAR-1, promoting AMP induction and antifungal defense in the epidermis (venkatesh2021gproteincoupledreceptors pages 2-4, taffoni2015mechanismsofinnate pages 5-6)</td>
+</tr>
+<tr>
+<td>STA-2</td>
+<td>STAT-like transcription factor</td>
+<td>Downstream nuclear effector of PMK-1 pathway</td>
+<td>Required for transcriptional activation of nlp genes and contributes to AMP expression after fungal infection, wounding, and damage sensing (garciasanchez2021ubiquitinrelatedprocessesand pages 9-10, taffoni2015mechanismsofinnate pages 5-6, kim2018signalinginthe pages 9-12, zhu2023c.eleganshemidesmosomes pages 1-2)</td>
+</tr>
+<tr>
+<td>ELT-3</td>
+<td>GATA transcription factor</td>
+<td>Co-regulator with STA-2 downstream of signaling cascade</td>
+<td>Works with STA-2 to promote epidermal AMP gene transcription in response to DCAR-1 pathway activation (taffoni2015mechanismsofinnate pages 5-6)</td>
+</tr>
+<tr>
+<td>nlp-29/cnc (target genes)</td>
+<td>Antimicrobial peptide genes / transcriptional outputs</td>
+<td>Terminal output</td>
+<td>Encode epidermally induced antimicrobial effectors. nlp-29 is a canonical DCAR-1–p38 MAPK target; cnc genes can also be induced in related epidermal defense programs, with some regulation occurring through a non-canonical DBL-1/TGF-β branch depending on stimulus context (taffoni2015mechanismsofinnate pages 4-5, taffoni2015mechanismsofinnate pages 5-6, dierking2016antimicrobialeffectorsin pages 4-5)</td>
+</tr>
+</tbody>
+</table>
+<p><em>Table: This table summarizes the experimentally supported DCAR-1 epidermal signaling pathway in C. elegans, from HPLA sensing at the receptor to antimicrobial peptide gene induction. It is useful for tracing how damage-associated signaling is converted into antifungal and wound-response outputs.</em></p>
+<h3 id="41-detailed-pathway-description">4.1 Detailed Pathway Description</h3>
+<p>Upon activation by HPLA, DCAR-1 couples to the heterotrimeric G protein subunits GPA-12 (Gα) and RACK-1 (Gβ), which are required for downstream signal transduction to antimicrobial peptide gene expression (taffoni2015mechanismsofinnate pages 5-6, venkatesh2021gproteincoupledreceptors pages 2-4). The G-protein signaling activates phospholipase C enzymes EGL-8 and PLC-3, which hydrolyze phosphatidylinositol 4,5-bisphosphate (PIP2) to produce diacylglycerol (DAG), a lipid second messenger (taffoni2015mechanismsofinnate pages 5-6). DAG in turn activates the serine/threonine protein kinase C TPA-1 (taffoni2015mechanismsofinnate pages 5-6, kim2018signalinginthe pages 9-12).</p>
+<p>TPA-1 acts upstream of TIR-1, a TIR-domain adaptor protein homologous to mammalian SARM1, which serves as a scaffold linking PKC-dependent signaling to the core p38 MAPK cascade (taffoni2015mechanismsofinnate pages 5-6, dierking2016antimicrobialeffectorsin pages 4-5). The MAPK module consists of the MAP3K NSY-1, the MAP2K SEK-1, and the p38 MAPK PMK-1, which constitutes the terminal kinase in the cascade (taffoni2015mechanismsofinnate pages 5-6, kim2018signalinginthe pages 9-12).</p>
+<p>PMK-1 activates the STAT-like transcription factor STA-2 and the GATA transcription factor ELT-3, which together drive transcription of <em>nlp</em> antimicrobial peptide genes, including the canonical target <em>nlp-29</em> (taffoni2015mechanismsofinnate pages 5-6, kim2018signalinginthe pages 9-12, dierking2016antimicrobialeffectorsin pages 4-5). The caenacin (<em>cnc</em>) AMP gene family is also regulated through this pathway, although <em>cnc</em> gene induction shows additional complexity: after wounding, <em>cnc</em> induction is p38 MAPK-dependent, but after fungal infection, <em>cnc</em> expression is regulated through a non-canonical DBL-1/TGF-β pathway that operates independently of p38 MAPK (taffoni2015mechanismsofinnate pages 5-6, dierking2016antimicrobialeffectorsin pages 4-5).</p>
+<h3 id="42-relationship-to-broader-immune-signaling">4.2 Relationship to Broader Immune Signaling</h3>
+<p>The TIR-1/NSY-1/SEK-1/PMK-1 p38 MAPK cascade is a highly conserved signaling module that also functions in the <em>C. elegans</em> intestine to regulate resistance to bacterial pathogens (kim2018signalinginthe pages 9-12). In the epidermis, this cascade is specifically wired downstream of the DCAR-1 GPCR pathway, whereas in the intestine, different upstream activators engage the same MAPK module (kim2018signalinginthe pages 9-12). This tissue-specific utilization of a shared signaling core highlights how <em>C. elegans</em> achieves distinct immune responses in different tissues using modular signaling architecture.</p>
+<h2 id="5-recent-developments-20232025">5. Recent Developments (2023–2025)</h2>
+<h3 id="51-dcar-1-independent-damage-sensing-via-hemidesmosomes">5.1 DCAR-1-Independent Damage Sensing via Hemidesmosomes</h3>
+<p>A 2023 study by Zhu et al. revealed an important nuance in epidermal damage sensing. Through systematic analysis of collagen-encoding genes, the authors demonstrated that certain types of collagen damage (specifically damage to DPY-7 collagen) can induce <em>nlp-29</em> expression independently of DCAR-1 and PMK-1, via a hemidesmosome-based damage-sensing mechanism (zhu2023c.eleganshemidesmosomes pages 10-12). In this alternative pathway, disruption of DPY collagen substructures causes the separation of collagen BLI-1 from the hemidesmosome receptor MUP-4, leading to release of STA-2 from hemidesmosomes and direct induction of AMP gene expression (zhu2023c.eleganshemidesmosomes pages 1-2, zhu2023c.eleganshemidesmosomes pages 10-12). This finding demonstrates that while DCAR-1 is a major DAMP sensor, the epidermis employs multiple, partially overlapping damage-sensing mechanisms, and DCAR-1 only partially accounts for collagen damage-induced immune responses (zhu2023c.eleganshemidesmosomes pages 1-2).</p>
+<h3 id="52-dcar-1-pathway-and-cisplatin-resistance">5.2 DCAR-1 Pathway and Cisplatin Resistance</h3>
+<p>Raj et al. (2023) identified the p38 MAPK pathway—in which DCAR-1 functions as the upstream DAMP receptor in the epidermis—as a critical determinant of cisplatin toxicity resistance in post-mitotic <em>C. elegans</em> adults (raj2023cisplatintoxicityis pages 10-13, raj2023cisplatintoxicityis pages 13-13). The study demonstrated that cisplatin exposure activates the p38 MAPK/ATF-7 immune signaling axis, and mutations in pathway components including <em>dcar-1</em> increased sensitivity to cisplatin-induced necrotic damage (raj2023cisplatintoxicityis pages 10-13, raj2023cisplatintoxicityis pages 13-14). This work extended the functional significance of the DCAR-1 pathway beyond pathogen defense to xenobiotic stress responses.</p>
+<h3 id="53-pathogen-virulence-strategies-targeting-the-dcar-1-pathway">5.3 Pathogen Virulence Strategies Targeting the DCAR-1 Pathway</h3>
+<p>Zhang et al. (2021) demonstrated that the fungal pathogen <em>D. coniospora</em> produces enterotoxins (DcEntA and DcEntB) that can interfere with the DCAR-1-initiated immune cascade at multiple levels, including blocking STA-2 nuclear translocation and disrupting vesicle trafficking in the epidermis (zhang2021antagonisticfungalenterotoxins pages 10-12). This illustrates the co-evolutionary arms race between host damage sensing and pathogen immune evasion strategies.</p>
+<h2 id="6-evolutionary-and-comparative-significance">6. Evolutionary and Comparative Significance</h2>
+<p>DCAR-1 represents a noncanonical pattern recognition receptor in <em>C. elegans</em> innate immunity (venkatesh2021gproteincoupledreceptors pages 2-4). Unlike mammals, where TLRs, NLRs, and other canonical PRRs directly detect pathogen-derived molecules, <em>C. elegans</em> appears to primarily rely on sensing the damage caused by pathogens rather than pathogen molecules themselves (venkatesh2021gproteincoupledreceptors pages 2-4, kim2018signalinginthe pages 14-16). DCAR-1's function as a DAMP sensor—detecting an endogenous tyrosine metabolite that accumulates upon tissue damage—exemplifies this "guard" or damage-sensing strategy of immune activation (venkatesh2021gproteincoupledreceptors pages 2-4, kim2018signalinginthe pages 14-16). The unique worm TOL-1 (TLR homolog) is not essential for most pathogen defenses, making GPCR-based sensing through receptors like DCAR-1 a particularly important immune detection mechanism in this organism (venkatesh2021gproteincoupledreceptors pages 2-4).</p>
+<h2 id="7-summary">7. Summary</h2>
+<p>DCAR-1 is a rhodopsin-family GPCR that functions as the primary damage-associated molecular pattern sensor in the <em>C. elegans</em> epidermis. Localized to the apical surface of the hyp7 epidermal syncytium, it detects the endogenous ligand HPLA—a tyrosine metabolite that accumulates upon cuticle disruption, fungal infection, or wounding. Ligand binding activates a well-characterized signaling cascade through G-proteins (GPA-12/RACK-1), phospholipase C, DAG, PKC (TPA-1), the TIR-1 adaptor, and the p38 MAPK module (NSY-1/SEK-1/PMK-1), culminating in STA-2- and ELT-3-dependent transcription of antimicrobial peptide genes including <em>nlp-29</em>. Recent work has revealed additional DCAR-1-independent damage-sensing mechanisms in the epidermis and extended the functional relevance of the DCAR-1/p38 MAPK pathway to xenobiotic stress resistance. DCAR-1 remains the only well-documented GPCR functioning as an innate immune DAMP receptor in <em>C. elegans</em>, providing a paradigmatic example of how metazoans can employ GPCRs for immune surveillance at epithelial barriers.</p>
+<p>References</p>
+<ol>
+<li>
+<p>(venkatesh2021gproteincoupledreceptors pages 2-4): Siddharth R. Venkatesh and Varsha Singh. G protein-coupled receptors: the choreographers of innate immunity in caenorhabditis elegans. PLOS Pathogens, 17:e1009151, Jan 2021. URL: https://doi.org/10.1371/journal.ppat.1009151, doi:10.1371/journal.ppat.1009151. This article has 17 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(taffoni2015mechanismsofinnate pages 5-6): Clara Taffoni and Nathalie Pujol. Mechanisms of innate immunity in c. elegans epidermis. Tissue Barriers, 3:e1078432, Oct 2015. URL: https://doi.org/10.1080/21688370.2015.1078432, doi:10.1080/21688370.2015.1078432. This article has 75 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(garciasanchez2021ubiquitinrelatedprocessesand pages 9-10): Juan A. Garcia-Sanchez, Jonathan J. Ewbank, and Orane Visvikis. Ubiquitin-related processes and innate immunity in c. elegans. Cellular and Molecular Life Sciences, 78:4305-4333, Feb 2021. URL: https://doi.org/10.1007/s00018-021-03787-w, doi:10.1007/s00018-021-03787-w. This article has 15 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(taffoni2015mechanismsofinnate pages 4-5): Clara Taffoni and Nathalie Pujol. Mechanisms of innate immunity in c. elegans epidermis. Tissue Barriers, 3:e1078432, Oct 2015. URL: https://doi.org/10.1080/21688370.2015.1078432, doi:10.1080/21688370.2015.1078432. This article has 75 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(kim2018signalinginthe pages 14-16): Dennis H. Kim and J. Ewbank. Signaling in the innate immune response. WormBook, pages 1-35, Aug 2018. URL: https://doi.org/10.1895/wormbook.1.83.2, doi:10.1895/wormbook.1.83.2. This article has 181 citations.</p>
+</li>
+<li>
+<p>(zhang2021antagonisticfungalenterotoxins pages 10-12): Xing Zhang, Benjamin W. Harding, Dina Aggad, Damien Courtine, Jia-Xuan Chen, Nathalie Pujol, and Jonathan J. Ewbank. Antagonistic fungal enterotoxins intersect at multiple levels with host innate immune defences. Jun 2021. URL: https://doi.org/10.1371/journal.pgen.1009600, doi:10.1371/journal.pgen.1009600. This article has 21 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(dierking2016antimicrobialeffectorsin pages 4-5): Katja Dierking, Wentao Yang, and Hinrich Schulenburg. Antimicrobial effectors in the nematode caenorhabditis elegans: an outgroup to the arthropoda. Philosophical Transactions of the Royal Society B: Biological Sciences, 371:20150299, May 2016. URL: https://doi.org/10.1098/rstb.2015.0299, doi:10.1098/rstb.2015.0299. This article has 107 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(kim2018signalinginthe pages 9-12): Dennis H. Kim and J. Ewbank. Signaling in the innate immune response. WormBook, pages 1-35, Aug 2018. URL: https://doi.org/10.1895/wormbook.1.83.2, doi:10.1895/wormbook.1.83.2. This article has 181 citations.</p>
+</li>
+<li>
+<p>(zhu2023c.eleganshemidesmosomes pages 1-2): Yi Zhu, Wenna Li, Yifang Dong, Chujie Xia, and Rong Fu. C. elegans hemidesmosomes sense collagen damage to trigger innate immune response in the epidermis. Cells, 12:2223, Sep 2023. URL: https://doi.org/10.3390/cells12182223, doi:10.3390/cells12182223. This article has 13 citations.</p>
+</li>
+<li>
+<p>(zhu2023c.eleganshemidesmosomes pages 10-12): Yi Zhu, Wenna Li, Yifang Dong, Chujie Xia, and Rong Fu. C. elegans hemidesmosomes sense collagen damage to trigger innate immune response in the epidermis. Cells, 12:2223, Sep 2023. URL: https://doi.org/10.3390/cells12182223, doi:10.3390/cells12182223. This article has 13 citations.</p>
+</li>
+<li>
+<p>(raj2023cisplatintoxicityis pages 10-13): Dorota Raj, Bashar Kraish, Jari Martikainen, Agnieszka Podraza-Farhanieh, Gautam Kao, and Peter Naredi. Cisplatin toxicity is counteracted by the activation of the p38/atf-7 signaling pathway in post-mitotic c. elegans. Nature Communications, May 2023. URL: https://doi.org/10.1038/s41467-023-38568-5, doi:10.1038/s41467-023-38568-5. This article has 13 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(raj2023cisplatintoxicityis pages 13-13): Dorota Raj, Bashar Kraish, Jari Martikainen, Agnieszka Podraza-Farhanieh, Gautam Kao, and Peter Naredi. Cisplatin toxicity is counteracted by the activation of the p38/atf-7 signaling pathway in post-mitotic c. elegans. Nature Communications, May 2023. URL: https://doi.org/10.1038/s41467-023-38568-5, doi:10.1038/s41467-023-38568-5. This article has 13 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(raj2023cisplatintoxicityis pages 13-14): Dorota Raj, Bashar Kraish, Jari Martikainen, Agnieszka Podraza-Farhanieh, Gautam Kao, and Peter Naredi. Cisplatin toxicity is counteracted by the activation of the p38/atf-7 signaling pathway in post-mitotic c. elegans. Nature Communications, May 2023. URL: https://doi.org/10.1038/s41467-023-38568-5, doi:10.1038/s41467-023-38568-5. This article has 13 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+</ol>
+<h2 id="artifacts">Artifacts</h2>
+<ul>
+<li><a href="dcar-1-deep-research-falcon_artifacts/artifact-00.md">Edison artifact artifact-00</a></li>
+<li><a href="dcar-1-deep-research-falcon_artifacts/artifact-01.md">Edison artifact artifact-01</a></li>
+</ul>
+<h2 id="citations">Citations</h2>
+<ol>
+<li>venkatesh2021gproteincoupledreceptors pages 2-4</li>
+<li>kim2018signalinginthe pages 14-16</li>
+<li>taffoni2015mechanismsofinnate pages 5-6</li>
+<li>kim2018signalinginthe pages 9-12</li>
+<li>zhang2021antagonisticfungalenterotoxins pages 10-12</li>
+<li>garciasanchez2021ubiquitinrelatedprocessesand pages 9-10</li>
+<li>taffoni2015mechanismsofinnate pages 4-5</li>
+<li>dierking2016antimicrobialeffectorsin pages 4-5</li>
+<li>raj2023cisplatintoxicityis pages 10-13</li>
+<li>raj2023cisplatintoxicityis pages 13-13</li>
+<li>raj2023cisplatintoxicityis pages 13-14</li>
+<li>https://doi.org/10.1371/journal.ppat.1009151,</li>
+<li>https://doi.org/10.1080/21688370.2015.1078432,</li>
+<li>https://doi.org/10.1007/s00018-021-03787-w,</li>
+<li>https://doi.org/10.1895/wormbook.1.83.2,</li>
+<li>https://doi.org/10.1371/journal.pgen.1009600,</li>
+<li>https://doi.org/10.1098/rstb.2015.0299,</li>
+<li>https://doi.org/10.3390/cells12182223,</li>
+<li>https://doi.org/10.1038/s41467-023-38568-5,</li>
+</ol>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(dcar-1-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="G5EDI0" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="dcar-1-c-elegans-research-notes">DCAR-1 (C. elegans) — research notes</h1>
+<p>UniProt: G5EDI0 (G5EDI0_CAEEL) · WormBase: WBGene00007395 · sequence name C06H5.7 ·<br />
+Reactome: R-CEL-416476 "G alpha (q) signalling events" · 396 aa, 7-TM class A (rhodopsin-like)<br />
+GPCR (PROSITE PS50262 G_PROTEIN_RECEP_F1_2; PANTHER PTHR24243). Chromosome V.</p>
+<p>DCAR-1 = "DihydroCaffeic Acid Receptor 1". Two distinct, experimentally established<br />
+functional contexts, in two tissues:</p>
+<ol>
+<li><strong>Epidermal innate immunity</strong> (flagship function; Zugasti et al. 2014, Nat Immunol,<br />
+   PMID:25086774). DCAR-1 is a plasma-membrane GPCR on the apical surface of the hyp7<br />
+   epidermal syncytium that senses the endogenous tyrosine-derived metabolite HPLA<br />
+   (4-hydroxyphenyllactic acid, a damage-associated molecular pattern, DAMP) produced upon<br />
+   fungal infection/wounding, and triggers antimicrobial-peptide (nlp-29 cluster) gene<br />
+   expression via the GPA-12 (Gα) → TIR-1 → NSY-1/SEK-1/PMK-1 (p38 MAPK) → STA-2 cascade in<br />
+   the epidermis. Required for resistance to the fungus <em>Drechmeria coniospora</em>.</li>
+<li><strong>Neuronal chemosensory avoidance</strong> (Aoki et al. 2011, J Neurosci, PMID:22090488).<br />
+   DCAR-1 was originally identified in a Xenopus oocyte expression screen as a receptor<br />
+   for the water-soluble repellent dihydrocaffeic acid (DHCA); expressed in the ASH (and<br />
+   ASI, PVQ) sensory neurons, where it mediates avoidance of DHCA acting with ocr-2/osm-9.</li>
+</ol>
+<h2 id="known-well-supported">KNOWN (well supported)</h2>
+<ul>
+<li><strong>7-TM class A GPCR.</strong> UniProt/InterPro: 7 predicted TM helices, GPCR family 1 profile<br />
+  domain (PS50262), CDD 7tm_classA_rhodopsin-like, PANTHER PTHR24243. FunFam name<br />
+  "DihydroCaffeic Acid Receptor". Reactome links it to "G alpha (q) signalling events".</li>
+<li><strong>Innate immune receptor.</strong> <a href="https://pubmed.ncbi.nlm.nih.gov/25086774" title="we identified the G protein-coupled receptor   (GPCR) DCAR-1 as being required for the response to fungal infection and wounding.">PMID:25086774</a> Sole<br />
+  hit from an RNAi screen of 1,150 GPCR genes for reduced nlp-29p::gfp AMP induction; two<br />
+  null alleles (tm2484, nj66) confirm. dcar-1 mutants are markedly more susceptible to<br />
+<em>D. coniospora</em> while having normal development/longevity and normal resistance to<br />
+<em>P. aeruginosa</em>.</li>
+<li><strong>Acts via p38 MAPK / GPA-12 in epidermis.</strong> <a href="https://pubmed.ncbi.nlm.nih.gov/25086774" title="DCAR-1 acted in the   epidermis to regulate the expression of antimicrobial peptides via a conserved p38   mitogen-activated protein kinase pathway.">PMID:25086774</a> <a href="https://pubmed.ncbi.nlm.nih.gov/25086774" title="dcar-1 alone acts upstream   or in parallel to GPA-12">PMID:25086774</a>. Methods list gpa-12(pk322), tir-1(tm3036), pmk-1(km25),<br />
+  tpa-1(fr1) epistasis strains — this is the GPA-12→TIR-1→p38/PMK-1 cassette. Links to the<br />
+  already-reviewed <strong>gpa-12</strong> (Gα12/13 ortholog).</li>
+<li><strong>Endogenous ligand = HPLA (a DAMP).</strong> <a href="https://pubmed.ncbi.nlm.nih.gov/25086774" title="the tyrosine derivative   4-hydroxyphenyllactic acid (HPLA) as an endogenous ligand">PMID:25086774</a>. Identified by comparative<br />
+  metabolomics: HPLA present at low level in controls, increased upon infection and in<br />
+  cuticle-defective dpy-10 mutants. <a href="https://pubmed.ncbi.nlm.nih.gov/25086774" title="HPLA can act through DCAR-1 to regulate   the epidermal innate immune response">PMID:25086774</a>. <a href="https://pubmed.ncbi.nlm.nih.gov/25086774" title="HPLA appears to act as a DAMP, to   the best of our knowledge, the first described for C. elegans.">PMID:25086774</a></li>
+<li><strong>Exogenous ligand = DHCA.</strong> <a href="https://pubmed.ncbi.nlm.nih.gov/25086774" title="Dihydrocaffeic acid (DHCA) has been described   as a potent ligand for DCAR-1 in both in vivo and in heterologous Xenopus oocyte assays">PMID:25086774</a>.<br />
+  Original identification: <a href="https://pubmed.ncbi.nlm.nih.gov/22090488" title="we identified a candidate dihydrocaffeic acid   receptor (DCAR), DCAR-1. DCAR-1 is a novel seven-transmembrane protein that is expressed   in the ASH avoidance sensory neurons of C. elegans.">PMID:22090488</a></li>
+<li><strong>Localization.</strong> Apical plasma membrane in hyp7 epidermis:<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/25086774" title="dcar-1 was expressed on the apical surface in the major epidermal   syncytium, hyp7">PMID:25086774</a> (IDA, GO:0016324). Neuronal expression in ASH/ASI/PVQ (ciliated sensory<br />
+  neurons); WormBase IDA GO:0097730 non-motile cilium from PMID:22090488 (abstract-only in<br />
+  cache; the cilium sub-localization is not stated in the abstract but was curated by<br />
+  WormBase from the full text — trust the curator).</li>
+<li><strong>Response to wounding.</strong> <a href="https://pubmed.ncbi.nlm.nih.gov/25086774">PMID:25086774</a> dcar-1 mutants show "an almost complete block of<br />
+  nlp-29p::gfp induction following physical injury", i.e. activation is damage/wound-dependent<br />
+  even without a pathogen (GO:0009611 response to wounding, IMP).</li>
+<li><strong>Cell-autonomous, tissue-separable.</strong> Epidermal (col-12p) but not neuronal (sra-6p)<br />
+  expression rescues AMP induction/immunity; conversely neuronal expression rescues the<br />
+  avoidance phenotype. <a href="https://pubmed.ncbi.nlm.nih.gov/25086774" title="dcar-1 acts in an epidermis-specific and   cell-autonomous manner to regulate AMP gene expression and defense against infection">PMID:25086774</a>.</li>
+<li><strong>Phylogenetically nematode-restricted.</strong> <a href="https://pubmed.ncbi.nlm.nih.gov/25086774" title="Clear homologs of DCAR-1 can be   found in nematode genomes, but not in other animals'">PMID:25086774</a>.</li>
+</ul>
+<h2 id="not-known-open-for-knowledge_gaps">NOT known / open (for knowledge_gaps)</h2>
+<ul>
+<li><strong>Structural basis of HPLA/DHCA sensing is unknown.</strong> No direct binding data, no structure,<br />
+  and the ligand-binding pocket / residues are undefined. HPLA binding is inferred from<br />
+  correlative genetics + metabolomics, not a direct receptor-binding assay:<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/25086774" title="We provide strong correlative evidence that HPLA is an endogenous ligand   for DCAR-1. Proving this definitively is not straightforward">PMID:25086774</a>. Whether DCAR-1 is even the<br />
+  direct HPLA receptor (vs an upstream sensor) is not biochemically proven.</li>
+<li><strong>Whether DCAR-1 has other (neuropeptide or microbial) ligands / roles is unknown.</strong> Its<br />
+  natural neuronal ligand and whether it detects any microbe-associated molecular pattern are<br />
+  undetermined: <a href="https://pubmed.ncbi.nlm.nih.gov/25086774" title="It is not known whether any GPCR recognizes specific   microbe-associated molecular patterns.">PMID:25086774</a> A speculated second role in pathogen-avoidance<br />
+  behavior is unproven.</li>
+<li><strong>HPLA biosynthesis / how infection raises HPLA is uncharacterized.</strong> <a href="https://pubmed.ncbi.nlm.nih.gov/25086774" title="Although its biosynthetic pathway has not been characterized in any eukaryote, HPLA is   likely derived from tyrosine">PMID:25086774</a>; whether the fungus contributes to HPLA or it is purely host<br />
+  damage-derived is an open question.</li>
+<li><strong>Nematode-restricted receptor with a conserved-metabolite ligand</strong> — whether an<br />
+  HPLA/DAMP-sensing receptor exists outside nematodes is unknown: <a href="https://pubmed.ncbi.nlm.nih.gov/25086774" title="It could be   that receptor(s) for HPLA exist outside the nematode phylum, but are not recognizable from   their primary sequence.">PMID:25086774</a></li>
+</ul>
+<h2 id="annotation-review-plan-existing_annotations">Annotation review plan (existing_annotations)</h2>
+<table>
+<thead>
+<tr>
+<th>term</th>
+<th>ev</th>
+<th>ref</th>
+<th>action</th>
+<th>rationale</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>GO:0004930 G protein-coupled receptor activity</td>
+<td>IEA</td>
+<td>GO_REF:0000104</td>
+<td>ACCEPT (core MF)</td>
+<td>7-TM class A GPCR; receptor for HPLA/DHCA</td>
+</tr>
+<tr>
+<td>GO:0007186 GPCR signaling pathway</td>
+<td>IEA</td>
+<td>GO_REF:0000104</td>
+<td>ACCEPT (core BP)</td>
+<td>signals via GPA-12 Gα</td>
+</tr>
+<tr>
+<td>GO:0007165 signal transduction</td>
+<td>IEA</td>
+<td>GO_REF:0000104</td>
+<td>KEEP_AS_NON_CORE</td>
+<td>correct but generic parent of GPCR signaling</td>
+</tr>
+<tr>
+<td>GO:0050832 defense response to fungus</td>
+<td>IMP</td>
+<td>PMID:25086774</td>
+<td>ACCEPT (core BP)</td>
+<td>required for anti-D. coniospora defense</td>
+</tr>
+<tr>
+<td>GO:0009611 response to wounding</td>
+<td>IMP</td>
+<td>PMID:25086774</td>
+<td>ACCEPT (core BP)</td>
+<td>wound/damage-activated AMP induction</td>
+</tr>
+<tr>
+<td>GO:0016324 apical plasma membrane</td>
+<td>IDA</td>
+<td>PMID:25086774</td>
+<td>ACCEPT (core CC)</td>
+<td>apical hyp7 surface</td>
+</tr>
+<tr>
+<td>GO:0005886 plasma membrane</td>
+<td>IBA</td>
+<td>GO_REF:0000033</td>
+<td>ACCEPT</td>
+<td>correct (parent of apical PM)</td>
+</tr>
+<tr>
+<td>GO:0016020 membrane</td>
+<td>IEA</td>
+<td>GO_REF:0000120</td>
+<td>KEEP_AS_NON_CORE</td>
+<td>generic; subsumed by apical PM</td>
+</tr>
+<tr>
+<td>GO:0097730 non-motile cilium</td>
+<td>IDA</td>
+<td>PMID:22090488</td>
+<td>KEEP_AS_NON_CORE</td>
+<td>neuronal (ASH) chemosensory localization; abstract-only cache, defer to WB curator</td>
+</tr>
+<tr>
+<td>GO:0008188 neuropeptide receptor activity</td>
+<td>IBA</td>
+<td>GO_REF:0000033</td>
+<td>REMOVE</td>
+<td>over-propagated family IBA; DCAR-1 ligands are small-molecule metabolites (HPLA/DHCA), not neuropeptides</td>
+</tr>
+<tr>
+<td>GO:0007218 neuropeptide signaling pathway</td>
+<td>IBA</td>
+<td>GO_REF:0000033</td>
+<td>REMOVE</td>
+<td>same; not a neuropeptide receptor</td>
+</tr>
+</tbody>
+</table>
+<p>Proposed new term candidate: a specific MF for "dihydroxyphenyl/hydroxyphenyllactic acid<br />
+(DAMP) receptor activity" — currently only GO:0004930 available. Note as ontology gap.</p>
+<h2 id="deep-research-provenance">Deep research provenance</h2>
+<p>The <code>just deep-research-falcon</code> recipe reported a 600s timeout on both the initial run and<br />
+the retry (and the perplexity-lite fallback returned HTTP 401, quota exhausted). However the<br />
+underlying Edison/falcon client kept running and, on the retry, DID write a genuine report<br />
+(<code>dcar-1-deep-research-falcon.md</code>, ~1005s runtime, 19 citations, 2 artifacts) after the<br />
+recipe's wrapper had already exited. That file was inspected and is authentic Edison output:<br />
+it correctly identifies DCAR-1, HPLA as the DAMP ligand, apical hyp7 epidermal localization,<br />
+and the full GPA-12 -&gt; PLC/DAG -&gt; TPA-1(PKC) -&gt; TIR-1 -&gt; NSY-1/SEK-1/PMK-1(p38) -&gt; STA-2/ELT-3<br />
+-&gt; nlp-29 pathway, plus the neuronal DHCA-avoidance origin. It is included in the commit and<br />
+referenced. No <code>-deep-research-*.md</code> file was fabricated.</p>
+<p>All annotation/core-function <code>supporting_text</code> quotes are PMID-anchored (verified as verbatim<br />
+whitespace-normalized substrings of PMID:25086774 full text and PMID:22090488 abstract). The<br />
+single <code>file:</code> deep-research quote used was grep-verified against the falcon report (the<br />
+reference validator skips <code>file:</code> prefixes).</p>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: G5EDI0
+gene_symbol: dcar-1
+product_type: PROTEIN
+status: COMPLETE
+taxon:
+  id: NCBITaxon:6239
+  label: Caenorhabditis elegans
+description: &gt;-
+  DCAR-1 (DihydroCaffeic Acid Receptor 1) is a seven-transmembrane, class A
+  (rhodopsin-like) G protein-coupled receptor of Caenorhabditis elegans that acts
+  in two distinct tissues. In the epidermis it is a plasma-membrane receptor,
+  localized to the apical surface of the hyp7 syncytium, that senses the
+  endogenous tyrosine-derived metabolite 4-hydroxyphenyllactic acid (HPLA), a
+  damage-associated molecular pattern produced upon fungal infection and
+  wounding, and triggers antimicrobial peptide (nlp-29 cluster) gene expression
+  through a Galpha (GPA-12) / p38 MAP kinase (TIR-1, NSY-1, SEK-1, PMK-1) /
+  STA-2 signalling cassette, conferring resistance to the natural fungal pathogen
+  Drechmeria coniospora. In sensory neurons (ASH, ASI, PVQ) the same receptor
+  detects the exogenous water-soluble repellent dihydrocaffeic acid (DHCA) and
+  mediates an avoidance response, acting with the TRPV channel subunits OCR-2 and
+  OSM-9. DCAR-1 thus couples small-molecule (catecholic/phenolic acid) ligand
+  detection to Galpha signalling, with clearly recognizable homologs restricted to
+  nematode genomes.
+existing_annotations:
+  - term:
+      id: GO:0004930
+      label: G protein-coupled receptor activity
+    evidence_type: IEA
+    original_reference_id: GO_REF:0000104
+    qualifier: enables
+    review:
+      summary: &gt;-
+        DCAR-1 is a bona fide seven-transmembrane class A GPCR (7 predicted TM
+        helices; PROSITE G_PROTEIN_RECEP_F1_2; PANTHER PTHR24243) that functions
+        as a receptor for small-molecule ligands: HPLA in the epidermis and DHCA
+        in sensory neurons, in both cases coupling to Galpha signalling.
+      action: ACCEPT
+      reason: &gt;-
+        The GPCR activity is directly supported experimentally. DCAR-1 was
+        identified as a heterologously expressible receptor for DHCA and shown to
+        respond to HPLA, and it signals via the Galpha protein GPA-12. This is a
+        core molecular function of the gene.
+      supported_by:
+        - reference_id: PMID:22090488
+          supporting_text: &gt;-
+            we identified a candidate dihydrocaffeic acid receptor (DCAR),
+            DCAR-1. DCAR-1 is a novel seven-transmembrane protein that is
+            expressed in the ASH avoidance sensory neurons of C. elegans.
+        - reference_id: PMID:25086774
+          supporting_text: &gt;-
+            Dihydrocaffeic acid (DHCA) has been described as a potent ligand for
+            DCAR-1 in both in vivo and in heterologous Xenopus oocyte assays
+  - term:
+      id: GO:0007186
+      label: G protein-coupled receptor signaling pathway
+    evidence_type: IEA
+    original_reference_id: GO_REF:0000104
+    qualifier: involved_in
+    review:
+      summary: &gt;-
+        DCAR-1 initiates GPCR signalling: in the epidermis it acts upstream of
+        (or in parallel to) the Galpha protein GPA-12 to control downstream p38
+        MAPK (PMK-1) signalling.
+      action: ACCEPT
+      reason: &gt;-
+        Core biological process. Genetic epistasis places DCAR-1 at the top of a
+        Galpha (GPA-12) -&gt; p38 MAPK cascade, consistent with canonical GPCR
+        signalling.
+      supported_by:
+        - reference_id: PMID:25086774
+          supporting_text: dcar-1 alone acts upstream or in parallel to GPA-12
+  - term:
+      id: GO:0007165
+      label: signal transduction
+    evidence_type: IEA
+    original_reference_id: GO_REF:0000104
+    qualifier: involved_in
+    review:
+      summary: &gt;-
+        Correct but generic. Signal transduction is a high-level parent of the
+        more specific G protein-coupled receptor signaling pathway (GO:0007186)
+        that is also annotated and better captures DCAR-1&#39;s activity.
+      action: KEEP_AS_NON_CORE
+      reason: &gt;-
+        The term is not wrong - DCAR-1 does transduce signals - but it is
+        subsumed by the more informative GPCR signaling pathway annotation, so it
+        is retained as non-core rather than treated as a distinct core function.
+      supported_by:
+        - reference_id: PMID:25086774
+          supporting_text: multiple elements of the downstream signal transduction cascade
+  - term:
+      id: GO:0050832
+      label: defense response to fungus
+    evidence_type: IMP
+    original_reference_id: PMID:25086774
+    qualifier: involved_in
+    review:
+      summary: &gt;-
+        Loss of dcar-1 (RNAi and two null alleles, tm2484 and nj66) abolishes
+        infection-induced antimicrobial peptide expression and markedly increases
+        susceptibility to the fungus Drechmeria coniospora; DCAR-1 was the sole
+        GPCR hit from a screen of 1,150 GPCR genes.
+      action: ACCEPT
+      reason: &gt;-
+        Strong IMP evidence for a core function. DCAR-1 is required in the
+        epidermis for the innate immune response to fungal infection.
+      supported_by:
+        - reference_id: PMID:25086774
+          supporting_text: &gt;-
+            dcar-1 emerged alone as an innate immune receptor gene acting
+            upstream of (or in parallel to) gpa-12
+        - reference_id: PMID:25086774
+          supporting_text: &gt;-
+            dcar-1 mutants exhibited a markedly heightened susceptibility to D.
+            coniospora infection
+  - term:
+      id: GO:0009611
+      label: response to wounding
+    evidence_type: IMP
+    original_reference_id: PMID:25086774
+    qualifier: involved_in
+    review:
+      summary: &gt;-
+        dcar-1 mutants show an almost complete block of antimicrobial peptide
+        (nlp-29p::gfp) induction after sterile physical injury, showing that
+        DCAR-1 mediates the response to wounding/damage independently of a
+        pathogen - consistent with detection of an endogenous damage signal
+        (HPLA/DAMP).
+      action: ACCEPT
+      reason: &gt;-
+        Well-supported IMP for a core damage-sensing function; wounding and
+        infection converge on the same DCAR-1-dependent, HPLA-driven pathway.
+      supported_by:
+        - reference_id: PMID:25086774
+          supporting_text: &gt;-
+            an almost complete block of nlp-29p::gfp induction following physical
+            injury
+        - reference_id: PMID:25086774
+          supporting_text: demonstrating that dcar-1 can be activated in the absence of a pathogen
+  - term:
+      id: GO:0016324
+      label: apical plasma membrane
+    evidence_type: IDA
+    original_reference_id: PMID:25086774
+    qualifier: located_in
+    review:
+      summary: &gt;-
+        A rescuing dcar-1p::dcar-1::gfp translational reporter localized DCAR-1
+        to the apical surface of the major epidermal syncytium hyp7, the site
+        where it acts to drive antimicrobial peptide expression.
+      action: ACCEPT
+      reason: &gt;-
+        Direct IDA localization to the apical plasma membrane; a core cellular
+        location for the receptor&#39;s immune function.
+      supported_by:
+        - reference_id: PMID:25086774
+          supporting_text: &gt;-
+            dcar-1 was expressed on the apical surface in the major epidermal
+            syncytium, hyp7
+  - term:
+      id: GO:0005886
+      label: plasma membrane
+    evidence_type: IBA
+    original_reference_id: GO_REF:0000033
+    qualifier: is_active_in
+    review:
+      summary: &gt;-
+        Plasma membrane localization inferred from phylogeny is consistent with
+        DCAR-1 being a cell-surface 7-TM GPCR and with the direct (IDA) apical
+        plasma membrane localization in the epidermis.
+      action: ACCEPT
+      reason: &gt;-
+        Correct and corroborated by experimental data; a parent of the more
+        specific apical plasma membrane annotation.
+      supported_by:
+        - reference_id: PMID:25086774
+          supporting_text: &gt;-
+            dcar-1 was expressed on the apical surface in the major epidermal
+            syncytium, hyp7
+  - term:
+      id: GO:0016020
+      label: membrane
+    evidence_type: IEA
+    original_reference_id: GO_REF:0000120
+    qualifier: located_in
+    review:
+      summary: &gt;-
+        Generic membrane localization from InterPro/UniProt subcellular-location
+        pipelines; correct for a multi-pass membrane protein but uninformative
+        relative to the plasma membrane / apical plasma membrane annotations.
+      action: KEEP_AS_NON_CORE
+      reason: &gt;-
+        Not wrong, but subsumed by the more specific and experimentally supported
+        plasma membrane and apical plasma membrane terms.
+  - term:
+      id: GO:0097730
+      label: non-motile cilium
+    evidence_type: IDA
+    original_reference_id: PMID:22090488
+    qualifier: located_in
+    review:
+      summary: &gt;-
+        WormBase IDA localization associated with DCAR-1&#39;s expression in the
+        ciliated ASH (and ASI, PVQ) sensory neurons, where it detects the
+        repellent DHCA. This reflects the neuronal chemosensory role, distinct
+        from the epidermal immune role.
+      action: KEEP_AS_NON_CORE
+      reason: &gt;-
+        The cached copy of PMID:22090488 is abstract-only, so the specific cilium
+        sub-localization cannot be re-verified from the cached text; per curation
+        policy the WormBase curator&#39;s experimental (IDA) call is trusted and not
+        overruled. It is retained as a non-core location because it belongs to the
+        neuronal chemosensory context rather than the flagship epidermal immune
+        function.
+      supported_by:
+        - reference_id: PMID:22090488
+          supporting_text: expressed in the ASH avoidance sensory neurons of C. elegans
+  - term:
+      id: GO:0008188
+      label: neuropeptide receptor activity
+    evidence_type: IBA
+    original_reference_id: GO_REF:0000033
+    qualifier: enables
+    review:
+      summary: &gt;-
+        This activity was propagated by phylogenetic (IBA) inference from the
+        broad class A GPCR family (PTHR24243), some of whose members are
+        neuropeptide receptors. However, the two experimentally characterized
+        ligands of DCAR-1 are small-molecule catecholic/phenolic acids - HPLA
+        (a tyrosine-derived metabolite/DAMP) in the epidermis and DHCA in
+        neurons - not neuropeptides.
+      action: REMOVE
+      reason: &gt;-
+        Over-propagated family-level IBA that is contradicted by the direct
+        experimental characterization of DCAR-1&#39;s ligands. DCAR-1 is not a
+        neuropeptide receptor; its molecular function is adequately and correctly
+        captured by G protein-coupled receptor activity (GO:0004930). Removing
+        this avoids an unsupported and misleading molecular-function assertion.
+      supported_by:
+        - reference_id: PMID:25086774
+          supporting_text: &gt;-
+            the tyrosine derivative 4-hydroxyphenyllactic acid (HPLA) as an
+            endogenous ligand
+        - reference_id: PMID:25086774
+          supporting_text: &gt;-
+            Dihydrocaffeic acid (DHCA) has been described as a potent ligand for
+            DCAR-1 in both in vivo and in heterologous Xenopus oocyte assays
+      propagation_review:
+        root_cause: PROPAGATION_BAD
+        failure_modes:
+          - WRONG_ORTHOLOG_OR_PARALOG
+          - FUNCTIONAL_DIVERGENCE
+        source_entities:
+          - source_id: PANTHER:PTN002797693
+            source_label: PTHR24243 class A GPCR IBA seed node
+            source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
+            comment: &gt;-
+              Neuropeptide-receptor activity is valid for genuine peptide-receptor
+              members of this large class A GPCR family, but DCAR-1&#39;s characterized
+              ligands are small-molecule metabolites (HPLA, DHCA), not neuropeptides.
+          - source_id: WB:WBGene00019616
+            source_label: C. elegans family member in the IBA with/from set
+            source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
+            comment: &gt;-
+              Co-annotated family member; it does not establish a neuropeptide ligand
+              for DCAR-1.
+  - term:
+      id: GO:0007218
+      label: neuropeptide signaling pathway
+    evidence_type: IBA
+    original_reference_id: GO_REF:0000033
+    qualifier: involved_in
+    review:
+      summary: &gt;-
+        Companion IBA propagation to the neuropeptide receptor activity call,
+        inferred from the GPCR family rather than from DCAR-1&#39;s own biology.
+        DCAR-1 signalling is driven by small-molecule ligands (HPLA, DHCA), not
+        by neuropeptides.
+      action: REMOVE
+      reason: &gt;-
+        Over-propagated family-level IBA not supported by any evidence specific
+        to DCAR-1 and contradicted by its characterized small-molecule ligands.
+        The gene&#39;s signalling role is correctly captured by G protein-coupled
+        receptor signaling pathway (GO:0007186) and the defense/wounding process
+        terms.
+      supported_by:
+        - reference_id: PMID:25086774
+          supporting_text: &gt;-
+            HPLA can act through DCAR-1 to regulate the epidermal innate immune
+            response
+      propagation_review:
+        root_cause: PROPAGATION_BAD
+        failure_modes:
+          - WRONG_ORTHOLOG_OR_PARALOG
+          - FUNCTIONAL_DIVERGENCE
+        source_entities:
+          - source_id: PANTHER:PTN002797693
+            source_label: PTHR24243 class A GPCR IBA seed node
+            source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
+            comment: &gt;-
+              Neuropeptide signalling is valid for genuine peptide-receptor members
+              of this family, but DCAR-1 signals in response to small-molecule
+              metabolites (HPLA, DHCA), not neuropeptides.
+          - source_id: WB:WBGene00019616
+            source_label: C. elegans family member in the IBA with/from set
+            source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
+            comment: &gt;-
+              Co-annotated family member; it does not establish neuropeptide
+              signalling for DCAR-1.
+  - term:
+      id: GO:0007635
+      label: chemosensory behavior
+    evidence_type: IMP
+    original_reference_id: PMID:22090488
+    qualifier: involved_in
+    review:
+      summary: &gt;-
+        In ASH sensory neurons DCAR-1 is required for avoidance of the water-
+        soluble repellent dihydrocaffeic acid (DHCA): dcar-1 null mutants are
+        defective in DHCA avoidance and ASH-specific expression rescues the
+        defect (Aoki et al. 2011), a role corroborated in Zugasti et al. 2014.
+      action: NEW
+      reason: &gt;-
+        Not present in GOA, but the neuronal chemosensory (repellent-avoidance)
+        function is directly established by IMP evidence and is genetically
+        separable from the epidermal immune role. Added so that the receptor&#39;s
+        second, well-supported evolved function is captured in the structured
+        annotations (mirrors the neuronal core_function).
+      supported_by:
+        - reference_id: PMID:22090488
+          supporting_text: &gt;-
+            dcar-1 mutant animals are defective in avoidance response to DHCA, and
+            cell-specific expression of dcar-1 in the ASH neurons
+        - reference_id: PMID:25086774
+          supporting_text: &gt;-
+            In neurons, dcar-1 mediates an avoidance response to specific
+            repellents, acting in concert with ocr-2 and osm-9
+core_functions:
+  - description: &gt;-
+      DCAR-1 acts as an epidermal innate-immune GPCR: it is a plasma-membrane
+      (apical hyp7) receptor that detects the endogenous damage-associated
+      metabolite HPLA (and, exogenously, DHCA) generated upon fungal infection or
+      wounding, and transduces this via Galpha (GPA-12) and the p38 MAPK cascade
+      to induce antimicrobial peptide genes and confer resistance to Drechmeria
+      coniospora.
+    molecular_function:
+      id: GO:0004930
+      label: G protein-coupled receptor activity
+    directly_involved_in:
+      - id: GO:0050832
+        label: defense response to fungus
+      - id: GO:0009611
+        label: response to wounding
+      - id: GO:0007186
+        label: G protein-coupled receptor signaling pathway
+    locations:
+      - id: GO:0016324
+        label: apical plasma membrane
+      - id: GO:0005886
+        label: plasma membrane
+    supported_by:
+      - reference_id: PMID:25086774
+        supporting_text: &gt;-
+          DCAR-1 acted in the epidermis to regulate the expression of
+          antimicrobial peptides via a conserved p38 mitogen-activated protein
+          kinase pathway.
+      - reference_id: PMID:25086774
+        supporting_text: &gt;-
+          Our findings reveal DCAR-1 and its cognate ligand HPLA to be triggers
+          of the epidermal innate immune response
+      - reference_id: PMID:25086774
+        supporting_text: &gt;-
+          dcar-1 was expressed on the apical surface in the major epidermal
+          syncytium, hyp7
+      - reference_id: file:worm/dcar-1/dcar-1-deep-research-falcon.md
+        supporting_text: &gt;-
+          DAMP-sensing GPCR that activates epidermal innate immunity in response
+          to fungal infection and wounding
+  - description: &gt;-
+      In ciliated ASH (and ASI, PVQ) sensory neurons DCAR-1 acts as a
+      chemoreceptor for the exogenous water-soluble repellent dihydrocaffeic acid
+      (DHCA), driving an avoidance response together with the TRPV channel
+      subunits OCR-2 and OSM-9. This neuronal chemosensory role is genetically and
+      functionally separable from the epidermal immune role (neuronal expression
+      rescues avoidance but not antimicrobial peptide induction).
+    molecular_function:
+      id: GO:0004930
+      label: G protein-coupled receptor activity
+    directly_involved_in:
+      - id: GO:0007635
+        label: chemosensory behavior
+      - id: GO:0007186
+        label: G protein-coupled receptor signaling pathway
+    locations:
+      - id: GO:0005886
+        label: plasma membrane
+    supported_by:
+      - reference_id: PMID:22090488
+        supporting_text: &gt;-
+          DCAR-1 as the first seven-transmembrane receptor required for avoidance
+          of a water-soluble repellent, DHCA, in C. elegans
+      - reference_id: PMID:25086774
+        supporting_text: &gt;-
+          In neurons, dcar-1 mediates an avoidance response to specific
+          repellents, acting in concert with ocr-2 and osm-9
+proposed_new_terms:
+  - proposed_name: 4-hydroxyphenyllactate (HPLA) receptor activity
+    proposed_definition: &gt;-
+      Combining with the tyrosine-derived metabolite 4-hydroxyphenyllactic acid
+      (HPLA), a damage-associated molecular pattern, to initiate a change in cell
+      activity, typically via coupling to a heterotrimeric G protein. Applies to
+      GPCRs, such as nematode DCAR-1, that detect HPLA (and structurally related
+      catecholic/phenolic acids) to trigger downstream signalling.
+    justification: &gt;-
+      DCAR-1&#39;s specific molecular function - detection of the small-molecule DAMP
+      HPLA - can currently only be annotated with the generic parent
+      G protein-coupled receptor activity (GO:0004930). No ontology term expresses
+      the ligand-specific activity, leaving the receptor&#39;s most distinctive
+      feature un-annotatable (an ontology gap).
+    proposed_parent:
+      id: GO:0004930
+      label: G protein-coupled receptor activity
+    supported_by:
+      - reference_id: PMID:25086774
+        supporting_text: &gt;-
+          the tyrosine derivative 4-hydroxyphenyllactic acid (HPLA) as an
+          endogenous ligand
+knowledge_gaps:
+  - gap_statement: &gt;-
+      The structural and biochemical basis of ligand recognition by DCAR-1 is
+      unknown: there is no direct binding assay, no structure, and no defined
+      ligand-binding pocket or residues. Whether DCAR-1 is the direct receptor for
+      HPLA (versus an upstream/indirect sensor) has not been demonstrated
+      biochemically.
+    boundary: &gt;-
+      It is firmly established that DCAR-1 is a 7-TM class A GPCR required in the
+      epidermis for HPLA/DHCA-triggered antimicrobial peptide induction and
+      anti-fungal defense, and that it can respond to DHCA in a heterologous
+      Xenopus oocyte system. The evidence that HPLA is the endogenous ligand is
+      genetic and metabolomic (correlative), not a direct receptor-binding
+      measurement.
+    gap_kind:
+      - BIOLOGY
+    dark_aspect: RESIDUAL_SUBGAP
+    status: OPEN
+    significance: &gt;-
+      HPLA is the first described damage-associated molecular pattern (DAMP) in
+      C. elegans; defining how DCAR-1 binds it would establish the molecular logic
+      of DAMP sensing by a metazoan GPCR and enable rational tests of whether
+      analogous receptors exist beyond nematodes.
+    resolution: &gt;-
+      Direct ligand-binding/activation assays (e.g. purified receptor or
+      cell-based GPCR activation with HPLA titration), mutagenesis of predicted
+      binding-pocket residues, and structural determination of the DCAR-1-HPLA
+      complex.
+    provenance:
+      - reference_id: PMID:25086774
+        supporting_text: &gt;-
+          We provide strong correlative evidence that HPLA is an endogenous
+          ligand for DCAR-1. Proving this definitively is not straightforward
+  - gap_statement: &gt;-
+      It is unknown whether DCAR-1 has ligands or roles beyond HPLA/DHCA -
+      including its natural neuronal ligand, whether it recognizes any
+      microbe-associated molecular pattern, and whether it contributes to
+      pathogen-avoidance behaviour as a second host-defense role.
+    boundary: &gt;-
+      DCAR-1 is known to detect the endogenous metabolite HPLA (epidermal
+      immunity) and the exogenous repellent DHCA (neuronal avoidance via ASH/ASI/
+      PVQ with OCR-2/OSM-9). Beyond these, its ligand spectrum and the physiological
+      relevance of its neuronal signalling to host defense are not established.
+    gap_kind:
+      - BIOLOGY
+    dark_aspect: MF_DARK
+    status: OPEN
+    significance: &gt;-
+      GPCRs are proposed to be an under-explored class of immunomodulatory
+      receptors; clarifying whether DCAR-1 senses microbial patterns or only host
+      damage signals would sharpen models of how nematodes discriminate infection
+      from sterile injury.
+    resolution: &gt;-
+      Systematic ligand/deorphanization screens, tests for direct microbe-derived
+      agonists, and behavioural/immune assays separating DCAR-1&#39;s neuronal and
+      epidermal contributions to defense.
+    provenance:
+      - reference_id: PMID:25086774
+        supporting_text: &gt;-
+          It is not known whether any GPCR recognizes specific
+          microbe-associated molecular patterns.
+  - gap_statement: &gt;-
+      The biosynthetic origin of the DAMP ligand HPLA, and the mechanism by which
+      infection and cuticle damage raise its levels, are uncharacterized -
+      including whether the invading fungus contributes to HPLA production or the
+      increase is entirely host-derived.
+    boundary: &gt;-
+      HPLA is a tyrosine-derived metabolite that increases upon infection and in
+      cuticle-defective dpy-10 mutants, and epidermal overexpression of the
+      candidate aminotransferase tatn-1 raises dcar-1-dependent antimicrobial
+      peptide expression. The enzymes and regulatory logic of HPLA production
+      remain undefined and were only partially probed (candidate aminotransferase
+      knockdowns were inconclusive, likely due to redundancy).
+    gap_kind:
+      - BIOLOGY
+    dark_aspect: BP_DARK
+    status: OPEN
+    significance: &gt;-
+      Understanding how HPLA is generated would reveal how damage and infection
+      are converted into a diffusible immune-activating signal, and whether the
+      pathway is a host stress response or a pathogen-influenced process.
+    resolution: &gt;-
+      Genetic and biochemical dissection of tyrosine catabolism/HPLA synthesis in
+      the epidermis, isotope-tracing of HPLA under infection, and host-versus-
+      pathogen source discrimination.
+    provenance:
+      - reference_id: PMID:25086774
+        supporting_text: &gt;-
+          Although its biosynthetic pathway has not been characterized in any
+          eukaryote, HPLA is likely derived from tyrosine
+suggested_questions:
+  - question: &gt;-
+      Does DCAR-1 bind HPLA directly, and which extracellular/transmembrane
+      residues form the ligand-binding pocket?
+    experts:
+      - Jonathan J Ewbank
+      - Nathalie Pujol
+  - question: &gt;-
+      Do HPLA-sensing receptors functionally analogous to DCAR-1 exist outside
+      the nematode phylum, given that HPLA is a conserved tyrosine metabolite?
+    experts:
+      - Jonathan J Ewbank
+suggested_experiments:
+  - hypothesis: &gt;-
+      DCAR-1 is the direct receptor for HPLA and couples to GPA-12.
+    description: &gt;-
+      Express DCAR-1 in a heterologous GPCR-activation system (as previously done
+      with DHCA in Xenopus oocytes) and measure dose-dependent activation by HPLA
+      and structurally related phenolic acids; test coupling specificity against
+      GPA-12 versus other Galpha subunits.
+    experiment_type: heterologous receptor activation / ligand-response assay
+  - hypothesis: &gt;-
+      HPLA is generated in the epidermis by a defined tyrosine-catabolic route
+      whose flux increases with damage.
+    description: &gt;-
+      Use targeted metabolomics with isotope-labelled tyrosine to trace HPLA
+      production before and after infection/wounding, combined with epidermis-
+      specific RNAi/overexpression of candidate aminotransferases and reductases
+      (e.g. tatn-1) to identify the biosynthetic enzymes.
+    experiment_type: stable-isotope metabolomics + tissue-specific genetics
+references:
+  - id: GO_REF:0000033
+    title: Annotation inferences using phylogenetic trees
+    findings: []
+  - id: GO_REF:0000104
+    title: &gt;-
+      Electronic Gene Ontology annotations created by transferring manual GO
+      annotations between related proteins based on shared sequence features
+    findings: []
+  - id: GO_REF:0000120
+    title: Combined Automated Annotation using Multiple IEA Methods
+    findings: []
+  - id: PMID:22090488
+    title: &gt;-
+      A seven-transmembrane receptor that mediates avoidance response to
+      dihydrocaffeic acid, a water-soluble repellent in Caenorhabditis elegans.
+    findings:
+      - statement: &gt;-
+          DCAR-1 is a novel seven-transmembrane receptor for the water-soluble
+          repellent dihydrocaffeic acid (DHCA), expressed in the ASH avoidance
+          sensory neurons; dcar-1 mutants are defective in DHCA avoidance and
+          ASH-specific expression rescues the defect.
+        supporting_text: &gt;-
+          we identified a candidate dihydrocaffeic acid receptor (DCAR), DCAR-1.
+          DCAR-1 is a novel seven-transmembrane protein that is expressed in the
+          ASH avoidance sensory neurons of C. elegans.
+        reference_section_type: ABSTRACT
+        full_text_unavailable: true
+    reference_review:
+      relevance: HIGH
+      correctness: VERIFIED
+      review_notes: &gt;-
+        PubMed-verified (Aoki et al., J Neurosci 2011). Original identification of
+        DCAR-1 as a 7-TM receptor for the repellent DHCA expressed in ASH sensory
+        neurons; establishes the neuronal chemosensory role and the receptor&#39;s
+        small-molecule ligand. Cached copy is abstract-only (full text
+        unavailable), so the non-motile cilium localization it supports cannot be
+        re-verified from the cache and is deferred to the WormBase curator.
+  - id: PMID:25086774
+    title: &gt;-
+      Activation of a G protein-coupled receptor by its endogenous ligand triggers
+      the innate immune response of Caenorhabditis elegans.
+    findings:
+      - statement: &gt;-
+          DCAR-1 was the sole hit from an RNAi screen of 1,150 GPCR genes required
+          for infection- and wounding-induced antimicrobial peptide expression,
+          acting upstream of (or in parallel to) the Galpha protein GPA-12 in the
+          epidermal p38 MAPK pathway.
+        supporting_text: &gt;-
+          dcar-1 emerged alone as an innate immune receptor gene acting upstream
+          of (or in parallel to) gpa-12
+        reference_section_type: RESULTS
+      - statement: &gt;-
+          The tyrosine-derived metabolite HPLA is an endogenous damage-associated
+          ligand for DCAR-1 that increases upon infection and cuticle damage and
+          drives DCAR-1-dependent antimicrobial peptide expression in the epidermis.
+        supporting_text: &gt;-
+          the tyrosine derivative 4-hydroxyphenyllactic acid (HPLA) as an
+          endogenous ligand
+        reference_section_type: ABSTRACT
+    reference_review:
+      relevance: HIGH
+      correctness: VERIFIED
+      review_notes: &gt;-
+        PubMed-verified (Zugasti et al., Nat Immunol 2014); full text available in
+        cache. Flagship paper establishing DCAR-1 as the epidermal innate-immune
+        GPCR, identifying HPLA as its endogenous DAMP ligand, the apical hyp7
+        localization, and the GPA-12/p38-MAPK signalling context. Directly
+        supports the defense-response, wounding, GPCR-signalling and apical
+        plasma membrane annotations.
+  - id: file:worm/dcar-1/dcar-1-deep-research-falcon.md
+    title: Deep research report (Edison/falcon) for C. elegans dcar-1
+    findings: []
+    reference_review:
+      relevance: MEDIUM
+      correctness: VERIFIED
+      review_notes: &gt;-
+        Automated Edison/falcon deep-research report (19 citations). Content was
+        inspected and corroborates the primary literature: DCAR-1 as an apical
+        epidermal HPLA/DAMP-sensing GPCR driving the GPA-12 -&gt; PLC/DAG -&gt; TPA-1 -&gt;
+        TIR-1 -&gt; p38/PMK-1 -&gt; STA-2 antimicrobial-peptide pathway, and the
+        neuronal DHCA-avoidance origin. Used only for corroboration; all primary
+        evidence in this review is PMID-anchored, and the single file quote used
+        was grep-verified (the reference validator skips file: prefixes).
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/genes/worm/dyf-11/dyf-11-ai-review.html
+++ b/genes/worm/dyf-11/dyf-11-ai-review.html
@@ -1,0 +1,4781 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>dyf-11 - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        .propagation-review {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f8fafc;
+            border-left: 3px solid #64748b;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .propagation-title {
+            font-weight: 600;
+            color: #334155;
+            margin-bottom: 0.25rem;
+        }
+
+        .propagation-row {
+            margin-top: 0.25rem;
+        }
+
+        .propagation-source {
+            margin-top: 0.5rem;
+            padding-top: 0.5rem;
+            border-top: 1px solid #e5e7eb;
+        }
+
+        .propagation-source-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #1d4ed8;
+        }
+
+        .propagation-comment {
+            color: #4b5563;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>dyf-11</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/Q17595" target="_blank" class="term-link">
+                        Q17595
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Caenorhabditis elegans</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-complete">
+                    COMPLETE
+                </span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Aliases:</span>
+                <div class="aliases">
+
+                    <span class="badge">MIP-T3</span>
+
+                    <span class="badge">TRAF3IP1</span>
+
+                    <span class="badge">IFT54</span>
+
+                    <span class="badge">C02H7.1</span>
+
+                </div>
+            </div>
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "dyf-11";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="Q17595" data-a="DESCRIPTION: dyf-11 encodes the Caenorhabditis elegans ortholog..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>dyf-11 encodes the Caenorhabditis elegans ortholog of MIP-T3/TRAF3IP1 (IFT54), a 535-residue structural subunit of intraflagellar transport (IFT) complex B. IFT-B, together with IFT-A and the kinesin-2 and dynein-2 motors, drives the bidirectional transport of ciliary cargo that builds and maintains the sensory cilia of ciliated neurons. The protein has no catalytic domain; it comprises conserved N- and C-terminal TRAF3IP1 domains flanking a long charged/disordered central region and a C-terminal coiled coil. DYF-11 is expressed under X-box/RFX (daf-19) control specifically in ciliated sensory neurons and localizes to the ciliary base (transition zone/basal body) and along the ciliary axoneme, where it undergoes processive IFT movement. It is required to assemble and maintain an intact motor-IFT particle: in its absence kinesin-II, IFT-A, IFT-dynein and BBSome components fail to enter cilia and the axoneme is severely truncated, so full-length medial and distal ciliary segments do not form. Loss of dyf-11 therefore disrupts cilium-dependent sensory behaviors (chemosensation, osmotic avoidance, dauer formation, dye filling) and perturbs lipid homeostasis. The ciliary role is conserved: human MIP-T3 localizes to basal bodies and cilia, and zebrafish mipt3 is required for gastrulation movements and interacts genetically with the Bardet-Biedl protein Bbs4.</p>
+    </div>
+
+
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030992" target="_blank" class="term-link">
+                                    GO:0030992
+                                </a>
+                            </span>
+                            <span class="term-label">intraciliary transport particle B</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q17595" data-a="GO:0030992" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> DYF-11/IFT54 is a subunit of intraflagellar transport complex B (IFT-B). This IBA transfer is strongly corroborated by C. elegans experimental data and by biochemical assignment to ComplexPortal CPX-1290.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Core cellular-component identity. Phylogenetically inferred and independently confirmed experimentally (PMID:18369462).
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/18369462" target="_blank" class="term-link">
+                                        PMID:18369462
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">DYF-11 functions as a novel component of IFT subcomplex B</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005930" target="_blank" class="term-link">
+                                    GO:0005930
+                                </a>
+                            </span>
+                            <span class="term-label">axoneme</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q17595" data-a="GO:0005930" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> DYF-11 acts within the ciliary axoneme, where IFT trains move. The is_active_in qualifier is appropriate for an IFT-B component that translocates along the axoneme.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Consistent with the experimental IDA axoneme localization (PMID:18369462).
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/18369462" target="_blank" class="term-link">
+                                        PMID:18369462
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">the DYF-11::GFP protein was found to be highly enriched at transition zones and within ciliary axonemes</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0036064" target="_blank" class="term-link">
+                                    GO:0036064
+                                </a>
+                            </span>
+                            <span class="term-label">ciliary basal body</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q17595" data-a="GO:0036064" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> DYF-11 localizes to and functions at the ciliary base (transition zone/basal body), where IFT trains assemble and load.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Corroborated by the experimental IDA basal-body/transition-zone localization (PMID:18369462).
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/18369462" target="_blank" class="term-link">
+                                        PMID:18369462
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">the DYF-11::GFP protein was found to be highly enriched at transition zones and within ciliary axonemes</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0070507" target="_blank" class="term-link">
+                                    GO:0070507
+                                </a>
+                            </span>
+                            <span class="term-label">regulation of microtubule cytoskeleton organization</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q17595" data-a="GO:0070507" data-r="GO_REF:0000033" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> DYF-11&#39;s effect on microtubules is to build the axonemal microtubule structure via IFT, which is more precisely captured by cilium assembly (GO:0060271). The general &#34;regulation of microtubule cytoskeleton organization&#34; term over-generalizes this structural role and is not directly supported by evidence of a regulatory activity.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Over-general phylogenetic transfer; DYF-11 does not regulate microtubule dynamics per se — it is a structural IFT-B subunit whose microtubule-related role is axoneme assembly, already annotated as cilium assembly and intraciliary transport.
+                        </div>
+
+
+
+                        <div class="propagation-review">
+                            <div class="propagation-title">Propagation Review</div>
+                            <div class="propagation-row">
+                                <strong>Root cause:</strong>
+                                <span class="badge">TERM SCOPING PROBLEM</span>
+                            </div>
+
+                            <div class="propagation-row">
+                                <strong>Failure modes:</strong>
+
+                                <span class="badge">GRANULARITY MISMATCH</span>
+
+                            </div>
+
+
+                            <div class="propagation-source">
+                                <strong>Sources checked:</strong>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">PANTHER:PTN000773545</span>
+
+                                    &middot; TRAF3IP1 family node
+
+
+                                    <span class="badge">SUPPORTS SOURCE BUT NOT TARGET</span>
+
+
+                                    <div class="propagation-comment">The IFT54/TRAF3IP1 family node&#39;s microtubule-related activity is axonemal assembly via IFT, not regulation of microtubule dynamics; the transferred term is scoped too broadly for the structural role.</div>
+
+                                </div>
+
+                            </div>
+
+                        </div>
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0060271" target="_blank" class="term-link">
+                                    GO:0060271
+                                </a>
+                            </span>
+                            <span class="term-label">cilium assembly</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q17595" data-a="GO:0060271" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> DYF-11 is required to build full-length sensory cilia; dyf-11 nulls have severely truncated cilia lacking medial and distal segments.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Core biological process, strongly supported experimentally (PMID:18369462; PMID:18245347).
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/18369462" target="_blank" class="term-link">
+                                        PMID:18369462
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">the cilia of dyf-11 mutants were truncated substantially</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042073" target="_blank" class="term-link">
+                                    GO:0042073
+                                </a>
+                            </span>
+                            <span class="term-label">intraciliary transport</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q17595" data-a="GO:0042073" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> DYF-11 functions in intraflagellar (intraciliary) transport as an IFT-B subunit that undergoes bidirectional IFT movement along the axoneme.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Core biological process, confirmed experimentally in worm (PMID:18369462).
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/18369462" target="_blank" class="term-link">
+                                        PMID:18369462
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">the GFP-tagged protein moves bi-directionally along the length of amphid and phasmid ciliary axonemes</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005930" target="_blank" class="term-link">
+                                    GO:0005930
+                                </a>
+                            </span>
+                            <span class="term-label">axoneme</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000044
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q17595" data-a="GO:0005930" data-r="GO_REF:0000044" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic mapping of the UniProt cilium-axoneme subcellular-location keyword. Redundant with the experimental IDA axoneme annotation and correct.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct location, corroborated by experimental IDA (PMID:18369462).
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/18369462" target="_blank" class="term-link">
+                                        PMID:18369462
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">the DYF-11::GFP protein was found to be highly enriched at transition zones and within ciliary axonemes</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008017" target="_blank" class="term-link">
+                                    GO:0008017
+                                </a>
+                            </span>
+                            <span class="term-label">microtubule binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q17595" data-a="GO:0008017" data-r="GO_REF:0000002" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> InterPro2GO transfer for the TRAF3IP1/MIP-T3 family, which is named for its microtubule-interacting property; human MIP-T3 was shown to bind microtubules, and Li et al. suggest a proportion of C. elegans DYF-11 may associate directly with microtubules. This is the most informative molecular-function term available for DYF-11, though direct microtubule binding by the worm protein has not been experimentally demonstrated.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Best-supported molecular function; consistent with family identity and IFT-B axonemal role.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/18369462" target="_blank" class="term-link">
+                                        PMID:18369462
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">MIP-T3 proteins range in size from 484 to 625 amino acids and have no recognizable domains except for a predicted coiled-coil region near the C-terminus</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0048513" target="_blank" class="term-link">
+                                    GO:0048513
+                                </a>
+                            </span>
+                            <span class="term-label">animal organ development</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000117
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q17595" data-a="GO:0048513" data-r="GO_REF:0000117" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Over-general ARBA machine-learning inference. C. elegans lacks the vertebrate organs implied, and DYF-11&#39;s characterized role is restricted to sensory ciliogenesis. Not informative.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Vague electronic annotation with no experimental support in this organism; DYF-11&#39;s role is specific to sensory cilium assembly/function.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0048731" target="_blank" class="term-link">
+                                    GO:0048731
+                                </a>
+                            </span>
+                            <span class="term-label">system development</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000117
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q17595" data-a="GO:0048731" data-r="GO_REF:0000117" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Over-general ARBA machine-learning inference; uninformative for a sensory-cilium IFT protein.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Vague electronic annotation; DYF-11&#39;s characterized function is ciliogenesis, better captured by cilium assembly.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0070507" target="_blank" class="term-link">
+                                    GO:0070507
+                                </a>
+                            </span>
+                            <span class="term-label">regulation of microtubule cytoskeleton organization</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000117
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q17595" data-a="GO:0070507" data-r="GO_REF:0000117" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Duplicate of the IBA transfer of the same term via an ARBA model. Over-generalizes DYF-11&#39;s structural axoneme-assembly role.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> DYF-11 is a structural IFT-B subunit, not a regulator of microtubule dynamics; the microtubule-related role is axoneme assembly (cilium assembly / intraciliary transport).
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005929" target="_blank" class="term-link">
+                                    GO:0005929
+                                </a>
+                            </span>
+                            <span class="term-label">cilium</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">NAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/28479320" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:28479320
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Dynein-Driven Retrograde Intraflagellar Transport Is Triphas...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q17595" data-a="GO:0005929" data-r="PMID:28479320" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> ComplexPortal (CPX-1290) assertion that DYF-11 localizes to the cilium. Correct but general; the more specific axoneme and basal-body IDA locations are also annotated.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct ciliary location; consistent with experimental IDA localization.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030992" target="_blank" class="term-link">
+                                    GO:0030992
+                                </a>
+                            </span>
+                            <span class="term-label">intraciliary transport particle B</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">NAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/28479320" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:28479320
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Dynein-Driven Retrograde Intraflagellar Transport Is Triphas...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q17595" data-a="GO:0030992" data-r="PMID:28479320" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> ComplexPortal (CPX-1290) assertion of IFT-B membership, consistent with the experimental IDA and phylogenetic annotations.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Core cellular-component identity; independently confirmed (PMID:18369462).
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/28479320" target="_blank" class="term-link">
+                                        PMID:28479320
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">intraflagellar transport (IFT)-B complex abolishes dynein-2&#39;s ciliary localization</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042073" target="_blank" class="term-link">
+                                    GO:0042073
+                                </a>
+                            </span>
+                            <span class="term-label">intraciliary transport</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">NAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/28479320" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:28479320
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Dynein-Driven Retrograde Intraflagellar Transport Is Triphas...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q17595" data-a="GO:0042073" data-r="PMID:28479320" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> ComplexPortal assertion that DYF-11 functions in intraciliary transport, consistent with experimental data.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Core biological process; confirmed experimentally (PMID:18369462).
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0060271" target="_blank" class="term-link">
+                                    GO:0060271
+                                </a>
+                            </span>
+                            <span class="term-label">cilium assembly</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">NAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/28479320" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:28479320
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Dynein-Driven Retrograde Intraflagellar Transport Is Triphas...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q17595" data-a="GO:0060271" data-r="PMID:28479320" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> ComplexPortal assertion that DYF-11 functions in cilium assembly, consistent with the truncated-cilia phenotype of dyf-11 mutants.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Core biological process; strongly supported (PMID:18369462; PMID:18245347).
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008306" target="_blank" class="term-link">
+                                    GO:0008306
+                                </a>
+                            </span>
+                            <span class="term-label">associative learning</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/20837997" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:20837997
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Reversal of salt preference is directed by the insulin/PI3K ...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q17595" data-a="GO:0008306" data-r="PMID:20837997" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> A dyf-11 defect in salt-chemotaxis plasticity would be an indirect consequence of loss of functional sensory (ASE) cilia rather than a direct role in learning/memory. The cited paper is cached abstract-only and its abstract does not mention dyf-11, so the specific evidence cannot be verified here. Retained as a pleiotropic, non-core sensory phenotype rather than removed (experimental IMP; defer to curator).
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Downstream/pleiotropic behavioral consequence of ciliary dysfunction, not a core molecular function of an IFT-B structural subunit; supporting full text unavailable in the cache.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0036064" target="_blank" class="term-link">
+                                    GO:0036064
+                                </a>
+                            </span>
+                            <span class="term-label">ciliary basal body</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/18369462" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:18369462
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    An essential role for DYF-11/MIP-T3 in assembling functional...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q17595" data-a="GO:0036064" data-r="PMID:18369462" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> DYF-11::GFP is highly enriched at the transition zone/basal body in ciliated sensory neurons; human MIP-T3 likewise localizes to the basal body.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Core, directly observed cellular-component location.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/18369462" target="_blank" class="term-link">
+                                        PMID:18369462
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">V5 epitope-tagged human MIP-T3 also localizes to the basal body</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005930" target="_blank" class="term-link">
+                                    GO:0005930
+                                </a>
+                            </span>
+                            <span class="term-label">axoneme</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/18369462" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:18369462
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    An essential role for DYF-11/MIP-T3 in assembling functional...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q17595" data-a="GO:0005930" data-r="PMID:18369462" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> DYF-11::GFP is directly observed enriched within ciliary axonemes and moves along their length.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Core, directly observed cellular-component location.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/18369462" target="_blank" class="term-link">
+                                        PMID:18369462
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">the DYF-11::GFP protein was found to be highly enriched at transition zones and within ciliary axonemes</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030992" target="_blank" class="term-link">
+                                    GO:0030992
+                                </a>
+                            </span>
+                            <span class="term-label">intraciliary transport particle B</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/18369462" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:18369462
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    An essential role for DYF-11/MIP-T3 in assembling functional...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q17595" data-a="GO:0030992" data-r="PMID:18369462" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> DYF-11 was directly characterized as a novel component of IFT subcomplex B based on its IFT movement and genetic behavior relative to kinesin/BBS/IFT mutants.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Core cellular-component identity, directly established.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/18369462" target="_blank" class="term-link">
+                                        PMID:18369462
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">DYF-11 functions as a novel component of IFT subcomplex B</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042073" target="_blank" class="term-link">
+                                    GO:0042073
+                                </a>
+                            </span>
+                            <span class="term-label">intraciliary transport</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/18369462" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:18369462
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    An essential role for DYF-11/MIP-T3 in assembling functional...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q17595" data-a="GO:0042073" data-r="PMID:18369462" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Loss of dyf-11 disrupts IFT, mislocalizing kinesin-II, IFT-A, dynein and BBSome components and truncating cilia, demonstrating a functional requirement in IFT.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Core biological process; strong loss-of-function evidence.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/18369462" target="_blank" class="term-link">
+                                        PMID:18369462
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">DYF-11 is an intraflagellar transport protein critical for the formation of full-length, functional sensory cilia</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0045184" target="_blank" class="term-link">
+                                    GO:0045184
+                                </a>
+                            </span>
+                            <span class="term-label">establishment of protein localization</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/18369462" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:18369462
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    An essential role for DYF-11/MIP-T3 in assembling functional...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-modify">
+                            MODIFY
+                        </span>
+                        <span class="vote-buttons" data-g="Q17595" data-a="GO:0045184" data-r="PMID:18369462" data-act="MODIFY">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> In dyf-11 mutants, IFT-associated proteins (CHE-11/IFT-A, OSM-5/IFT-B, XBX-1/dynein, BBS-7, KAP-1/kinesin-II) fail to enter cilia. This is specifically the failure to localize proteins to the cilium, better captured by GO:0061512 &#34;protein localization to cilium&#34; than by the very general &#34;establishment of protein localization&#34;.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Term too general; the experiment shows DYF-11 is required for delivering IFT proteins into the cilium.
+                        </div>
+
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0061512" target="_blank" class="term-link">
+                                    protein localization to cilium
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/18369462" target="_blank" class="term-link">
+                                        PMID:18369462
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">none of the proteins were observed to enter the (truncated) amphid and phasmid cilia</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0055088" target="_blank" class="term-link">
+                                    GO:0055088
+                                </a>
+                            </span>
+                            <span class="term-label">lipid homeostasis</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/18369462" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:18369462
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    An essential role for DYF-11/MIP-T3 in assembling functional...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q17595" data-a="GO:0055088" data-r="PMID:18369462" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> dyf-11 mutants show increased intestinal Nile Red (lipid) staining, rescued by DYF-11::GFP, reflecting the conserved cilia-lipid connection. This is a downstream systemic consequence of ciliary dysfunction, not a core molecular function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Real, rescued loss-of-function phenotype but pleiotropic/indirect (secondary to defective sensory-cilia signaling), not a core function of an IFT-B subunit.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/18369462" target="_blank" class="term-link">
+                                        PMID:18369462
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">indicative of an increased lipid accumulation phenotype</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0065003" target="_blank" class="term-link">
+                                    GO:0065003
+                                </a>
+                            </span>
+                            <span class="term-label">protein-containing complex assembly</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/18369462" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:18369462
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    An essential role for DYF-11/MIP-T3 in assembling functional...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q17595" data-a="GO:0065003" data-r="PMID:18369462" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> DYF-11 is required to assemble a functional motor-IFT particle, including loading of the kinesin-II motor; in its absence multiple IFT components fail to assemble/enter cilia. The term is general but captures this assembly role.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Supported by loss-of-function mislocalization of IFT-machinery components; DYF-11 is needed for assembly/integrity of the IFT particle.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/18369462" target="_blank" class="term-link">
+                                        PMID:18369462
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">may help with the assembly of Kinesin-II onto the IFT complex</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006935" target="_blank" class="term-link">
+                                    GO:0006935
+                                </a>
+                            </span>
+                            <span class="term-label">chemotaxis</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/18245347" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:18245347
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The conserved proteins CHE-12 and DYF-11 are required for se...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q17595" data-a="GO:0006935" data-r="PMID:18245347" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> dyf-11 mutants are chemotaxis-defective because their sensory cilia are truncated and nonfunctional. This is a sensory readout downstream of the ciliary defect rather than a direct chemotaxis function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Pleiotropic sensory-behavior phenotype secondary to loss of functional cilia; not a core molecular function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/18245347" target="_blank" class="term-link">
+                                        PMID:18245347
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">chemotaxis defective</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006972" target="_blank" class="term-link">
+                                    GO:0006972
+                                </a>
+                            </span>
+                            <span class="term-label">hyperosmotic response</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/18245347" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:18245347
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The conserved proteins CHE-12 and DYF-11 are required for se...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q17595" data-a="GO:0006972" data-r="PMID:18245347" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Annotation reflects the osmotic-avoidance (Osm) phenotype of dyf-11 mutants, a cilium-dependent sensory behavior. It is a downstream consequence of nonfunctional sensory cilia rather than a direct role in the cellular hyperosmotic stress response.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Pleiotropic sensory-behavior phenotype secondary to ciliary dysfunction; retained as non-core (experimental IMP; defer to curator on full text).
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0043053" target="_blank" class="term-link">
+                                    GO:0043053
+                                </a>
+                            </span>
+                            <span class="term-label">dauer entry</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/18245347" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:18245347
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The conserved proteins CHE-12 and DYF-11 are required for se...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q17595" data-a="GO:0043053" data-r="PMID:18245347" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> dyf-11 mutants are dauer-formation defective, consistent with loss of the ciliary sensory input that governs the dauer decision. Downstream consequence of ciliary dysfunction.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Pleiotropic developmental phenotype secondary to defective sensory-cilia signaling; not a core molecular function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/18369462" target="_blank" class="term-link">
+                                        PMID:18369462
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">found that dyf-11 mutants are Daf-d at both temperatures</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1905515" target="_blank" class="term-link">
+                                    GO:1905515
+                                </a>
+                            </span>
+                            <span class="term-label">non-motile cilium assembly</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/18245347" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:18245347
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The conserved proteins CHE-12 and DYF-11 are required for se...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q17595" data-a="GO:1905515" data-r="PMID:18245347" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> C. elegans sensory cilia are non-motile, and DYF-11 is required to build them: in dyf-11 mutants the medial and distal ciliary segments are absent. This is the most specific and accurate biological-process term for DYF-11.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Core biological process; the specific non-motile-cilium wording matches the worm sensory cilium and is directly supported.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/18245347" target="_blank" class="term-link">
+                                        PMID:18245347
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">medial and distal segments are absent</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>DYF-11/IFT54 (MIP-T3/TRAF3IP1 ortholog) is a structural subunit of intraflagellar transport (IFT) complex B in ciliated sensory neurons. It localizes to the ciliary base (transition zone/basal body) and axoneme, undergoes bidirectional IFT, and is required for assembling and maintaining a functional motor-IFT particle. In its absence kinesin-II, IFT-A, IFT-dynein and BBSome components fail to enter cilia, the axoneme is truncated, and full-length sensory cilia do not form. Its only informative molecular-function term is microtubule binding (the MIP-T3 family property); it has no catalytic domain and acts as a structural/adaptor component of IFT-B.</h3>
+                <span class="vote-buttons" data-g="Q17595" data-a="FUNCTION: DYF-11/IFT54 (MIP-T3/TRAF3IP1 ortholog) is a struc..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008017" target="_blank" class="term-link">
+                            microtubule binding
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042073" target="_blank" class="term-link">
+                                intraciliary transport
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1905515" target="_blank" class="term-link">
+                                non-motile cilium assembly
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0061512" target="_blank" class="term-link">
+                                protein localization to cilium
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0036064" target="_blank" class="term-link">
+                                ciliary basal body
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005930" target="_blank" class="term-link">
+                                axoneme
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">In Complex:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030992" target="_blank" class="term-link">
+                            intraciliary transport particle B
+                        </a>
+                    </span>
+                </div>
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/18369462" target="_blank" class="term-link">
+                                PMID:18369462
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">DYF-11 functions as a novel component of IFT subcomplex B</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/18369462" target="_blank" class="term-link">
+                                PMID:18369462
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">the GFP-tagged protein moves bi-directionally along the length of amphid and phasmid ciliary axonemes</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/18245347" target="_blank" class="term-link">
+                                PMID:18245347
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">function at an early stage of IFT-B particle assembly</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000002.md" target="_blank" class="term-link">
+                            GO_REF:0000002
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation through association of InterPro records with GO terms</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
+                            GO_REF:0000033
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Annotation inferences using phylogenetic trees</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
+                            GO_REF:0000044
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000117.md" target="_blank" class="term-link">
+                            GO_REF:0000117
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Electronic Gene Ontology annotations created by ARBA machine learning models</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/18245347" target="_blank" class="term-link">
+                            PMID:18245347
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">The conserved proteins CHE-12 and DYF-11 are required for sensory cilium function in Caenorhabditis elegans.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/18369462" target="_blank" class="term-link">
+                            PMID:18369462
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">An essential role for DYF-11/MIP-T3 in assembling functional intraflagellar transport complexes.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/20837997" target="_blank" class="term-link">
+                            PMID:20837997
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Reversal of salt preference is directed by the insulin/PI3K and Gq/PKC signaling in Caenorhabditis elegans.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/28479320" target="_blank" class="term-link">
+                            PMID:28479320
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Dynein-Driven Retrograde Intraflagellar Transport Is Triphasic in C. elegans Sensory Cilia.</div>
+
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Questions for Experts</h2>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Does C. elegans DYF-11 bind microtubules directly, or is its microtubule association mediated through other IFT-B subunits?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q17595" data-a="Q: Does C. elegans DYF-11 bind microtubules directly,..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Which IFT-B subunit(s) does DYF-11 contact directly, and does it partner with an IFT20 ortholog as vertebrate IFT54 does?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q17595" data-a="Q: Which IFT-B subunit(s) does DYF-11 contact directl..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Experiments</h2>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> In vitro microtubule co-sedimentation and IFT-B reconstitution assays with purified DYF-11 to define direct microtubule binding and subunit interactions.</p>
+
+
+
+                </div>
+                <span class="vote-buttons" data-g="Q17595" data-a="EXPERIMENT: In vitro microtubule co-sedimentation and IFT-B re..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Live-imaging epistasis of GFP-tagged IFT components in dyf-11 and other IFT-B mutant backgrounds to order DYF-11 within the IFT-B assembly hierarchy.</p>
+
+
+
+                </div>
+                <span class="vote-buttons" data-g="Q17595" data-a="EXPERIMENT: Live-imaging epistasis of GFP-tagged IFT component..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Knowledge Gaps</h2>
+        <p style="color: #555; font-size: 0.92rem; margin-top: -0.3rem;">
+            What is <em>not</em> known — curated, literature-grounded statements of the open
+            unknowns (the inverse of core functions).
+        </p>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The specific molecular function of DYF-11/IFT54 within IFT complex B is undefined. It has no catalytic domain and only a C-terminal coiled coil; whether it binds microtubules directly in C. elegans, and which specific IFT-B subunit(s) it bridges (vertebrate IFT54 partners with IFT20), is not established. It reads as MF-dark despite a well-defined cellular role.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span><span class="badge">ONTOLOGY</span>
+                <span class="badge">MF_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> DYF-11 is firmly established as an IFT-B subunit that localizes to the transition zone/basal body and axoneme, undergoes bidirectional IFT, and is required for assembling a functional motor-IFT particle and building full-length sensory cilia. Its only informative GO molecular-function term is the family-level microtubule binding (GO:0008017), which has not been experimentally demonstrated for the worm protein.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> IFT54/TRAF3IP1 is a conserved core IFT-B protein whose human ortholog is linked to ciliopathy phenotypes; defining its molecular activity (microtubule binding vs a specific IFT-B scaffolding interaction) is central to understanding IFT-B architecture.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Test direct microtubule binding of purified DYF-11; map its IFT-B interaction partners (e.g. an IFT20 ortholog) by biochemistry/structure; isolate separation-of-function alleles; consider a molecular-function term for an IFT-B structural/scaffolding subunit activity.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"MIP-T3 proteins range in size from 484 to 625 amino acids and have no recognizable domains except for a predicted coiled-coil region near the C-terminus"</em> — PMID:18369462</li>
+
+                <li><em>"that affects the core machinery, remains to be determined"</em> — PMID:18369462</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> How DYF-11 promotes assembly/loading of the kinesin-II motor and other IFT components onto trains at the ciliary base is not understood at the mechanistic level, nor is it resolved whether it acts specifically at an early step of IFT-B particle assembly.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">RESIDUAL_SUBGAP</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> Loss of dyf-11 mislocalizes kinesin-II (KAP-1), IFT-A (CHE-11), dynein (XBX-1) and BBSome (BBS-7) components so they fail to enter cilia, and DYF-11 undergoes IFT-like movement and may act early in IFT-B assembly; the molecular steps linking DYF-11 to motor/particle assembly are undefined.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> DYF-11 has a more severe assembly phenotype than typical IFT-B mutants and uniquely affects kinesin-II loading, so its mechanism bears on how the anterograde motor is coupled to IFT trains.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Order the IFT-B assembly hierarchy with epistasis/live-imaging and in vitro reconstitution; determine whether DYF-11 directly contacts kinesin-II or acts through other IFT-B subunits.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"function at an early stage of IFT-B particle assembly"</em> — PMID:18245347</li>
+
+                <li><em>"may help with the assembly of Kinesin-II onto the IFT complex"</em> — PMID:18369462</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> Whether C. elegans DYF-11 has an IFT-independent role — for example in dendrite/neurite protein trafficking, analogous to the vertebrate MIP-T3/DISC1 axis — is untested.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">RESIDUAL_SUBGAP</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> DYF-11::GFP is occasionally seen in dendritic extensions beyond the cilium, and vertebrate MIP-T3 interacts with DISC1 and microtubules in neurite/centrosome contexts; no non-ciliary function has been assayed in the worm.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Distinguishing a dedicated ciliary IFT role from a broader neuronal trafficking role would clarify whether MIP-T3/TRAF3IP1 acquired dual functions during evolution.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Assay dyf-11 dendritic transport and non-ciliary phenotypes with cell-type-specific rescue and cargo-trafficking reporters.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"Whether C. elegans DYF-11 has dendrite-associated functions whose disruption could affect ciliogenesis represents an interesting question that will need to be addressed"</em> — PMID:18369462</li>
+
+            </ul>
+
+
+        </div>
+
+    </div>
+
+
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Deep Research Sections -->
+
+    <div class="section">
+        <h2 class="section-title">Deep Research</h2>
+
+        <details class="deep-research-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; gap: 1rem;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Falcon</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(dyf-11-deep-research-falcon.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="Q17595" data-a="DEEP_RESEARCH: Falcon" data-r="" data-act="DEEP_RESEARCH" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This deep research is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This deep research needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+
+                <div class="report-meta">
+
+                    <span class="report-meta-text">Comprehensive Research Report: *dyf-11* (C. elegans) — TRAF3IP1/IFT54 Ortholog</span>
+
+
+                    <span class="report-badge">Falcon</span>
+
+
+                    <span class="report-badge">Edison Scientific Literature</span>
+
+
+                    <span class="report-badge">24 citations</span>
+
+
+                    <span class="report-badge">1 artifacts</span>
+
+
+                    <span class="report-meta-text">2026-07-04T12:27:32.512634</span>
+
+
+
+                </div>
+
+
+                <div class="artifact-list">
+
+
+
+                    <div class="artifact-link">
+                        <a href="dyf-11-deep-research-falcon_artifacts/artifact-00.md" class="term-link">Edison artifact artifact-00</a>
+                        <span>(text/markdown)</span>
+                    </div>
+
+
+                </div>
+
+                <p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h1 id="comprehensive-research-report-dyf-11-c-elegans-traf3ip1ift54-ortholog">Comprehensive Research Report: <em>dyf-11</em> (C. elegans) — TRAF3IP1/IFT54 Ortholog</h1>
+<h2 id="1-gene-identity-and-nomenclature">1. Gene Identity and Nomenclature</h2>
+<p>The <em>C. elegans</em> gene <em>dyf-11</em> (systematic name C02H7.1; UniProt Q17595) encodes the nematode ortholog of mammalian TRAF3-interacting protein 1 (TRAF3IP1), also known as intraflagellar transport protein 54 (IFT54) or MIP-T3 (sun2025multipleregulatorsconstrain pages 4-6, emmer2010molecularmechanismsof pages 5-6). The name <em>dyf-11</em> derives from "dye-filling defective," reflecting the phenotype of mutant animals whose sensory neurons fail to take up lipophilic fluorescent dyes — a hallmark of ciliary structural defects. The protein belongs to the conserved TRAF3IP1 family and is a subunit of the IFT-B complex, specifically the peripheral IFT-B2 subcomplex (taschner2016theintraflagellartransport pages 5-6, liu2025structuremakesa pages 1-2, nakayama2018ciliaryproteintrafficking pages 3-3).</p>
+<p>The following table summarizes the key molecular, functional, and phenotypic properties of DYF-11/IFT54/TRAF3IP1:</p>
+<table>
+<thead>
+<tr>
+<th>Property</th>
+<th>Details</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Verified identity</td>
+<td><strong>C. elegans dyf-11</strong> corresponds to UniProt Q17595 and is the nematode ortholog of mammalian <strong>TRAF3IP1/IFT54</strong>; literature also identifies DYF-11 as an IFT-associated ciliary protein in sensory neurons (sun2025multipleregulatorsconstrain pages 4-6, emmer2010molecularmechanismsof pages 5-6)</td>
+</tr>
+<tr>
+<td>Gene names / orthologs across species</td>
+<td><strong>C. elegans:</strong> dyf-11; <strong>human/vertebrates:</strong> TRAF3IP1, also called <strong>IFT54</strong>; older literature also refers to mammalian family members as <strong>MIP-T3</strong>. Reviews and primary studies consistently place these proteins in the conserved IFT-B2/peripheral IFT-B subcomplex (bizet2015mutationsintraf3ip1ift54 pages 3-4, hiyamizu2023multipleinteractionsof pages 1-2, taschner2016theintraflagellartransport pages 5-6, nakayama2018ciliaryproteintrafficking pages 3-3)</td>
+</tr>
+<tr>
+<td>Protein family / complex membership</td>
+<td>DYF-11/TRAF3IP1/IFT54 belongs to the conserved <strong>IFT54/TRAF3IP1 family</strong> and is a component of the <strong>IFT-B2 (peripheral IFT-B) subcomplex</strong> together with IFT20, IFT38, IFT57, IFT80, and IFT172 (hiyamizu2023multipleinteractionsof pages 1-2, taschner2016theintraflagellartransport pages 5-6, liu2025structuremakesa pages 1-2, nakayama2018ciliaryproteintrafficking pages 3-3)</td>
+</tr>
+<tr>
+<td>Key domains</td>
+<td>IFT54 contains an <strong>N-terminal calponin homology (CH) domain</strong> and a <strong>C-terminal coiled-coil region</strong>. The CH domain is the major tubulin-binding module within IFT-B2, while the coiled-coil region mediates stable association with IFT20 (taschner2016intraflagellartransportproteins pages 4-5, taschner2016intraflagellartransportproteins pages 3-4, bizet2015mutationsintraf3ip1ift54 pages 3-4)</td>
+</tr>
+<tr>
+<td>Key biochemical interactions</td>
+<td>Forms a stable <strong>IFT54–IFT20 heterodimer</strong>; the IFT54/20 unit associates with <strong>IFT57/38</strong> and interfaces with <strong>IFT80</strong> within IFT-B2. IFT-B2 is linked to IFT-B1 mainly through the <strong>IFT57/38–IFT88/52N</strong> connection (taschner2016intraflagellartransportproteins pages 4-5, taschner2016intraflagellartransportproteins pages 12-13, taschner2016theintraflagellartransport pages 5-6, taschner2016intraflagellartransportproteins pages 9-10, taschner2016intraflagellartransportproteins pages 5-5)</td>
+</tr>
+<tr>
+<td>Motor interactions</td>
+<td>IFT54 interacts with both major IFT motors: reviews state it binds <strong>kinesin-2</strong> and <strong>dynein-2</strong>, and 2023 work showed extensive functional interaction with dynein-2, especially via <strong>WDR60</strong>, supporting retrograde transport coupling (hiyamizu2023multipleinteractionsof pages 1-2, pigino2021intraflagellartransport pages 3-3)</td>
+</tr>
+<tr>
+<td>Cargo-related interactions</td>
+<td>The CH domain binds <strong>αβ-tubulin</strong> directly through a basic surface patch; the measured affinity for soluble tubulin is in the <strong>low micromolar range (~3 ± 1 μM)</strong>, supporting a role in tubulin delivery during ciliogenesis (taschner2016intraflagellartransportproteins pages 4-5, taschner2016intraflagellartransportproteins pages 3-4, taschner2016intraflagellartransportproteins pages 12-13, taschner2016intraflagellartransportproteins pages 8-9)</td>
+</tr>
+<tr>
+<td>Subcellular localization</td>
+<td>In vertebrate cells, IFT54 localizes to the <strong>ciliary transition zone/transition fibers</strong>, co-localizes with <strong>Cep164</strong>, and is also detected near <strong>proximal centrioles</strong> with <strong>γ-tubulin</strong>; in <strong>C. elegans</strong>, the DYF-11 homolog <strong>translocates within sensory cilia via IFT</strong> (bizet2015mutationsintraf3ip1ift54 pages 3-4, bizet2015mutationsintraf3ip1ift54 pages 6-7, emmer2010molecularmechanismsof pages 5-6)</td>
+</tr>
+<tr>
+<td>Expression / cell-type context in worm</td>
+<td>Available worm evidence places DYF-11 in <strong>ciliated sensory neurons</strong>, where it functions in sensory cilia formation and transport-dependent signaling homeostasis (sun2025multipleregulatorsconstrain pages 4-6, emmer2010molecularmechanismsof pages 5-6)</td>
+</tr>
+<tr>
+<td>Primary molecular function</td>
+<td>DYF-11/IFT54 is best understood as a <strong>structural and cargo-binding adapter in IFT-B2</strong> that helps couple the IFT particle to tubulin cargo and to anterograde/retrograde motors, thereby supporting <strong>ciliogenesis, cilium maintenance, and bidirectional intraflagellar transport</strong> (hiyamizu2023multipleinteractionsof pages 1-2, taschner2016intraflagellartransportproteins pages 4-5, pigino2021intraflagellartransport pages 3-3, taschner2016theintraflagellartransport pages 5-6)</td>
+</tr>
+<tr>
+<td>Broader biological role</td>
+<td>Required for <strong>sensory cilium formation/function</strong> in nematodes and for conserved ciliary assembly in other systems; defects impair entry/localization of IFT54 at the ciliary compartment and perturb effective IFT (bizet2015mutationsintraf3ip1ift54 pages 3-4, sun2025multipleregulatorsconstrain pages 4-6, bizet2015mutationsintraf3ip1ift54 pages 6-7)</td>
+</tr>
+<tr>
+<td>Extraciliary function</td>
+<td>Beyond cilia, TRAF3IP1/IFT54 acts as a <strong>negative regulator of cytoplasmic microtubule stability</strong> through <strong>MAP4</strong>, influencing epithelial organization, polarity, and tissue morphogenesis (bizet2015mutationsintraf3ip1ift54 pages 1-2, bizet2015mutationsintraf3ip1ift54 pages 8-9, bizet2015mutationsintraf3ip1ift54 pages 11-12, bizet2015mutationsintraf3ip1ift54 pages 7-8, bizet2015mutationsintraf3ip1ift54 pages 3-4)</td>
+</tr>
+<tr>
+<td>Worm mutant phenotypes</td>
+<td><strong>dyf-11 mutants</strong> show severe <strong>dye-filling defects</strong> in amphid and phasmid neurons (reported as essentially <strong>0% dye fill</strong> in a recent re-analysis), consistent with strong defects in sensory cilia biogenesis/function; mutants also misaccumulate <strong>GFP::DLK-1</strong> in ciliary regions (sun2025multipleregulatorsconstrain pages 4-6)</td>
+</tr>
+<tr>
+<td>Human disease relevance of ortholog</td>
+<td>Mutations in human <strong>TRAF3IP1/IFT54</strong> cause ciliopathy phenotypes including <strong>nephronophthisis</strong>, <strong>retinal degeneration/Senior-Løken syndrome</strong>, and sometimes <strong>Bardet-Biedl-like features</strong>; disease mechanisms likely combine ciliary transport defects with abnormal microtubule stabilization (bizet2015mutationsintraf3ip1ift54 pages 1-2, bizet2015mutationsintraf3ip1ift54 pages 8-9, bizet2015mutationsintraf3ip1ift54 pages 11-12, bizet2015mutationsintraf3ip1ift54 pages 3-4)</td>
+</tr>
+<tr>
+<td>Recent developments</td>
+<td>Recent studies emphasize that IFT54 is not just a static IFT-B subunit: <strong>2023</strong> work clarified its multiple contacts with <strong>dynein-2</strong> needed for effective IFT, and newer structural/assembly studies place IFT54 as important for proper <strong>IFT-B2 assembly and recruitment</strong> during ciliogenesis (hiyamizu2023multipleinteractionsof pages 1-2, liu2025structuremakesa pages 1-2)</td>
+</tr>
+</tbody>
+</table>
+<p><em>Table: This table summarizes the verified identity, conserved orthology, domain architecture, interactions, localization, functions, and phenotypes of C. elegans DYF-11 and its mammalian ortholog TRAF3IP1/IFT54. It is useful as a compact reference for the gene’s core ciliary role and its broader relevance to ciliopathy biology.</em></p>
+<h2 id="2-protein-architecture-and-domain-structure">2. Protein Architecture and Domain Structure</h2>
+<p>DYF-11/IFT54 contains two principal structural elements. The <strong>N-terminal calponin homology (CH) domain</strong> is the major tubulin-binding module within the IFT-B2 subcomplex. Crystal structures of the IFT54 CH domain reveal that tubulin binding is mediated by basic, surface-exposed residues; specifically, a triple KKK64/66/69EEE point mutant abolished tubulin binding, indicating that these Arg/Lys-rich residues at the edge of a conserved basic patch mediate the interaction with αβ-tubulin heterodimers (taschner2016intraflagellartransportproteins pages 4-5, taschner2016intraflagellartransportproteins pages 1-2, taschner2016intraflagellartransportproteins pages 8-9). The measured affinity for soluble αβ-tubulin is in the low micromolar range (Kd = 3 ± 1 μM), comparable to the IFT81/74 tubulin-binding site in the IFT-B1 core (taschner2016intraflagellartransportproteins pages 4-5, taschner2016intraflagellartransportproteins pages 12-13). Notably, among the three IFT-B2 CH-domain proteins (IFT54, IFT57, IFT38), only IFT54 binds tubulin; the CH domains of IFT38 and IFT57 instead mediate interactions with IFT80 and IFT172, respectively (taschner2016intraflagellartransportproteins pages 1-2, taschner2016intraflagellartransportproteins pages 3-4).</p>
+<p>The <strong>C-terminal coiled-coil region</strong> mediates the stable heterodimeric interaction between IFT54 and IFT20, forming the IFT54/20 dimer that is a fundamental building block of IFT-B2 (taschner2016intraflagellartransportproteins pages 3-4, bizet2015mutationsintraf3ip1ift54 pages 3-4, taschner2016theintraflagellartransport pages 5-6). IFT54 stabilizes IFT20 within the complex (liu2025structuremakesa pages 1-2).</p>
+<h2 id="3-position-within-the-ift-b-complex">3. Position within the IFT-B Complex</h2>
+<p>The IFT-B complex, which comprises 16 subunits, is organized into two subcomplexes: the IFT-B1 core (IFT22, IFT25, IFT27, IFT46, IFT52, IFT56, IFT70, IFT74, IFT81, IFT88) and the IFT-B2 peripheral subcomplex (IFT20, IFT38, IFT54, IFT57, IFT80, IFT172) (taschner2016theintraflagellartransport pages 5-6, nakayama2018ciliaryproteintrafficking pages 3-3). Within IFT-B2, the IFT54/20 heterodimer interacts with the IFT57/38 heterodimer, and IFT54/20 also directly contacts IFT80 (taschner2016intraflagellartransportproteins pages 12-13, taschner2016intraflagellartransportproteins pages 5-5). The IFT-B2 subcomplex is connected to IFT-B1 primarily through a salt-stable interaction between IFT57/38 and the IFT88/52N connector module; IFT54 thus is not a direct bridge to IFT-B1 but is critical for IFT-B2 structural integrity (taschner2016intraflagellartransportproteins pages 9-10, taschner2016intraflagellartransportproteins pages 8-9). Complete loss of IFT54 prevents normal IFT-B2 subcomplex formation and results in cells with no cilia, demonstrating its essential role in ciliogenesis (liu2025structuremakesa pages 1-2).</p>
+<h2 id="4-molecular-function-intraflagellar-transport-and-motor-coupling">4. Molecular Function: Intraflagellar Transport and Motor Coupling</h2>
+<p>DYF-11/IFT54 functions primarily as a <strong>structural and cargo-binding adapter</strong> within the intraflagellar transport machinery. Its principal roles include:</p>
+<p><strong>Tubulin cargo transport:</strong> The CH domain of IFT54 provides one of two tubulin-binding sites within the IFT-B complex (the other being the IFT81/74 module in IFT-B1), potentially allowing the transport of two tubulin heterodimers per IFT-B particle to ciliary tips for axonemal growth (taschner2016intraflagellartransportproteins pages 4-5, taschner2016intraflagellartransportproteins pages 3-4, taschner2016intraflagellartransportproteins pages 12-13).</p>
+<p><strong>Motor protein coupling:</strong> IFT54 directly interacts with both the anterograde motor kinesin-2 and the retrograde motor dynein-2 (pigino2021intraflagellartransport pages 3-3). In particular, IFT54 interacts with the dynein-2 subunit WDR60 through a conserved region N-terminal to the light chain-binding domains of WDR60. These interactions are functionally important: N-terminal truncation mutants of WDR60 lacking the IFT54-binding site fail to rescue the aberrant accumulation of IFT machinery around the ciliary tip that characterizes WDR60-knockout cells (hiyamizu2023multipleinteractionsof pages 1-2, hiyamizu2023multipleinteractionsof pages 3-4). IFT54 also interacts with the dynein-2 subunit D1bLIC through residues 261–275 (liu2025structuremakesa pages 1-2). These multiple motor-IFT-B contacts ensure the proper coupling of dynein-2 to anterograde IFT trains for its delivery to the ciliary tip and subsequent activation of retrograde transport (hiyamizu2023multipleinteractionsof pages 1-2).</p>
+<h2 id="5-subcellular-localization">5. Subcellular Localization</h2>
+<p>In mammalian cells, IFT54 localizes at the <strong>ciliary transition zone and transition fibers</strong> (where it co-localizes with Cep164), at the <strong>proximal centrioles</strong> (co-localizing with γ-tubulin), and along the ciliary axoneme as part of IFT trains (bizet2015mutationsintraf3ip1ift54 pages 3-4). Mutations in TRAF3IP1 impair IFT54 entry into the ciliary compartment at the transition zone, leading to reduced localization at the ciliary distal tip and altered distribution at the basal body region (bizet2015mutationsintraf3ip1ift54 pages 6-7).</p>
+<p>In <em>C. elegans</em>, the DYF-11 homolog translocates within sensory cilia via IFT (emmer2010molecularmechanismsof pages 5-6). DYF-11 is expressed in ciliated sensory neurons, including the amphid and phasmid neurons, where it is required for proper cilia biogenesis and sensory function (sun2025multipleregulatorsconstrain pages 4-6).</p>
+<h2 id="6-mutant-phenotypes-in-c-elegans">6. Mutant Phenotypes in <em>C. elegans</em></h2>
+<p>Loss-of-function mutations in <em>dyf-11</em> cause profound defects in sensory cilia. The <em>dyf-11(ju1730)</em> allele, which contains a G-to-A nucleotide change altering the initiation codon ATG to ATA, results in severe <strong>dye-filling defects</strong>, with 0% dye fill in both amphid and phasmid sensory neurons, indicating complete loss of neuronal access to the environment (sun2025multipleregulatorsconstrain pages 4-6). This phenotype classifies <em>dyf-11</em> mutants as strongly Dyf (dye-filling defective), consistent with significant disruption of cilium structure or accessibility.</p>
+<p>Additionally, <em>dyf-11</em> mutants display increased misaccumulation of GFP::DLK-1 (a MAP3K) in the ciliary region. The DLK-1 misaccumulation is exacerbated by loss of function in <em>cebp-1</em>, the b-Zip transcription factor acting downstream of DLK-1, indicating that IFT-dependent feedback regulation of DLK-1 protein abundance is disrupted in <em>dyf-11</em> mutants (sun2025multipleregulatorsconstrain pages 4-6). The defective chemosensory abilities of <em>dyf-11</em> mutants have also been noted in studies of salt chemotaxis learning, where altered cilium biogenesis impacts sensory neuron function.</p>
+<h2 id="7-extraciliary-function-microtubule-stabilization-via-map4">7. Extraciliary Function: Microtubule Stabilization via MAP4</h2>
+<p>Beyond its ciliary roles, TRAF3IP1/IFT54 has a critical <strong>extraciliary function as a negative regulator of cytoplasmic microtubule stability</strong> through its interaction with MAP4 (microtubule-associated protein 4) (bizet2015mutationsintraf3ip1ift54 pages 1-2, bizet2015mutationsintraf3ip1ift54 pages 8-9, bizet2015mutationsintraf3ip1ift54 pages 11-12). Mutations in TRAF3IP1 that impair the N-terminal MAP4-binding region lead to increased cytoplasmic MAP4 expression and excessive microtubule stabilization (bizet2015mutationsintraf3ip1ift54 pages 8-9, bizet2015mutationsintraf3ip1ift54 pages 3-4). This results in altered epithelialization and polarity in renal cells: TRAF3IP1-knockdown cells show disorganized microtubule networks, decreased trans-epithelial resistance, reduced β-catenin localization at cell junctions, and impaired lumen formation in 3D spheroid cultures (bizet2015mutationsintraf3ip1ift54 pages 7-8).</p>
+<p>Importantly, these extraciliary defects are functionally distinct from the mild ciliary structural abnormalities caused by TRAF3IP1 mutations. The mild ciliary defects alone appear insufficient to explain the broad phenotypic spectrum observed in patients, suggesting that the MAP4-mediated microtubule dysregulation contributes significantly to disease pathogenesis (bizet2015mutationsintraf3ip1ift54 pages 8-9, bizet2015mutationsintraf3ip1ift54 pages 11-12, bizet2015mutationsintraf3ip1ift54 pages 3-4).</p>
+<h2 id="8-disease-associations-of-the-human-ortholog-traf3ip1">8. Disease Associations of the Human Ortholog TRAF3IP1</h2>
+<p>Mutations in human <em>TRAF3IP1</em> cause a range of ciliopathy phenotypes. The most common presentation is <strong>nephronophthisis (NPH) with retinal degeneration</strong> (Senior-Løken syndrome), with end-stage renal disease occurring in early childhood (ages 3–6) and retinitis pigmentosa with vision loss and nystagmus (bizet2015mutationsintraf3ip1ift54 pages 1-2, bizet2015mutationsintraf3ip1ift54 pages 3-4). Some patients also present with features of Bardet-Biedl syndrome, including developmental delay, polydactyly, obesity, and hypogonadism, as well as hepatic complications such as Caroli disease, cholestasis, and hepatic fibrosis (bizet2015mutationsintraf3ip1ift54 pages 1-2, bizet2015mutationsintraf3ip1ift54 pages 3-4). The obesity phenotype may be explained by defective cAMP/PKA signaling, a shared feature among IFT gene mutations (bizet2015mutationsintraf3ip1ift54 pages 8-9). In zebrafish models, knockdown of <em>traf3ip1</em> causes pronephric cysts and microphthalmia, recapitulating key features of the human disease (bizet2015mutationsintraf3ip1ift54 pages 1-2, bizet2015mutationsintraf3ip1ift54 pages 11-12).</p>
+<h2 id="9-recent-developments">9. Recent Developments</h2>
+<p>Recent structural and biochemical studies have advanced understanding of IFT54/DYF-11 function. Work by Hiyamizu et al. (2023) demonstrated that multiple interactions between the dynein-2 and IFT-B complexes are required for effective intraflagellar transport, with IFT54 being a key contributor to the dynein-2–IFT-B connection through its interaction with WDR60 (hiyamizu2023multipleinteractionsof pages 1-2, hiyamizu2023multipleinteractionsof pages 3-4). A 2025 review emphasized the structural importance of IFT54 within the IFT-B2 architecture, noting that complete loss of IFT54 abolishes cilia formation and that the protein's CH domain, while less critical than IFT81's for tubulin transport, contributes to the overall tubulin delivery capacity of IFT-B (liu2025structuremakesa pages 1-2). Additional recent work has placed IFT54 in the context of IFT-B2 assembly and recruitment to the mother centriole/basal body, a process essential for initiating ciliogenesis (liu2025structuremakesa pages 1-2).</p>
+<h2 id="10-summary">10. Summary</h2>
+<p><em>dyf-11</em> encodes the <em>C. elegans</em> ortholog of mammalian TRAF3IP1/IFT54, a conserved component of the IFT-B2 peripheral subcomplex essential for intraflagellar transport and ciliogenesis. The protein functions as a structural adapter within the IFT particle, coupling the transport machinery to tubulin cargo via its N-terminal CH domain and to IFT motors (both kinesin-2 and dynein-2) for bidirectional ciliary trafficking. In the nematode, DYF-11 localizes to sensory cilia and translocates via IFT; its loss results in complete dye-filling defects and defective chemosensory function. Beyond cilia, the protein has an important extraciliary role in regulating cytoplasmic microtubule dynamics through MAP4, with disease-relevant consequences for epithelial organization and tissue morphogenesis.</p>
+<p>References</p>
+<ol>
+<li>
+<p>(sun2025multipleregulatorsconstrain pages 4-6): Yue Sun, Junxiang Zhou, Arunima Debnath, Bokun Xie, Zhiping Wang, and Yishi Jin. Multiple regulators constrain the abundance of caenorhabditis elegans dlk-1 in ciliated sensory neurons. G3: Genes | Genomes | Genetics, Jan 2025. URL: https://doi.org/10.1093/g3journal/jkaf004, doi:10.1093/g3journal/jkaf004. This article has 1 citations.</p>
+</li>
+<li>
+<p>(emmer2010molecularmechanismsof pages 5-6): Brian T. Emmer, Danijela Maric, and David M. Engman. Molecular mechanisms of protein and lipid targeting to ciliary membranes. Journal of Cell Science, 123:529-536, Feb 2010. URL: https://doi.org/10.1242/jcs.062968, doi:10.1242/jcs.062968. This article has 160 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(taschner2016theintraflagellartransport pages 5-6): Michael Taschner and Esben Lorentzen. The intraflagellar transport machinery. Cold Spring Harbor perspectives in biology, 8 10:a028092, Oct 2016. URL: https://doi.org/10.1101/cshperspect.a028092, doi:10.1101/cshperspect.a028092. This article has 419 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(liu2025structuremakesa pages 1-2): Ying Liu, Yong Zhang, Hua Ni, and Peiwei Liu. Structure makes a difference: <scp>ift</scp> complex in ciliary function and ciliopathy. Cytoskeleton, Sep 2025. URL: https://doi.org/10.1002/cm.70033, doi:10.1002/cm.70033. This article has 1 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(nakayama2018ciliaryproteintrafficking pages 3-3): Kazuhisa Nakayama and Yohei Katoh. Ciliary protein trafficking mediated by ift and bbsome complexes with the aid of kinesin-2 and dynein-2 motors. Journal of biochemistry, 163 3:155-164, Mar 2018. URL: https://doi.org/10.1093/jb/mvx087, doi:10.1093/jb/mvx087. This article has 160 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(bizet2015mutationsintraf3ip1ift54 pages 3-4): Albane A. Bizet, Anita Becker-Heck, Rebecca Ryan, Kristina Weber, Emilie Filhol, Pauline Krug, Jan Halbritter, Marion Delous, Marie-Christine Lasbennes, Bolan Linghu, Edward J. Oakeley, Mohammed Zarhrate, Patrick Nitschké, Meriem Garfa-Traore, Fabrizio Serluca, Fan Yang, Tewis Bouwmeester, Lucile Pinson, Elisabeth Cassuto, Philippe Dubot, Neveen A. Soliman Elshakhs, José A. Sahel, Rémi Salomon, Iain A. Drummond, Marie-Claire Gubler, Corinne Antignac, Salahdine Chibout, Joseph D. Szustakowski, Friedhelm Hildebrandt, Esben Lorentzen, Andreas W. Sailer, Alexandre Benmerah, Pierre Saint-Mezard, and Sophie Saunier. Mutations in traf3ip1/ift54 reveal a new role for ift proteins in microtubule stabilization. Nature Communications, 6:8666-8666, Oct 2015. URL: https://doi.org/10.1038/ncomms9666, doi:10.1038/ncomms9666. This article has 124 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(hiyamizu2023multipleinteractionsof pages 1-2): Shunya Hiyamizu, Hantian Qiu, Laura Vuolo, Nicola L. Stevenson, Caroline Shak, Kate J. Heesom, Yuki Hamada, Yuta Tsurumi, Shuhei Chiba, Yohei Katoh, David J. Stephens, and Kazuhisa Nakayama. Multiple interactions of the dynein-2 complex with the ift-b complex are required for effective intraflagellar transport. Journal of Cell Science, Feb 2023. URL: https://doi.org/10.1242/jcs.260462, doi:10.1242/jcs.260462. This article has 18 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(taschner2016intraflagellartransportproteins pages 4-5): Michael Taschner, Kristina Weber, André Mourão, Melanie Vetter, Mayanka Awasthi, Marc Stiegler, Sagar Bhogaraju, and Esben Lorentzen. Intraflagellar transport proteins 172, 80, 57, 54, 38, and 20 form a stable tubulin‐binding ift‐b2 complex. The EMBO Journal, 35:773-790, Feb 2016. URL: https://doi.org/10.15252/embj.201593164, doi:10.15252/embj.201593164. This article has 224 citations.</p>
+</li>
+<li>
+<p>(taschner2016intraflagellartransportproteins pages 3-4): Michael Taschner, Kristina Weber, André Mourão, Melanie Vetter, Mayanka Awasthi, Marc Stiegler, Sagar Bhogaraju, and Esben Lorentzen. Intraflagellar transport proteins 172, 80, 57, 54, 38, and 20 form a stable tubulin‐binding ift‐b2 complex. The EMBO Journal, 35:773-790, Feb 2016. URL: https://doi.org/10.15252/embj.201593164, doi:10.15252/embj.201593164. This article has 224 citations.</p>
+</li>
+<li>
+<p>(taschner2016intraflagellartransportproteins pages 12-13): Michael Taschner, Kristina Weber, André Mourão, Melanie Vetter, Mayanka Awasthi, Marc Stiegler, Sagar Bhogaraju, and Esben Lorentzen. Intraflagellar transport proteins 172, 80, 57, 54, 38, and 20 form a stable tubulin‐binding ift‐b2 complex. The EMBO Journal, 35:773-790, Feb 2016. URL: https://doi.org/10.15252/embj.201593164, doi:10.15252/embj.201593164. This article has 224 citations.</p>
+</li>
+<li>
+<p>(taschner2016intraflagellartransportproteins pages 9-10): Michael Taschner, Kristina Weber, André Mourão, Melanie Vetter, Mayanka Awasthi, Marc Stiegler, Sagar Bhogaraju, and Esben Lorentzen. Intraflagellar transport proteins 172, 80, 57, 54, 38, and 20 form a stable tubulin‐binding ift‐b2 complex. The EMBO Journal, 35:773-790, Feb 2016. URL: https://doi.org/10.15252/embj.201593164, doi:10.15252/embj.201593164. This article has 224 citations.</p>
+</li>
+<li>
+<p>(taschner2016intraflagellartransportproteins pages 5-5): Michael Taschner, Kristina Weber, André Mourão, Melanie Vetter, Mayanka Awasthi, Marc Stiegler, Sagar Bhogaraju, and Esben Lorentzen. Intraflagellar transport proteins 172, 80, 57, 54, 38, and 20 form a stable tubulin‐binding ift‐b2 complex. The EMBO Journal, 35:773-790, Feb 2016. URL: https://doi.org/10.15252/embj.201593164, doi:10.15252/embj.201593164. This article has 224 citations.</p>
+</li>
+<li>
+<p>(pigino2021intraflagellartransport pages 3-3): Gaia Pigino. Intraflagellar transport. Current Biology, 31:R530-R536, May 2021. URL: https://doi.org/10.1016/j.cub.2021.03.081, doi:10.1016/j.cub.2021.03.081. This article has 71 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(taschner2016intraflagellartransportproteins pages 8-9): Michael Taschner, Kristina Weber, André Mourão, Melanie Vetter, Mayanka Awasthi, Marc Stiegler, Sagar Bhogaraju, and Esben Lorentzen. Intraflagellar transport proteins 172, 80, 57, 54, 38, and 20 form a stable tubulin‐binding ift‐b2 complex. The EMBO Journal, 35:773-790, Feb 2016. URL: https://doi.org/10.15252/embj.201593164, doi:10.15252/embj.201593164. This article has 224 citations.</p>
+</li>
+<li>
+<p>(bizet2015mutationsintraf3ip1ift54 pages 6-7): Albane A. Bizet, Anita Becker-Heck, Rebecca Ryan, Kristina Weber, Emilie Filhol, Pauline Krug, Jan Halbritter, Marion Delous, Marie-Christine Lasbennes, Bolan Linghu, Edward J. Oakeley, Mohammed Zarhrate, Patrick Nitschké, Meriem Garfa-Traore, Fabrizio Serluca, Fan Yang, Tewis Bouwmeester, Lucile Pinson, Elisabeth Cassuto, Philippe Dubot, Neveen A. Soliman Elshakhs, José A. Sahel, Rémi Salomon, Iain A. Drummond, Marie-Claire Gubler, Corinne Antignac, Salahdine Chibout, Joseph D. Szustakowski, Friedhelm Hildebrandt, Esben Lorentzen, Andreas W. Sailer, Alexandre Benmerah, Pierre Saint-Mezard, and Sophie Saunier. Mutations in traf3ip1/ift54 reveal a new role for ift proteins in microtubule stabilization. Nature Communications, 6:8666-8666, Oct 2015. URL: https://doi.org/10.1038/ncomms9666, doi:10.1038/ncomms9666. This article has 124 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(bizet2015mutationsintraf3ip1ift54 pages 1-2): Albane A. Bizet, Anita Becker-Heck, Rebecca Ryan, Kristina Weber, Emilie Filhol, Pauline Krug, Jan Halbritter, Marion Delous, Marie-Christine Lasbennes, Bolan Linghu, Edward J. Oakeley, Mohammed Zarhrate, Patrick Nitschké, Meriem Garfa-Traore, Fabrizio Serluca, Fan Yang, Tewis Bouwmeester, Lucile Pinson, Elisabeth Cassuto, Philippe Dubot, Neveen A. Soliman Elshakhs, José A. Sahel, Rémi Salomon, Iain A. Drummond, Marie-Claire Gubler, Corinne Antignac, Salahdine Chibout, Joseph D. Szustakowski, Friedhelm Hildebrandt, Esben Lorentzen, Andreas W. Sailer, Alexandre Benmerah, Pierre Saint-Mezard, and Sophie Saunier. Mutations in traf3ip1/ift54 reveal a new role for ift proteins in microtubule stabilization. Nature Communications, 6:8666-8666, Oct 2015. URL: https://doi.org/10.1038/ncomms9666, doi:10.1038/ncomms9666. This article has 124 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(bizet2015mutationsintraf3ip1ift54 pages 8-9): Albane A. Bizet, Anita Becker-Heck, Rebecca Ryan, Kristina Weber, Emilie Filhol, Pauline Krug, Jan Halbritter, Marion Delous, Marie-Christine Lasbennes, Bolan Linghu, Edward J. Oakeley, Mohammed Zarhrate, Patrick Nitschké, Meriem Garfa-Traore, Fabrizio Serluca, Fan Yang, Tewis Bouwmeester, Lucile Pinson, Elisabeth Cassuto, Philippe Dubot, Neveen A. Soliman Elshakhs, José A. Sahel, Rémi Salomon, Iain A. Drummond, Marie-Claire Gubler, Corinne Antignac, Salahdine Chibout, Joseph D. Szustakowski, Friedhelm Hildebrandt, Esben Lorentzen, Andreas W. Sailer, Alexandre Benmerah, Pierre Saint-Mezard, and Sophie Saunier. Mutations in traf3ip1/ift54 reveal a new role for ift proteins in microtubule stabilization. Nature Communications, 6:8666-8666, Oct 2015. URL: https://doi.org/10.1038/ncomms9666, doi:10.1038/ncomms9666. This article has 124 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(bizet2015mutationsintraf3ip1ift54 pages 11-12): Albane A. Bizet, Anita Becker-Heck, Rebecca Ryan, Kristina Weber, Emilie Filhol, Pauline Krug, Jan Halbritter, Marion Delous, Marie-Christine Lasbennes, Bolan Linghu, Edward J. Oakeley, Mohammed Zarhrate, Patrick Nitschké, Meriem Garfa-Traore, Fabrizio Serluca, Fan Yang, Tewis Bouwmeester, Lucile Pinson, Elisabeth Cassuto, Philippe Dubot, Neveen A. Soliman Elshakhs, José A. Sahel, Rémi Salomon, Iain A. Drummond, Marie-Claire Gubler, Corinne Antignac, Salahdine Chibout, Joseph D. Szustakowski, Friedhelm Hildebrandt, Esben Lorentzen, Andreas W. Sailer, Alexandre Benmerah, Pierre Saint-Mezard, and Sophie Saunier. Mutations in traf3ip1/ift54 reveal a new role for ift proteins in microtubule stabilization. Nature Communications, 6:8666-8666, Oct 2015. URL: https://doi.org/10.1038/ncomms9666, doi:10.1038/ncomms9666. This article has 124 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(bizet2015mutationsintraf3ip1ift54 pages 7-8): Albane A. Bizet, Anita Becker-Heck, Rebecca Ryan, Kristina Weber, Emilie Filhol, Pauline Krug, Jan Halbritter, Marion Delous, Marie-Christine Lasbennes, Bolan Linghu, Edward J. Oakeley, Mohammed Zarhrate, Patrick Nitschké, Meriem Garfa-Traore, Fabrizio Serluca, Fan Yang, Tewis Bouwmeester, Lucile Pinson, Elisabeth Cassuto, Philippe Dubot, Neveen A. Soliman Elshakhs, José A. Sahel, Rémi Salomon, Iain A. Drummond, Marie-Claire Gubler, Corinne Antignac, Salahdine Chibout, Joseph D. Szustakowski, Friedhelm Hildebrandt, Esben Lorentzen, Andreas W. Sailer, Alexandre Benmerah, Pierre Saint-Mezard, and Sophie Saunier. Mutations in traf3ip1/ift54 reveal a new role for ift proteins in microtubule stabilization. Nature Communications, 6:8666-8666, Oct 2015. URL: https://doi.org/10.1038/ncomms9666, doi:10.1038/ncomms9666. This article has 124 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(taschner2016intraflagellartransportproteins pages 1-2): Michael Taschner, Kristina Weber, André Mourão, Melanie Vetter, Mayanka Awasthi, Marc Stiegler, Sagar Bhogaraju, and Esben Lorentzen. Intraflagellar transport proteins 172, 80, 57, 54, 38, and 20 form a stable tubulin‐binding ift‐b2 complex. The EMBO Journal, 35:773-790, Feb 2016. URL: https://doi.org/10.15252/embj.201593164, doi:10.15252/embj.201593164. This article has 224 citations.</p>
+</li>
+<li>
+<p>(hiyamizu2023multipleinteractionsof pages 3-4): Shunya Hiyamizu, Hantian Qiu, Laura Vuolo, Nicola L. Stevenson, Caroline Shak, Kate J. Heesom, Yuki Hamada, Yuta Tsurumi, Shuhei Chiba, Yohei Katoh, David J. Stephens, and Kazuhisa Nakayama. Multiple interactions of the dynein-2 complex with the ift-b complex are required for effective intraflagellar transport. Journal of Cell Science, Feb 2023. URL: https://doi.org/10.1242/jcs.260462, doi:10.1242/jcs.260462. This article has 18 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+</ol>
+<h2 id="artifacts">Artifacts</h2>
+<ul>
+<li><a href="dyf-11-deep-research-falcon_artifacts/artifact-00.md">Edison artifact artifact-00</a></li>
+</ul>
+<h2 id="citations">Citations</h2>
+<ol>
+<li>sun2025multipleregulatorsconstrain pages 4-6</li>
+<li>liu2025structuremakesa pages 1-2</li>
+<li>pigino2021intraflagellartransport pages 3-3</li>
+<li>hiyamizu2023multipleinteractionsof pages 1-2</li>
+<li>emmer2010molecularmechanismsof pages 5-6</li>
+<li>taschner2016theintraflagellartransport pages 5-6</li>
+<li>nakayama2018ciliaryproteintrafficking pages 3-3</li>
+<li>taschner2016intraflagellartransportproteins pages 4-5</li>
+<li>taschner2016intraflagellartransportproteins pages 3-4</li>
+<li>taschner2016intraflagellartransportproteins pages 12-13</li>
+<li>taschner2016intraflagellartransportproteins pages 9-10</li>
+<li>taschner2016intraflagellartransportproteins pages 5-5</li>
+<li>taschner2016intraflagellartransportproteins pages 8-9</li>
+<li>taschner2016intraflagellartransportproteins pages 1-2</li>
+<li>hiyamizu2023multipleinteractionsof pages 3-4</li>
+<li>https://doi.org/10.1093/g3journal/jkaf004,</li>
+<li>https://doi.org/10.1242/jcs.062968,</li>
+<li>https://doi.org/10.1101/cshperspect.a028092,</li>
+<li>https://doi.org/10.1002/cm.70033,</li>
+<li>https://doi.org/10.1093/jb/mvx087,</li>
+<li>https://doi.org/10.1038/ncomms9666,</li>
+<li>https://doi.org/10.1242/jcs.260462,</li>
+<li>https://doi.org/10.15252/embj.201593164,</li>
+<li>https://doi.org/10.1016/j.cub.2021.03.081,</li>
+</ol>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(dyf-11-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="Q17595" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="dyf-11-c-elegans-research-notes">dyf-11 (C. elegans) research notes</h1>
+<p>UniProt: Q17595 (Q17595_CAEEL) | WormBase: WBGene00001127 / C02H7.1 | Chromosome X<br />
+Human ortholog: <strong>TRAF3IP1 / MIP-T3 / IFT54</strong>. PANTHER family PTHR31363 (TRAF3-interacting protein 1).<br />
+Reactome: R-CEL-5620924 (Intraflagellar transport). ComplexPortal: CPX-1290 (IFT complex B).</p>
+<h2 id="identity-nomenclature-important">Identity / nomenclature (IMPORTANT)</h2>
+<p>dyf-11 is the true C. elegans <strong>IFT54</strong> ortholog (= MIP-T3 / TRAF3IP1). The flagship project doc<br />
+<code>projects/CAEEL_CILIOPATHY.md</code> erroneously lists both dyf-3 and dyf-11 as "IFT54"; dyf-3 is<br />
+actually the CLUAP1/IFT38 ortholog. This review curates dyf-11 as IFT54/MIP-T3/TRAF3IP1, which is<br />
+the assignment made by the primary cloning paper and by UniProt/InterPro/PANTHER.<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/18369462" title="the C. elegans MIP-T3 ortholog DYF-11 is an intraflagellar transport (IFT) protein">PMID:18369462</a></p>
+<h2 id="protein-features-from-uniprot-q17595">Protein features (from UniProt Q17595)</h2>
+<ul>
+<li>535 aa; TRAF3IP1 family. Domains: TRAF3IP1 N-terminal (PF10243, aa 3-111) and TRAF3IP1 C-terminal<br />
+  (PF17749, aa 390-535). Long central disordered/charged region (aa ~107-391). C-terminal coiled coil<br />
+  (aa 426-520). No catalytic domain.</li>
+<li>SubCellular (ARBA): cilium axoneme; cilium basal body. Keywords: Cilium biogenesis/degradation,<br />
+  Coiled coil, Cytoskeleton, Cell projection.</li>
+<li>The family lacks recognizable catalytic motifs.<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/18369462" title="MIP-T3 proteins range in size from 484 to 625 amino acids and have no recognizable domains except for a predicted coiled-coil region near the C-terminus">PMID:18369462</a></li>
+</ul>
+<h2 id="known-well-supported">KNOWN (well supported)</h2>
+<h3 id="dyf-11-is-an-ift-b-intraflagellar-transport-subcomplex-b-protein">DYF-11 is an IFT-B (intraflagellar transport subcomplex B) protein</h3>
+<p>Primary cloning/characterization paper: Li et al. 2008, PLoS Genet (FULL TEXT available).<br />
+- dyf-11(mn392) is a nonsense/null allele in C02H7.1 = the MIP-T3 ortholog; the Dyf (dye-filling)<br />
+  defect is fully rescued by wild-type C02H7.1::GFP.<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/18369462" title="the dye-filling defect of dyf-11(mn392) is fully rescued by introducing a transgene expressing the wild-type copy of the C02H7.1 coding region">PMID:18369462</a><br />
+- DYF-11 "functions as a novel component of IFT subcomplex B."<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/18369462" title="DYF-11 functions as a novel component of IFT subcomplex B">PMID:18369462</a><br />
+- Plays a critical role in assembling functional kinesin motor-IFT particle complexes.<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/18369462" title="plays a critical role in assembling functional kinesin motor-IFT particle complexes">PMID:18369462</a></p>
+<h3 id="localization-transition-zonebasal-body-and-ciliary-axoneme-undergoes-ift">Localization: transition zone/basal body and ciliary axoneme; undergoes IFT</h3>
+<ul>
+<li>DYF-11::GFP "highly enriched at transition zones and within ciliary axonemes."<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/18369462" title="the DYF-11::GFP protein was found to be highly enriched at transition zones and within ciliary axonemes">PMID:18369462</a></li>
+<li>Moves bidirectionally (IFT) along amphid/phasmid axonemes; anterograde biphasic velocity<br />
+  0.74 um/s (middle segment, doublet MTs) and 1.15 um/s (distal segment, singlet MTs).<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/18369462" title="the GFP-tagged protein moves bi-directionally along the length of amphid and phasmid ciliary axonemes">PMID:18369462</a></li>
+<li>Accumulates at ciliary tips in che-11 (IFT-A/retrograde) mutant → confirms it is an IFT cargo/component.<br />
+  Enters distal segment of bbs mutants and osm-3 middle segment → behaves like OSM-3-kinesin/IFT-B.</li>
+<li>Human MIP-T3 (V5-tagged) localizes to basal body (pre-ciliated) and axoneme (ciliated IMCD3 cells).<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/18369462" title="mammalian MIP-T3 localizes to basal bodies and cilia">PMID:18369462</a></li>
+<li>Expressed in all C. elegans ciliated neurons, under X-box (RFX/daf-19) control.<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/18245347" title="while DYF-11 is expressed in all C. elegans ciliated neurons">PMID:18245347</a></li>
+</ul>
+<h3 id="required-for-cilium-assembly-and-for-integrityassembly-of-the-whole-ift-machinery">Required for cilium assembly and for integrity/assembly of the whole IFT machinery</h3>
+<ul>
+<li>dyf-11 null cilia are strongly truncated (amphid 2.4 um, phasmid 2.6 um vs 5.7 um WT), similar to<br />
+  IFT-B mutants. In dyf-11, "medial and distal segments are absent."<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/18245347" title="in dyf-11 animals, medial and distal segments are absent">PMID:18245347</a></li>
+<li>In dyf-11 mutants, IFT components (KAP-1/Kinesin-II, CHE-11/IFT-A, XBX-1/dynein, BBS-7) mislocalize<br />
+  and fail to enter cilia; only OSM-3 still enters the residual cilium.<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/18369462" title="CHE-11, XBX-1, and BBS-7 were anchored to transition zones but their signal intensities were significantly reduced compared to wild-type, and none of the proteins were observed to enter the (truncated) amphid and phasmid cilia">PMID:18369462</a></li>
+<li>DYF-11 "may function at an early stage of IFT-B particle assembly."<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/18245347" title="DYF-11 undergoes IFT-like movement and may function at an early stage of IFT-B particle assembly">PMID:18245347</a></li>
+<li>IFT-B complex disruption abolishes dynein-2 ciliary entry (dyf-11 is part of that IFT-B module).<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/28479320" title="intraflagellar transport (IFT)-B complex abolishes dynein-2's ciliary localization">PMID:28479320</a></li>
+</ul>
+<h3 id="sensory-physiological-phenotypes-downstream-consequences-of-loss-of-functional-cilia">Sensory / physiological phenotypes (downstream consequences of loss of functional cilia)</h3>
+<ul>
+<li>Chemotaxis-defective and osmotic-avoidance-defective (Che, Osm).<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/18369462" title="dyf-11 mutants are defective in both chemotaxis and osmo-avoidance">PMID:18369462</a><br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/18245347" title="These mutants fail to concentrate lipophilic dyes from their surroundings in sensory neurons and are chemotaxis defective">PMID:18245347</a></li>
+<li>Dauer-formation defective (Daf-d) at 20 and 25 C.<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/18369462" title="we found that dyf-11 mutants are Daf-d at both temperatures">PMID:18369462</a></li>
+<li>Increased intestinal lipid (Nile Red) accumulation, rescued by DYF-11::GFP → cilia–lipid link.<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/18369462" title="dyf-11 mutants also show, compared to the wild-type and rescue strains, a pronounced increase in Nile Red staining within intestinal cells, indicative of an increased lipid accumulation phenotype">PMID:18369462</a></li>
+<li>Normal lifespan; no gross morphological/locomotory defects → the role is highly cilia-specific.</li>
+</ul>
+<h3 id="conserved-developmental-role-in-vertebrates">Conserved developmental role in vertebrates</h3>
+<ul>
+<li>Zebrafish mipt3 morphants show gastrulation/convergent-extension defects and act synergistically<br />
+  with bbs4, consistent with a conserved cilia/basal-body role.<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/18369462" title="zebrafish mipt3 functions synergistically with the Bardet-Biedl syndrome protein Bbs4 to ensure proper gastrulation">PMID:18369462</a></li>
+</ul>
+<h2 id="not-known-uncertain">NOT known / uncertain</h2>
+<ul>
+<li>The <strong>specific molecular function</strong> of DYF-11 within IFT-B is undefined: no catalytic domain, only<br />
+  a C-terminal coiled coil; whether it directly binds microtubules in the worm (family = "Microtubule-<br />
+  Interacting Protein"; human MIP-T3 binds MTs) or bridges specific IFT-B subunits (vertebrate IFT54<br />
+  binds IFT20) is not established in C. elegans.<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/18369462" title="Whether DYF-11 operates as an integral IFT component, or potentially as an associated 'cargo' protein that affects the core machinery, remains to be determined">PMID:18369462</a></li>
+<li>Whether DYF-11 has an <strong>IFT-independent</strong> role (e.g. dendrite/neurite trafficking, analogous to the<br />
+  vertebrate MIP-T3–DISC1 axis) in the worm is untested.<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/18369462" title="Whether C. elegans DYF-11 has dendrite-associated functions whose disruption could affect ciliogenesis represents an interesting question that will need to be addressed">PMID:18369462</a></li>
+<li>The mechanism by which DYF-11 promotes loading/assembly of Kinesin-II onto IFT trains is unknown.<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/18369462" title="may help with the assembly of Kinesin-II onto the IFT complex">PMID:18369462</a></li>
+</ul>
+<h2 id="annotation-review-reasoning-see-yaml">Annotation review reasoning (see YAML)</h2>
+<ul>
+<li>CORE: IFT particle B membership (GO:0030992), intraciliary transport (GO:0042073), (non-motile)<br />
+  cilium assembly (GO:0060271 / GO:1905515), axoneme/basal body/cilium localization, microtubule<br />
+  binding (GO:0008017, family/InterPro MF), IFT complex assembly (GO:0065003), protein localization<br />
+  to cilium.</li>
+<li>MODIFY: GO:0045184 "establishment of protein localization" is too general → GO:0061512 "protein<br />
+  localization to cilium" (dyf-11 mutants fail to deliver IFT proteins into cilia).</li>
+<li>NON-CORE (pleiotropic downstream sensory phenotypes): chemotaxis, hyperosmotic response, dauer<br />
+  entry, associative learning, lipid homeostasis — all secondary to loss of functional sensory cilia.</li>
+<li>OVER-ANNOTATED (vague/ARBA/electronic): animal organ development, system development (ARBA, not<br />
+  informative for a worm ciliary protein); regulation of microtubule cytoskeleton organization<br />
+  (IBA+ARBA) over-generalizes DYF-11's structural axoneme-assembly role, better captured by cilium<br />
+  assembly.</li>
+<li>GO:0020837997 (associative learning, PMID:20837997): the cached record is abstract-only and the<br />
+  abstract does not mention dyf-11; the paper is about ASE salt-chemotaxis plasticity. Kept as<br />
+  non-core (indirect sensory consequence), flagged full_text_unavailable; not removed (experimental<br />
+  IMP; defer to curator).</li>
+</ul>
+<h2 id="deep-research">Deep research</h2>
+<p><code>just deep-research-falcon worm dyf-11 --fallback perplexity-lite</code> completed successfully<br />
+(falcon / Edison Scientific, ~24 min, 24 citations) → <code>dyf-11-deep-research-falcon.md</code>. Review is<br />
+grounded primarily in the four cached primary publications above plus UniProt/GOA/InterPro/PANTHER;<br />
+the falcon report corroborates the IFT-B/IFT54 assignment and cilium-assembly role.</p>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: Q17595
+gene_symbol: dyf-11
+product_type: PROTEIN
+status: COMPLETE
+aliases:
+- MIP-T3
+- TRAF3IP1
+- IFT54
+- C02H7.1
+taxon:
+  id: NCBITaxon:6239
+  label: Caenorhabditis elegans
+description: &gt;-
+  dyf-11 encodes the Caenorhabditis elegans ortholog of MIP-T3/TRAF3IP1 (IFT54), a
+  535-residue structural subunit of intraflagellar transport (IFT) complex B. IFT-B,
+  together with IFT-A and the kinesin-2 and dynein-2 motors, drives the bidirectional
+  transport of ciliary cargo that builds and maintains the sensory cilia of ciliated
+  neurons. The protein has no catalytic domain; it comprises conserved N- and C-terminal
+  TRAF3IP1 domains flanking a long charged/disordered central region and a C-terminal
+  coiled coil. DYF-11 is expressed under X-box/RFX (daf-19) control specifically in
+  ciliated sensory neurons and localizes to the ciliary base (transition zone/basal body)
+  and along the ciliary axoneme, where it undergoes processive IFT movement. It is
+  required to assemble and maintain an intact motor-IFT particle: in its absence
+  kinesin-II, IFT-A, IFT-dynein and BBSome components fail to enter cilia and the axoneme
+  is severely truncated, so full-length medial and distal ciliary segments do not form.
+  Loss of dyf-11 therefore disrupts cilium-dependent sensory behaviors (chemosensation,
+  osmotic avoidance, dauer formation, dye filling) and perturbs lipid homeostasis. The
+  ciliary role is conserved: human MIP-T3 localizes to basal bodies and cilia, and
+  zebrafish mipt3 is required for gastrulation movements and interacts genetically with
+  the Bardet-Biedl protein Bbs4.
+references:
+- id: GO_REF:0000002
+  title: Gene Ontology annotation through association of InterPro records with GO terms
+  findings: []
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: &gt;-
+      InterPro2GO mapping of the TRAF3IP1 family (IPR018799) to microtubule binding
+      (GO:0008017). The family is named for its microtubule-interacting property
+      (MIP-T3 = Microtubule-Interacting Protein associated with TRAF3) and human MIP-T3
+      was shown to bind microtubules, so the molecular-function transfer is reasonable at
+      the family level.
+- id: GO_REF:0000033
+  title: Annotation inferences using phylogenetic trees
+  findings: []
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Standard GO_Central IBA pipeline. The phylogenetic inferences (IFT complex B
+      membership, intraciliary transport, cilium assembly, axoneme and basal body
+      localization) are all independently corroborated by C. elegans experimental data,
+      so the IBA transfers are sound. The &#34;regulation of microtubule cytoskeleton
+      organization&#34; transfer over-generalizes the axoneme-assembly role.
+- id: GO_REF:0000044
+  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location
+    vocabulary mapping, accompanied by conservative changes to GO terms applied by
+    UniProt
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Electronic mapping of the UniProt cilium-axoneme subcellular-location keyword to
+      GO:0005930; redundant with the experimental IDA axoneme annotation but not incorrect.
+- id: GO_REF:0000117
+  title: Electronic Gene Ontology annotations created by ARBA machine learning models
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: LOW_QUALITY
+    review_notes: &gt;-
+      ARBA machine-learning annotations. The &#34;animal organ development&#34; and &#34;system
+      development&#34; terms are over-general electronic inferences that are not informative
+      for a nematode sensory-cilium protein; &#34;regulation of microtubule cytoskeleton
+      organization&#34; over-generalizes the structural axoneme-assembly role.
+- id: PMID:18245347
+  title: The conserved proteins CHE-12 and DYF-11 are required for sensory cilium
+    function in Caenorhabditis elegans.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Bacaj, Lu &amp; Shaham 2008 (Genetics), independent characterization of dyf-11. Cached
+      record is abstract-only (full_text_available: false), but the abstract directly
+      establishes that dyf-11 mutant cilia lack medial and distal segments, that DYF-11
+      undergoes IFT-like movement and may act at an early stage of IFT-B particle
+      assembly, and that DYF-11 is expressed in all ciliated neurons. The four WormBase
+      IMP annotations to this PMID (chemotaxis, hyperosmotic response, dauer entry,
+      non-motile cilium assembly) rest on full-text assays not in the cached abstract.
+- id: PMID:18369462
+  title: An essential role for DYF-11/MIP-T3 in assembling functional intraflagellar
+    transport complexes.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Li et al. 2008 (PLoS Genet, PMC2268012), the primary cloning and functional
+      characterization paper. Full text available. Establishes dyf-11 = the C. elegans
+      MIP-T3/TRAF3IP1 ortholog, its localization to transition zone/basal body and
+      axoneme, its bidirectional IFT movement, its identity as a novel IFT-B component,
+      and its requirement for assembly/integrity of the motor-IFT machinery. Supports the
+      core cellular-component, transport, and cilium-assembly annotations.
+- id: PMID:20837997
+  title: Reversal of salt preference is directed by the insulin/PI3K and Gq/PKC signaling
+    in Caenorhabditis elegans.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: UNVERIFIED
+    review_notes: &gt;-
+      Adachi et al. 2010 (Genetics). The PMID resolves to the correct paper on ASE
+      salt-chemotaxis plasticity, but the cached record is abstract-only and the abstract
+      does not mention dyf-11; the associative-learning IMP therefore cannot be verified
+      from the cache. Any dyf-11 salt-learning phenotype is an indirect consequence of
+      loss of functional sensory cilia rather than a core function.
+- id: PMID:28479320
+  title: Dynein-Driven Retrograde Intraflagellar Transport Is Triphasic in C. elegans
+    Sensory Cilia.
+  findings: []
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Yi et al. 2017 (Curr Biol). Source of the ComplexPortal (CPX-1290) NAS annotations
+      placing DYF-11 in IFT complex B. Abstract-only cache, but the abstract confirms that
+      an intact IFT-B complex is required for dynein-2 ciliary entry, consistent with
+      DYF-11&#39;s IFT-B membership.
+existing_annotations:
+- term:
+    id: GO:0030992
+    label: intraciliary transport particle B
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: part_of
+  review:
+    summary: &gt;-
+      DYF-11/IFT54 is a subunit of intraflagellar transport complex B (IFT-B). This IBA
+      transfer is strongly corroborated by C. elegans experimental data and by biochemical
+      assignment to ComplexPortal CPX-1290.
+    action: ACCEPT
+    reason: &gt;-
+      Core cellular-component identity. Phylogenetically inferred and independently
+      confirmed experimentally (PMID:18369462).
+    supported_by:
+    - reference_id: PMID:18369462
+      supporting_text: DYF-11 functions as a novel component of IFT subcomplex B
+      reference_section_type: ABSTRACT
+- term:
+    id: GO:0005930
+    label: axoneme
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: is_active_in
+  review:
+    summary: &gt;-
+      DYF-11 acts within the ciliary axoneme, where IFT trains move. The is_active_in
+      qualifier is appropriate for an IFT-B component that translocates along the axoneme.
+    action: ACCEPT
+    reason: &gt;-
+      Consistent with the experimental IDA axoneme localization (PMID:18369462).
+    supported_by:
+    - reference_id: PMID:18369462
+      supporting_text: the DYF-11::GFP protein was found to be highly enriched at
+        transition zones and within ciliary axonemes
+      reference_section_type: RESULTS
+- term:
+    id: GO:0036064
+    label: ciliary basal body
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: is_active_in
+  review:
+    summary: &gt;-
+      DYF-11 localizes to and functions at the ciliary base (transition zone/basal body),
+      where IFT trains assemble and load.
+    action: ACCEPT
+    reason: &gt;-
+      Corroborated by the experimental IDA basal-body/transition-zone localization
+      (PMID:18369462).
+    supported_by:
+    - reference_id: PMID:18369462
+      supporting_text: the DYF-11::GFP protein was found to be highly enriched at
+        transition zones and within ciliary axonemes
+      reference_section_type: RESULTS
+- term:
+    id: GO:0070507
+    label: regulation of microtubule cytoskeleton organization
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      DYF-11&#39;s effect on microtubules is to build the axonemal microtubule structure via
+      IFT, which is more precisely captured by cilium assembly (GO:0060271). The general
+      &#34;regulation of microtubule cytoskeleton organization&#34; term over-generalizes this
+      structural role and is not directly supported by evidence of a regulatory activity.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      Over-general phylogenetic transfer; DYF-11 does not regulate microtubule dynamics
+      per se — it is a structural IFT-B subunit whose microtubule-related role is axoneme
+      assembly, already annotated as cilium assembly and intraciliary transport.
+    propagation_review:
+      root_cause: TERM_SCOPING_PROBLEM
+      failure_modes:
+      - GRANULARITY_MISMATCH
+      source_entities:
+      - source_id: PANTHER:PTN000773545
+        source_label: TRAF3IP1 family node
+        source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
+        comment: &gt;-
+          The IFT54/TRAF3IP1 family node&#39;s microtubule-related activity is axonemal
+          assembly via IFT, not regulation of microtubule dynamics; the transferred term
+          is scoped too broadly for the structural role.
+- term:
+    id: GO:0060271
+    label: cilium assembly
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      DYF-11 is required to build full-length sensory cilia; dyf-11 nulls have severely
+      truncated cilia lacking medial and distal segments.
+    action: ACCEPT
+    reason: &gt;-
+      Core biological process, strongly supported experimentally (PMID:18369462;
+      PMID:18245347).
+    supported_by:
+    - reference_id: PMID:18369462
+      supporting_text: the cilia of dyf-11 mutants were truncated substantially
+      reference_section_type: RESULTS
+- term:
+    id: GO:0042073
+    label: intraciliary transport
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      DYF-11 functions in intraflagellar (intraciliary) transport as an IFT-B subunit that
+      undergoes bidirectional IFT movement along the axoneme.
+    action: ACCEPT
+    reason: &gt;-
+      Core biological process, confirmed experimentally in worm (PMID:18369462).
+    supported_by:
+    - reference_id: PMID:18369462
+      supporting_text: the GFP-tagged protein moves bi-directionally along the length of
+        amphid and phasmid ciliary axonemes
+      reference_section_type: RESULTS
+- term:
+    id: GO:0005930
+    label: axoneme
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000044
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Electronic mapping of the UniProt cilium-axoneme subcellular-location keyword.
+      Redundant with the experimental IDA axoneme annotation and correct.
+    action: ACCEPT
+    reason: &gt;-
+      Correct location, corroborated by experimental IDA (PMID:18369462).
+    supported_by:
+    - reference_id: PMID:18369462
+      supporting_text: the DYF-11::GFP protein was found to be highly enriched at
+        transition zones and within ciliary axonemes
+      reference_section_type: RESULTS
+- term:
+    id: GO:0008017
+    label: microtubule binding
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: enables
+  review:
+    summary: &gt;-
+      InterPro2GO transfer for the TRAF3IP1/MIP-T3 family, which is named for its
+      microtubule-interacting property; human MIP-T3 was shown to bind microtubules, and
+      Li et al. suggest a proportion of C. elegans DYF-11 may associate directly with
+      microtubules. This is the most informative molecular-function term available for
+      DYF-11, though direct microtubule binding by the worm protein has not been
+      experimentally demonstrated.
+    action: ACCEPT
+    reason: &gt;-
+      Best-supported molecular function; consistent with family identity and IFT-B
+      axonemal role.
+    supported_by:
+    - reference_id: PMID:18369462
+      supporting_text: MIP-T3 proteins range in size from 484 to 625 amino acids and have
+        no recognizable domains except for a predicted coiled-coil region near the
+        C-terminus
+      reference_section_type: RESULTS
+- term:
+    id: GO:0048513
+    label: animal organ development
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000117
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Over-general ARBA machine-learning inference. C. elegans lacks the vertebrate organs
+      implied, and DYF-11&#39;s characterized role is restricted to sensory ciliogenesis. Not
+      informative.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      Vague electronic annotation with no experimental support in this organism; DYF-11&#39;s
+      role is specific to sensory cilium assembly/function.
+- term:
+    id: GO:0048731
+    label: system development
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000117
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Over-general ARBA machine-learning inference; uninformative for a sensory-cilium IFT
+      protein.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      Vague electronic annotation; DYF-11&#39;s characterized function is ciliogenesis, better
+      captured by cilium assembly.
+- term:
+    id: GO:0070507
+    label: regulation of microtubule cytoskeleton organization
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000117
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Duplicate of the IBA transfer of the same term via an ARBA model. Over-generalizes
+      DYF-11&#39;s structural axoneme-assembly role.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      DYF-11 is a structural IFT-B subunit, not a regulator of microtubule dynamics; the
+      microtubule-related role is axoneme assembly (cilium assembly / intraciliary
+      transport).
+- term:
+    id: GO:0005929
+    label: cilium
+  evidence_type: NAS
+  original_reference_id: PMID:28479320
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      ComplexPortal (CPX-1290) assertion that DYF-11 localizes to the cilium. Correct but
+      general; the more specific axoneme and basal-body IDA locations are also annotated.
+    action: ACCEPT
+    reason: &gt;-
+      Correct ciliary location; consistent with experimental IDA localization.
+- term:
+    id: GO:0030992
+    label: intraciliary transport particle B
+  evidence_type: NAS
+  original_reference_id: PMID:28479320
+  qualifier: part_of
+  review:
+    summary: &gt;-
+      ComplexPortal (CPX-1290) assertion of IFT-B membership, consistent with the
+      experimental IDA and phylogenetic annotations.
+    action: ACCEPT
+    reason: &gt;-
+      Core cellular-component identity; independently confirmed (PMID:18369462).
+    supported_by:
+    - reference_id: PMID:28479320
+      supporting_text: intraflagellar transport (IFT)-B complex abolishes dynein-2&#39;s
+        ciliary localization
+      reference_section_type: ABSTRACT
+- term:
+    id: GO:0042073
+    label: intraciliary transport
+  evidence_type: NAS
+  original_reference_id: PMID:28479320
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      ComplexPortal assertion that DYF-11 functions in intraciliary transport, consistent
+      with experimental data.
+    action: ACCEPT
+    reason: &gt;-
+      Core biological process; confirmed experimentally (PMID:18369462).
+- term:
+    id: GO:0060271
+    label: cilium assembly
+  evidence_type: NAS
+  original_reference_id: PMID:28479320
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      ComplexPortal assertion that DYF-11 functions in cilium assembly, consistent with
+      the truncated-cilia phenotype of dyf-11 mutants.
+    action: ACCEPT
+    reason: &gt;-
+      Core biological process; strongly supported (PMID:18369462; PMID:18245347).
+- term:
+    id: GO:0008306
+    label: associative learning
+  evidence_type: IMP
+  original_reference_id: PMID:20837997
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      A dyf-11 defect in salt-chemotaxis plasticity would be an indirect consequence of
+      loss of functional sensory (ASE) cilia rather than a direct role in learning/memory.
+      The cited paper is cached abstract-only and its abstract does not mention dyf-11, so
+      the specific evidence cannot be verified here. Retained as a pleiotropic, non-core
+      sensory phenotype rather than removed (experimental IMP; defer to curator).
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Downstream/pleiotropic behavioral consequence of ciliary dysfunction, not a core
+      molecular function of an IFT-B structural subunit; supporting full text unavailable
+      in the cache.
+- term:
+    id: GO:0036064
+    label: ciliary basal body
+  evidence_type: IDA
+  original_reference_id: PMID:18369462
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      DYF-11::GFP is highly enriched at the transition zone/basal body in ciliated sensory
+      neurons; human MIP-T3 likewise localizes to the basal body.
+    action: ACCEPT
+    reason: &gt;-
+      Core, directly observed cellular-component location.
+    supported_by:
+    - reference_id: PMID:18369462
+      supporting_text: V5 epitope-tagged human MIP-T3 also localizes to the basal body
+      reference_section_type: RESULTS
+- term:
+    id: GO:0005930
+    label: axoneme
+  evidence_type: IDA
+  original_reference_id: PMID:18369462
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      DYF-11::GFP is directly observed enriched within ciliary axonemes and moves along
+      their length.
+    action: ACCEPT
+    reason: &gt;-
+      Core, directly observed cellular-component location.
+    supported_by:
+    - reference_id: PMID:18369462
+      supporting_text: the DYF-11::GFP protein was found to be highly enriched at
+        transition zones and within ciliary axonemes
+      reference_section_type: RESULTS
+- term:
+    id: GO:0030992
+    label: intraciliary transport particle B
+  evidence_type: IDA
+  original_reference_id: PMID:18369462
+  qualifier: part_of
+  review:
+    summary: &gt;-
+      DYF-11 was directly characterized as a novel component of IFT subcomplex B based on
+      its IFT movement and genetic behavior relative to kinesin/BBS/IFT mutants.
+    action: ACCEPT
+    reason: &gt;-
+      Core cellular-component identity, directly established.
+    supported_by:
+    - reference_id: PMID:18369462
+      supporting_text: DYF-11 functions as a novel component of IFT subcomplex B
+      reference_section_type: ABSTRACT
+- term:
+    id: GO:0042073
+    label: intraciliary transport
+  evidence_type: IMP
+  original_reference_id: PMID:18369462
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Loss of dyf-11 disrupts IFT, mislocalizing kinesin-II, IFT-A, dynein and BBSome
+      components and truncating cilia, demonstrating a functional requirement in IFT.
+    action: ACCEPT
+    reason: &gt;-
+      Core biological process; strong loss-of-function evidence.
+    supported_by:
+    - reference_id: PMID:18369462
+      supporting_text: &#39;DYF-11 is an intraflagellar transport protein critical for the
+        formation of full-length, functional sensory cilia&#39;
+      reference_section_type: DISCUSSION
+- term:
+    id: GO:0045184
+    label: establishment of protein localization
+  evidence_type: IMP
+  original_reference_id: PMID:18369462
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      In dyf-11 mutants, IFT-associated proteins (CHE-11/IFT-A, OSM-5/IFT-B, XBX-1/dynein,
+      BBS-7, KAP-1/kinesin-II) fail to enter cilia. This is specifically the failure to
+      localize proteins to the cilium, better captured by GO:0061512 &#34;protein localization
+      to cilium&#34; than by the very general &#34;establishment of protein localization&#34;.
+    action: MODIFY
+    reason: &gt;-
+      Term too general; the experiment shows DYF-11 is required for delivering IFT proteins
+      into the cilium.
+    proposed_replacement_terms:
+    - id: GO:0061512
+      label: protein localization to cilium
+    supported_by:
+    - reference_id: PMID:18369462
+      supporting_text: none of the proteins were observed to enter the (truncated) amphid
+        and phasmid cilia
+      reference_section_type: RESULTS
+- term:
+    id: GO:0055088
+    label: lipid homeostasis
+  evidence_type: IMP
+  original_reference_id: PMID:18369462
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      dyf-11 mutants show increased intestinal Nile Red (lipid) staining, rescued by
+      DYF-11::GFP, reflecting the conserved cilia-lipid connection. This is a downstream
+      systemic consequence of ciliary dysfunction, not a core molecular function.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Real, rescued loss-of-function phenotype but pleiotropic/indirect (secondary to
+      defective sensory-cilia signaling), not a core function of an IFT-B subunit.
+    supported_by:
+    - reference_id: PMID:18369462
+      supporting_text: indicative of an increased lipid accumulation phenotype
+      reference_section_type: RESULTS
+- term:
+    id: GO:0065003
+    label: protein-containing complex assembly
+  evidence_type: IMP
+  original_reference_id: PMID:18369462
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      DYF-11 is required to assemble a functional motor-IFT particle, including loading of
+      the kinesin-II motor; in its absence multiple IFT components fail to assemble/enter
+      cilia. The term is general but captures this assembly role.
+    action: ACCEPT
+    reason: &gt;-
+      Supported by loss-of-function mislocalization of IFT-machinery components; DYF-11 is
+      needed for assembly/integrity of the IFT particle.
+    supported_by:
+    - reference_id: PMID:18369462
+      supporting_text: may help with the assembly of Kinesin-II onto the IFT complex
+      reference_section_type: DISCUSSION
+- term:
+    id: GO:0006935
+    label: chemotaxis
+  evidence_type: IMP
+  original_reference_id: PMID:18245347
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      dyf-11 mutants are chemotaxis-defective because their sensory cilia are truncated and
+      nonfunctional. This is a sensory readout downstream of the ciliary defect rather than
+      a direct chemotaxis function.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Pleiotropic sensory-behavior phenotype secondary to loss of functional cilia; not a
+      core molecular function.
+    supported_by:
+    - reference_id: PMID:18245347
+      supporting_text: chemotaxis defective
+      reference_section_type: ABSTRACT
+- term:
+    id: GO:0006972
+    label: hyperosmotic response
+  evidence_type: IMP
+  original_reference_id: PMID:18245347
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Annotation reflects the osmotic-avoidance (Osm) phenotype of dyf-11 mutants, a
+      cilium-dependent sensory behavior. It is a downstream consequence of nonfunctional
+      sensory cilia rather than a direct role in the cellular hyperosmotic stress response.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Pleiotropic sensory-behavior phenotype secondary to ciliary dysfunction; retained as
+      non-core (experimental IMP; defer to curator on full text).
+- term:
+    id: GO:0043053
+    label: dauer entry
+  evidence_type: IMP
+  original_reference_id: PMID:18245347
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      dyf-11 mutants are dauer-formation defective, consistent with loss of the ciliary
+      sensory input that governs the dauer decision. Downstream consequence of ciliary
+      dysfunction.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Pleiotropic developmental phenotype secondary to defective sensory-cilia signaling;
+      not a core molecular function.
+    supported_by:
+    - reference_id: PMID:18369462
+      supporting_text: found that dyf-11 mutants are Daf-d at both temperatures
+      reference_section_type: RESULTS
+- term:
+    id: GO:1905515
+    label: non-motile cilium assembly
+  evidence_type: IMP
+  original_reference_id: PMID:18245347
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      C. elegans sensory cilia are non-motile, and DYF-11 is required to build them: in
+      dyf-11 mutants the medial and distal ciliary segments are absent. This is the most
+      specific and accurate biological-process term for DYF-11.
+    action: ACCEPT
+    reason: &gt;-
+      Core biological process; the specific non-motile-cilium wording matches the worm
+      sensory cilium and is directly supported.
+    supported_by:
+    - reference_id: PMID:18245347
+      supporting_text: medial and distal segments are absent
+      reference_section_type: ABSTRACT
+core_functions:
+- description: &gt;-
+    DYF-11/IFT54 (MIP-T3/TRAF3IP1 ortholog) is a structural subunit of intraflagellar
+    transport (IFT) complex B in ciliated sensory neurons. It localizes to the ciliary
+    base (transition zone/basal body) and axoneme, undergoes bidirectional IFT, and is
+    required for assembling and maintaining a functional motor-IFT particle. In its
+    absence kinesin-II, IFT-A, IFT-dynein and BBSome components fail to enter cilia, the
+    axoneme is truncated, and full-length sensory cilia do not form. Its only informative
+    molecular-function term is microtubule binding (the MIP-T3 family property); it has no
+    catalytic domain and acts as a structural/adaptor component of IFT-B.
+  molecular_function:
+    id: GO:0008017
+    label: microtubule binding
+  in_complex:
+    id: GO:0030992
+    label: intraciliary transport particle B
+  directly_involved_in:
+  - id: GO:0042073
+    label: intraciliary transport
+  - id: GO:1905515
+    label: non-motile cilium assembly
+  - id: GO:0061512
+    label: protein localization to cilium
+  locations:
+  - id: GO:0036064
+    label: ciliary basal body
+  - id: GO:0005930
+    label: axoneme
+  supported_by:
+  - reference_id: PMID:18369462
+    supporting_text: DYF-11 functions as a novel component of IFT subcomplex B
+    reference_section_type: ABSTRACT
+  - reference_id: PMID:18369462
+    supporting_text: the GFP-tagged protein moves bi-directionally along the length of
+      amphid and phasmid ciliary axonemes
+    reference_section_type: RESULTS
+  - reference_id: PMID:18245347
+    supporting_text: function at an early stage of IFT-B particle assembly
+    reference_section_type: ABSTRACT
+knowledge_gaps:
+- gap_statement: &gt;-
+    The specific molecular function of DYF-11/IFT54 within IFT complex B is undefined. It
+    has no catalytic domain and only a C-terminal coiled coil; whether it binds microtubules
+    directly in C. elegans, and which specific IFT-B subunit(s) it bridges (vertebrate IFT54
+    partners with IFT20), is not established. It reads as MF-dark despite a well-defined
+    cellular role.
+  boundary: &gt;-
+    DYF-11 is firmly established as an IFT-B subunit that localizes to the transition
+    zone/basal body and axoneme, undergoes bidirectional IFT, and is required for assembling
+    a functional motor-IFT particle and building full-length sensory cilia. Its only
+    informative GO molecular-function term is the family-level microtubule binding
+    (GO:0008017), which has not been experimentally demonstrated for the worm protein.
+  gap_kind:
+  - BIOLOGY
+  - ONTOLOGY
+  dark_aspect: MF_DARK
+  status: OPEN
+  significance: &gt;-
+    IFT54/TRAF3IP1 is a conserved core IFT-B protein whose human ortholog is linked to
+    ciliopathy phenotypes; defining its molecular activity (microtubule binding vs a
+    specific IFT-B scaffolding interaction) is central to understanding IFT-B architecture.
+  resolution: &gt;-
+    Test direct microtubule binding of purified DYF-11; map its IFT-B interaction partners
+    (e.g. an IFT20 ortholog) by biochemistry/structure; isolate separation-of-function
+    alleles; consider a molecular-function term for an IFT-B structural/scaffolding subunit
+    activity.
+  provenance:
+  - reference_id: PMID:18369462
+    supporting_text: MIP-T3 proteins range in size from 484 to 625 amino acids and have no
+      recognizable domains except for a predicted coiled-coil region near the C-terminus
+    reference_section_type: RESULTS
+  - reference_id: PMID:18369462
+    supporting_text: that affects the core machinery, remains to be determined
+    reference_section_type: RESULTS
+- gap_statement: &gt;-
+    How DYF-11 promotes assembly/loading of the kinesin-II motor and other IFT components
+    onto trains at the ciliary base is not understood at the mechanistic level, nor is it
+    resolved whether it acts specifically at an early step of IFT-B particle assembly.
+  boundary: &gt;-
+    Loss of dyf-11 mislocalizes kinesin-II (KAP-1), IFT-A (CHE-11), dynein (XBX-1) and
+    BBSome (BBS-7) components so they fail to enter cilia, and DYF-11 undergoes IFT-like
+    movement and may act early in IFT-B assembly; the molecular steps linking DYF-11 to
+    motor/particle assembly are undefined.
+  gap_kind:
+  - BIOLOGY
+  dark_aspect: RESIDUAL_SUBGAP
+  status: OPEN
+  significance: &gt;-
+    DYF-11 has a more severe assembly phenotype than typical IFT-B mutants and uniquely
+    affects kinesin-II loading, so its mechanism bears on how the anterograde motor is
+    coupled to IFT trains.
+  resolution: &gt;-
+    Order the IFT-B assembly hierarchy with epistasis/live-imaging and in vitro
+    reconstitution; determine whether DYF-11 directly contacts kinesin-II or acts through
+    other IFT-B subunits.
+  provenance:
+  - reference_id: PMID:18245347
+    supporting_text: function at an early stage of IFT-B particle assembly
+    reference_section_type: ABSTRACT
+  - reference_id: PMID:18369462
+    supporting_text: may help with the assembly of Kinesin-II onto the IFT complex
+    reference_section_type: DISCUSSION
+- gap_statement: &gt;-
+    Whether C. elegans DYF-11 has an IFT-independent role — for example in dendrite/neurite
+    protein trafficking, analogous to the vertebrate MIP-T3/DISC1 axis — is untested.
+  boundary: &gt;-
+    DYF-11::GFP is occasionally seen in dendritic extensions beyond the cilium, and
+    vertebrate MIP-T3 interacts with DISC1 and microtubules in neurite/centrosome contexts;
+    no non-ciliary function has been assayed in the worm.
+  gap_kind:
+  - BIOLOGY
+  dark_aspect: RESIDUAL_SUBGAP
+  status: OPEN
+  significance: &gt;-
+    Distinguishing a dedicated ciliary IFT role from a broader neuronal trafficking role
+    would clarify whether MIP-T3/TRAF3IP1 acquired dual functions during evolution.
+  resolution: &gt;-
+    Assay dyf-11 dendritic transport and non-ciliary phenotypes with cell-type-specific
+    rescue and cargo-trafficking reporters.
+  provenance:
+  - reference_id: PMID:18369462
+    supporting_text: Whether C. elegans DYF-11 has dendrite-associated functions whose
+      disruption could affect ciliogenesis represents an interesting question that will need
+      to be addressed
+    reference_section_type: DISCUSSION
+suggested_questions:
+- question: &gt;-
+    Does C. elegans DYF-11 bind microtubules directly, or is its microtubule association
+    mediated through other IFT-B subunits?
+- question: &gt;-
+    Which IFT-B subunit(s) does DYF-11 contact directly, and does it partner with an IFT20
+    ortholog as vertebrate IFT54 does?
+suggested_experiments:
+- description: &gt;-
+    In vitro microtubule co-sedimentation and IFT-B reconstitution assays with purified
+    DYF-11 to define direct microtubule binding and subunit interactions.
+- description: &gt;-
+    Live-imaging epistasis of GFP-tagged IFT components in dyf-11 and other IFT-B mutant
+    backgrounds to order DYF-11 within the IFT-B assembly hierarchy.
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/genes/worm/fis-2/fis-2-ai-review.html
+++ b/genes/worm/fis-2/fis-2-ai-review.html
@@ -1,0 +1,3592 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>fis-2 - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        .propagation-review {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f8fafc;
+            border-left: 3px solid #64748b;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .propagation-title {
+            font-weight: 600;
+            color: #334155;
+            margin-bottom: 0.25rem;
+        }
+
+        .propagation-row {
+            margin-top: 0.25rem;
+        }
+
+        .propagation-source {
+            margin-top: 0.5rem;
+            padding-top: 0.5rem;
+            border-top: 1px solid #e5e7eb;
+        }
+
+        .propagation-source-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #1d4ed8;
+        }
+
+        .propagation-comment {
+            color: #4b5563;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>fis-2</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/Q6AHP8" target="_blank" class="term-link">
+                        Q6AHP8
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Caenorhabditis elegans</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-draft">
+                    DRAFT
+                </span>
+            </div>
+
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "fis-2";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="Q6AHP8" data-a="DESCRIPTION: fis-2 (F13B9.8) is one of two Caenorhabditis elega..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>fis-2 (F13B9.8) is one of two Caenorhabditis elegans homologs of FIS1, a small (151 aa) tail-anchored protein of the mitochondrial outer membrane. Like other FIS1-family members it has a cytosol-facing tetratricopeptide-repeat (TPR) fold and a single C-terminal transmembrane helix that anchors it in the outer membrane with the TPR body exposed to the cytosol. The worm genome encodes a second FIS1 homolog, fis-1, with which fis-2 acts partly redundantly. In mammals and fungi FIS1 proteins are receptor/adaptor factors implicated in recruiting the dynamin-related GTPase DRP1 to the outer membrane during mitochondrial (and peroxisomal) fission. In C. elegans, however, loss of fis-2 (alone or together with fis-1) does not detectably impair mitochondrial or peroxisomal fission or morphology; the essential fission machinery is instead MFF/DRP-1. The functions demonstrated for fis-2 are downstream of, or parallel to, fission: it has a minor pro-apoptotic role in promoting the elimination of mitochondria in dying cells, acting downstream of the CED-3 caspase and independently of DRP-1 and CED-9, and it contributes (redundantly with fis-1) to the orderly disposal of damaged mitochondria, where loss of both paralogs causes stress-induced accumulation of large autophagic (LGG-1/LC3-positive) aggregates containing mitochondrial remnants. fis-2 is thus a mitochondrial outer membrane FIS1-family protein linked to mitochondrial quality control and cell-death execution rather than to the core fission reaction.</p>
+    </div>
+
+
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008289" target="_blank" class="term-link">
+                                    GO:0008289
+                                </a>
+                            </span>
+                            <span class="term-label">lipid binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q6AHP8" data-a="GO:0008289" data-r="GO_REF:0000033" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Family-level phylogenetic (IBA) inference of a generic &#34;lipid binding&#34; molecular function. There is no C. elegans-specific evidence that FIS-2 binds lipid; its C-terminal transmembrane helix mediates membrane anchoring, which is not the same as a lipid-binding molecular function. This is a weak, uninformative over-propagation for this gene.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> No experimental support in worm; the informative molecular function inferred for FIS1-family proteins is adaptor/receptor activity (GO:0060090), not lipid binding. Membrane anchoring via the tail-anchor TM helix does not justify a lipid-binding MF.
+                        </div>
+
+
+
+                        <div class="propagation-review">
+                            <div class="propagation-title">Propagation Review</div>
+                            <div class="propagation-row">
+                                <strong>Root cause:</strong>
+                                <span class="badge">TERM SCOPING PROBLEM</span>
+                            </div>
+
+                            <div class="propagation-row">
+                                <strong>Failure modes:</strong>
+
+                                <span class="badge">GRANULARITY MISMATCH</span>
+
+                            </div>
+
+
+                            <div class="propagation-source">
+                                <strong>Sources checked:</strong>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">PANTHER:PTN000326738</span>
+
+                                    &middot; FIS1 family node
+
+
+                                    <span class="badge">SOURCE WEAK OR INFERRED</span>
+
+
+                                </div>
+
+                            </div>
+
+                        </div>
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0060090" target="_blank" class="term-link">
+                                    GO:0060090
+                                </a>
+                            </span>
+                            <span class="term-label">molecular adaptor activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q6AHP8" data-a="GO:0060090" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> The most informative molecular-function term available for a FIS1-family protein: an outer-membrane receptor/adaptor that helps bring the fission GTPase DRP-1 into the fission/degradation machinery. Consistent with fis-2 being a tail-anchored mitochondrial outer membrane protein that acts within the DRP-1/MAM disposal machinery. Important caveat: this is entirely family-level inference — no worm FIS-2 protein has been shown to bind DRP-1, an adaptor, or any partner (see knowledge_gaps).
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Best-supported and most informative MF term for this gene; consistent with the family function (Drp1 recruitment/adaptor). Retained as the representative molecular function while flagged as an MF-dark gap because it is undemonstrated for fis-2 specifically.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/24196833" target="_blank" class="term-link">
+                                        PMID:24196833
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Recruitment of Drp1 to mitochondria is mediated by proteins that are anchored in the mitochondrial outer membrane</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/24196833" target="_blank" class="term-link">
+                                        PMID:24196833
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Fis1 is part of the MAM complex and contributes to a late stage of the removal process but is not required for entry of Drp1 into the MAM or fission</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005741" target="_blank" class="term-link">
+                                    GO:0005741
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial outer membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q6AHP8" data-a="GO:0005741" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Mitochondrial outer membrane is the expected site of action for a FIS1-family tail-anchored protein and is consistent with the fis-2 IDA mitochondrion localization (PMID:18722182) and ISS from human FIS1. Accept as the core cellular component, recognizing that OM-resolution localization of worm fis-2 is inferred (homology + tail-anchor topology) rather than directly resolved.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Well-supported localization consistent with the family and with the experimental (IDA) mitochondrial annotation; core to FIS-2 function.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005778" target="_blank" class="term-link">
+                                    GO:0005778
+                                </a>
+                            </span>
+                            <span class="term-label">peroxisomal membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q6AHP8" data-a="GO:0005778" data-r="GO_REF:0000033" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Peroxisomal membrane localization is inferred from mammalian/plant FIS1 homologs, which act in peroxisome fission. Plausible for worm fis-2 by homology but not directly demonstrated, and fis-1;fis-2 mutants have normal (punctate) peroxisomes. Retain as a non-core, homology-based localization.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> No direct worm evidence for peroxisomal localization or a peroxisomal role; family-level propagation. Not a core function of C. elegans fis-2.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/24196833" target="_blank" class="term-link">
+                                        PMID:24196833
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">showing punctate peroxisomes in wild-type and Fis1 mutants</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000266" target="_blank" class="term-link">
+                                    GO:0000266
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial fission</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q6AHP8" data-a="GO:0000266" data-r="GO_REF:0000033" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Mitochondrial fission is the ancestral FIS1-family process, but in C. elegans loss of fis-2 (alone or with fis-1) does NOT impair mitochondrial fission or morphology, and Fis1 homologs are not essential for fission or DRP-1 recruitment (MFF/DRP-1 are the essential factors). Retain as non-core: fis-2 belongs to the fission machinery at the family level but is not required for fission in worm.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Defensible at the family level, but loss-of-function is phenotypically silent for fission in worm; this is not the core, essential fission determinant.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/24196833" target="_blank" class="term-link">
+                                        PMID:24196833
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Our results show that fis-1 and fis-2 single and double mutants have wild-type mitochondrial morphologies, as also shown by others</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/24196833" target="_blank" class="term-link">
+                                        PMID:24196833
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Mff and Fis1 are not essential for fission or for Drp1 recruitment to mitochondria in C. elegans</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016559" target="_blank" class="term-link">
+                                    GO:0016559
+                                </a>
+                            </span>
+                            <span class="term-label">peroxisome fission</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q6AHP8" data-a="GO:0016559" data-r="GO_REF:0000033" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Peroxisome fission is a documented FIS1 function in mammals and plants, but in C. elegans fis-1;fis-2 mutants have normal punctate peroxisomes and only Mff/Drp1 loss produces tubular (fission-defective) peroxisomes. Family-level propagation not supported by direct worm evidence; retain as non-core.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> No demonstrated peroxisome-fission role for worm fis-2; the worm data show normal peroxisomes in Fis1 mutants. Keep as homology-based, non-core.
+                        </div>
+
+
+
+                        <div class="propagation-review">
+                            <div class="propagation-title">Propagation Review</div>
+                            <div class="propagation-row">
+                                <strong>Root cause:</strong>
+                                <span class="badge">PROPAGATION BAD</span>
+                            </div>
+
+                            <div class="propagation-row">
+                                <strong>Failure modes:</strong>
+
+                                <span class="badge">FUNCTIONAL DIVERGENCE</span>
+
+                            </div>
+
+
+                            <div class="propagation-source">
+                                <strong>Sources checked:</strong>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">PANTHER:PTN000326738</span>
+
+                                    &middot; FIS1 family node
+
+
+                                    <span class="badge">SUPPORTS SOURCE BUT NOT TARGET</span>
+
+
+                                </div>
+
+                            </div>
+
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/24196833" target="_blank" class="term-link">
+                                        PMID:24196833
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">showing punctate peroxisomes in wild-type and Fis1 mutants and tubular peroxisomes in drp-1 mutant and Mff double mutants</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000266" target="_blank" class="term-link">
+                                    GO:0000266
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial fission</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q6AHP8" data-a="GO:0000266" data-r="GO_REF:0000002" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic InterPro2GO mapping of the Fis1 domain (IPR016543) to mitochondrial fission. Same considerations as the IBA mitochondrial-fission annotation: defensible at the family/domain level but not the core essential fission role in worm.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Redundant with the IBA mitochondrial-fission annotation; family/domain-level inference. Non-core given the loss-of-function-silent fission phenotype in worm.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005739" target="_blank" class="term-link">
+                                    GO:0005739
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrion</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000120
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q6AHP8" data-a="GO:0005739" data-r="GO_REF:0000120" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Automated electronic annotation to the mitochondrion. Correct and corroborated by the direct experimental (IDA) mitochondrial localization from PMID:18722182 and by ISS from human FIS1.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Well-supported core localization; consistent with the experimental IDA annotation.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005741" target="_blank" class="term-link">
+                                    GO:0005741
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial outer membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000044
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q6AHP8" data-a="GO:0005741" data-r="GO_REF:0000044" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> UniProt subcellular-location mapping to mitochondrial outer membrane, consistent with the FIS1 tail-anchor topology and ISS from human FIS1.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Well-supported core localization; redundant with the ISS annotation and consistent with the experimental mitochondrial localization.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005778" target="_blank" class="term-link">
+                                    GO:0005778
+                                </a>
+                            </span>
+                            <span class="term-label">peroxisomal membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000044
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q6AHP8" data-a="GO:0005778" data-r="GO_REF:0000044" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> UniProt subcellular-location mapping to peroxisomal membrane, transferred from the mammalian FIS1 dual localization. Not directly shown in worm; non-core.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Homology-based peroxisomal localization; no direct C. elegans evidence. Retain as non-core.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005741" target="_blank" class="term-link">
+                                    GO:0005741
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial outer membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ISS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000024
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q6AHP8" data-a="GO:0005741" data-r="GO_REF:0000024" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> ISS transfer of mitochondrial outer membrane localization from human FIS1 (Q9Y3D6). Consistent with the fis-2 IDA mitochondrial localization and the tail-anchor topology.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Well-supported core localization; consistent with experimental worm data.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005778" target="_blank" class="term-link">
+                                    GO:0005778
+                                </a>
+                            </span>
+                            <span class="term-label">peroxisomal membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ISS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000024
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q6AHP8" data-a="GO:0005778" data-r="GO_REF:0000024" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> ISS transfer of peroxisomal membrane localization from human FIS1. Plausible by homology but not demonstrated in worm; non-core.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Homology-based; no direct worm evidence for peroxisomal localization.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0036498" target="_blank" class="term-link">
+                                    GO:0036498
+                                </a>
+                            </span>
+                            <span class="term-label">IRE1-mediated unfolded protein response</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">HEP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/16184190" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:16184190
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Genetic interactions due to constitutive and inducible gene ...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q6AHP8" data-a="GO:0036498" data-r="PMID:16184190" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> High-throughput expression-profiling (HEP) annotation: fis-2 (F13B9.8) was identified as a UPR-regulated gene in a genome-wide microarray study of the C. elegans unfolded protein response. This reflects transcriptional co-regulation of fis-2 with the IRE1/XBP-1 UPR, not a demonstrated functional role of fis-2 within the UPR pathway. fis-2 is not named in the paper&#39;s text (the evidence is in supplementary tables), so no verbatim supporting quote is available.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Expression-based (HEP) association only; being a UPR target gene does not establish that fis-2 acts in the UPR. Retain as a peripheral, non-core annotation reflecting transcriptional responsiveness, not core function.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005739" target="_blank" class="term-link">
+                                    GO:0005739
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrion</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/18722182" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:18722182
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Caenorhabditis elegans drp-1 and fis-2 regulate distinct cel...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q6AHP8" data-a="GO:0005739" data-r="PMID:18722182" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct experimental (IDA) mitochondrial localization of FIS-2 curated by WormBase from Breckenridge et al. 2008. This is the strongest, fis-2-specific evidence for FIS-2 localization and anchors the core cellular component. The cached record is abstract-only, so the localization figure is not quotable here; the annotation is retained on the WormBase curator&#39;s IDA assignment.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Direct experimental assay in C. elegans (WormBase IDA); the experimental basis for FIS-2 mitochondrial localization.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006915" target="_blank" class="term-link">
+                                    GO:0006915
+                                </a>
+                            </span>
+                            <span class="term-label">apoptotic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IGI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/18722182" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:18722182
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Caenorhabditis elegans drp-1 and fis-2 regulate distinct cel...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q6AHP8" data-a="GO:0006915" data-r="PMID:18722182" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> The only individually demonstrated fis-2 function. Genetic-interaction (IGI) evidence: fis-2 has a minor pro-apoptotic role, revealed in sensitized genetic backgrounds, acting downstream of the CED-3 caspase and independently of DRP-1 and CED-9 to promote elimination of mitochondria in dying cells and facilitate cell-death execution. The effect is minor (fis-2 single mutants show only small changes in cell-corpse numbers), so this is a genuine but non-essential role.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Experimentally supported, fis-2-specific role in cell-death execution (IGI with ced-3). This is the best-characterized function of fis-2 and should be retained.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/18722182" target="_blank" class="term-link">
+                                        PMID:18722182
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">minor proapoptotic roles for drp-1 and fis-2, a homolog of human Fis1, are revealed in sensitized genetic backgrounds</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/18722182" target="_blank" class="term-link">
+                                        PMID:18722182
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">reveal distinct roles for drp-1 and fis-2 as mediators of cell-death execution downstream of caspase activation</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000423" target="_blank" class="term-link">
+                                    GO:0000423
+                                </a>
+                            </span>
+                            <span class="term-label">mitophagy</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IGI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/24196833" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:24196833
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Mutations in Fis1 disrupt orderly disposal of defective mito...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-new">
+                            NEW
+                        </span>
+                        <span class="vote-buttons" data-g="Q6AHP8" data-a="GO:0000423" data-r="PMID:24196833" data-act="NEW">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Proposed new annotation (not currently in GOA). Genetic loss of both FIS1 paralogs (the fis-1;fis-2 double mutant) disrupts the orderly disposal of defective mitochondria: mitochondrial stress induces accumulation of large LGG-1/LC3-positive autophagic aggregates containing mitochondrial remnants and DRP-1, and these aggregates/mitophagosome spots are suppressed by drp-1, mff, and pink-1 mutations. fis-2 is genetically part of this pathway (drp-1 fis-1 fis-2 and pink-1 fis-1 fis-2 triple mutants). IMPORTANT: the disposal phenotype was only demonstrated in the fis-1;fis-2 double, so fis-2&#39;s contribution is redundant with fis-1, not shown to be fis-2-autonomous.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Captures the experimentally supported biological process in which fis-2 participates (coupling stress-induced fission to mitophagic disposal), currently absent from GOA. Annotated as IGI (redundancy with fis-1) to reflect that the phenotype requires loss of both paralogs.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/24196833" target="_blank" class="term-link">
+                                        PMID:24196833
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">pink-1 single and pink-1 fis-1 fis-2 triple mutant animals had no colocalizing spots, as expected for a complete block of mitophagy</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/24196833" target="_blank" class="term-link">
+                                        PMID:24196833
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">a drp-1 fis-1 fis-2 triple mutant strain also had reduced number and size of aggregates when treated with Paraquat</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>FIS-2 is a tail-anchored mitochondrial outer membrane protein of the FIS1 family that functions in the disposal of mitochondria rather than in the core fission reaction. Its individually demonstrated role is a minor pro-apoptotic (cell-death execution) function: acting downstream of the CED-3 caspase and independently of DRP-1 and CED-9, it promotes elimination of mitochondria in dying cells. Redundantly with the paralog fis-1, it also contributes to the orderly, PINK-1-dependent disposal of stress-damaged mitochondria downstream of MFF/DRP-1-mediated fission. Its molecular activity is inferred, at the family level only, to be that of a membrane adaptor/receptor.</h3>
+                <span class="vote-buttons" data-g="Q6AHP8" data-a="FUNCTION: FIS-2 is a tail-anchored mitochondrial outer membr..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0060090" target="_blank" class="term-link">
+                            molecular adaptor activity
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006915" target="_blank" class="term-link">
+                                apoptotic process
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000423" target="_blank" class="term-link">
+                                mitophagy
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005741" target="_blank" class="term-link">
+                                mitochondrial outer membrane
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/18722182" target="_blank" class="term-link">
+                                PMID:18722182
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">minor proapoptotic roles for drp-1 and fis-2, a homolog of human Fis1, are revealed in sensitized genetic backgrounds</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/24196833" target="_blank" class="term-link">
+                                PMID:24196833
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">pink-1 single and pink-1 fis-1 fis-2 triple mutant animals had no colocalizing spots, as expected for a complete block of mitophagy</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/24196833" target="_blank" class="term-link">
+                                PMID:24196833
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">Fis1 is part of the MAM complex and contributes to a late stage of the removal process but is not required for entry of Drp1 into the MAM or fission</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000002.md" target="_blank" class="term-link">
+                            GO_REF:0000002
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation through association of InterPro records with GO terms</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000024.md" target="_blank" class="term-link">
+                            GO_REF:0000024
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Manual transfer of experimentally-verified manual GO annotation data to orthologs by curator judgment of sequence similarity</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
+                            GO_REF:0000033
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Annotation inferences using phylogenetic trees</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
+                            GO_REF:0000044
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000120.md" target="_blank" class="term-link">
+                            GO_REF:0000120
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Combined Automated Annotation using Multiple IEA Methods</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/16184190" target="_blank" class="term-link">
+                            PMID:16184190
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Genetic interactions due to constitutive and inducible gene regulation mediated by the unfolded protein response in C. elegans.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">A genome-wide C. elegans UPR microarray study. fis-2 (F13B9.8) is not named in the abstract or main text; its identification as a UPR-regulated gene is in the supplementary microarray tables, which is the basis of the WormBase HEP annotation to IRE1-mediated UPR.</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/18722182" target="_blank" class="term-link">
+                            PMID:18722182
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Caenorhabditis elegans drp-1 and fis-2 regulate distinct cell-death execution pathways downstream of ced-3 and independent of ced-9.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">fis-2 (a homolog of human Fis1) has a minor pro-apoptotic role revealed in sensitized genetic backgrounds, acting downstream of the CED-3 caspase and independently of DRP-1 and CED-9 to promote elimination of mitochondria in dying cells.</div>
+
+                        <div class="finding-text">"minor proapoptotic roles for drp-1 and fis-2, a homolog of human Fis1, are revealed in sensitized genetic backgrounds"</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/24196833" target="_blank" class="term-link">
+                            PMID:24196833
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Mutations in Fis1 disrupt orderly disposal of defective mitochondria.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">C. elegans fis-2 single and fis-1;fis-2 double mutants have wild-type mitochondrial (and peroxisomal) morphology; Fis1 homologs are not essential for fission or for DRP-1 recruitment, unlike MFF/DRP-1.</div>
+
+                        <div class="finding-text">"Our results show that fis-1 and fis-2 single and double mutants have wild-type mitochondrial morphologies, as also shown by others"</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Loss of both FIS1 paralogs (the fis-1;fis-2 &#34;Fis1&#34; double mutant) causes stress-induced accumulation of large LGG-1 autophagic aggregates containing mitochondrial remnants and DRP-1; drp-1 fis-1 fis-2 and pink-1 fis-1 fis-2 triple mutants place fis-2 genetically in the mitophagic disposal pathway downstream of DRP-1/MFF and PINK-1.</div>
+
+                        <div class="finding-text">"pink-1 single and pink-1 fis-1 fis-2 triple mutant animals had no colocalizing spots, as expected for a complete block of mitophagy"</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Questions for Experts</h2>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Does a fis-2 single loss-of-function (independent of fis-1) measurably alter mitophagic flux or mitochondrial quality control, or is fis-2 fully redundant with fis-1?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q6AHP8" data-a="Q: Does a fis-2 single loss-of-function (independent ..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Does C. elegans FIS-2 physically interact with DRP-1 or MAM/ER-mitochondria components, and does it use an adaptor intermediate, as mammalian FIS1 does under stress?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q6AHP8" data-a="Q: Does C. elegans FIS-2 physically interact with DRP..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Do the two worm FIS1 paralogs partition functionally (fis-2 toward cell-death-execution disposal, fis-1 toward UVC/mtDNA-damage removal), or are they interchangeable?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q6AHP8" data-a="Q: Do the two worm FIS1 paralogs partition functional..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Experiments</h2>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Compare stage-resolved mitophagy flux (mito-Rosella / mtKeima or LGG-1 puncta maturation) after Paraquat or antimycin A across wild-type, fis-2 single, fis-1 single, and fis-1;fis-2 double mutants, with allele-specific rescue, to isolate any fis-2-autonomous step.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: FIS-2 makes a distinct, non-redundant contribution to stress-induced mitophagy that is masked by the paralog fis-1 in double-mutant analyses.</em></p>
+
+
+                </div>
+                <span class="vote-buttons" data-g="Q6AHP8" data-a="EXPERIMENT: Compare stage-resolved mitophagy flux (mito-Rosell..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Use proximity labeling (TurboID) or co-immunoprecipitation of endogenously tagged FIS-2 from C. elegans under basal and mitochondrial-stress conditions to identify DRP-1, MAM, and autophagy/apoptosis interactors and to test for adaptor intermediates, comparing the FIS-2 and FIS-1 interactomes.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: Worm FIS-2 has direct or adaptor-mediated partners at the mitochondrial outer membrane / ER-mitochondrial interface.</em></p>
+
+
+                </div>
+                <span class="vote-buttons" data-g="Q6AHP8" data-a="EXPERIMENT: Use proximity labeling (TurboID) or co-immunopreci..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Knowledge Gaps</h2>
+        <p style="color: #555; font-size: 0.92rem; margin-top: -0.3rem;">
+            What is <em>not</em> known — curated, literature-grounded statements of the open
+            unknowns (the inverse of core functions).
+        </p>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The molecular activity of FIS-2 is entirely undetermined experimentally. Its only molecular-function annotation (&#34;molecular adaptor activity&#34;) is a phylogenetic (IBA) propagation from the FIS1 family; no C. elegans FIS-2 protein has been shown to bind DRP-1, a fission adaptor, lipid, or any other partner, and no biochemical or structural study of worm FIS-2 exists.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">MF_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> Established: FIS-2 is a FIS1-family tail-anchored protein of the mitochondrial outer membrane (IDA mitochondrion; ISS/tail-anchor topology) that participates genetically in mitochondrial disposal. Unknown: what FIS-2 actually does at the molecular level - its direct binding partner(s) and the biochemical activity, if any, beyond membrane anchoring.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> FIS1 has long been presumed a fission receptor; worm (and mammalian) data reassign the family to mitochondrial quality-control roles whose mechanism is unresolved. For the fis-2 paralog specifically, even the assumed adaptor activity is untested, making it a genuinely dark molecular function relevant to PINK1/Parkin quality-control biology.</p>
+
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"Mff and Fis1 are not essential for fission or for Drp1 recruitment to mitochondria in C. elegans"</em> — PMID:24196833</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> Whether FIS-2 has any non-redundant, fis-2-autonomous role in mitochondrial disposal/mitophagy is unresolved. Every mitophagy/LGG-1-aggregate phenotype was scored in the fis-1(tm1867); fis-2(gk414) double mutant (the &#34;Fis1 mutant&#34;), and both single mutants have wild-type mitochondrial morphology, so the individual contribution of fis-2 to orderly disposal (versus complete redundancy with, or dispensability relative to, fis-1) has not been measured.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">RESIDUAL_SUBGAP</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> Established: the fis-1;fis-2 double mutant accumulates stress-induced LGG-1 aggregates and lies genetically downstream of MFF/DRP-1 and PINK-1. Unknown: what a fis-2 single loss-of-function does to mitophagic flux, and whether fis-2 contributes anything the paralog fis-1 does not.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Distinguishing redundant from specialized paralog functions is required before fis-2 can be assigned a specific mitophagy role rather than a family-level one, and determines whether fis-2 is a distinct quality-control node or a fis-1 backup.</p>
+
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"Our results show that fis-1 and fis-2 single and double mutants have wild-type mitochondrial morphologies, as also shown by others"</em> — PMID:24196833</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The direct binding partners and interactome of C. elegans FIS-2 are unmapped. It is unknown whether FIS-2 binds DRP-1 (directly or via an adaptor intermediate analogous to yeast Mdv1/Caf4), whether it joins an ER-mitochondria (MAM) fission/disposal complex as mammalian FIS1 does under stress, and which downstream autophagy or apoptotic-machinery factors it engages.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span><span class="badge">CURATION</span>
+                <span class="badge">MF_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> Established (in mammals): stress induces a DRP-1-FIS1 co-immunoprecipitable complex that also contains ER/MAM proteins. Unknown (for worm FIS-2): its physical interactors, and whether the mammalian complex applies to this paralog.</p>
+
+
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"Recruitment of Drp1 to mitochondria is mediated by proteins that are anchored in the mitochondrial outer membrane"</em> — PMID:24196833</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The mechanism and biological significance of the fis-2-specific pro-apoptotic role are unknown. fis-2 promotes elimination of mitochondria in dying cells downstream of CED-3 and independently of DRP-1/CED-9, but whether this uses the same membrane machinery as its (redundant) mitophagy role, why the effect is only detectable in sensitized backgrounds, and why this activity is foregrounded for fis-2 but not fis-1, are all unresolved.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">MF_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> Established: in sensitized backgrounds fis-2 has a minor, CED-3-dependent, DRP-1/CED-9-independent pro-apoptotic effect on mitochondrial elimination. Unknown: the molecular basis of this activity and its relationship to the paralog-redundant mitophagy pathway.</p>
+
+
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"drp-1 and fis-2 function independent of one another and the Bcl-2 homolog CED-9 and downstream of the CED-3 caspase to promote elimination of mitochondria in dying cells"</em> — PMID:18722182</li>
+
+            </ul>
+
+
+        </div>
+
+    </div>
+
+
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Deep Research Sections -->
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(fis-2-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="Q6AHP8" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="fis-2-c-elegans-gene-review-notes">fis-2 (C. elegans) — Gene Review Notes</h1>
+<p>UniProt: Q6AHP8 (FIS12_CAEEL); WormBase F13B9.8 / WBGene00001425; ORF F13B9.8; Chromosome X.<br />
+Human ortholog: FIS1 (Q9Y3D6). Paralog in worm: fis-1 (Q20291, WBGene00001424) — a first FIS1<br />
+homologue reviewed separately (PR #1672, merged). Part of the flagship<br />
+<code>projects/CAEEL_MITOPHAGY.md</code> project.</p>
+<p>151 aa tail-anchored protein: cytosol-facing TPR-fold body (CDD cd12212 Fis1; Pfam PF14852<br />
+Fis1_TPR_N + PF14853 Fis1_TPR_C) + a single C-terminal transmembrane helix (UniProt FT<br />
+TRANSMEM 126..146) that anchors it in the mitochondrial outer membrane. Belongs to the FIS1<br />
+family (PIRSF008835; PANTHER PTHR13247:SF0). PE 3: Inferred from homology (no experimental<br />
+protein-level evidence beyond localization/genetics).</p>
+<h2 id="deep-research-provenance">Deep research provenance</h2>
+<p>Falcon deep research (<code>just deep-research-falcon worm fis-2 --fallback perplexity-lite</code>) was<br />
+attempted TWICE. Both runs timed out after the built-in 600 s falcon limit under heavy<br />
+concurrent Edison load (multiple sibling worktrees were simultaneously running falcon jobs for<br />
+other worm genes), and the perplexity-lite fallback failed with an HTTP 401<br />
+<code>insufficient_quota</code> error on both attempts. No <code>fis-2-deep-research-falcon.md</code> (or<br />
+perplexity-lite) file was produced, so none is committed (never fabricate a <code>-deep-research-*</code><br />
+file). This review is therefore grounded directly in UniProt (Q6AHP8), GOA (15 annotations),<br />
+and cached primary literature. Critically, the one paper that directly characterises worm<br />
+fis-2 loss-of-function (PMID:24196833, full text cached) and the paper that reports a<br />
+fis-2-specific apoptotic phenotype (PMID:18722182, ABSTRACT-ONLY in cache) were both read<br />
+directly, so every existing annotation could be adjudicated without an UNDECIDED call.</p>
+<h2 id="provenance-sources">Provenance sources</h2>
+<ul>
+<li>UniProt Q6AHP8 record (<code>fis-2-uniprot.txt</code>)</li>
+<li>GOA (<code>fis-2-goa.tsv</code>) — 15 annotations</li>
+<li>Primary literature (cached):</li>
+<li>PMID:24196833 Shen et al. 2014 Mol Biol Cell — "Mutations in Fis1 disrupt orderly disposal<br />
+    of defective mitochondria" (FULL TEXT). Directly studies C. elegans fis-1/fis-2 using the<br />
+    fis-1(tm1867); fis-2(gk414) double mutant (referred to throughout as the "Fis1 mutant") plus<br />
+    drp-1 fis-1 fis-2 and pink-1 fis-1 fis-2 triple mutants.</li>
+<li>PMID:18722182 Breckenridge et al. 2008 Mol Cell — "C. elegans drp-1 and fis-2 regulate<br />
+    distinct cell-death execution pathways downstream of ced-3 and independent of ced-9"<br />
+    (ABSTRACT ONLY in cache; abstract explicitly foregrounds fis-2). Source of the fis-2 IDA<br />
+    mitochondrion localization and the fis-2 IGI apoptosis annotation.</li>
+<li>PMID:16184190 Shen et al. 2005 PLoS Genet — C. elegans UPR microarray study (FULL TEXT).<br />
+    fis-2 (F13B9.8) is NOT named in the abstract/main text; the HEP annotation<br />
+    (GO:0036498, IRE1-mediated UPR) derives from supplementary microarray tables where fis-2<br />
+    scored as a UPR-regulated (target) gene. No verbatim fis-2 quote is available from this<br />
+    paper.</li>
+</ul>
+<h2 id="known-well-supported">KNOWN (well supported)</h2>
+<h3 id="localization-mitochondrion-mitochondrial-outer-membrane-known-for-fis-2">Localization: mitochondrion / mitochondrial outer membrane (KNOWN for fis-2)</h3>
+<ul>
+<li>Direct experimental (IDA) mitochondrial localization was assigned by WormBase from<br />
+  PMID:18722182 (UniProt: "SUBCELLULAR LOCATION: ... Mitochondrion<br />
+  {ECO:0000269|PubMed:18722182}"). The cached abstract does not restate the localization<br />
+  (full text has the fis-2::GFP data); defer to the WB curator for the IDA.</li>
+<li>Outer-membrane sub-localization is by ISS from human FIS1 (Q9Y3D6) and by the tail-anchor<br />
+  topology (UniProt DOMAIN: "The C-terminus is required for mitochondrial or peroxisomal<br />
+  localization, while the N-terminus is necessary for mitochondrial or peroxisomal fission").<br />
+  This is family-level / homology-based for worm fis-2, not directly demonstrated at OM<br />
+  resolution. Peroxisomal-membrane localization is purely ISS/IBA from mammalian/plant FIS1.</li>
+</ul>
+<h3 id="fis-2-specific-role-minor-pro-apoptotic-cell-death-execution-function-known-minor">fis-2-specific role: minor pro-apoptotic / cell-death-execution function (KNOWN, minor)</h3>
+<ul>
+<li>This is the ONLY function experimentally demonstrated for fis-2 individually.<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/18722182" title="minor proapoptotic roles for drp-1 and fis-2, a homolog of human Fis1, are revealed in sensitized genetic backgrounds">PMID:18722182</a></li>
+<li>Acts downstream of the CED-3 caspase, independent of drp-1 and of CED-9, to eliminate<br />
+  mitochondria in dying cells.<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/18722182" title="downstream of the CED-3 caspase to promote elimination of mitochondria in dying cells, an event that could facilitate cell-death execution">PMID:18722182</a><br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/18722182" title="reveal distinct roles for drp-1 and fis-2 as mediators of cell-death execution downstream of caspase activation">PMID:18722182</a></li>
+<li>Basis of the GOA IGI GO:0006915 apoptotic process annotation (genetic interaction with ced-3,<br />
+  WB:WBGene00000423). Note: minor, only in sensitized backgrounds; the fis-2 single mutant has<br />
+  only "minor" effects on cell corpses (UniProt DISRUPTION PHENOTYPE from PMID:18722182).</li>
+</ul>
+<h3 id="redundant-role-in-orderly-disposal-of-defective-mitochondria-mitophagy-known-but-only-via-the-double-mutant">Redundant role in orderly disposal of defective mitochondria / mitophagy (KNOWN, but only via the double mutant)</h3>
+<ul>
+<li>In PMID:24196833 the "Fis1 mutant" is the fis-1(tm1867); fis-2(gk414) double.<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/24196833" title="generating fis-1(tm1867); fis-2(gk414) and mff-1(tm2955); mff-2(tm3041) double mutants">PMID:24196833</a></li>
+<li>The double mutant accumulates large LGG-1 (worm LC3) autophagic aggregates containing<br />
+  mitochondrial remnants and DRP-1 under mitochondrial stress.<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/24196833" title="causing the formation of large aggregates containing LGG-1, DRP-1, and remnants of mitochondria">PMID:24196833</a></li>
+<li>fis-2 is genetically part of the disposal pathway: a drp-1 fis-1 fis-2 triple mutant suppresses<br />
+  the aggregates, and a pink-1 fis-1 fis-2 triple mutant abolishes mitophagosome spots.<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/24196833" title="a drp-1 fis-1 fis-2 triple mutant strain also had reduced number and size of aggregates when treated with Paraquat">PMID:24196833</a><br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/24196833" title="pink-1 single and pink-1 fis-1 fis-2 triple mutant animals had no colocalizing spots, as expected for a complete block of mitophagy">PMID:24196833</a></li>
+<li>Model (family level, largely mammalian coIP): FIS1 is a MOM factor in the DRP-1/MAM fission<br />
+  complex acting at a late disposal step.<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/24196833" title="Fis1 is part of the MAM complex and contributes to a late stage of the removal process but is not required for entry of Drp1 into the MAM or fission">PMID:24196833</a></li>
+</ul>
+<h2 id="not-known-important-negatives">NOT known / important negatives</h2>
+<h3 id="fis-2-is-not-required-for-mitochondrial-fission-in-c-elegans-fis-2-specific-negative">fis-2 is NOT required for mitochondrial fission in C. elegans (fis-2-specific negative)</h3>
+<ul>
+<li>The fis-2 SINGLE mutant (and the fis-1;fis-2 double) has wild-type mitochondrial morphology.<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/24196833" title="Our results show that fis-1 and fis-2 single and double mutants have wild-type mitochondrial morphologies, as also shown by others">PMID:24196833</a></li>
+<li>Fis1 homologues are not essential for fission or for DRP-1 recruitment in worm (Mff is the<br />
+  relevant recruiter; drp-1 the essential mechanochemical GTPase).<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/24196833" title="Mff and Fis1 are not essential for fission or for Drp1 recruitment to mitochondria in C. elegans">PMID:24196833</a></li>
+<li>So the family-propagated GO:0000266 mitochondrial fission (IBA + IEA) is defensible only at<br />
+  the family/machinery level; it is NOT the core essential fission role in worm → non-core.</li>
+</ul>
+<h3 id="fis-2-is-not-required-for-peroxisome-fission-in-c-elegans-negative">fis-2 is NOT required for peroxisome fission in C. elegans (negative)</h3>
+<ul>
+<li>Fis1 mutants (= fis-1;fis-2 double) have normal punctate peroxisomes; only Mff/Drp1 loss gives<br />
+  tubular (fission-defective) peroxisomes.<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/24196833" title="showing punctate peroxisomes in wild-type and Fis1 mutants and tubular peroxisomes in drp-1 mutant and Mff double mutants">PMID:24196833</a></li>
+<li>GO:0016559 peroxisome fission (IBA) and GO:0005778 peroxisomal membrane (IBA/ISS/IEA) are<br />
+  family-level propagations with no direct worm support → non-core.</li>
+</ul>
+<h3 id="lipid-binding-go0008289-iba-weakly-supported">lipid binding (GO:0008289, IBA) — weakly supported</h3>
+<ul>
+<li>No worm fis-2 evidence for lipid binding. The C-terminal TM helix mediates membrane anchoring,<br />
+  which is not a "lipid binding" molecular function. Generic family-level over-propagation →<br />
+  over-annotated.</li>
+</ul>
+<h3 id="molecular-adaptor-activity-go0060090-iba-best-available-mf-but-undemonstrated-for-fis-2">molecular adaptor activity (GO:0060090, IBA) — best available MF, but undemonstrated for fis-2</h3>
+<ul>
+<li>Assigned purely by phylogenetic propagation from the FIS1 family. It is the most informative<br />
+  MF term available and is consistent with fis-2 being a tail-anchored MOM protein in the<br />
+  fission/disposal machinery, but NO worm fis-2 protein has been shown to bind DRP-1, an<br />
+  adaptor, or any partner. Accept as the representative MF, but flag as an MF-dark knowledge gap.</li>
+</ul>
+<h2 id="difference-from-the-fis-1-paralog-why-fis-2-needs-its-own-evidence">Difference from the fis-1 paralog (why fis-2 needs its own evidence)</h2>
+<ul>
+<li>fis-1 review concluded fis-1 is dispensable for fission and acts (redundantly with fis-2) in<br />
+  orderly mitochondrial disposal; its individually demonstrated data were localization<br />
+  (YFP::FIS-1 as OM marker, PMID:21248201) and the UVC/mtDNA-damage-removal role<br />
+  (fis-1 RNAi, PMID:24058863).</li>
+<li>fis-2's individually demonstrated datum is different: the minor pro-apoptotic / cell-death<br />
+  execution role (PMID:18722182, Breckenridge — which foregrounds fis-2, not fis-1). The<br />
+  mitophagy/LGG-1 disposal phenotype (PMID:24196833) was only ever scored in the fis-1;fis-2<br />
+  DOUBLE mutant, so it demonstrates a redundant contribution, not an fis-2-autonomous role.</li>
+<li>Open question: do the two paralogs partition (fis-2 → apoptotic disposal per Breckenridge;<br />
+  fis-1 → UVC/mtDNA damage removal per Bess/Shen; both → stress mitophagy), or are they fully<br />
+  interchangeable? Not resolved in the literature.</li>
+</ul>
+<h2 id="unknowns-candidate-knowledge-gaps-the-point-for-a-dark-paralog">Unknowns (candidate knowledge gaps — the point for a dark paralog)</h2>
+<ol>
+<li>MF-dark: the molecular activity of fis-2 is entirely inferred. "Molecular adaptor activity"<br />
+   is a family-level IBA; there is no worm fis-2 binding/biochemical data at all.</li>
+<li>Whether fis-2 has ANY non-redundant function distinct from fis-1 is unresolved: the disposal<br />
+   phenotype requires loss of BOTH paralogs (double mutant), and both single mutants have normal<br />
+   mitochondrial morphology. fis-2's autonomous contribution to mitophagy is undetermined.</li>
+<li>fis-2's interactome is unmapped: no worm data on whether fis-2 binds DRP-1 (directly or via an<br />
+   adaptor), participates in a MAM/ER-mitochondria complex, or what distinguishes it from fis-1.</li>
+<li>The mechanism and physiological significance of the minor, sensitized-background pro-apoptotic<br />
+   role, and whether it reflects the same disposal machinery acting in dying cells, is unknown.</li>
+</ol>
+<h2 id="curation-decisions-summary-see-fis-2-ai-reviewyaml">Curation decisions summary (see fis-2-ai-review.yaml)</h2>
+<ul>
+<li>ACCEPT (core/representative): GO:0060090 molecular adaptor activity (IBA, best MF, flagged<br />
+  MF-dark); GO:0005739 mitochondrion (IDA, fis-2-specific); GO:0005741 mitochondrial outer<br />
+  membrane (ISS, IEA-SubCell); GO:0005739 mitochondrion (IEA); GO:0006915 apoptotic process<br />
+  (IGI, the one demonstrated fis-2-specific function).</li>
+<li>KEEP_AS_NON_CORE: GO:0000266 mitochondrial fission (IBA, IEA); GO:0005741 mito OM (IBA<br />
+  is_active_in); GO:0005778 peroxisomal membrane (IBA/ISS/IEA); GO:0016559 peroxisome fission<br />
+  (IBA); GO:0036498 IRE1-mediated UPR (HEP, expression-only).</li>
+<li>MARK_AS_OVER_ANNOTATED: GO:0008289 lipid binding (IBA).</li>
+<li>NEW (proposed): GO:0000423 mitophagy (IGI, redundant with fis-1; only shown in the double<br />
+  mutant) — flagged as redundant, not fis-2-autonomous.</li>
+</ul>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: Q6AHP8
+gene_symbol: fis-2
+product_type: PROTEIN
+status: DRAFT
+taxon:
+  id: NCBITaxon:6239
+  label: Caenorhabditis elegans
+description: &gt;-
+  fis-2 (F13B9.8) is one of two Caenorhabditis elegans homologs of FIS1, a small
+  (151 aa) tail-anchored protein of the mitochondrial outer membrane. Like other
+  FIS1-family members it has a cytosol-facing tetratricopeptide-repeat (TPR) fold
+  and a single C-terminal transmembrane helix that anchors it in the outer
+  membrane with the TPR body exposed to the cytosol. The worm genome encodes a
+  second FIS1 homolog, fis-1, with which fis-2 acts partly redundantly. In
+  mammals and fungi FIS1 proteins are receptor/adaptor factors implicated in
+  recruiting the dynamin-related GTPase DRP1 to the outer membrane during
+  mitochondrial (and peroxisomal) fission. In C. elegans, however, loss of fis-2
+  (alone or together with fis-1) does not detectably impair mitochondrial or
+  peroxisomal fission or morphology; the essential fission machinery is instead
+  MFF/DRP-1. The functions demonstrated for fis-2 are downstream of, or parallel
+  to, fission: it has a minor pro-apoptotic role in promoting the elimination of
+  mitochondria in dying cells, acting downstream of the CED-3 caspase and
+  independently of DRP-1 and CED-9, and it contributes (redundantly with fis-1)
+  to the orderly disposal of damaged mitochondria, where loss of both paralogs
+  causes stress-induced accumulation of large autophagic (LGG-1/LC3-positive)
+  aggregates containing mitochondrial remnants. fis-2 is thus a mitochondrial
+  outer membrane FIS1-family protein linked to mitochondrial quality control and
+  cell-death execution rather than to the core fission reaction.
+references:
+- id: GO_REF:0000002
+  title: Gene Ontology annotation through association of InterPro records with GO
+    terms
+  findings: []
+- id: GO_REF:0000024
+  title: Manual transfer of experimentally-verified manual GO annotation data to orthologs
+    by curator judgment of sequence similarity
+  findings: []
+- id: GO_REF:0000033
+  title: Annotation inferences using phylogenetic trees
+  findings: []
+- id: GO_REF:0000044
+  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location
+    vocabulary mapping, accompanied by conservative changes to GO terms applied by
+    UniProt
+  findings: []
+- id: GO_REF:0000120
+  title: Combined Automated Annotation using Multiple IEA Methods
+  findings: []
+- id: PMID:16184190
+  title: Genetic interactions due to constitutive and inducible gene regulation mediated
+    by the unfolded protein response in C. elegans.
+  findings:
+  - statement: &gt;-
+      A genome-wide C. elegans UPR microarray study. fis-2 (F13B9.8) is not named
+      in the abstract or main text; its identification as a UPR-regulated gene is
+      in the supplementary microarray tables, which is the basis of the WormBase
+      HEP annotation to IRE1-mediated UPR.
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PMC full text confirmed (full_text_available: true). This is a
+      transcriptional-profiling study of the C. elegans UPR; fis-2 appears only as
+      a high-throughput expression-profiling (HEP) target in supplementary data.
+      No verbatim fis-2 quote is available. Supports at most that fis-2 mRNA is
+      UPR-responsive, not that fis-2 functions in the UPR; used to justify a
+      non-core, expression-based annotation only.
+- id: PMID:18722182
+  title: Caenorhabditis elegans drp-1 and fis-2 regulate distinct cell-death execution
+    pathways downstream of ced-3 and independent of ced-9.
+  findings:
+  - statement: &gt;-
+      fis-2 (a homolog of human Fis1) has a minor pro-apoptotic role revealed in
+      sensitized genetic backgrounds, acting downstream of the CED-3 caspase and
+      independently of DRP-1 and CED-9 to promote elimination of mitochondria in
+      dying cells.
+    supporting_text: &gt;-
+      minor proapoptotic roles for drp-1 and fis-2, a homolog of human Fis1, are
+      revealed in sensitized genetic backgrounds
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Cached record is abstract-only (full_text_available: false). The abstract
+      directly foregrounds fis-2 and is the source of the fis-2-specific IGI
+      apoptosis annotation and (via full text not in cache) the IDA mitochondrion
+      localization curated by WormBase. This is the ONLY paper demonstrating an
+      individual (fis-2 single-gene) loss-of-function phenotype for fis-2.
+- id: PMID:24196833
+  title: Mutations in Fis1 disrupt orderly disposal of defective mitochondria.
+  findings:
+  - statement: &gt;-
+      C. elegans fis-2 single and fis-1;fis-2 double mutants have wild-type
+      mitochondrial (and peroxisomal) morphology; Fis1 homologs are not essential
+      for fission or for DRP-1 recruitment, unlike MFF/DRP-1.
+    supporting_text: &gt;-
+      Our results show that fis-1 and fis-2 single and double mutants have wild-type
+      mitochondrial morphologies, as also shown by others
+  - statement: &gt;-
+      Loss of both FIS1 paralogs (the fis-1;fis-2 &#34;Fis1&#34; double mutant) causes
+      stress-induced accumulation of large LGG-1 autophagic aggregates containing
+      mitochondrial remnants and DRP-1; drp-1 fis-1 fis-2 and pink-1 fis-1 fis-2
+      triple mutants place fis-2 genetically in the mitophagic disposal pathway
+      downstream of DRP-1/MFF and PINK-1.
+    supporting_text: &gt;-
+      pink-1 single and pink-1 fis-1 fis-2 triple mutant animals had no colocalizing
+      spots, as expected for a complete block of mitophagy
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PMC full text confirmed. Directly characterizes C. elegans fis-2 using the
+      fis-1(tm1867); fis-2(gk414) double mutant (called the &#34;Fis1 mutant&#34;
+      throughout) plus drp-1 fis-1 fis-2 and pink-1 fis-1 fis-2 triple mutants.
+      Establishes that fis-2 is dispensable for fission and contributes REDUNDANTLY
+      (only demonstrated in the double mutant) to orderly disposal of defective
+      mitochondria. Not in the GOA seed set; added here because it is the primary
+      loss-of-function characterization of worm fis-2.
+existing_annotations:
+- term:
+    id: GO:0008289
+    label: lipid binding
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Family-level phylogenetic (IBA) inference of a generic &#34;lipid binding&#34;
+      molecular function. There is no C. elegans-specific evidence that FIS-2 binds
+      lipid; its C-terminal transmembrane helix mediates membrane anchoring, which
+      is not the same as a lipid-binding molecular function. This is a weak,
+      uninformative over-propagation for this gene.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      No experimental support in worm; the informative molecular function inferred
+      for FIS1-family proteins is adaptor/receptor activity (GO:0060090), not lipid
+      binding. Membrane anchoring via the tail-anchor TM helix does not justify a
+      lipid-binding MF.
+    propagation_review:
+      root_cause: TERM_SCOPING_PROBLEM
+      failure_modes:
+      - GRANULARITY_MISMATCH
+      source_entities:
+      - source_id: PANTHER:PTN000326738
+        source_label: FIS1 family node
+        source_status: SOURCE_WEAK_OR_INFERRED
+- term:
+    id: GO:0060090
+    label: molecular adaptor activity
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: enables
+  review:
+    summary: &gt;-
+      The most informative molecular-function term available for a FIS1-family
+      protein: an outer-membrane receptor/adaptor that helps bring the fission
+      GTPase DRP-1 into the fission/degradation machinery. Consistent with fis-2
+      being a tail-anchored mitochondrial outer membrane protein that acts within
+      the DRP-1/MAM disposal machinery. Important caveat: this is entirely
+      family-level inference — no worm FIS-2 protein has been shown to bind DRP-1,
+      an adaptor, or any partner (see knowledge_gaps).
+    action: ACCEPT
+    reason: &gt;-
+      Best-supported and most informative MF term for this gene; consistent with
+      the family function (Drp1 recruitment/adaptor). Retained as the representative
+      molecular function while flagged as an MF-dark gap because it is undemonstrated
+      for fis-2 specifically.
+    supported_by:
+    - reference_id: PMID:24196833
+      supporting_text: &gt;-
+        Recruitment of Drp1 to mitochondria is mediated by proteins that are anchored
+        in the mitochondrial outer membrane
+    - reference_id: PMID:24196833
+      supporting_text: &gt;-
+        Fis1 is part of the MAM complex and contributes to a late stage of the removal
+        process but is not required for entry of Drp1 into the MAM or fission
+- term:
+    id: GO:0005741
+    label: mitochondrial outer membrane
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: is_active_in
+  review:
+    summary: &gt;-
+      Mitochondrial outer membrane is the expected site of action for a FIS1-family
+      tail-anchored protein and is consistent with the fis-2 IDA mitochondrion
+      localization (PMID:18722182) and ISS from human FIS1. Accept as the core
+      cellular component, recognizing that OM-resolution localization of worm fis-2
+      is inferred (homology + tail-anchor topology) rather than directly resolved.
+    action: ACCEPT
+    reason: &gt;-
+      Well-supported localization consistent with the family and with the
+      experimental (IDA) mitochondrial annotation; core to FIS-2 function.
+- term:
+    id: GO:0005778
+    label: peroxisomal membrane
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: is_active_in
+  review:
+    summary: &gt;-
+      Peroxisomal membrane localization is inferred from mammalian/plant FIS1
+      homologs, which act in peroxisome fission. Plausible for worm fis-2 by
+      homology but not directly demonstrated, and fis-1;fis-2 mutants have normal
+      (punctate) peroxisomes. Retain as a non-core, homology-based localization.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      No direct worm evidence for peroxisomal localization or a peroxisomal role;
+      family-level propagation. Not a core function of C. elegans fis-2.
+    supported_by:
+    - reference_id: PMID:24196833
+      supporting_text: showing punctate peroxisomes in wild-type and Fis1 mutants
+- term:
+    id: GO:0000266
+    label: mitochondrial fission
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Mitochondrial fission is the ancestral FIS1-family process, but in C. elegans
+      loss of fis-2 (alone or with fis-1) does NOT impair mitochondrial fission or
+      morphology, and Fis1 homologs are not essential for fission or DRP-1
+      recruitment (MFF/DRP-1 are the essential factors). Retain as non-core: fis-2
+      belongs to the fission machinery at the family level but is not required for
+      fission in worm.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Defensible at the family level, but loss-of-function is phenotypically silent
+      for fission in worm; this is not the core, essential fission determinant.
+    supported_by:
+    - reference_id: PMID:24196833
+      supporting_text: &gt;-
+        Our results show that fis-1 and fis-2 single and double mutants have wild-type
+        mitochondrial morphologies, as also shown by others
+    - reference_id: PMID:24196833
+      supporting_text: &gt;-
+        Mff and Fis1 are not essential for fission or for Drp1 recruitment to
+        mitochondria in C. elegans
+- term:
+    id: GO:0016559
+    label: peroxisome fission
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Peroxisome fission is a documented FIS1 function in mammals and plants, but in
+      C. elegans fis-1;fis-2 mutants have normal punctate peroxisomes and only
+      Mff/Drp1 loss produces tubular (fission-defective) peroxisomes. Family-level
+      propagation not supported by direct worm evidence; retain as non-core.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      No demonstrated peroxisome-fission role for worm fis-2; the worm data show
+      normal peroxisomes in Fis1 mutants. Keep as homology-based, non-core.
+    supported_by:
+    - reference_id: PMID:24196833
+      supporting_text: &gt;-
+        showing punctate peroxisomes in wild-type and Fis1 mutants and tubular
+        peroxisomes in drp-1 mutant and Mff double mutants
+    propagation_review:
+      root_cause: PROPAGATION_BAD
+      failure_modes:
+      - FUNCTIONAL_DIVERGENCE
+      source_entities:
+      - source_id: PANTHER:PTN000326738
+        source_label: FIS1 family node
+        source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
+- term:
+    id: GO:0000266
+    label: mitochondrial fission
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Electronic InterPro2GO mapping of the Fis1 domain (IPR016543) to mitochondrial
+      fission. Same considerations as the IBA mitochondrial-fission annotation:
+      defensible at the family/domain level but not the core essential fission role
+      in worm.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Redundant with the IBA mitochondrial-fission annotation; family/domain-level
+      inference. Non-core given the loss-of-function-silent fission phenotype in
+      worm.
+- term:
+    id: GO:0005739
+    label: mitochondrion
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000120
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Automated electronic annotation to the mitochondrion. Correct and corroborated
+      by the direct experimental (IDA) mitochondrial localization from PMID:18722182
+      and by ISS from human FIS1.
+    action: ACCEPT
+    reason: &gt;-
+      Well-supported core localization; consistent with the experimental IDA
+      annotation.
+- term:
+    id: GO:0005741
+    label: mitochondrial outer membrane
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000044
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      UniProt subcellular-location mapping to mitochondrial outer membrane,
+      consistent with the FIS1 tail-anchor topology and ISS from human FIS1.
+    action: ACCEPT
+    reason: &gt;-
+      Well-supported core localization; redundant with the ISS annotation and
+      consistent with the experimental mitochondrial localization.
+- term:
+    id: GO:0005778
+    label: peroxisomal membrane
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000044
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      UniProt subcellular-location mapping to peroxisomal membrane, transferred from
+      the mammalian FIS1 dual localization. Not directly shown in worm; non-core.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Homology-based peroxisomal localization; no direct C. elegans evidence. Retain
+      as non-core.
+- term:
+    id: GO:0005741
+    label: mitochondrial outer membrane
+  evidence_type: ISS
+  original_reference_id: GO_REF:0000024
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      ISS transfer of mitochondrial outer membrane localization from human FIS1
+      (Q9Y3D6). Consistent with the fis-2 IDA mitochondrial localization and the
+      tail-anchor topology.
+    action: ACCEPT
+    reason: Well-supported core localization; consistent with experimental worm data.
+- term:
+    id: GO:0005778
+    label: peroxisomal membrane
+  evidence_type: ISS
+  original_reference_id: GO_REF:0000024
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      ISS transfer of peroxisomal membrane localization from human FIS1. Plausible by
+      homology but not demonstrated in worm; non-core.
+    action: KEEP_AS_NON_CORE
+    reason: Homology-based; no direct worm evidence for peroxisomal localization.
+- term:
+    id: GO:0036498
+    label: IRE1-mediated unfolded protein response
+  evidence_type: HEP
+  original_reference_id: PMID:16184190
+  qualifier: acts_upstream_of_or_within
+  review:
+    summary: &gt;-
+      High-throughput expression-profiling (HEP) annotation: fis-2 (F13B9.8) was
+      identified as a UPR-regulated gene in a genome-wide microarray study of the
+      C. elegans unfolded protein response. This reflects transcriptional
+      co-regulation of fis-2 with the IRE1/XBP-1 UPR, not a demonstrated functional
+      role of fis-2 within the UPR pathway. fis-2 is not named in the paper&#39;s text
+      (the evidence is in supplementary tables), so no verbatim supporting quote is
+      available.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Expression-based (HEP) association only; being a UPR target gene does not
+      establish that fis-2 acts in the UPR. Retain as a peripheral, non-core
+      annotation reflecting transcriptional responsiveness, not core function.
+- term:
+    id: GO:0005739
+    label: mitochondrion
+  evidence_type: IDA
+  original_reference_id: PMID:18722182
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Direct experimental (IDA) mitochondrial localization of FIS-2 curated by
+      WormBase from Breckenridge et al. 2008. This is the strongest, fis-2-specific
+      evidence for FIS-2 localization and anchors the core cellular component. The
+      cached record is abstract-only, so the localization figure is not quotable
+      here; the annotation is retained on the WormBase curator&#39;s IDA assignment.
+    action: ACCEPT
+    reason: &gt;-
+      Direct experimental assay in C. elegans (WormBase IDA); the experimental basis
+      for FIS-2 mitochondrial localization.
+- term:
+    id: GO:0006915
+    label: apoptotic process
+  evidence_type: IGI
+  original_reference_id: PMID:18722182
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      The only individually demonstrated fis-2 function. Genetic-interaction (IGI)
+      evidence: fis-2 has a minor pro-apoptotic role, revealed in sensitized
+      genetic backgrounds, acting downstream of the CED-3 caspase and independently
+      of DRP-1 and CED-9 to promote elimination of mitochondria in dying cells and
+      facilitate cell-death execution. The effect is minor (fis-2 single mutants
+      show only small changes in cell-corpse numbers), so this is a genuine but
+      non-essential role.
+    action: ACCEPT
+    reason: &gt;-
+      Experimentally supported, fis-2-specific role in cell-death execution (IGI
+      with ced-3). This is the best-characterized function of fis-2 and should be
+      retained.
+    supported_by:
+    - reference_id: PMID:18722182
+      supporting_text: &gt;-
+        minor proapoptotic roles for drp-1 and fis-2, a homolog of human Fis1, are
+        revealed in sensitized genetic backgrounds
+    - reference_id: PMID:18722182
+      supporting_text: &gt;-
+        reveal distinct roles for drp-1 and fis-2 as mediators of cell-death
+        execution downstream of caspase activation
+- term:
+    id: GO:0000423
+    label: mitophagy
+  evidence_type: IGI
+  original_reference_id: PMID:24196833
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Proposed new annotation (not currently in GOA). Genetic loss of both FIS1
+      paralogs (the fis-1;fis-2 double mutant) disrupts the orderly disposal of
+      defective mitochondria: mitochondrial stress induces accumulation of large
+      LGG-1/LC3-positive autophagic aggregates containing mitochondrial remnants
+      and DRP-1, and these aggregates/mitophagosome spots are suppressed by drp-1,
+      mff, and pink-1 mutations. fis-2 is genetically part of this pathway
+      (drp-1 fis-1 fis-2 and pink-1 fis-1 fis-2 triple mutants). IMPORTANT: the
+      disposal phenotype was only demonstrated in the fis-1;fis-2 double, so fis-2&#39;s
+      contribution is redundant with fis-1, not shown to be fis-2-autonomous.
+    action: NEW
+    reason: &gt;-
+      Captures the experimentally supported biological process in which fis-2
+      participates (coupling stress-induced fission to mitophagic disposal),
+      currently absent from GOA. Annotated as IGI (redundancy with fis-1) to reflect
+      that the phenotype requires loss of both paralogs.
+    supported_by:
+    - reference_id: PMID:24196833
+      supporting_text: &gt;-
+        pink-1 single and pink-1 fis-1 fis-2 triple mutant animals had no colocalizing
+        spots, as expected for a complete block of mitophagy
+    - reference_id: PMID:24196833
+      supporting_text: &gt;-
+        a drp-1 fis-1 fis-2 triple mutant strain also had reduced number and size of
+        aggregates when treated with Paraquat
+core_functions:
+- description: &gt;-
+    FIS-2 is a tail-anchored mitochondrial outer membrane protein of the FIS1
+    family that functions in the disposal of mitochondria rather than in the core
+    fission reaction. Its individually demonstrated role is a minor pro-apoptotic
+    (cell-death execution) function: acting downstream of the CED-3 caspase and
+    independently of DRP-1 and CED-9, it promotes elimination of mitochondria in
+    dying cells. Redundantly with the paralog fis-1, it also contributes to the
+    orderly, PINK-1-dependent disposal of stress-damaged mitochondria downstream
+    of MFF/DRP-1-mediated fission. Its molecular activity is inferred, at the
+    family level only, to be that of a membrane adaptor/receptor.
+  molecular_function:
+    id: GO:0060090
+    label: molecular adaptor activity
+  directly_involved_in:
+  - id: GO:0006915
+    label: apoptotic process
+  - id: GO:0000423
+    label: mitophagy
+  locations:
+  - id: GO:0005741
+    label: mitochondrial outer membrane
+  supported_by:
+  - reference_id: PMID:18722182
+    supporting_text: &gt;-
+      minor proapoptotic roles for drp-1 and fis-2, a homolog of human Fis1, are
+      revealed in sensitized genetic backgrounds
+  - reference_id: PMID:24196833
+    supporting_text: &gt;-
+      pink-1 single and pink-1 fis-1 fis-2 triple mutant animals had no colocalizing
+      spots, as expected for a complete block of mitophagy
+  - reference_id: PMID:24196833
+    supporting_text: &gt;-
+      Fis1 is part of the MAM complex and contributes to a late stage of the removal
+      process but is not required for entry of Drp1 into the MAM or fission
+knowledge_gaps:
+- gap_statement: &gt;-
+    The molecular activity of FIS-2 is entirely undetermined experimentally. Its
+    only molecular-function annotation (&#34;molecular adaptor activity&#34;) is a
+    phylogenetic (IBA) propagation from the FIS1 family; no C. elegans FIS-2
+    protein has been shown to bind DRP-1, a fission adaptor, lipid, or any other
+    partner, and no biochemical or structural study of worm FIS-2 exists.
+  boundary: &gt;-
+    Established: FIS-2 is a FIS1-family tail-anchored protein of the mitochondrial
+    outer membrane (IDA mitochondrion; ISS/tail-anchor topology) that participates
+    genetically in mitochondrial disposal. Unknown: what FIS-2 actually does at the
+    molecular level - its direct binding partner(s) and the biochemical activity,
+    if any, beyond membrane anchoring.
+  gap_kind:
+  - BIOLOGY
+  dark_aspect: MF_DARK
+  status: OPEN
+  significance: &gt;-
+    FIS1 has long been presumed a fission receptor; worm (and mammalian) data
+    reassign the family to mitochondrial quality-control roles whose mechanism is
+    unresolved. For the fis-2 paralog specifically, even the assumed adaptor
+    activity is untested, making it a genuinely dark molecular function relevant to
+    PINK1/Parkin quality-control biology.
+  provenance:
+  - reference_id: PMID:24196833
+    supporting_text: &gt;-
+      Mff and Fis1 are not essential for fission or for Drp1 recruitment to
+      mitochondria in C. elegans
+- gap_statement: &gt;-
+    Whether FIS-2 has any non-redundant, fis-2-autonomous role in mitochondrial
+    disposal/mitophagy is unresolved. Every mitophagy/LGG-1-aggregate phenotype
+    was scored in the fis-1(tm1867); fis-2(gk414) double mutant (the &#34;Fis1
+    mutant&#34;), and both single mutants have wild-type mitochondrial morphology, so
+    the individual contribution of fis-2 to orderly disposal (versus complete
+    redundancy with, or dispensability relative to, fis-1) has not been measured.
+  boundary: &gt;-
+    Established: the fis-1;fis-2 double mutant accumulates stress-induced LGG-1
+    aggregates and lies genetically downstream of MFF/DRP-1 and PINK-1. Unknown:
+    what a fis-2 single loss-of-function does to mitophagic flux, and whether fis-2
+    contributes anything the paralog fis-1 does not.
+  gap_kind:
+  - BIOLOGY
+  dark_aspect: RESIDUAL_SUBGAP
+  status: OPEN
+  significance: &gt;-
+    Distinguishing redundant from specialized paralog functions is required before
+    fis-2 can be assigned a specific mitophagy role rather than a family-level one,
+    and determines whether fis-2 is a distinct quality-control node or a fis-1
+    backup.
+  provenance:
+  - reference_id: PMID:24196833
+    supporting_text: &gt;-
+      Our results show that fis-1 and fis-2 single and double mutants have wild-type
+      mitochondrial morphologies, as also shown by others
+- gap_statement: &gt;-
+    The direct binding partners and interactome of C. elegans FIS-2 are unmapped.
+    It is unknown whether FIS-2 binds DRP-1 (directly or via an adaptor
+    intermediate analogous to yeast Mdv1/Caf4), whether it joins an
+    ER-mitochondria (MAM) fission/disposal complex as mammalian FIS1 does under
+    stress, and which downstream autophagy or apoptotic-machinery factors it
+    engages.
+  boundary: &gt;-
+    Established (in mammals): stress induces a DRP-1-FIS1 co-immunoprecipitable
+    complex that also contains ER/MAM proteins. Unknown (for worm FIS-2): its
+    physical interactors, and whether the mammalian complex applies to this
+    paralog.
+  gap_kind:
+  - BIOLOGY
+  - CURATION
+  dark_aspect: MF_DARK
+  status: OPEN
+  provenance:
+  - reference_id: PMID:24196833
+    supporting_text: &gt;-
+      Recruitment of Drp1 to mitochondria is mediated by proteins that are anchored
+      in the mitochondrial outer membrane
+- gap_statement: &gt;-
+    The mechanism and biological significance of the fis-2-specific pro-apoptotic
+    role are unknown. fis-2 promotes elimination of mitochondria in dying cells
+    downstream of CED-3 and independently of DRP-1/CED-9, but whether this uses the
+    same membrane machinery as its (redundant) mitophagy role, why the effect is
+    only detectable in sensitized backgrounds, and why this activity is
+    foregrounded for fis-2 but not fis-1, are all unresolved.
+  boundary: &gt;-
+    Established: in sensitized backgrounds fis-2 has a minor, CED-3-dependent,
+    DRP-1/CED-9-independent pro-apoptotic effect on mitochondrial elimination.
+    Unknown: the molecular basis of this activity and its relationship to the
+    paralog-redundant mitophagy pathway.
+  gap_kind:
+  - BIOLOGY
+  dark_aspect: MF_DARK
+  status: OPEN
+  provenance:
+  - reference_id: PMID:18722182
+    supporting_text: &gt;-
+      drp-1 and fis-2 function independent of one another and the Bcl-2 homolog
+      CED-9 and downstream of the CED-3 caspase to promote elimination of
+      mitochondria in dying cells
+proposed_new_terms: []
+suggested_questions:
+- question: &gt;-
+    Does a fis-2 single loss-of-function (independent of fis-1) measurably alter
+    mitophagic flux or mitochondrial quality control, or is fis-2 fully redundant
+    with fis-1?
+- question: &gt;-
+    Does C. elegans FIS-2 physically interact with DRP-1 or MAM/ER-mitochondria
+    components, and does it use an adaptor intermediate, as mammalian FIS1 does
+    under stress?
+- question: &gt;-
+    Do the two worm FIS1 paralogs partition functionally (fis-2 toward
+    cell-death-execution disposal, fis-1 toward UVC/mtDNA-damage removal), or are
+    they interchangeable?
+suggested_experiments:
+- hypothesis: &gt;-
+    FIS-2 makes a distinct, non-redundant contribution to stress-induced mitophagy
+    that is masked by the paralog fis-1 in double-mutant analyses.
+  description: &gt;-
+    Compare stage-resolved mitophagy flux (mito-Rosella / mtKeima or LGG-1 puncta
+    maturation) after Paraquat or antimycin A across wild-type, fis-2 single,
+    fis-1 single, and fis-1;fis-2 double mutants, with allele-specific rescue, to
+    isolate any fis-2-autonomous step.
+- hypothesis: &gt;-
+    Worm FIS-2 has direct or adaptor-mediated partners at the mitochondrial outer
+    membrane / ER-mitochondrial interface.
+  description: &gt;-
+    Use proximity labeling (TurboID) or co-immunoprecipitation of endogenously
+    tagged FIS-2 from C. elegans under basal and mitochondrial-stress conditions to
+    identify DRP-1, MAM, and autophagy/apoptosis interactors and to test for
+    adaptor intermediates, comparing the FIS-2 and FIS-1 interactomes.
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/genes/worm/glh-2/glh-2-ai-review.html
+++ b/genes/worm/glh-2/glh-2-ai-review.html
@@ -1,0 +1,4421 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>glh-2 - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        .propagation-review {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f8fafc;
+            border-left: 3px solid #64748b;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .propagation-title {
+            font-weight: 600;
+            color: #334155;
+            margin-bottom: 0.25rem;
+        }
+
+        .propagation-row {
+            margin-top: 0.25rem;
+        }
+
+        .propagation-source {
+            margin-top: 0.5rem;
+            padding-top: 0.5rem;
+            border-top: 1px solid #e5e7eb;
+        }
+
+        .propagation-source-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #1d4ed8;
+        }
+
+        .propagation-comment {
+            color: #4b5563;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>glh-2</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/Q966L9" target="_blank" class="term-link">
+                        Q966L9
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Caenorhabditis elegans</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-complete">
+                    COMPLETE
+                </span>
+            </div>
+
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "glh-2";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="Q966L9" data-a="DESCRIPTION: GLH-2 (Germline Helicase 2) is a Vasa/DDX4-class A..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>GLH-2 (Germline Helicase 2) is a Vasa/DDX4-class ATP-dependent DEAD-box RNA helicase and a constitutive component of the germline-specific P granules of Caenorhabditis elegans. It is one of four partially redundant GLH paralogs (GLH-1, GLH-2, GLH-3, GLH-4); glh-1 and glh-2 map close together and arose from a relatively recent duplication. The protein has a central DEAD-box helicase core (ATP-binding and C-terminal helicase domains with the Q motif and DEAD box), six CCHC-type zinc fingers of the retroviral nucleocapsid RNA-binding type, and a large N-terminal glycine/FG-rich intrinsically disordered region typical of GLH proteins. GLH-2 is present in P granules at all stages of germline development, is cytoplasmic in oocytes and the early embryo and perinuclear in later germ cells, and physically associates with the JNK-family MAP kinase KGB-1 as well as with itself. Within the GLH family, GLH-1 is the key member for fertility (with GLH-4 acting redundantly), whereas a glh-2 deletion is not individually essential; GLH-2 contributes to germline proliferation, gametogenesis and P-granule biology in a largely redundant manner.</p>
+    </div>
+
+
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003724" target="_blank" class="term-link">
+                                    GO:0003724
+                                </a>
+                            </span>
+                            <span class="term-label">RNA helicase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q966L9" data-a="GO:0003724" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetic (IBA) inference of ATP-dependent RNA helicase activity from the Vasa/DDX4 DEAD-box subfamily. GLH-2 has the complete DEAD-box helicase core (Q motif, DEAD box, ATP-binding and helicase C-terminal domains) plus six CCHC RNA-binding zinc fingers.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Core molecular function, well-supported by domain architecture and family membership (DDX4/VASA subfamily). Consistent with the IDA and IEA RNA-helicase annotations. Note that direct in vitro unwinding activity has not been demonstrated for GLH-2 specifically (captured in knowledge_gaps).
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/8943022" target="_blank" class="term-link">
+                                        PMID:8943022
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Both components are putative germ-line RNA helicases (GLHs) that contain CCHC zinc fingers of the type found in the RNA-binding nucleocapsid proteins of retroviruses.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005634" target="_blank" class="term-link">
+                                    GO:0005634
+                                </a>
+                            </span>
+                            <span class="term-label">nucleus</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q966L9" data-a="GO:0005634" data-r="GO_REF:0000033" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IBA inference of nuclear localization propagated from Vasa/DDX4-family members. GLH-2 is predominantly a cytoplasmic/perinuclear P-granule protein (cytoplasmic in oocytes and early embryo, perinuclear in later germ cells), so the nucleus is not its principal site of action. However, unlike GLH-1, GLH-2 has separately been reported (WormBase/secondary sources; not verifiable from the abstract-only cached primaries) to associate with sperm chromatin, so a minor nuclear association cannot be excluded.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Predominant, experimentally documented localization is the perinuclear cytoplasmic P granule, not the nucleus, so nucleus is not a core location. A confident REMOVE is not warranted given the general uncertainty of the phylogenetic inference and a reported (secondary-source) GLH-2 sperm-chromatin association; retained as non-core rather than removed.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12435362" target="_blank" class="term-link">
+                                        PMID:12435362
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">These putative ATP-dependent enzymes localize to the P granules, which are nonmembranous complexes of protein and RNA exclusively found in the cytoplasm of all C. elegans germ cells and germ cell precursors.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0007276" target="_blank" class="term-link">
+                                    GO:0007276
+                                </a>
+                            </span>
+                            <span class="term-label">gamete generation</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q966L9" data-a="GO:0007276" data-r="GO_REF:0000033" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IBA inference that GLH-2 participates in gamete generation. Consistent with the germline expression and P-granule localization of GLH proteins and with antisense-induced sterility, though a glh-2 deletion alone is largely fertile.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Broad germline-process term. GLH-2 contributes to gametogenesis but in a partially redundant manner (glh-2 null is not individually sterile; GLH-1/GLH-4 carry the essential function). The more specific germ cell development term better captures the supported role; retained as non-core.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/18430929" target="_blank" class="term-link">
+                                        PMID:18430929
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The other GLHs are not essential.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0007281" target="_blank" class="term-link">
+                                    GO:0007281
+                                </a>
+                            </span>
+                            <span class="term-label">germ cell development</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q966L9" data-a="GO:0007281" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IBA inference of a role in germ cell development, consistent with GLH-2&#39;s constitutive P-granule localization throughout germline development and with the experimental antisense phenotype.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Best-supported biological-process term for GLH-2, corroborated by the IMP annotation from antisense knockdown (PMID:8943022). Represents GLH-2&#39;s core germline role, albeit exercised largely redundantly with the other GLHs.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/8943022" target="_blank" class="term-link">
+                                        PMID:8943022
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">suggesting that either or both genes are required for normal germ-line development</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030154" target="_blank" class="term-link">
+                                    GO:0030154
+                                </a>
+                            </span>
+                            <span class="term-label">cell differentiation</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q966L9" data-a="GO:0030154" data-r="GO_REF:0000033" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Very general IBA differentiation term. GLH-2 acts in germ-cell (germline) differentiation as part of P-granule biology, but this generic term is far less informative than germ cell development.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct in the broadest sense but uninformative; germ cell development (GO:0007281) is the more specific and appropriate term. Retained as non-core.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/8943022" target="_blank" class="term-link">
+                                        PMID:8943022
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">suggesting that either or both genes are required for normal germ-line development</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0043186" target="_blank" class="term-link">
+                                    GO:0043186
+                                </a>
+                            </span>
+                            <span class="term-label">P granule</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q966L9" data-a="GO:0043186" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> GLH-2 is a constitutive component of germline P granules, the defining localization of the GLH family, present at all stages of germline development.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Core, experimentally established localization (also annotated by IDA). P-granule residence is central to GLH-2&#39;s function as a germline RNP helicase.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/8943022" target="_blank" class="term-link">
+                                        PMID:8943022
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Both GLH proteins localize in the P granules at all stage of germ-line development.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003729" target="_blank" class="term-link">
+                                    GO:0003729
+                                </a>
+                            </span>
+                            <span class="term-label">mRNA binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q966L9" data-a="GO:0003729" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IBA inference of mRNA binding from the Vasa/DDX4 subfamily. GLH-2 has six CCHC-type RNA-binding zinc fingers and a DEAD-box core that engages RNA, making RNA/mRNA binding well-motivated structurally.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> RNA binding is a core molecular feature of GLH-2 (CCHC zinc fingers plus DEAD-box domain); mRNA binding is a reasonable specific for a germline RNP helicase. The precise cellular RNA substrates of GLH-2 have not been identified (see knowledge_gaps).
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/8943022" target="_blank" class="term-link">
+                                        PMID:8943022
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">contain CCHC zinc fingers of the type found in the RNA-binding nucleocapsid proteins of retroviruses</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003676" target="_blank" class="term-link">
+                                    GO:0003676
+                                </a>
+                            </span>
+                            <span class="term-label">nucleic acid binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q966L9" data-a="GO:0003676" data-r="GO_REF:0000002" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Very general IEA annotation inferred from InterPro domains (CCHC zinc fingers and the DEAD/DEAH box helicase domain).
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct but overly general; subsumed by the more specific and informative RNA binding / mRNA binding annotations. Retained as non-core.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    GO_REF:0000002
+
+                                </span>
+
+                                <div class="support-text">InterPro:IPR001878|InterPro:IPR011545|InterPro:IPR036875</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003724" target="_blank" class="term-link">
+                                    GO:0003724
+                                </a>
+                            </span>
+                            <span class="term-label">RNA helicase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000120
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q966L9" data-a="GO:0003724" data-r="GO_REF:0000120" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic annotation of RNA helicase activity from combined IEA methods (InterPro DEAD-box signatures and EC 3.6.4.13).
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Redundant with the higher-quality IBA and IDA RNA-helicase annotations but correct; the automated inference from DEAD-box domain architecture is accurate.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    GO_REF:0000120
+
+                                </span>
+
+                                <div class="support-text">ARBA:ARBA00028402|InterPro:IPR014014|EC:3.6.4.13</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005524" target="_blank" class="term-link">
+                                    GO:0005524
+                                </a>
+                            </span>
+                            <span class="term-label">ATP binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q966L9" data-a="GO:0005524" data-r="GO_REF:0000002" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> GLH-2 binds ATP as substrate for its helicase/ATPase cycle; it has a conserved P-loop/Walker A ATP-binding motif (residues 596-603) within the helicase ATP-binding domain.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Essential supporting activity for DEAD-box RNA helicase function; well-supported by domain architecture (IPR011545).
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    GO_REF:0000002
+
+                                </span>
+
+                                <div class="support-text">InterPro:IPR011545</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0007281" target="_blank" class="term-link">
+                                    GO:0007281
+                                </a>
+                            </span>
+                            <span class="term-label">germ cell development</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000117
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q966L9" data-a="GO:0007281" data-r="GO_REF:0000117" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic (ARBA) annotation of germ cell development, consistent with the IBA and experimental IMP annotations.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Redundant with the IBA and IMP germ cell development annotations but correct.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    GO_REF:0000117
+
+                                </span>
+
+                                <div class="support-text">ARBA:ARBA00028319</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008270" target="_blank" class="term-link">
+                                    GO:0008270
+                                </a>
+                            </span>
+                            <span class="term-label">zinc ion binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q966L9" data-a="GO:0008270" data-r="GO_REF:0000002" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> GLH-2 has six CCHC-type zinc fingers (positions 257-274, 282-299, 371-388, 396-413, 453-470, 473-490) that each coordinate a zinc ion.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Well-supported by domain architecture; the six CCHC fingers are a distinctive feature of GLH-2 (more than GLH-1&#39;s four).
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/8943022" target="_blank" class="term-link">
+                                        PMID:8943022
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The predicted GLH-1 protein has four CCHC fingers; GLH-2 has six.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008432" target="_blank" class="term-link">
+                                    GO:0008432
+                                </a>
+                            </span>
+                            <span class="term-label">JUN kinase binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000117
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q966L9" data-a="GO:0008432" data-r="GO_REF:0000117" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic (ARBA) annotation of JUN kinase binding, supported by the experimental IPI evidence that GLH proteins bind the JNK-family MAP kinase KGB-1.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Consistent with the IPI annotation from PMID:12435362; GLHs (including GLH-2) physically associate with KGB-1.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12435362" target="_blank" class="term-link">
+                                        PMID:12435362
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">KGB-1 is a putative JNK MAP kinase that GLHs bind.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0009791" target="_blank" class="term-link">
+                                    GO:0009791
+                                </a>
+                            </span>
+                            <span class="term-label">post-embryonic development</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000117
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q966L9" data-a="GO:0009791" data-r="GO_REF:0000117" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic (ARBA) annotation of post-embryonic development, consistent with the IMP annotation reflecting the larval/adult timing of germline proliferation.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Broad developmental term; redundant with the IMP annotation and less informative than germ cell development. Retained as non-core.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    GO_REF:0000117
+
+                                </span>
+
+                                <div class="support-text">ARBA:ARBA00029007</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016887" target="_blank" class="term-link">
+                                    GO:0016887
+                                </a>
+                            </span>
+                            <span class="term-label">ATP hydrolysis activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000116
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q966L9" data-a="GO:0016887" data-r="GO_REF:0000116" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> GLH-2 catalyzes ATP hydrolysis (RHEA:13065; ATP + H2O = ADP + phosphate + H+) as the energetic step of its DEAD-box RNA helicase cycle.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Core catalytic step of the DEAD-box helicase, correctly inferred from the Rhea reaction mapping and consistent with EC 3.6.4.13. Whether this ATPase/unwinding activity is catalytically required for GLH-2&#39;s in vivo role has not been directly tested (see knowledge_gaps).
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    GO_REF:0000116
+
+                                </span>
+
+                                <div class="support-text">RHEA:13065</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0043186" target="_blank" class="term-link">
+                                    GO:0043186
+                                </a>
+                            </span>
+                            <span class="term-label">P granule</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000117
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q966L9" data-a="GO:0043186" data-r="GO_REF:0000117" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic (ARBA) annotation of P-granule localization, redundant with the direct experimental (IDA) evidence.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct and strongly corroborated by IDA; P-granule residence is a defining feature of GLH-2.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    GO_REF:0000117
+
+                                </span>
+
+                                <div class="support-text">ARBA:ARBA00026989</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/12435362" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:12435362
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The GLH proteins, Caenorhabditis elegans P granule component...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-modify">
+                            MODIFY
+                        </span>
+                        <span class="vote-buttons" data-g="Q966L9" data-a="GO:0005515" data-r="PMID:12435362" data-act="MODIFY">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IPI annotation (with UniProtKB:O44408 = KGB-1) recording a physical interaction between GLH-2 and the JNK-family MAP kinase KGB-1, demonstrated by yeast two-hybrid and GST pull-down.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> &#34;Protein binding&#34; is uninformative. The interacting partner recorded in the with/from field is KGB-1, a JUN/JNK-family kinase, so the more specific JUN kinase binding (GO:0008432) captures the same experimental interaction and is already annotated separately.
+                        </div>
+
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008432" target="_blank" class="term-link">
+                                    JUN kinase binding
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12435362" target="_blank" class="term-link">
+                                        PMID:12435362
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">KGB-1 is a putative JNK MAP kinase that GLHs bind.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008432" target="_blank" class="term-link">
+                                    GO:0008432
+                                </a>
+                            </span>
+                            <span class="term-label">JUN kinase binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/12435362" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:12435362
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The GLH proteins, Caenorhabditis elegans P granule component...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q966L9" data-a="GO:0008432" data-r="PMID:12435362" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Experimentally demonstrated interaction between GLH proteins (including GLH-2) and KGB-1, a C. elegans JNK-family MAP kinase, by yeast two-hybrid and GST pull-down. The GLH-KGB-1 interaction maps to the GLH C-terminus.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Well-supported experimental interaction (IPI). KGB-1 is a fertility factor whose loss phenocopies glh-1/glh-4 sterility, making the interaction functionally relevant to germline homeostasis.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12435362" target="_blank" class="term-link">
+                                        PMID:12435362
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">GST pull-down assays independently established that these proteins bind GLHs.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003724" target="_blank" class="term-link">
+                                    GO:0003724
+                                </a>
+                            </span>
+                            <span class="term-label">RNA helicase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/8943022" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:8943022
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Multiple potential germ-line helicases are components of the...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q966L9" data-a="GO:0003724" data-r="PMID:8943022" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Original characterization of GLH-2 as a putative RNA helicase based on the DEAD-box helicase domain and CCHC zinc fingers. The IDA code is generous here since the evidence is primarily sequence/domain-based rather than a direct in vitro unwinding assay.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The RNA helicase classification is sound from the complete DEAD-box motif complement and DDX4/VASA family membership, and is reinforced by the IBA/IEA annotations. Per curation guidance, an experimental annotation whose full text was read by the curator is not removed; the caveat about lacking a direct biochemical assay is recorded in knowledge_gaps.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/8943022" target="_blank" class="term-link">
+                                        PMID:8943022
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Both components are putative germ-line RNA helicases (GLHs) that contain CCHC zinc fingers</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0007281" target="_blank" class="term-link">
+                                    GO:0007281
+                                </a>
+                            </span>
+                            <span class="term-label">germ cell development</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/8943022" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:8943022
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Multiple potential germ-line helicases are components of the...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q966L9" data-a="GO:0007281" data-r="PMID:8943022" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Antisense knockdown of glh-2 causes sterility in some offspring, providing experimental evidence for a requirement in germline development. Later deletion-allele analysis (PMID:18430929) showed a glh-2 null is not individually sterile, indicating GLH-2&#39;s contribution is real but largely redundant with the other GLHs.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Direct experimental (IMP) evidence for a role in germ cell development; the curator read the full text. The deletion-allele refinement (non-essential individually) is captured in the reason and knowledge_gaps rather than by removing a valid experimental annotation.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/8943022" target="_blank" class="term-link">
+                                        PMID:8943022
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Injection of antisense glh-1 or glh-2 RNA into wild-type worms causes some offspring to develop into sterile adults, suggesting that either or both genes are required for normal germ-line development.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0009791" target="_blank" class="term-link">
+                                    GO:0009791
+                                </a>
+                            </span>
+                            <span class="term-label">post-embryonic development</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/8943022" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:8943022
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Multiple potential germ-line helicases are components of the...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q966L9" data-a="GO:0009791" data-r="PMID:8943022" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IMP annotation reflecting that glh-2 function is required during post-embryonic (larval-to-adult) germline proliferation, the developmental window in which GLH proteins accumulate.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Broad developmental term derived from the same antisense-sterility experiment; germ cell development is the more informative term. Retained as non-core.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/8943022" target="_blank" class="term-link">
+                                        PMID:8943022
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Injection of antisense glh-1 or glh-2 RNA into wild-type worms causes some offspring to develop into sterile adults</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016070" target="_blank" class="term-link">
+                                    GO:0016070
+                                </a>
+                            </span>
+                            <span class="term-label">RNA metabolic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ISS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/8943022" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:8943022
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Multiple potential germ-line helicases are components of the...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q966L9" data-a="GO:0016070" data-r="PMID:8943022" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> ISS annotation based on sequence similarity to RNA helicases. GLH-2 participates in RNA metabolism through RNP engagement/remodeling within P granules, but the specific RNA process it acts in is not defined for GLH-2.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct but very broad. No glh-2-specific evidence supports a more precise RNA-process term (e.g. a defined small-RNA or RNP-remodeling step), so the term is retained as non-core rather than replaced with an unsupported specific.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/8943022" target="_blank" class="term-link">
+                                        PMID:8943022
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Both components are putative germ-line RNA helicases (GLHs)</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0043186" target="_blank" class="term-link">
+                                    GO:0043186
+                                </a>
+                            </span>
+                            <span class="term-label">P granule</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/8943022" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:8943022
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Multiple potential germ-line helicases are components of the...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q966L9" data-a="GO:0043186" data-r="PMID:8943022" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct experimental identification of GLH-2 as a P-granule component using an antibody specific for GLH-2. This is the foundational evidence for GLH-2&#39;s defining subcellular localization.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> High-quality direct experimental (IDA) evidence for the core localization of GLH-2 in germline P granules.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/8943022" target="_blank" class="term-link">
+                                        PMID:8943022
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Both GLH proteins localize in the P granules at all stage of germ-line development.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>ATP-dependent DEAD-box RNA helicase that engages and remodels RNA/RNP within germline P granules through an ATP-binding and hydrolysis cycle. GLH-2 exercises this activity as a constitutive, partially redundant member of the GLH (Vasa/DDX4) family rather than as the essential family member.</h3>
+                <span class="vote-buttons" data-g="Q966L9" data-a="FUNCTION: ATP-dependent DEAD-box RNA helicase that engages a..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003724" target="_blank" class="term-link">
+                            RNA helicase activity
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0007281" target="_blank" class="term-link">
+                                germ cell development
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0043186" target="_blank" class="term-link">
+                                P granule
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/8943022" target="_blank" class="term-link">
+                                PMID:8943022
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">Both components are putative germ-line RNA helicases (GLHs) that contain CCHC zinc fingers of the type found in the RNA-binding nucleocapsid proteins of retroviruses.</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>RNA-binding component of germline P granules, engaging RNA through six CCHC-type zinc fingers together with the DEAD-box core; contributes to P-granule ribonucleoprotein organization in germ cells.</h3>
+                <span class="vote-buttons" data-g="Q966L9" data-a="FUNCTION: RNA-binding component of germline P granules, enga..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003729" target="_blank" class="term-link">
+                            mRNA binding
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0007281" target="_blank" class="term-link">
+                                germ cell development
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0043186" target="_blank" class="term-link">
+                                P granule
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/8943022" target="_blank" class="term-link">
+                                PMID:8943022
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">The predicted GLH-1 protein has four CCHC fingers; GLH-2 has six.</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000002.md" target="_blank" class="term-link">
+                            GO_REF:0000002
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation through association of InterPro records with GO terms</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
+                            GO_REF:0000033
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Annotation inferences using phylogenetic trees</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Phylogenetic (IBA) inference based on conservation within the Vasa/DDX4 DEAD-box helicase family</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000116.md" target="_blank" class="term-link">
+                            GO_REF:0000116
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Automatic Gene Ontology annotation based on Rhea mapping</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">RHEA:13065 (ATP + H2O = ADP + phosphate + H+) maps to ATP hydrolysis activity</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000117.md" target="_blank" class="term-link">
+                            GO_REF:0000117
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Electronic Gene Ontology annotations created by ARBA machine learning models</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000120.md" target="_blank" class="term-link">
+                            GO_REF:0000120
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Combined Automated Annotation using Multiple IEA Methods</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/8943022" target="_blank" class="term-link">
+                            PMID:8943022
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Multiple potential germ-line helicases are components of the germ-line-specific P granules of Caenorhabditis elegans.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">GLH-1 and GLH-2 are putative germline RNA helicases with retroviral-type CCHC zinc fingers</div>
+
+                        <div class="finding-text">"Both components are putative germ-line RNA helicases (GLHs) that contain CCHC zinc fingers of the type found in the RNA-binding nucleocapsid proteins of retroviruses."</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <div class="finding-statement">GLH-2 has six CCHC zinc fingers (GLH-1 has four)</div>
+
+                        <div class="finding-text">"The predicted GLH-1 protein has four CCHC fingers; GLH-2 has six."</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Both GLH proteins localize to P granules at all stages of germline development</div>
+
+                        <div class="finding-text">"Both GLH proteins localize in the P granules at all stage of germ-line development."</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Antisense glh-1 or glh-2 causes sterility in some offspring, indicating a requirement for normal germline development</div>
+
+                        <div class="finding-text">"Injection of antisense glh-1 or glh-2 RNA into wild-type worms causes some offspring to develop into sterile adults, suggesting that either or both genes are required for normal germ-line development."</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <div class="finding-statement">glh-1 and glh-2 map within a few hundred kb and likely arose from a recent duplication</div>
+
+                        <div class="finding-text">"As these very similar glh genes physically map within several hundred kilobases of one another, it seems likely that they represent a fairly recent gene duplication event."</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/12435362" target="_blank" class="term-link">
+                            PMID:12435362
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">The GLH proteins, Caenorhabditis elegans P granule components, associate with CSN-5 and KGB-1, proteins necessary for fertility, and with ZYX-1, a predicted cytoskeletal protein.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">The GLHs are a family of four germline RNA helicases that localize to cytoplasmic P granules</div>
+
+                        <div class="finding-text">"The GLH proteins belong to a family of four germline RNA helicases in Caenorhabditis elegans."</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <div class="finding-statement">GLHs bind KGB-1, a JNK-family MAP kinase, confirmed by GST pull-down</div>
+
+                        <div class="finding-text">"KGB-1 is a putative JNK MAP kinase that GLHs bind."</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Three GLH interactors (CSN-5, KGB-1, ZYX-1) were identified and confirmed to bind GLHs</div>
+
+                        <div class="finding-text">"GST pull-down assays independently established that these proteins bind GLHs."</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Loss of CSN-5 or KGB-1 stops oogenesis (like loss of GLH-1/GLH-4) but not initial P-granule assembly</div>
+
+                        <div class="finding-text">"Similar to the loss of GLH-1 and GLH-4, loss of either CSN-5 or KGB-1 causes oogenesis to cease, but does not affect the initial assembly of P granules."</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/18430929" target="_blank" class="term-link">
+                            PMID:18430929
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Genetic analysis of the Caenorhabditis elegans GLH family of P-granule proteins.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">C. elegans has four Vasa-family germline helicases, GLH-1 to GLH-4</div>
+
+                        <div class="finding-text">"In contrast to the single Vasa gene in most systems analyzed, Caenorhabditis elegans has four Vasa family members, the germline helicases GLH-1, GLH-2, GLH-3, and GLH-4."</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Deletion-allele analysis shows GLH-1 is the key family member for fertility</div>
+
+                        <div class="finding-text">"Our analysis of deletion alleles of each glh gene demonstrates that GLH-1 is the key member of the family"</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <div class="finding-statement">GLH-2, GLH-3 and GLH-4 are not individually essential</div>
+
+                        <div class="finding-text">"The other GLHs are not essential."</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <div class="finding-statement">GLH-1 and GLH-4 are required for proper association of PGL proteins with P granules (GLHs upstream of PGLs)</div>
+
+                        <div class="finding-text">"GLH-1 and GLH-4 are required for proper association of the PGL family of proteins with P granules"</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Questions for Experts</h2>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Does GLH-2 have any non-redundant germline function, or is it fully buffered by GLH-1/GLH-4? A glh-2 deletion is largely fertile, yet the protein is constitutively present in P granules at all germline stages.</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q966L9" data-a="Q: Does GLH-2 have any non-redundant germline functio..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> What is the functional significance of the reported association of GLH-2 with sperm chromatin? This nuclear association is distinct from the perinuclear-cytoplasmic localization shared with the other GLHs and could indicate a GLH-2-specific role.</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q966L9" data-a="Q: What is the functional significance of the reporte..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Do the six CCHC zinc fingers of GLH-2 (versus four in GLH-1) confer distinct RNA-binding specificity or a distinct set of RNA targets?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q966L9" data-a="Q: Do the six CCHC zinc fingers of GLH-2 (versus four..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Experiments</h2>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> In vitro RNA-unwinding and ATPase assays with purified GLH-2 to directly test whether it is a catalytically active DEAD-box RNA helicase and to characterize substrate preference.</p>
+
+
+
+                </div>
+                <span class="vote-buttons" data-g="Q966L9" data-a="EXPERIMENT: In vitro RNA-unwinding and ATPase assays with puri..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> CLIP-seq (or equivalent in vivo RNA-target mapping) of endogenously tagged GLH-2 in the germline to identify its bound RNAs and test whether these differ from GLH-1 targets.</p>
+
+
+
+                </div>
+                <span class="vote-buttons" data-g="Q966L9" data-a="EXPERIMENT: CLIP-seq (or equivalent in vivo RNA-target mapping..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Germline phenotyping of a catalytically-dead GLH-2 allele (DEAD-motif substitutions) and of glh-2 in combination with glh-1/glh-3/glh-4 mutations, to resolve GLH-2&#39;s specific and redundant contributions to fertility and P-granule organization.</p>
+
+
+
+                </div>
+                <span class="vote-buttons" data-g="Q966L9" data-a="EXPERIMENT: Germline phenotyping of a catalytically-dead GLH-2..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> IP-mass spectrometry of GLH-2 complexes compared to GLH-1/GLH-4, to identify GLH-2-specific interactors beyond the shared KGB-1/CSN-5/ZYX-1 partners.</p>
+
+
+
+                </div>
+                <span class="vote-buttons" data-g="Q966L9" data-a="EXPERIMENT: IP-mass spectrometry of GLH-2 complexes compared t..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Knowledge Gaps</h2>
+        <p style="color: #555; font-size: 0.92rem; margin-top: -0.3rem;">
+            What is <em>not</em> known — curated, literature-grounded statements of the open
+            unknowns (the inverse of core functions).
+        </p>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The non-redundant, GLH-2-specific molecular contribution to germline function is undetermined. It is unknown whether GLH-2 performs any unique step, substrate engagement, or regulatory role, or whether it acts purely as a partially redundant buffer for GLH-1/GLH-4.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">MF_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> A glh-2 deletion allele is not individually sterile; deletion-allele genetics establish GLH-1 (with redundant GLH-4) as the family member essential for fertility, while GLH-2 (and GLH-3) are not essential. GLH-2 is nonetheless a constitutive P-granule component expressed throughout germline development.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Distinguishing genuine functional specialization from mere redundancy is required before GLH-2 can be assigned a specific, non-inherited role, and would clarify why C. elegans retains four Vasa paralogs.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> glh-2 single-mutant molecular phenotyping (e.g. germline RNP/small-RNA profiling, GLH-2-specific interactome and RNA-target mapping) and paralog swap/rescue experiments assessing whether GLH-2 can substitute for GLH-1.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"The other GLHs are not essential."</em> — PMID:18430929</li>
+
+                <li><em>"Our analysis of deletion alleles of each glh gene demonstrates that GLH-1 is the key member of the family"</em> — PMID:18430929</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The direct in vivo RNA substrates of GLH-2 are unknown. Neither the RNAs bound by its six CCHC zinc fingers nor the transcripts it engages/remodels within P granules have been identified.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">MF_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> Domain architecture (six retroviral-type CCHC zinc fingers plus a complete DEAD-box helicase core) firmly predicts RNA binding, and GLH-2 resides in RNA-containing P granules, but no CLIP/target-identification study has defined its bound RNAs.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Identifying GLH-2&#39;s RNA targets would convert a homology-based &#34;RNA/mRNA binding&#34; inference into a mechanistic account of what GLH-2 does to which transcripts.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> In vivo crosslinking/immunoprecipitation (CLIP-seq) or equivalent RNA-target mapping for tagged GLH-2 in the germline.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"Both components are putative germ-line RNA helicases (GLHs) that contain CCHC zinc fingers of the type found in the RNA-binding nucleocapsid proteins of retroviruses."</em> — PMID:8943022</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> Whether GLH-2 has catalytically active ATP-dependent RNA-unwinding activity, and whether that catalysis is required for its in vivo role, is untested. No in vitro helicase/ATPase assay and no catalytic-dead (DEAD-motif / ATPase-cycle) allele analysis has been reported for GLH-2.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">RESIDUAL_SUBGAP</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> GLH-2 carries all conserved DEAD-box catalytic motifs (Q motif, DEAD box, Walker A/B, helicase C-terminal domain) and is classified EC 3.6.4.13; for the paralog GLH-1, ATPase-cycle mutations are known to perturb P-granule dynamics, but no comparable biochemistry or mutant analysis exists for GLH-2.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> DEAD-box family membership does not guarantee catalytic activity in vivo; testing GLH-2 catalysis distinguishes an active helicase from a scaffolding/RNA-clamp role and would confirm or qualify the RNA-helicase and ATP-hydrolysis annotations.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Purified-protein RNA-unwinding/ATPase assays and germline analysis of a catalytically-dead GLH-2 allele (e.g. DEAD-&gt;DAAD/DQAD substitutions).</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"Both components are putative germ-line RNA helicases (GLHs)"</em> — PMID:8943022</li>
+
+                <li><em>"The Vasa DEAD-box helicases are widespread markers of germ cells across species"</em> — PMID:18430929</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The mechanistic role of GLH-2 in P-granule assembly and organization is unresolved. Whether GLH-2 is required for, or merely present in, perinuclear condensate assembly and PGL recruitment has not been tested for GLH-2 individually.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">MF_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> Epistasis placing GLHs upstream of PGL proteins in P-granule assembly was established specifically for GLH-1 and GLH-4; P granules still form when GLH-1/GLH-4 are lost (via remaining GLH-2/GLH-3), but GLH-2&#39;s own contribution to condensate assembly has not been isolated.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Clarifying GLH-2&#39;s assembly role would show whether the four GLH paralogs contribute equivalently to condensate formation or have distinct structural/enzymatic inputs.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Live-imaging and epistasis of P-granule/PGL organization in glh-2 single and glh-2-containing multiple-mutant backgrounds, with and without catalytic activity.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"GLH-1 and GLH-4 are required for proper association of the PGL family of proteins with P granules"</em> — PMID:18430929</li>
+
+                <li><em>"loss of either CSN-5 or KGB-1 causes oogenesis to cease, but does not affect the initial assembly of P granules"</em> — PMID:12435362</li>
+
+            </ul>
+
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Tags</h2>
+        <div class="aliases">
+
+            <span class="badge">caeel-p-granules</span>
+
+        </div>
+    </div>
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Deep Research Sections -->
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(glh-2-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="Q966L9" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="glh-2-germline-helicase-2-research-notes">glh-2 (Germline helicase 2) — research notes</h1>
+<p>UniProt: Q966L9 (GLH2_CAEEL). WormBase: WBGene00001599 / C55B7.1. NCBI taxon 6239.<br />
+Family: DEAD-box helicase, DDX4/VASA subfamily. 974 aa, EC 3.6.4.13.<br />
+Human ortholog: DDX4 (VASA). Part of the CAEEL_P_GRANULES flagship project; glh-1 and glh-4<br />
+are already reviewed, glh-2 is the last GLH paralog.<br />
+See also the completed sibling reviews for paralog context:<br />
+genes/worm/glh-1/glh-1-ai-review.yaml and genes/worm/glh-4/glh-4-ai-review.yaml.</p>
+<h2 id="protein-architecture-from-uniprot-q966l9">Protein architecture (from UniProt Q966L9)</h2>
+<ul>
+<li>Central DEAD-box helicase core: Helicase ATP-binding domain (583-767), Helicase C-terminal<br />
+  domain (803-950). Q motif (552-580), DEAD box motif (710-713), ATP-binding P-loop (596-603).</li>
+<li>SIX CCHC-type zinc fingers (257-274, 282-299, 371-388, 396-413, 453-470, 473-490) — this<br />
+  distinguishes GLH-2 from GLH-1 (which has four). CCHC fingers are of the retroviral<br />
+  nucleocapsid RNA-binding type.</li>
+<li>Large N-terminal intrinsically disordered region (212-435 disordered) rich in Gly and<br />
+  FG/FGG-like Gly-Phe repeats (glycine-rich compositional bias). These FGG repeats in GLH<br />
+  proteins mediate perinuclear anchoring via FG-nucleoporins (established for GLH-1/GLH-4).</li>
+<li>PE 1: Evidence at protein level.</li>
+</ul>
+<h2 id="known-glh-2-specific-evidence">KNOWN (glh-2-specific evidence)</h2>
+<h3 id="molecular-function-structure">Molecular function / structure</h3>
+<ul>
+<li>GLH-2 is a putative germline RNA helicase with SIX CCHC zinc fingers.<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/8943022" title="The predicted GLH-1 protein has four CCHC fingers; GLH-2 has six">PMID:8943022</a></li>
+<li>Both GLH-1 and GLH-2 are "putative germ-line RNA helicases (GLHs) that contain CCHC zinc<br />
+  fingers of the type found in the RNA-binding nucleocapsid proteins of retroviruses."<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/8943022">PMID:8943022</a></li>
+<li>UniProt: "Probable ATP-binding RNA helicase." Catalytic activity ATP + H2O = ADP + Pi + H+<br />
+  (RHEA:13065), EC 3.6.4.13. Belongs to DEAD box helicase family, DDX4/VASA subfamily.</li>
+<li>NOTE: direct in vitro RNA-unwinding / ATPase biochemistry has NOT been published for GLH-2<br />
+  specifically (nor, in fact, for GLH-1). The "RNA helicase activity" IDA (PMID:8943022) is<br />
+  sequence/domain-based, not a biochemical unwinding assay. This is a genuine MF-dark gap.</li>
+</ul>
+<h3 id="localization">Localization</h3>
+<ul>
+<li>Constitutive P-granule component; both GLH proteins "localize in the P granules at all stage<br />
+  of germ-line development." <a href="https://pubmed.ncbi.nlm.nih.gov/8943022">PMID:8943022</a></li>
+<li>P granules are perinuclear (nuclear-pore associated) cytoplasmic RNP condensates in germ<br />
+  cells. GLH-2 is cytoplasmic in oocytes/early embryo and perinuclear in later stages<br />
+  (secondary source: Alliance/WormBase gene page, from Gruidl 1996 / Spike 2008 — not used as<br />
+  a verbatim citation because primary full text not cached).</li>
+<li>The IBA "nucleus" annotation: GLH proteins are predominantly perinuclear-cytoplasmic. HOWEVER<br />
+  GLH-2 has separately been reported to associate with sperm chromatin (noted in the Spike 2008<br />
+  discussion), i.e. a possible bona fide nuclear association distinct from glh-1. So unlike the<br />
+  glh-1 review (which REMOVED nucleus), for glh-2 nucleus is better kept as non-core than<br />
+  removed outright.</li>
+</ul>
+<h3 id="biological-process-genetics">Biological process / genetics</h3>
+<ul>
+<li>Antisense knockdown: "Injection of antisense glh-1 or glh-2 RNA into wild-type worms causes<br />
+  some offspring to develop into sterile adults, suggesting that either or both genes are<br />
+  required for normal germ-line development." <a href="https://pubmed.ncbi.nlm.nih.gov/8943022">PMID:8943022</a> — this is the experimental basis<br />
+  for the glh-2 IMP annotations (germ cell development, post-embryonic development). It is a<br />
+  combined glh-1/glh-2 antisense experiment, so the glh-2-specific contribution is not cleanly<br />
+  separable.</li>
+<li>The two glh genes "display different patterns of RNA and protein accumulation in the germ<br />
+  lines of hermaphrodites and males" and "physically map within several hundred kilobases of<br />
+  one another, it seems likely that they represent a fairly recent gene duplication event."<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/8943022">PMID:8943022</a> — glh-1 and glh-2 are recent paralogs.</li>
+<li>Deletion genetics (Spike et al. 2008, PMID:18430929, abstract cached): "Caenorhabditis<br />
+  elegans has four Vasa family members, the germline helicases GLH-1, GLH-2, GLH-3, and GLH-4."<br />
+  "Our analysis of deletion alleles of each glh gene demonstrates that GLH-1 is the key member<br />
+  of the family". "The other GLHs are not essential." "GLH-4 serves redundant roles with<br />
+  GLH-1". "GLH-1 and GLH-4 are required for proper association of the PGL family of proteins<br />
+  with P granules". =&gt; a glh-2 null (um2) is NOT sterile on its own; GLH-1 (with GLH-4<br />
+  redundancy) carries the essential germline function, not GLH-2. glh-2(um2) shows only a<br />
+  modest ~25% brood reduction at 15C (secondary WebFetch of full text; not verbatim-cited).</li>
+</ul>
+<h3 id="protein-interactions">Protein interactions</h3>
+<ul>
+<li>"The GLH proteins belong to a family of four germline RNA helicases in Caenorhabditis<br />
+  elegans." <a href="https://pubmed.ncbi.nlm.nih.gov/12435362">PMID:12435362</a></li>
+<li>GLHs (including GLH-2) bind KGB-1, a JNK/JUN MAP kinase: "KGB-1 is a putative JNK MAP kinase<br />
+  that GLHs bind"; and CSN-5 (COP9 signalosome subunit 5) and ZYX-1 (zyxin-like). "GST<br />
+  pull-down assays independently established that these proteins bind GLHs." <a href="https://pubmed.ncbi.nlm.nih.gov/12435362">PMID:12435362</a><br />
+  =&gt; basis for the JUN kinase binding IPI and the generic protein binding IPI (with_from<br />
+  UniProtKB:O44408 = kgb-1). GLH-2 also self-associates in vitro (secondary source; the KGB-1<br />
+  and self-interaction are why "protein binding" and "JUN kinase binding" are annotated).</li>
+<li>csn-5 RNAi phenocopies glh-1;glh-4 double loss: "RNA interference (RNAi) with csn-5 results<br />
+  in sterile worms with small gonads and no oocytes, a defect essentially identical to that<br />
+  produced by RNAi with a combination of glh-1 and glh-4." "loss of either CSN-5 or KGB-1<br />
+  causes oogenesis to cease, but does not affect the initial assembly of P granules."<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/12435362">PMID:12435362</a> — note these fertility phenotypes are glh-1/glh-4-referenced, NOT glh-2.</li>
+</ul>
+<h2 id="not-known-knowledge-gaps-glh-2-specific">NOT known / knowledge gaps (glh-2-specific)</h2>
+<ol>
+<li>GLH-2's non-redundant molecular role vs GLH-1/GLH-4 is undefined. glh-2 single null is<br />
+   essentially fertile; whether GLH-2 has any unique substrate or step, or is purely a<br />
+   buffering paralog, is unknown. Spike 2008: "The other GLHs are not essential."</li>
+<li>Direct RNA substrates of GLH-2 are unknown. No CLIP/biochemical target identification; the<br />
+   six CCHC fingers predict RNA binding but bound RNAs are uncharacterized.</li>
+<li>Whether GLH-2 has catalytically active (ATP-dependent unwinding) helicase activity, and<br />
+   whether that activity is required in vivo, is untested. No in vitro helicase/ATPase assay<br />
+   and no catalytic-dead (DQAD/DEAD-motif) allele analysis has been reported for GLH-2 (unlike<br />
+   GLH-1, where ATPase-cycle mutants were made).</li>
+<li>Mechanistic contribution of GLH-2 to P-granule assembly/organization is unresolved. The<br />
+   epistasis placing GLHs upstream of PGL proteins was established with GLH-1/GLH-4; GLH-2's<br />
+   role in condensate assembly per se is unmeasured.</li>
+<li>The functional meaning of GLH-2's reported sperm-chromatin association (possible nuclear<br />
+   role) is unknown.</li>
+</ol>
+<h2 id="annotation-by-annotation-plan-23-goa-rows">Annotation-by-annotation plan (23 GOA rows)</h2>
+<ul>
+<li>MF RNA helicase activity (IBA GO_REF:33; IEA GO_REF:120; IDA PMID:8943022) -&gt; ACCEPT core;<br />
+  IDA is domain-based but sound.</li>
+<li>MF mRNA binding (IBA) -&gt; ACCEPT (CCHC fingers + DEAD-box; RNA binding is well supported;<br />
+  "mRNA" is a reasonable specific for a germline RNP helicase).</li>
+<li>MF nucleic acid binding (IEA InterPro) -&gt; ACCEPT but general (subsumed by RNA binding/mRNA).</li>
+<li>MF ATP binding (IEA InterPro) -&gt; ACCEPT (P-loop/Walker A).</li>
+<li>MF zinc ion binding (IEA InterPro) -&gt; ACCEPT (six CCHC fingers).</li>
+<li>MF ATP hydrolysis activity (IEA RHEA) -&gt; ACCEPT (DEAD-box ATPase; core catalytic step).</li>
+<li>MF JUN kinase binding (IEA GO_REF:117; IPI PMID:12435362 with WB:kgb-1) -&gt; ACCEPT<br />
+  (experimentally, GLHs bind KGB-1).</li>
+<li>MF protein binding (IPI PMID:12435362, with UniProtKB:O44408=kgb-1) -&gt; MODIFY: uninformative<br />
+  "protein binding"; the interactor is KGB-1 -&gt; propose JUN kinase binding (GO:0008432).</li>
+<li>CC P granule (IBA; IEA GO_REF:117; IDA PMID:8943022) -&gt; ACCEPT core (defining localization).</li>
+<li>CC nucleus (IBA GO_REF:33) -&gt; KEEP_AS_NON_CORE (predominantly perinuclear/cytoplasmic; weak<br />
+  sperm-chromatin nuclear hint; not core; do not REMOVE given genuine uncertainty).</li>
+<li>BP germ cell development (IBA; IEA GO_REF:117; IMP PMID:8943022) -&gt; ACCEPT (antisense sterile).</li>
+<li>BP gamete generation (IBA GO_REF:33) -&gt; ACCEPT/KEEP (broad; part of germline function).</li>
+<li>BP cell differentiation (IBA GO_REF:33) -&gt; KEEP_AS_NON_CORE (very general; germ cell dev is<br />
+  the informative term).</li>
+<li>BP post-embryonic development (IMP PMID:8943022; IEA GO_REF:117) -&gt; KEEP_AS_NON_CORE (broad;<br />
+  reflects timing of germline proliferation).</li>
+<li>BP RNA metabolic process (ISS PMID:8943022) -&gt; MODIFY/KEEP: very broad; RNP remodeling is<br />
+  the mechanistic intent but no glh-2-specific process term is strongly supported. Keep as<br />
+  non-core rather than invent specifics.</li>
+</ul>
+<h2 id="provenance-policy">Provenance policy</h2>
+<p>Cached publications used for verbatim supporting_text: PMID_8943022 (abstract-only),<br />
+PMID_12435362 (abstract-only), PMID_18430929 (abstract-only). No fabricated quotes; every<br />
+supporting_text below is a verbatim substring of a cached abstract.</p>
+<h2 id="deep-research-status-2026-07-04">Deep research status (2026-07-04)</h2>
+<p>Falcon deep-research was attempted TWICE (<code>just deep-research-falcon worm glh-2 --fallback
+perplexity-lite</code>). Both attempts hung: the deep-research-client (falcon provider) ran &gt;20 min<br />
+with zero output, the wrapper's 600s per-provider timeout left an orphaned falcon child, and<br />
+NO deep-research file (falcon or perplexity-lite fallback) was ever produced. Per repo policy<br />
+I did NOT fabricate a <code>-deep-research-*.md</code> file. The review is therefore grounded in UniProt<br />
+(Q966L9), the GOA TSV, and three cached primary/genetic papers (PMID:8943022 Gruidl 1996;<br />
+PMID:12435362 Smith 2002; PMID:18430929 Spike 2008), supplemented by non-cited WebSearch of<br />
+the Alliance/WormBase gene page for orientation only. Where glh-2-specific evidence is absent,<br />
+annotations are handled conservatively (KEEP_AS_NON_CORE / MODIFY, not REMOVE) and the<br />
+uncertainties are recorded as knowledge_gaps.</p>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: Q966L9
+gene_symbol: glh-2
+product_type: PROTEIN
+status: COMPLETE
+taxon:
+  id: NCBITaxon:6239
+  label: Caenorhabditis elegans
+description: GLH-2 (Germline Helicase 2) is a Vasa/DDX4-class ATP-dependent DEAD-box
+  RNA helicase and a constitutive component of the germline-specific P granules of
+  Caenorhabditis elegans. It is one of four partially redundant GLH paralogs (GLH-1,
+  GLH-2, GLH-3, GLH-4); glh-1 and glh-2 map close together and arose from a relatively
+  recent duplication. The protein has a central DEAD-box helicase core (ATP-binding
+  and C-terminal helicase domains with the Q motif and DEAD box), six CCHC-type zinc
+  fingers of the retroviral nucleocapsid RNA-binding type, and a large N-terminal
+  glycine/FG-rich intrinsically disordered region typical of GLH proteins. GLH-2 is
+  present in P granules at all stages of germline development, is cytoplasmic in oocytes
+  and the early embryo and perinuclear in later germ cells, and physically associates
+  with the JNK-family MAP kinase KGB-1 as well as with itself. Within the GLH family,
+  GLH-1 is the key member for fertility (with GLH-4 acting redundantly), whereas a
+  glh-2 deletion is not individually essential; GLH-2 contributes to germline proliferation,
+  gametogenesis and P-granule biology in a largely redundant manner.
+references:
+- id: GO_REF:0000002
+  title: Gene Ontology annotation through association of InterPro records with GO
+    terms
+  findings: []
+- id: GO_REF:0000033
+  title: Annotation inferences using phylogenetic trees
+  findings:
+  - statement: Phylogenetic (IBA) inference based on conservation within the Vasa/DDX4
+      DEAD-box helicase family
+- id: GO_REF:0000116
+  title: Automatic Gene Ontology annotation based on Rhea mapping
+  findings:
+  - statement: RHEA:13065 (ATP + H2O = ADP + phosphate + H+) maps to ATP hydrolysis
+      activity
+- id: GO_REF:0000117
+  title: Electronic Gene Ontology annotations created by ARBA machine learning models
+  findings: []
+- id: GO_REF:0000120
+  title: Combined Automated Annotation using Multiple IEA Methods
+  findings: []
+- id: PMID:8943022
+  title: Multiple potential germ-line helicases are components of the germ-line-specific
+    P granules of Caenorhabditis elegans.
+  findings:
+  - statement: GLH-1 and GLH-2 are putative germline RNA helicases with retroviral-type
+      CCHC zinc fingers
+    supporting_text: Both components are putative germ-line RNA helicases (GLHs) that
+      contain CCHC zinc fingers of the type found in the RNA-binding nucleocapsid
+      proteins of retroviruses.
+  - statement: GLH-2 has six CCHC zinc fingers (GLH-1 has four)
+    supporting_text: The predicted GLH-1 protein has four CCHC fingers; GLH-2 has
+      six.
+  - statement: Both GLH proteins localize to P granules at all stages of germline
+      development
+    supporting_text: Both GLH proteins localize in the P granules at all stage of
+      germ-line development.
+  - statement: Antisense glh-1 or glh-2 causes sterility in some offspring, indicating
+      a requirement for normal germline development
+    supporting_text: Injection of antisense glh-1 or glh-2 RNA into wild-type worms
+      causes some offspring to develop into sterile adults, suggesting that either
+      or both genes are required for normal germ-line development.
+  - statement: glh-1 and glh-2 map within a few hundred kb and likely arose from a
+      recent duplication
+    supporting_text: As these very similar glh genes physically map within several
+      hundred kilobases of one another, it seems likely that they represent a fairly
+      recent gene duplication event.
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: PMC19442-verified discovery paper that first identified GLH-1 and
+      GLH-2 as P-granule components; source of the six-CCHC-finger, P-granule localization,
+      antisense-sterility, and recent-duplication facts. Abstract-only in cache; the
+      experimental IDA/IMP/ISS annotations trace to this paper&#39;s full text.
+- id: PMID:12435362
+  title: The GLH proteins, Caenorhabditis elegans P granule components, associate
+    with CSN-5 and KGB-1, proteins necessary for fertility, and with ZYX-1, a predicted
+    cytoskeletal protein.
+  findings:
+  - statement: The GLHs are a family of four germline RNA helicases that localize
+      to cytoplasmic P granules
+    supporting_text: The GLH proteins belong to a family of four germline RNA helicases
+      in Caenorhabditis elegans.
+  - statement: GLHs bind KGB-1, a JNK-family MAP kinase, confirmed by GST pull-down
+    supporting_text: KGB-1 is a putative JNK MAP kinase that GLHs bind.
+  - statement: Three GLH interactors (CSN-5, KGB-1, ZYX-1) were identified and confirmed
+      to bind GLHs
+    supporting_text: GST pull-down assays independently established that these proteins
+      bind GLHs.
+  - statement: Loss of CSN-5 or KGB-1 stops oogenesis (like loss of GLH-1/GLH-4) but
+      not initial P-granule assembly
+    supporting_text: Similar to the loss of GLH-1 and GLH-4, loss of either CSN-5
+      or KGB-1 causes oogenesis to cease, but does not affect the initial assembly
+      of P granules.
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: PubMed-verified. Source of the GLH-KGB-1 (JUN kinase) interaction
+      annotated by IPI on glh-2, and of the GLH family/P-granule framing. The oogenesis/fertility
+      phenotypes cited here are attributed to GLH-1/GLH-4 and to CSN-5/KGB-1, not
+      to glh-2 individually.
+- id: PMID:18430929
+  title: Genetic analysis of the Caenorhabditis elegans GLH family of P-granule proteins.
+  findings:
+  - statement: C. elegans has four Vasa-family germline helicases, GLH-1 to GLH-4
+    supporting_text: In contrast to the single Vasa gene in most systems analyzed,
+      Caenorhabditis elegans has four Vasa family members, the germline helicases
+      GLH-1, GLH-2, GLH-3, and GLH-4.
+  - statement: Deletion-allele analysis shows GLH-1 is the key family member for fertility
+    supporting_text: Our analysis of deletion alleles of each glh gene demonstrates
+      that GLH-1 is the key member of the family
+  - statement: GLH-2, GLH-3 and GLH-4 are not individually essential
+    supporting_text: The other GLHs are not essential.
+  - statement: GLH-1 and GLH-4 are required for proper association of PGL proteins
+      with P granules (GLHs upstream of PGLs)
+    supporting_text: GLH-1 and GLH-4 are required for proper association of the PGL
+      family of proteins with P granules
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: PMC2323790-verified. Definitive genetic dissection showing a glh-2
+      deletion is not individually essential and that GLH-1 (with GLH-4) carries the
+      essential germline function; key for scoping glh-2&#39;s non-core, partially redundant
+      role. Abstract-only in cache.
+existing_annotations:
+- term:
+    id: GO:0003724
+    label: RNA helicase activity
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: enables
+  review:
+    summary: Phylogenetic (IBA) inference of ATP-dependent RNA helicase activity from
+      the Vasa/DDX4 DEAD-box subfamily. GLH-2 has the complete DEAD-box helicase core
+      (Q motif, DEAD box, ATP-binding and helicase C-terminal domains) plus six CCHC
+      RNA-binding zinc fingers.
+    action: ACCEPT
+    reason: Core molecular function, well-supported by domain architecture and family
+      membership (DDX4/VASA subfamily). Consistent with the IDA and IEA RNA-helicase
+      annotations. Note that direct in vitro unwinding activity has not been demonstrated
+      for GLH-2 specifically (captured in knowledge_gaps).
+    supported_by:
+    - reference_id: PMID:8943022
+      supporting_text: Both components are putative germ-line RNA helicases (GLHs)
+        that contain CCHC zinc fingers of the type found in the RNA-binding nucleocapsid
+        proteins of retroviruses.
+- term:
+    id: GO:0005634
+    label: nucleus
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: is_active_in
+  review:
+    summary: IBA inference of nuclear localization propagated from Vasa/DDX4-family
+      members. GLH-2 is predominantly a cytoplasmic/perinuclear P-granule protein
+      (cytoplasmic in oocytes and early embryo, perinuclear in later germ cells),
+      so the nucleus is not its principal site of action. However, unlike GLH-1, GLH-2
+      has separately been reported (WormBase/secondary sources; not verifiable from
+      the abstract-only cached primaries) to associate with sperm chromatin, so a minor
+      nuclear association cannot be excluded.
+    action: KEEP_AS_NON_CORE
+    reason: Predominant, experimentally documented localization is the perinuclear
+      cytoplasmic P granule, not the nucleus, so nucleus is not a core location. A
+      confident REMOVE is not warranted given the general uncertainty of the phylogenetic
+      inference and a reported (secondary-source) GLH-2 sperm-chromatin association;
+      retained as non-core rather than removed.
+    supported_by:
+    - reference_id: PMID:12435362
+      supporting_text: These putative ATP-dependent enzymes localize to the P granules,
+        which are nonmembranous complexes of protein and RNA exclusively found in
+        the cytoplasm of all C. elegans germ cells and germ cell precursors.
+- term:
+    id: GO:0007276
+    label: gamete generation
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: involved_in
+  review:
+    summary: IBA inference that GLH-2 participates in gamete generation. Consistent
+      with the germline expression and P-granule localization of GLH proteins and
+      with antisense-induced sterility, though a glh-2 deletion alone is largely fertile.
+    action: KEEP_AS_NON_CORE
+    reason: Broad germline-process term. GLH-2 contributes to gametogenesis but in
+      a partially redundant manner (glh-2 null is not individually sterile; GLH-1/GLH-4
+      carry the essential function). The more specific germ cell development term better
+      captures the supported role; retained as non-core.
+    supported_by:
+    - reference_id: PMID:18430929
+      supporting_text: The other GLHs are not essential.
+- term:
+    id: GO:0007281
+    label: germ cell development
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: involved_in
+  review:
+    summary: IBA inference of a role in germ cell development, consistent with GLH-2&#39;s
+      constitutive P-granule localization throughout germline development and with
+      the experimental antisense phenotype.
+    action: ACCEPT
+    reason: Best-supported biological-process term for GLH-2, corroborated by the
+      IMP annotation from antisense knockdown (PMID:8943022). Represents GLH-2&#39;s core
+      germline role, albeit exercised largely redundantly with the other GLHs.
+    supported_by:
+    - reference_id: PMID:8943022
+      supporting_text: suggesting that either or both genes are required for normal
+        germ-line development
+- term:
+    id: GO:0030154
+    label: cell differentiation
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: involved_in
+  review:
+    summary: Very general IBA differentiation term. GLH-2 acts in germ-cell (germline)
+      differentiation as part of P-granule biology, but this generic term is far less
+      informative than germ cell development.
+    action: KEEP_AS_NON_CORE
+    reason: Correct in the broadest sense but uninformative; germ cell development
+      (GO:0007281) is the more specific and appropriate term. Retained as non-core.
+    supported_by:
+    - reference_id: PMID:8943022
+      supporting_text: suggesting that either or both genes are required for normal
+        germ-line development
+- term:
+    id: GO:0043186
+    label: P granule
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: is_active_in
+  review:
+    summary: GLH-2 is a constitutive component of germline P granules, the defining
+      localization of the GLH family, present at all stages of germline development.
+    action: ACCEPT
+    reason: Core, experimentally established localization (also annotated by IDA).
+      P-granule residence is central to GLH-2&#39;s function as a germline RNP helicase.
+    supported_by:
+    - reference_id: PMID:8943022
+      supporting_text: Both GLH proteins localize in the P granules at all stage of
+        germ-line development.
+- term:
+    id: GO:0003729
+    label: mRNA binding
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: enables
+  review:
+    summary: IBA inference of mRNA binding from the Vasa/DDX4 subfamily. GLH-2 has
+      six CCHC-type RNA-binding zinc fingers and a DEAD-box core that engages RNA,
+      making RNA/mRNA binding well-motivated structurally.
+    action: ACCEPT
+    reason: RNA binding is a core molecular feature of GLH-2 (CCHC zinc fingers plus
+      DEAD-box domain); mRNA binding is a reasonable specific for a germline RNP helicase.
+      The precise cellular RNA substrates of GLH-2 have not been identified (see knowledge_gaps).
+    supported_by:
+    - reference_id: PMID:8943022
+      supporting_text: contain CCHC zinc fingers of the type found in the RNA-binding
+        nucleocapsid proteins of retroviruses
+- term:
+    id: GO:0003676
+    label: nucleic acid binding
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: enables
+  review:
+    summary: Very general IEA annotation inferred from InterPro domains (CCHC zinc
+      fingers and the DEAD/DEAH box helicase domain).
+    action: KEEP_AS_NON_CORE
+    reason: Correct but overly general; subsumed by the more specific and informative
+      RNA binding / mRNA binding annotations. Retained as non-core.
+    supported_by:
+    - reference_id: GO_REF:0000002
+      supporting_text: InterPro:IPR001878|InterPro:IPR011545|InterPro:IPR036875
+- term:
+    id: GO:0003724
+    label: RNA helicase activity
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000120
+  qualifier: enables
+  review:
+    summary: Electronic annotation of RNA helicase activity from combined IEA methods
+      (InterPro DEAD-box signatures and EC 3.6.4.13).
+    action: ACCEPT
+    reason: Redundant with the higher-quality IBA and IDA RNA-helicase annotations
+      but correct; the automated inference from DEAD-box domain architecture is accurate.
+    supported_by:
+    - reference_id: GO_REF:0000120
+      supporting_text: ARBA:ARBA00028402|InterPro:IPR014014|EC:3.6.4.13
+- term:
+    id: GO:0005524
+    label: ATP binding
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: enables
+  review:
+    summary: GLH-2 binds ATP as substrate for its helicase/ATPase cycle; it has a
+      conserved P-loop/Walker A ATP-binding motif (residues 596-603) within the helicase
+      ATP-binding domain.
+    action: ACCEPT
+    reason: Essential supporting activity for DEAD-box RNA helicase function; well-supported
+      by domain architecture (IPR011545).
+    supported_by:
+    - reference_id: GO_REF:0000002
+      supporting_text: InterPro:IPR011545
+- term:
+    id: GO:0007281
+    label: germ cell development
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000117
+  qualifier: involved_in
+  review:
+    summary: Electronic (ARBA) annotation of germ cell development, consistent with
+      the IBA and experimental IMP annotations.
+    action: ACCEPT
+    reason: Redundant with the IBA and IMP germ cell development annotations but correct.
+    supported_by:
+    - reference_id: GO_REF:0000117
+      supporting_text: ARBA:ARBA00028319
+- term:
+    id: GO:0008270
+    label: zinc ion binding
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: enables
+  review:
+    summary: GLH-2 has six CCHC-type zinc fingers (positions 257-274, 282-299, 371-388,
+      396-413, 453-470, 473-490) that each coordinate a zinc ion.
+    action: ACCEPT
+    reason: Well-supported by domain architecture; the six CCHC fingers are a distinctive
+      feature of GLH-2 (more than GLH-1&#39;s four).
+    supported_by:
+    - reference_id: PMID:8943022
+      supporting_text: The predicted GLH-1 protein has four CCHC fingers; GLH-2 has
+        six.
+- term:
+    id: GO:0008432
+    label: JUN kinase binding
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000117
+  qualifier: enables
+  review:
+    summary: Electronic (ARBA) annotation of JUN kinase binding, supported by the
+      experimental IPI evidence that GLH proteins bind the JNK-family MAP kinase KGB-1.
+    action: ACCEPT
+    reason: Consistent with the IPI annotation from PMID:12435362; GLHs (including
+      GLH-2) physically associate with KGB-1.
+    supported_by:
+    - reference_id: PMID:12435362
+      supporting_text: KGB-1 is a putative JNK MAP kinase that GLHs bind.
+- term:
+    id: GO:0009791
+    label: post-embryonic development
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000117
+  qualifier: involved_in
+  review:
+    summary: Electronic (ARBA) annotation of post-embryonic development, consistent
+      with the IMP annotation reflecting the larval/adult timing of germline proliferation.
+    action: KEEP_AS_NON_CORE
+    reason: Broad developmental term; redundant with the IMP annotation and less informative
+      than germ cell development. Retained as non-core.
+    supported_by:
+    - reference_id: GO_REF:0000117
+      supporting_text: ARBA:ARBA00029007
+- term:
+    id: GO:0016887
+    label: ATP hydrolysis activity
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000116
+  qualifier: enables
+  review:
+    summary: GLH-2 catalyzes ATP hydrolysis (RHEA:13065; ATP + H2O = ADP + phosphate
+      + H+) as the energetic step of its DEAD-box RNA helicase cycle.
+    action: ACCEPT
+    reason: Core catalytic step of the DEAD-box helicase, correctly inferred from
+      the Rhea reaction mapping and consistent with EC 3.6.4.13. Whether this ATPase/unwinding
+      activity is catalytically required for GLH-2&#39;s in vivo role has not been directly
+      tested (see knowledge_gaps).
+    supported_by:
+    - reference_id: GO_REF:0000116
+      supporting_text: RHEA:13065
+- term:
+    id: GO:0043186
+    label: P granule
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000117
+  qualifier: located_in
+  review:
+    summary: Electronic (ARBA) annotation of P-granule localization, redundant with
+      the direct experimental (IDA) evidence.
+    action: ACCEPT
+    reason: Correct and strongly corroborated by IDA; P-granule residence is a defining
+      feature of GLH-2.
+    supported_by:
+    - reference_id: GO_REF:0000117
+      supporting_text: ARBA:ARBA00026989
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:12435362
+  qualifier: enables
+  review:
+    summary: IPI annotation (with UniProtKB:O44408 = KGB-1) recording a physical interaction
+      between GLH-2 and the JNK-family MAP kinase KGB-1, demonstrated by yeast two-hybrid
+      and GST pull-down.
+    action: MODIFY
+    reason: &#39;&#34;Protein binding&#34; is uninformative. The interacting partner recorded
+      in the with/from field is KGB-1, a JUN/JNK-family kinase, so the more specific
+      JUN kinase binding (GO:0008432) captures the same experimental interaction and
+      is already annotated separately.&#39;
+    proposed_replacement_terms:
+    - id: GO:0008432
+      label: JUN kinase binding
+    supported_by:
+    - reference_id: PMID:12435362
+      supporting_text: KGB-1 is a putative JNK MAP kinase that GLHs bind.
+- term:
+    id: GO:0008432
+    label: JUN kinase binding
+  evidence_type: IPI
+  original_reference_id: PMID:12435362
+  qualifier: enables
+  review:
+    summary: Experimentally demonstrated interaction between GLH proteins (including
+      GLH-2) and KGB-1, a C. elegans JNK-family MAP kinase, by yeast two-hybrid and
+      GST pull-down. The GLH-KGB-1 interaction maps to the GLH C-terminus.
+    action: ACCEPT
+    reason: Well-supported experimental interaction (IPI). KGB-1 is a fertility factor
+      whose loss phenocopies glh-1/glh-4 sterility, making the interaction functionally
+      relevant to germline homeostasis.
+    supported_by:
+    - reference_id: PMID:12435362
+      supporting_text: GST pull-down assays independently established that these proteins
+        bind GLHs.
+- term:
+    id: GO:0003724
+    label: RNA helicase activity
+  evidence_type: IDA
+  original_reference_id: PMID:8943022
+  qualifier: enables
+  review:
+    summary: Original characterization of GLH-2 as a putative RNA helicase based on
+      the DEAD-box helicase domain and CCHC zinc fingers. The IDA code is generous
+      here since the evidence is primarily sequence/domain-based rather than a direct
+      in vitro unwinding assay.
+    action: ACCEPT
+    reason: The RNA helicase classification is sound from the complete DEAD-box motif
+      complement and DDX4/VASA family membership, and is reinforced by the IBA/IEA
+      annotations. Per curation guidance, an experimental annotation whose full text
+      was read by the curator is not removed; the caveat about lacking a direct biochemical
+      assay is recorded in knowledge_gaps.
+    supported_by:
+    - reference_id: PMID:8943022
+      supporting_text: Both components are putative germ-line RNA helicases (GLHs)
+        that contain CCHC zinc fingers
+- term:
+    id: GO:0007281
+    label: germ cell development
+  evidence_type: IMP
+  original_reference_id: PMID:8943022
+  qualifier: involved_in
+  review:
+    summary: Antisense knockdown of glh-2 causes sterility in some offspring, providing
+      experimental evidence for a requirement in germline development. Later deletion-allele
+      analysis (PMID:18430929) showed a glh-2 null is not individually sterile, indicating
+      GLH-2&#39;s contribution is real but largely redundant with the other GLHs.
+    action: ACCEPT
+    reason: Direct experimental (IMP) evidence for a role in germ cell development;
+      the curator read the full text. The deletion-allele refinement (non-essential
+      individually) is captured in the reason and knowledge_gaps rather than by removing
+      a valid experimental annotation.
+    supported_by:
+    - reference_id: PMID:8943022
+      supporting_text: Injection of antisense glh-1 or glh-2 RNA into wild-type worms
+        causes some offspring to develop into sterile adults, suggesting that either
+        or both genes are required for normal germ-line development.
+- term:
+    id: GO:0009791
+    label: post-embryonic development
+  evidence_type: IMP
+  original_reference_id: PMID:8943022
+  qualifier: involved_in
+  review:
+    summary: IMP annotation reflecting that glh-2 function is required during post-embryonic
+      (larval-to-adult) germline proliferation, the developmental window in which
+      GLH proteins accumulate.
+    action: KEEP_AS_NON_CORE
+    reason: Broad developmental term derived from the same antisense-sterility experiment;
+      germ cell development is the more informative term. Retained as non-core.
+    supported_by:
+    - reference_id: PMID:8943022
+      supporting_text: Injection of antisense glh-1 or glh-2 RNA into wild-type worms
+        causes some offspring to develop into sterile adults
+- term:
+    id: GO:0016070
+    label: RNA metabolic process
+  evidence_type: ISS
+  original_reference_id: PMID:8943022
+  qualifier: involved_in
+  review:
+    summary: ISS annotation based on sequence similarity to RNA helicases. GLH-2 participates
+      in RNA metabolism through RNP engagement/remodeling within P granules, but the
+      specific RNA process it acts in is not defined for GLH-2.
+    action: KEEP_AS_NON_CORE
+    reason: Correct but very broad. No glh-2-specific evidence supports a more precise
+      RNA-process term (e.g. a defined small-RNA or RNP-remodeling step), so the term
+      is retained as non-core rather than replaced with an unsupported specific.
+    supported_by:
+    - reference_id: PMID:8943022
+      supporting_text: Both components are putative germ-line RNA helicases (GLHs)
+- term:
+    id: GO:0043186
+    label: P granule
+  evidence_type: IDA
+  original_reference_id: PMID:8943022
+  qualifier: located_in
+  review:
+    summary: Direct experimental identification of GLH-2 as a P-granule component using
+      an antibody specific for GLH-2. This is the foundational evidence for GLH-2&#39;s
+      defining subcellular localization.
+    action: ACCEPT
+    reason: High-quality direct experimental (IDA) evidence for the core localization
+      of GLH-2 in germline P granules.
+    supported_by:
+    - reference_id: PMID:8943022
+      supporting_text: Both GLH proteins localize in the P granules at all stage of
+        germ-line development.
+core_functions:
+- description: ATP-dependent DEAD-box RNA helicase that engages and remodels RNA/RNP
+    within germline P granules through an ATP-binding and hydrolysis cycle. GLH-2
+    exercises this activity as a constitutive, partially redundant member of the GLH
+    (Vasa/DDX4) family rather than as the essential family member.
+  molecular_function:
+    id: GO:0003724
+    label: RNA helicase activity
+  directly_involved_in:
+  - id: GO:0007281
+    label: germ cell development
+  locations:
+  - id: GO:0043186
+    label: P granule
+  supported_by:
+  - reference_id: PMID:8943022
+    supporting_text: Both components are putative germ-line RNA helicases (GLHs) that
+      contain CCHC zinc fingers of the type found in the RNA-binding nucleocapsid
+      proteins of retroviruses.
+- description: RNA-binding component of germline P granules, engaging RNA through six
+    CCHC-type zinc fingers together with the DEAD-box core; contributes to P-granule
+    ribonucleoprotein organization in germ cells.
+  molecular_function:
+    id: GO:0003729
+    label: mRNA binding
+  directly_involved_in:
+  - id: GO:0007281
+    label: germ cell development
+  locations:
+  - id: GO:0043186
+    label: P granule
+  supported_by:
+  - reference_id: PMID:8943022
+    supporting_text: The predicted GLH-1 protein has four CCHC fingers; GLH-2 has
+      six.
+knowledge_gaps:
+- gap_statement: The non-redundant, GLH-2-specific molecular contribution to germline
+    function is undetermined. It is unknown whether GLH-2 performs any unique step,
+    substrate engagement, or regulatory role, or whether it acts purely as a partially
+    redundant buffer for GLH-1/GLH-4.
+  boundary: A glh-2 deletion allele is not individually sterile; deletion-allele genetics
+    establish GLH-1 (with redundant GLH-4) as the family member essential for fertility,
+    while GLH-2 (and GLH-3) are not essential. GLH-2 is nonetheless a constitutive
+    P-granule component expressed throughout germline development.
+  gap_kind:
+  - BIOLOGY
+  dark_aspect: MF_DARK
+  status: OPEN
+  significance: Distinguishing genuine functional specialization from mere redundancy
+    is required before GLH-2 can be assigned a specific, non-inherited role, and would
+    clarify why C. elegans retains four Vasa paralogs.
+  resolution: glh-2 single-mutant molecular phenotyping (e.g. germline RNP/small-RNA
+    profiling, GLH-2-specific interactome and RNA-target mapping) and paralog swap/rescue
+    experiments assessing whether GLH-2 can substitute for GLH-1.
+  provenance:
+  - reference_id: PMID:18430929
+    supporting_text: The other GLHs are not essential.
+  - reference_id: PMID:18430929
+    supporting_text: Our analysis of deletion alleles of each glh gene demonstrates
+      that GLH-1 is the key member of the family
+- gap_statement: The direct in vivo RNA substrates of GLH-2 are unknown. Neither the
+    RNAs bound by its six CCHC zinc fingers nor the transcripts it engages/remodels
+    within P granules have been identified.
+  boundary: Domain architecture (six retroviral-type CCHC zinc fingers plus a complete
+    DEAD-box helicase core) firmly predicts RNA binding, and GLH-2 resides in RNA-containing
+    P granules, but no CLIP/target-identification study has defined its bound RNAs.
+  gap_kind:
+  - BIOLOGY
+  dark_aspect: MF_DARK
+  status: OPEN
+  significance: Identifying GLH-2&#39;s RNA targets would convert a homology-based &#34;RNA/mRNA
+    binding&#34; inference into a mechanistic account of what GLH-2 does to which transcripts.
+  resolution: In vivo crosslinking/immunoprecipitation (CLIP-seq) or equivalent RNA-target
+    mapping for tagged GLH-2 in the germline.
+  provenance:
+  - reference_id: PMID:8943022
+    supporting_text: Both components are putative germ-line RNA helicases (GLHs) that
+      contain CCHC zinc fingers of the type found in the RNA-binding nucleocapsid
+      proteins of retroviruses.
+- gap_statement: Whether GLH-2 has catalytically active ATP-dependent RNA-unwinding
+    activity, and whether that catalysis is required for its in vivo role, is untested.
+    No in vitro helicase/ATPase assay and no catalytic-dead (DEAD-motif / ATPase-cycle)
+    allele analysis has been reported for GLH-2.
+  boundary: GLH-2 carries all conserved DEAD-box catalytic motifs (Q motif, DEAD box,
+    Walker A/B, helicase C-terminal domain) and is classified EC 3.6.4.13; for the
+    paralog GLH-1, ATPase-cycle mutations are known to perturb P-granule dynamics,
+    but no comparable biochemistry or mutant analysis exists for GLH-2.
+  gap_kind:
+  - BIOLOGY
+  dark_aspect: RESIDUAL_SUBGAP
+  status: OPEN
+  significance: DEAD-box family membership does not guarantee catalytic activity in
+    vivo; testing GLH-2 catalysis distinguishes an active helicase from a scaffolding/RNA-clamp
+    role and would confirm or qualify the RNA-helicase and ATP-hydrolysis annotations.
+  resolution: Purified-protein RNA-unwinding/ATPase assays and germline analysis of
+    a catalytically-dead GLH-2 allele (e.g. DEAD-&gt;DAAD/DQAD substitutions).
+  provenance:
+  - reference_id: PMID:8943022
+    supporting_text: Both components are putative germ-line RNA helicases (GLHs)
+  - reference_id: PMID:18430929
+    supporting_text: The Vasa DEAD-box helicases are widespread markers of germ cells
+      across species
+- gap_statement: The mechanistic role of GLH-2 in P-granule assembly and organization
+    is unresolved. Whether GLH-2 is required for, or merely present in, perinuclear
+    condensate assembly and PGL recruitment has not been tested for GLH-2 individually.
+  boundary: Epistasis placing GLHs upstream of PGL proteins in P-granule assembly
+    was established specifically for GLH-1 and GLH-4; P granules still form when GLH-1/GLH-4
+    are lost (via remaining GLH-2/GLH-3), but GLH-2&#39;s own contribution to condensate
+    assembly has not been isolated.
+  gap_kind:
+  - BIOLOGY
+  dark_aspect: MF_DARK
+  status: OPEN
+  significance: Clarifying GLH-2&#39;s assembly role would show whether the four GLH paralogs
+    contribute equivalently to condensate formation or have distinct structural/enzymatic
+    inputs.
+  resolution: Live-imaging and epistasis of P-granule/PGL organization in glh-2 single
+    and glh-2-containing multiple-mutant backgrounds, with and without catalytic activity.
+  provenance:
+  - reference_id: PMID:18430929
+    supporting_text: GLH-1 and GLH-4 are required for proper association of the PGL
+      family of proteins with P granules
+  - reference_id: PMID:12435362
+    supporting_text: loss of either CSN-5 or KGB-1 causes oogenesis to cease, but
+      does not affect the initial assembly of P granules
+proposed_new_terms: []
+suggested_questions:
+- question: Does GLH-2 have any non-redundant germline function, or is it fully buffered
+    by GLH-1/GLH-4? A glh-2 deletion is largely fertile, yet the protein is constitutively
+    present in P granules at all germline stages.
+- question: What is the functional significance of the reported association of GLH-2
+    with sperm chromatin? This nuclear association is distinct from the perinuclear-cytoplasmic
+    localization shared with the other GLHs and could indicate a GLH-2-specific role.
+- question: Do the six CCHC zinc fingers of GLH-2 (versus four in GLH-1) confer distinct
+    RNA-binding specificity or a distinct set of RNA targets?
+suggested_experiments:
+- description: In vitro RNA-unwinding and ATPase assays with purified GLH-2 to directly
+    test whether it is a catalytically active DEAD-box RNA helicase and to characterize
+    substrate preference.
+- description: CLIP-seq (or equivalent in vivo RNA-target mapping) of endogenously
+    tagged GLH-2 in the germline to identify its bound RNAs and test whether these
+    differ from GLH-1 targets.
+- description: Germline phenotyping of a catalytically-dead GLH-2 allele (DEAD-motif
+    substitutions) and of glh-2 in combination with glh-1/glh-3/glh-4 mutations, to
+    resolve GLH-2&#39;s specific and redundant contributions to fertility and P-granule
+    organization.
+- description: IP-mass spectrometry of GLH-2 complexes compared to GLH-1/GLH-4, to
+    identify GLH-2-specific interactors beyond the shared KGB-1/CSN-5/ZYX-1 partners.
+tags:
+- caeel-p-granules
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/genes/worm/gpa-12/gpa-12-ai-review.html
+++ b/genes/worm/gpa-12/gpa-12-ai-review.html
@@ -1,0 +1,3584 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>gpa-12 - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        .propagation-review {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f8fafc;
+            border-left: 3px solid #64748b;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .propagation-title {
+            font-weight: 600;
+            color: #334155;
+            margin-bottom: 0.25rem;
+        }
+
+        .propagation-row {
+            margin-top: 0.25rem;
+        }
+
+        .propagation-source {
+            margin-top: 0.5rem;
+            padding-top: 0.5rem;
+            border-top: 1px solid #e5e7eb;
+        }
+
+        .propagation-source-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #1d4ed8;
+        }
+
+        .propagation-comment {
+            color: #4b5563;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>gpa-12</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/Q19572" target="_blank" class="term-link">
+                        Q19572
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Caenorhabditis elegans</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-complete">
+                    COMPLETE
+                </span>
+            </div>
+
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "gpa-12";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="Q19572" data-a="DESCRIPTION: GPA-12 is a heterotrimeric guanine-nucleotide-bind..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>GPA-12 is a heterotrimeric guanine-nucleotide-binding protein (G protein) alpha subunit of the Galpha-12/13 subfamily, the C. elegans homolog of mammalian Galpha-12/Galpha-13. It has a canonical Galpha domain with intact G1-G5 nucleotide-binding motifs and functions as a GTP/GDP-regulated molecular switch that, in its GTP-bound state, engages downstream effectors to relay signals from the cell surface. Its best-characterized physiological role is in the epidermis (hypodermis), where GPA-12 signaling acts upstream of protein kinase C delta (TPA-1) and a conserved p38 MAPK cassette (TIR-1, NSY-1, SEK-1, PMK-1) and the STAT-like factor STA-2 to drive induction of antimicrobial peptide genes of the NLP (nlp-29 cluster) and CNC families in response to fungal infection and wounding. A constitutively active form (GPA-12 Q205L / G12QL) is sufficient to drive constitutive antimicrobial peptide gene expression, and, when hyperactivated more broadly, causes a developmental growth arrest through a pharyngeal-pumping (feeding) defect that also depends on TPA-1. gpa-12 loss-of-function animals are viable.</p>
+    </div>
+
+
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003925" target="_blank" class="term-link">
+                                    GO:0003925
+                                </a>
+                            </span>
+                            <span class="term-label">G protein activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q19572" data-a="GO:0003925" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct and core molecular function. GPA-12 is a heterotrimeric G protein alpha subunit (Galpha-12/13 subfamily) that cycles between GTP- and GDP-bound states to act as a signal-transducing molecular switch. GO:0003925 is the appropriate MF for such subunits, and its behavior is supported experimentally in worm by the constitutively active Q205L (catalytic-glutamine) mutant.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Best and most specific molecular-function term for a Galpha subunit; consistent with family membership, intact G1-G5 motifs, and the behavior of activated GPA-12.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12646136" target="_blank" class="term-link">
+                                        PMID:12646136
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">We characterized a C. elegans Galpha subunit gene, gpa-12, which is a homolog of mammalian G(12)/G(13)alpha, and found that animals defective in gpa-12 are viable</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
+                                    GO:0005737
+                                </a>
+                            </span>
+                            <span class="term-label">cytoplasm</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q19572" data-a="GO:0005737" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetic (IBA) localization to cytoplasm, independently corroborated by the experimental IDA cytoplasm annotation from PMID:12646136. This is a reasonable functional cellular compartment for a peripheral, membrane-associated Galpha subunit that cycles at the cytoplasmic face of the plasma membrane.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Consistent, independently corroborated cellular localization for a Galpha subunit; accepted as the cellular compartment in which GPA-12 acts.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0007188" target="_blank" class="term-link">
+                                    GO:0007188
+                                </a>
+                            </span>
+                            <span class="term-label">adenylate cyclase-modulating G protein-coupled receptor signaling pathway</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-remove">
+                            REMOVE
+                        </span>
+                        <span class="vote-buttons" data-g="Q19572" data-a="GO:0007188" data-r="GO_REF:0000033" data-act="REMOVE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Over-propagation from the pan-Galpha PANTHER family node. Adenylate cyclase/cAMP modulation is the defining function of the Gs (stimulatory) and Gi (inhibitory) subfamilies, not of the Galpha-12/13 subfamily to which GPA-12 belongs. There is no evidence that GPA-12 modulates adenylate cyclase, and this pathway type is biologically inappropriate for a G12/13 protein.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Biologically incorrect for the G12/13 subfamily; the term propagated electronically from Gs/Gi paralogs in the broad pan-Galpha tree and should not transfer to GPA-12.
+                        </div>
+
+
+
+                        <div class="propagation-review">
+                            <div class="propagation-title">Propagation Review</div>
+                            <div class="propagation-row">
+                                <strong>Root cause:</strong>
+                                <span class="badge">PROPAGATION BAD</span>
+                            </div>
+
+                            <div class="propagation-row">
+                                <strong>Failure modes:</strong>
+
+                                <span class="badge">WRONG ORTHOLOG OR PARALOG</span>
+
+                                <span class="badge">FUNCTIONAL DIVERGENCE</span>
+
+                            </div>
+
+
+                            <div class="propagation-source">
+                                <strong>Sources checked:</strong>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">PANTHER:PTN000026392</span>
+
+                                    &middot; pan-Galpha family node
+
+
+                                    <span class="badge">SUPPORTS SOURCE BUT NOT TARGET</span>
+
+
+                                </div>
+
+                            </div>
+
+                        </div>
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0007266" target="_blank" class="term-link">
+                                    GO:0007266
+                                </a>
+                            </span>
+                            <span class="term-label">Rho protein signal transduction</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q19572" data-a="GO:0007266" data-r="GO_REF:0000033" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Canonical mammalian Galpha-12/13 signaling activates RhoGEFs to relay signals through Rho GTPases, so this term is biologically apt at the family level and propagates from the G12/13 node (mouse Gna12/Gna13). However, the Rho effector arm has not been demonstrated for C. elegans GPA-12; the experimentally defined worm effector arm runs through phospholipase (PLC-3) and PKCdelta (TPA-1). Retained as a homology-based, non-core inference.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Homology-supported canonical G12/13 function, but not experimentally established in worm, where the demonstrated downstream arm is PLC/PKCdelta rather than Rho.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005834" target="_blank" class="term-link">
+                                    GO:0005834
+                                </a>
+                            </span>
+                            <span class="term-label">heterotrimeric G-protein complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q19572" data-a="GO:0005834" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct. As a Galpha subunit, GPA-12 assembles into a heterotrimeric G protein (Galpha-beta-gamma) complex; in the epidermal immune pathway it partners with the Gbeta RACK-1.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Accurate and well-supported complex membership for a Galpha subunit.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/22470487" target="_blank" class="term-link">
+                                        PMID:22470487
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Wounding and infection require G-protein signaling, involving the Gα protein GPA-12 and the Gß RACK-1, while infection specifically involves the Tribbles-like kinase NIPI-3</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031526" target="_blank" class="term-link">
+                                    GO:0031526
+                                </a>
+                            </span>
+                            <span class="term-label">brush border membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q19572" data-a="GO:0031526" data-r="GO_REF:0000033" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Over-specific location propagated from mammalian (rat) orthologs. Brush border membrane is the plasma membrane of intestinal microvilli; GPA-12&#39;s demonstrated site of action is the epidermis/hypodermis. There is no C. elegans evidence for brush border localization.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Narrow mammalian-tissue location transferred by phylogenetic inference; not supported for the worm protein and inconsistent with its known site of action.
+                        </div>
+
+
+
+                        <div class="propagation-review">
+                            <div class="propagation-title">Propagation Review</div>
+                            <div class="propagation-row">
+                                <strong>Root cause:</strong>
+                                <span class="badge">PROPAGATION BAD</span>
+                            </div>
+
+                            <div class="propagation-row">
+                                <strong>Failure modes:</strong>
+
+                                <span class="badge">CONTEXT OR TISSUE MISMATCH</span>
+
+                                <span class="badge">COMPARTMENT OR COMPLEX MISMATCH</span>
+
+                            </div>
+
+
+                            <div class="propagation-source">
+                                <strong>Sources checked:</strong>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">PANTHER:PTN000026689</span>
+
+                                    &middot; Galpha-12/13 node
+
+
+                                    <span class="badge">SUPPORTS SOURCE BUT NOT TARGET</span>
+
+
+                                </div>
+
+                            </div>
+
+                        </div>
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031752" target="_blank" class="term-link">
+                                    GO:0031752
+                                </a>
+                            </span>
+                            <span class="term-label">D5 dopamine receptor binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-remove">
+                            REMOVE
+                        </span>
+                        <span class="vote-buttons" data-g="Q19572" data-a="GO:0031752" data-r="GO_REF:0000033" data-act="REMOVE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Hyper-specific molecular function propagated from a single mammalian ortholog annotation. Binding to a D5 dopamine receptor is not a plausible or supported activity for C. elegans GPA-12 (worms lack a D5 dopamine receptor ortholog), and there is no worm evidence for it.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Over-propagated, organism-specific receptor-binding annotation with no relevance or evidence for the worm protein.
+                        </div>
+
+
+
+                        <div class="propagation-review">
+                            <div class="propagation-title">Propagation Review</div>
+                            <div class="propagation-row">
+                                <strong>Root cause:</strong>
+                                <span class="badge">PROPAGATION BAD</span>
+                            </div>
+
+                            <div class="propagation-row">
+                                <strong>Failure modes:</strong>
+
+                                <span class="badge">WRONG ORTHOLOG OR PARALOG</span>
+
+                                <span class="badge">CONTEXT OR TISSUE MISMATCH</span>
+
+                            </div>
+
+
+                            <div class="propagation-source">
+                                <strong>Sources checked:</strong>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">PANTHER:PTN000026689</span>
+
+                                    &middot; Galpha-12/13 node
+
+
+                                    <span class="badge">SUPPORTS SOURCE BUT NOT TARGET</span>
+
+
+                                </div>
+
+                            </div>
+
+                        </div>
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0001664" target="_blank" class="term-link">
+                                    GO:0001664
+                                </a>
+                            </span>
+                            <span class="term-label">G protein-coupled receptor binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q19572" data-a="GO:0001664" data-r="GO_REF:0000002" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Generic InterPro-based inference. Galpha subunits are activated by, and physically couple to, GPCRs, so GPCR binding is a defensible general molecular function. However, the specific cognate receptor for GPA-12 is not established, so this remains a generic, non-core capability.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> True general Galpha property (more informative than &#39;protein binding&#39;) but generic; the actual GPA-12 receptor is unknown.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003924" target="_blank" class="term-link">
+                                    GO:0003924
+                                </a>
+                            </span>
+                            <span class="term-label">GTPase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q19572" data-a="GO:0003924" data-r="GO_REF:0000002" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Galpha subunits have intrinsic GTPase activity that terminates signaling by returning the switch to the GDP-bound state. Correct for GPA-12, whose G-box motifs are intact and whose catalytic-glutamine (Q205L) mutant behaves as a GTP-hydrolysis-defective, constitutively active protein. The more specific GO:0003925 (G protein activity) better captures the defining signaling-switch role, so this generic GTPase term is retained as a supporting, non-core activity.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct enzymatic capability for a Galpha subunit, but a supporting activity underlying the switch rather than the defining core function, which is better represented by GO:0003925 (G protein activity).
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0007165" target="_blank" class="term-link">
+                                    GO:0007165
+                                </a>
+                            </span>
+                            <span class="term-label">signal transduction</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q19572" data-a="GO:0007165" data-r="GO_REF:0000002" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> High-level, generic biological process. True (GPA-12 is a signal transducer) but far less informative than the specific GPCR-signaling and immune-signaling processes it participates in.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct but uninformatively general; subsumed by more specific process terms.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0007186" target="_blank" class="term-link">
+                                    GO:0007186
+                                </a>
+                            </span>
+                            <span class="term-label">G protein-coupled receptor signaling pathway</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q19572" data-a="GO:0007186" data-r="GO_REF:0000002" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Appropriate mechanistic process term: Galpha subunits are the canonical transducers of GPCR signaling. This captures the pathway type through which GPA-12 relays signals in the epidermis, even though the specific receptor is not yet identified.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Accurate, mechanism-defining process for a Galpha subunit.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0007266" target="_blank" class="term-link">
+                                    GO:0007266
+                                </a>
+                            </span>
+                            <span class="term-label">Rho protein signal transduction</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q19572" data-a="GO:0007266" data-r="GO_REF:0000002" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> InterPro-based duplicate of the IBA Rho protein signal transduction annotation, reflecting the canonical G12/13 -&gt; RhoGEF -&gt; Rho effector arm. As with the IBA version, this is homology-based and not experimentally demonstrated for worm GPA-12.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Redundant with the IBA annotation; homology-supported canonical function not demonstrated in worm.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0019001" target="_blank" class="term-link">
+                                    GO:0019001
+                                </a>
+                            </span>
+                            <span class="term-label">guanyl nucleotide binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q19572" data-a="GO:0019001" data-r="GO_REF:0000002" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct supporting molecular function: GPA-12 binds guanine nucleotides (GTP/GDP) via its intact G-box motifs. This underlies the G protein switch but is a component capability rather than the core function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Accurate binding activity underpinning the GTPase/G-protein switch; supporting rather than core.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031683" target="_blank" class="term-link">
+                                    GO:0031683
+                                </a>
+                            </span>
+                            <span class="term-label">G-protein beta/gamma-subunit complex binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q19572" data-a="GO:0031683" data-r="GO_REF:0000002" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct: the Galpha subunit binds the Gbeta/gamma dimer to form the inactive heterotrimer, releasing it upon GTP loading. Consistent with the curated GO-CAM (gomodel:5b91dbd100002057), which models GPA-12&#39;s molecular function as Gbeta/gamma-subunit complex binding, partnered with the Gbeta RACK-1.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Accurate Galpha-Gbetagamma interaction supporting heterotrimer assembly; supporting rather than the core signaling function.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0010628" target="_blank" class="term-link">
+                                    GO:0010628
+                                </a>
+                            </span>
+                            <span class="term-label">positive regulation of gene expression</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/22470487" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:22470487
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The pseudokinase NIPI-4 is a novel regulator of antimicrobia...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q19572" data-a="GO:0010628" data-r="PMID:22470487" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Experimentally supported: epidermis-restricted active GPA-12* drives a marked constitutive increase in antimicrobial peptide gene expression (nlp-29, nlp-31, nlp-34 and cnc-1, cnc-4), an effect abolished in a nipi-4 mutant. This is the transcriptional-induction readout of GPA-12&#39;s epidermal immune signaling.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Directly supported by loss/gain-of-function transcriptional data; captures GPA-12&#39;s role in up-regulating immune-effector gene expression.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/22470487" target="_blank" class="term-link">
+                                        PMID:22470487
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">In uninfected transgenic worms carrying the Pcol-19::GPA-12* construct, we observed a very marked increase in the expression of Pnlp-29::GFP in the epidermis from the late L4 stage onwards</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/22470487" target="_blank" class="term-link">
+                                        PMID:22470487
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">the transgenic strain exhibited an elevated constitutive expression of nlp-29, nlp-31 and nlp-34, and cnc-1, cnc-4</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0050832" target="_blank" class="term-link">
+                                    GO:0050832
+                                </a>
+                            </span>
+                            <span class="term-label">defense response to fungus</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/22470487" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:22470487
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The pseudokinase NIPI-4 is a novel regulator of antimicrobia...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q19572" data-a="GO:0050832" data-r="PMID:22470487" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Experimentally supported core biological process. GPA-12 signaling is required for the epidermal antifungal defense program (nlp/cnc antimicrobial peptide induction) against the natural fungal pathogen Drechmeria coniospora.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Well-supported IMP annotation reflecting GPA-12&#39;s core physiological role in antifungal defense.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/22470487" target="_blank" class="term-link">
+                                        PMID:22470487
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">When we crossed the Pcol-19::GPA-12* transgene into nipi-4(fr106) mutant, the elevated expression of the Pnlp-29::GFP reporter provoked by the active form of GPA-12 was abrogated</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0061760" target="_blank" class="term-link">
+                                    GO:0061760
+                                </a>
+                            </span>
+                            <span class="term-label">antifungal innate immune response</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/19380113" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:19380113
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Antifungal innate immunity in C. elegans: PKCdelta links G p...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q19572" data-a="GO:0061760" data-r="PMID:19380113" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Experimentally supported and the most specific immune process term for GPA-12. Epidermal antifungal innate immunity (nlp-29 induction) requires G protein signaling acting through PKCdelta and the p38 MAPK cascade, with GPA-12 as the Galpha subunit; this is the same activity modeled in the curated GO-CAM (gomodel:5b91dbd100002057).
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Core, well-supported immune process; most specific and informative BP term for this gene.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/19380113" target="_blank" class="term-link">
+                                        PMID:19380113
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">This involves G protein signaling and specific C-type phospholipases acting upstream of PKCdelta</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/19380113" target="_blank" class="term-link">
+                                        PMID:19380113
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">C. elegans PKC acts through the p38 MAPK pathway to regulate nlp-29</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005634" target="_blank" class="term-link">
+                                    GO:0005634
+                                </a>
+                            </span>
+                            <span class="term-label">nucleus</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/12646136" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:12646136
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Hyperactivation of the G12-mediated signaling pathway in Cae...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q19572" data-a="GO:0005634" data-r="PMID:12646136" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> WormBase IDA nuclear localization from PMID:12646136. Nuclear localization is unusual for a Galpha subunit, and the primary imaging data are in the full text, which is not in the cache (abstract-only). Per curation guidance I do not overrule an experimental IDA I cannot fully verify; I retain it as a non-core localization and defer to the WormBase curator.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Experimental IDA from the curator (full text unavailable to verify); unusual for a Galpha and not a core function, but not to be removed on incomplete evidence.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
+                                    GO:0005737
+                                </a>
+                            </span>
+                            <span class="term-label">cytoplasm</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/12646136" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:12646136
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Hyperactivation of the G12-mediated signaling pathway in Cae...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q19572" data-a="GO:0005737" data-r="PMID:12646136" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> WormBase IDA cytoplasmic localization from PMID:12646136, consistent with the expected peripheral/cytoplasmic disposition of a membrane-associated Galpha subunit and with the IBA cytoplasm annotation. Accepted as the cellular compartment in which GPA-12 acts.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Experimentally curated localization for a Galpha, corroborated by phylogenetic inference; accepted as GPA-12&#39;s cellular compartment of action.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0050832" target="_blank" class="term-link">
+                                    GO:0050832
+                                </a>
+                            </span>
+                            <span class="term-label">defense response to fungus</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/19380113" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:19380113
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Antifungal innate immunity in C. elegans: PKCdelta links G p...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q19572" data-a="GO:0050832" data-r="PMID:19380113" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Experimentally supported core process (duplicate term with a distinct primary reference). GPA-12 is required for the epidermal antifungal defense response, as shown by its position upstream of PKCdelta and the p38 cascade controlling nlp-29 induction after fungal infection.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Well-supported IMP annotation from the Ziegler et al. study; reinforces the core antifungal-defense role.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/19380113" target="_blank" class="term-link">
+                                        PMID:19380113
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">This involves G protein signaling and specific C-type phospholipases acting upstream of PKCdelta</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>GPA-12 acts as a Galpha-12/13-type heterotrimeric G protein alpha subunit: a GTP/GDP-regulated molecular switch that transduces cell-surface (GPCR-type) signals in the C. elegans epidermis. Functioning upstream of PKCdelta (TPA-1) and the conserved TIR-1 -&gt; NSY-1 -&gt; SEK-1 -&gt; PMK-1 (p38) MAPK cascade and the STAT-like factor STA-2, GPA-12 signaling drives induction of NLP- and CNC-family antimicrobial peptide genes in the antifungal innate immune response and after wounding. It assembles into a heterotrimer with a Gbeta (RACK-1)/gamma dimer, and an activated form (Q205L) is sufficient to drive the antimicrobial peptide program.</h3>
+                <span class="vote-buttons" data-g="Q19572" data-a="FUNCTION: GPA-12 acts as a Galpha-12/13-type heterotrimeric ..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003925" target="_blank" class="term-link">
+                            G protein activity
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0061760" target="_blank" class="term-link">
+                                antifungal innate immune response
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0007186" target="_blank" class="term-link">
+                                G protein-coupled receptor signaling pathway
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
+                                cytoplasm
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">In Complex:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005834" target="_blank" class="term-link">
+                            heterotrimeric G-protein complex
+                        </a>
+                    </span>
+                </div>
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/19380113" target="_blank" class="term-link">
+                                PMID:19380113
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">This involves G protein signaling and specific C-type phospholipases acting upstream of PKCdelta</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/22470487" target="_blank" class="term-link">
+                                PMID:22470487
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">Wounding and infection require G-protein signaling, involving the Gα protein GPA-12 and the Gß RACK-1, while infection specifically involves the Tribbles-like kinase NIPI-3</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/12646136" target="_blank" class="term-link">
+                                PMID:12646136
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">We characterized a C. elegans Galpha subunit gene, gpa-12, which is a homolog of mammalian G(12)/G(13)alpha, and found that animals defective in gpa-12 are viable</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000002.md" target="_blank" class="term-link">
+                            GO_REF:0000002
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation through association of InterPro records with GO terms</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
+                            GO_REF:0000033
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Annotation inferences using phylogenetic trees</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/12646136" target="_blank" class="term-link">
+                            PMID:12646136
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Hyperactivation of the G12-mediated signaling pathway in Caenorhabditis elegans induces a developmental growth arrest via protein kinase C.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/19380113" target="_blank" class="term-link">
+                            PMID:19380113
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Antifungal innate immunity in C. elegans: PKCdelta links G protein signaling and a conserved p38 MAPK cascade.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/22470487" target="_blank" class="term-link">
+                            PMID:22470487
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">The pseudokinase NIPI-4 is a novel regulator of antimicrobial peptide gene expression.</div>
+
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Knowledge Gaps</h2>
+        <p style="color: #555; font-size: 0.92rem; margin-top: -0.3rem;">
+            What is <em>not</em> known — curated, literature-grounded statements of the open
+            unknowns (the inverse of core functions).
+        </p>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The cognate receptor and activating input for GPA-12 are not biochemically defined. It is unknown which cell-surface receptor couples to GPA-12 to initiate epidermal immune signaling, what ligand/damage cue activates it, and whether GPA-12 engages such a receptor directly.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">RESIDUAL_SUBGAP</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> Established: GPA-12 is a Galpha-12/13 subunit that acts upstream of PKCdelta (TPA-1) and the p38 MAPK cascade to drive antimicrobial peptide expression after fungal infection and wounding, and its activity is required for this response. Unknown: the identity of the activating receptor and whether coupling is direct.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Identifying the receptor that switches on GPA-12 would define the sensing step of epidermal surveillance immunity and connect damage/infection detection to the p38/PMK-1 defense program.</p>
+
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"Our current understanding of both epidermal and intestinal innate immunity is far from complete"</em> — PMID:22470487</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The immediate downstream effector of GPA-12 is undetermined. Genetic epistasis places GPA-12 upstream of phospholipase (PLC-3) and PKCdelta (TPA-1), but it is not known whether GPA-12 directly activates a phospholipase, a RhoGEF/Rho module (the canonical mammalian Galpha-12/13 effector arm), or another target.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">MF_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> Established: GPA-12/G-protein signaling acts genetically upstream of C-type phospholipases and PKCdelta, and activated GPA-12 drives the p38-dependent antimicrobial peptide program. Unknown: the direct biochemical effector; the canonical G12/13 -&gt; RhoGEF -&gt; Rho arm has not been demonstrated in worm.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Whether worm GPA-12 signals through a Rho arm (like mammalian G12/13) or through a phospholipase/PKCdelta arm (more Gq-like) determines how this subfamily was wired into nematode epidermal immunity and would resolve an apparent divergence from the mammalian paradigm.</p>
+
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"This involves G protein signaling and specific C-type phospholipases acting upstream of PKCdelta"</em> — PMID:19380113</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The full endogenous tissue and physiological repertoire of GPA-12 is unresolved. Its immune requirement is epidermis/cell-type restricted, and hyperactive G12 separately perturbs pharyngeal pumping/feeding and growth, but why the immune requirement is tissue-restricted and what other endogenous processes GPA-12 normally controls are not defined.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">BP_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> Established: active GPA-12 drives antimicrobial peptide expression in the epidermis and, when broadly hyperactivated, causes a growth arrest via a pharyngeal-pumping defect (with TPA-1 downstream); loss-of-function animals are viable. Unknown: the complete set of tissues/behaviors in which endogenous GPA-12 acts, and the basis of its tissue-restricted immune role.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Mapping GPA-12&#39;s endogenous functions would distinguish its dedicated immune role from its developmental/feeding role and clarify how one Galpha subunit is deployed across contexts.</p>
+
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"Expression of activated GPA-12 (G(12)QL) results in a developmental growth arrest caused by a feeding behavior defect that is due to a dramatic reduction in pharyngeal pumping"</em> — PMID:12646136</li>
+
+            </ul>
+
+
+        </div>
+
+    </div>
+
+
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Deep Research Sections -->
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(gpa-12-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="Q19572" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="gpa-12-c-elegans-research-notes">gpa-12 (C. elegans) — research notes</h1>
+<p>UniProt: Q19572 (GPA12_CAEEL) · WormBase: WBGene00001674 / F18G5.3 · 355 aa · Chromosome X</p>
+<h2 id="summary-identity">Summary / identity</h2>
+<p>GPA-12 is a heterotrimeric guanine-nucleotide-binding protein alpha subunit of the<br />
+<strong>Gα12/13 subfamily</strong> (InterPro IPR000469 Gprotein_alpha_12/13; PRINTS PR00440 GPROTEINA12;<br />
+PANTHER PTHR10218 "GTP-binding protein alpha subunit"). It is the C. elegans homolog of<br />
+mammalian Gα12/Gα13 <a href="https://pubmed.ncbi.nlm.nih.gov/12646136" title="a C. elegans Galpha subunit gene, gpa-12, which is a homolog of mammalian G(12)/G(13)alpha, and found that animals defective in gpa-12 are viable">PMID:12646136</a>.<br />
+The protein has the canonical G-alpha domain with all five G-box GTP/Mg2+-binding motifs<br />
+(G1 31–44 … G5 325–330; UniProt) and N-terminal cysteines (…MVCCFGKK…) typical of<br />
+membrane-anchored Gα subunits.</p>
+<h2 id="known-well-supported">KNOWN (well supported)</h2>
+<h3 id="molecular-function">Molecular function</h3>
+<ul>
+<li><strong>G protein (Gα) GTP/GDP molecular switch — GO:0003925 G protein activity.</strong> Family<br />
+  membership and the intact G1–G5 nucleotide-binding motifs (UniProt) support intrinsic<br />
+  guanine-nucleotide binding and GTPase-based cycling. The functional read-out of the switch<br />
+  is demonstrated genetically: a Q205L substitution in the catalytic Gln (the residue whose<br />
+  mutation blocks GTP hydrolysis in Gα subunits) yields a <strong>constitutively active</strong> GPA-12<br />
+  that drives constitutive antimicrobial-peptide gene expression [UniProt MUTAGEN Q205L,<br />
+  ECO:0000269|PMID:22470487]. Intrinsic GTPase activity of the worm protein has not been<br />
+  measured biochemically (inferred from homology + the behavior of the GQ→L mutant).</li>
+<li>Assembles into a <strong>heterotrimeric G protein complex</strong> (Gα·Gβγ). The curated GO-CAM<br />
+  (gomodel:5b91dbd100002057) models GPA-12's molecular function as <strong>GO:0031683 G-protein<br />
+  beta/gamma-subunit complex binding</strong>, partnered in the pathway with the Gβ RACK-1.</li>
+</ul>
+<h3 id="biological-process-epidermal-antifungal-innate-immunity-the-core-physiological-role">Biological process — epidermal antifungal innate immunity (the core physiological role)</h3>
+<ul>
+<li>Required for <strong>antifungal innate immune response / defense response to fungus</strong> in the<br />
+  epidermis: GPA-12 signaling is needed for infection- and wounding-induced up-regulation of<br />
+  antimicrobial peptides of the NLP (nlp-29 cluster) and CNC families<br />
+  [PMID:19380113 IMP; PMID:22470487 IMP].</li>
+<li><strong>Genetic pathway position (epistasis):</strong> GPA-12/G-protein signaling acts <strong>upstream of</strong><br />
+  PKCδ (TPA-1) and a conserved p38 MAPK cassette (TIR-1 → NSY-1 → SEK-1 → PMK-1) →<br />
+  STAT-like STA-2, driving nlp/cnc gene expression [PMID:19380113 "This involves G protein<br />
+  signaling and specific C-type phospholipases acting upstream of PKCdelta"; "C. elegans PKC<br />
+  acts through the p38 MAPK pathway to regulate nlp-29"]. In PMID:22470487:<br />
+  "Wounding and infection require G-protein signaling, involving the Gα protein GPA-12 and the<br />
+  Gß RACK-1, while infection specifically involves the Tribbles-like kinase NIPI-3".</li>
+<li><strong>Gain-of-function drives the effector program:</strong> epidermis-restricted expression of active<br />
+  GPA-12<em> (Pcol-19::GPA-12</em>) causes marked constitutive Pnlp-29::GFP expression<br />
+  ["In uninfected transgenic worms carrying the Pcol-19::GPA-12<em> construct, we observed a very<br />
+  marked increase in the expression of Pnlp-29::GFP in the epidermis from the late L4 stage<br />
+  onwards"] and constitutive nlp/cnc transcript induction ["the transgenic strain exhibited an<br />
+  elevated constitutive expression of nlp-29, nlp-31 and nlp-34, and cnc-1, cnc-4"]; this<br />
+  effect is abrogated in a nipi-4 (downstream pseudokinase) mutant ["When we crossed the<br />
+  Pcol-19::GPA-12</em> transgene into nipi-4(fr106) mutant, the elevated expression of the<br />
+  Pnlp-29::GFP reporter provoked by the active form of GPA-12 was abrogated"] (all<br />
+  PMID:22470487). → supports <strong>positive regulation of gene expression (GO:0010628, IMP)</strong>.</li>
+<li><strong>GO-CAM causal structure</strong> (gomodel:5b91dbd100002057, "Antifungal innate immune response in<br />
+  the hypodermis via MAPK cascade"): GPA-12 activity is causally <strong>upstream, positive effect</strong><br />
+  (RO:0002304) of TPA-1 activity, within GO:0061760 antifungal innate immune response<br />
+  (evidence PMID:19380113). Consistent with the literature.</li>
+</ul>
+<h3 id="a-second-developmental-context-g12-gain-of-function">A second, developmental context (Gα12 gain-of-function)</h3>
+<ul>
+<li>Activated <strong>GPA-12 (G12QL) causes a developmental growth arrest</strong> via a feeding defect<br />
+  (reduced pharyngeal pumping); genetic suppressors map to <strong>tpa-1</strong> (PKCθ/δ), placing TPA-1<br />
+  downstream of G12 signaling here too [PMID:12646136 "Expression of activated GPA-12 (G(12)QL)<br />
+  results in a developmental growth arrest caused by a feeding behavior defect that is due to a<br />
+  dramatic reduction in pharyngeal pumping"; "TPA-1 is a downstream target of both G(12)<br />
+  signaling and PMA in modulating feeding and growth in C. elegans"]. gpa-12 loss-of-function<br />
+  animals are viable (i.e. not essential).</li>
+</ul>
+<h3 id="localization">Localization</h3>
+<ul>
+<li>WormBase IDA: <strong>cytoplasm (GO:0005737)</strong> and <strong>nucleus (GO:0005634)</strong> [PMID:12646136, IDA].<br />
+  Full text of PMID:12646136 is not in cache (abstract-only); the localization data are in the<br />
+  full text I cannot read. Cytoplasmic/peripheral-membrane localization is expected for a Gα;<br />
+  nuclear localization of a Gα is unusual — I defer to the WormBase curator but treat these as<br />
+  non-core.</li>
+</ul>
+<h2 id="not-known-genuine-knowledge-gaps">NOT known / genuine knowledge gaps</h2>
+<ul>
+<li><strong>Cognate receptor / activating input.</strong> The receptor(s) and ligand(s) that activate GPA-12<br />
+  to launch epidermal immune signaling, and whether GPA-12 couples directly to a damage-sensing<br />
+  GPCR, are not established from the cached primary literature. PMID:22470487 states the<br />
+  upstream elements are only partly defined ("Our current understanding of both epidermal and<br />
+  intestinal innate immunity is far from complete"). (A candidate epidermal GPCR, DCAR-1,<br />
+  has been reported elsewhere in the field, but that paper is not in the cache and the direct<br />
+  GPA-12↔receptor biochemical coupling is not shown here.)</li>
+<li><strong>Direct downstream effector.</strong> Genetic epistasis places GPA-12 upstream of PLC-3 / TPA-1<br />
+  (PKCδ) and the p38 cascade, but the <em>immediate biochemical</em> effector of GPA-12 is unproven.<br />
+  Notably, the canonical mammalian Gα12/13 effector arm (RhoGEF → Rho; GO:0007266 Rho protein<br />
+  signal transduction) has not been demonstrated for the worm protein; in worm the demonstrated<br />
+  arm runs through phospholipase/PKCδ, which is more Gq-like. Whether GPA-12 directly engages a<br />
+  RhoGEF, a phospholipase, or another effector is unresolved.</li>
+<li><strong>Tissue-restricted requirement / broader physiology.</strong> GPA-12 is required for AMP induction<br />
+  in the hyp7 epidermal syncytium (UniProt DISRUPTION PHENOTYPE, from PMID:19380113 full text),<br />
+  and activated G12 separately perturbs pharyngeal pumping/feeding (PMID:12646136). The full<br />
+  endogenous tissue/behavioral repertoire of GPA-12, and why the immune requirement is<br />
+  epidermis/cell-type restricted, are not resolved.</li>
+</ul>
+<h2 id="annotation-review-plan-existing_annotations-20-total">Annotation review plan (existing_annotations, 20 total)</h2>
+<ul>
+<li>ACCEPT (core): GO:0003925 G protein activity (IBA); GO:0061760 antifungal innate immune<br />
+  response (IMP); GO:0050832 defense response to fungus (IMP, ×2); GO:0007186 GPCR signaling<br />
+  pathway (IEA); GO:0007266 Rho protein signal transduction (IBA) [canonical G12/13 effector,<br />
+  homology]; GO:0005834 heterotrimeric G-protein complex (IBA, part_of); GO:0010628 positive<br />
+  regulation of gene expression (IMP).</li>
+<li>ACCEPT / KEEP_AS_NON_CORE (true but generic or supporting): GO:0003924 GTPase activity (IEA);<br />
+  GO:0019001 guanyl nucleotide binding (IEA); GO:0031683 G-protein beta/gamma-subunit complex<br />
+  binding (IEA); GO:0001664 GPCR binding (IEA); GO:0007165 signal transduction (IEA, generic);<br />
+  GO:0007266 Rho signal transduction (IEA, redundant with IBA); GO:0005737 cytoplasm (IBA &amp; IDA).</li>
+<li>KEEP_AS_NON_CORE / defer: GO:0005634 nucleus (IDA) — unusual for a Gα, full text unavailable.</li>
+<li>REMOVE / MARK_AS_OVER_ANNOTATED (over-propagated to this G12/13 worm protein):</li>
+<li>GO:0007188 adenylate cyclase-modulating GPCR signaling pathway (IBA) — REMOVE: cAMP/adenylate<br />
+    cyclase modulation is a Gs/Gi function; G12/13 subfamily does not signal this way (pan-Gα<br />
+    PANTHER node PTN000026392 over-propagation).</li>
+<li>GO:0031752 D5 dopamine receptor binding (IBA) — REMOVE: hyper-specific mammalian receptor;<br />
+    no worm ortholog/evidence.</li>
+<li>GO:0031526 brush border membrane (IBA) — MARK_AS_OVER_ANNOTATED: mammalian intestinal<br />
+    microvillar location; GPA-12 acts in epidermis; no worm evidence.</li>
+</ul>
+<h2 id="key-references-cached">Key references (cached)</h2>
+<ul>
+<li>PMID:12646136 — van der Linden et al. 2003, Curr Biol. gpa-12 = Gα12/13 homolog; active G12QL<br />
+  → growth arrest via feeding/pharyngeal-pumping defect; TPA-1/PKC downstream. (abstract-only)</li>
+<li>PMID:19380113 — Ziegler et al. 2009, Cell Host Microbe. PKCδ links G-protein signaling and the<br />
+  p38 MAPK cascade in antifungal immunity; GPA-12 upstream of TPA-1/p38 → nlp-29. (abstract-only)</li>
+<li>PMID:22470487 — Labed et al. 2012, PLoS One. NIPI-4 pseudokinase downstream of TPA-1;<br />
+  epidermal GPA-12* drives constitutive nlp/cnc AMP expression, nipi-4-dependent. (full text)</li>
+<li>GO-CAM gomodel:5b91dbd100002057 — antifungal innate immune response in the hypodermis via MAPK<br />
+  cascade; GPA-12 (Gβγ-binding) causally upstream (+) of TPA-1.<br />
+</content></li>
+</ul>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: Q19572
+gene_symbol: gpa-12
+product_type: PROTEIN
+status: COMPLETE
+taxon:
+  id: NCBITaxon:6239
+  label: Caenorhabditis elegans
+description: &gt;-
+  GPA-12 is a heterotrimeric guanine-nucleotide-binding protein (G protein) alpha
+  subunit of the Galpha-12/13 subfamily, the C. elegans homolog of mammalian
+  Galpha-12/Galpha-13. It has a canonical Galpha domain with intact G1-G5
+  nucleotide-binding motifs and functions as a GTP/GDP-regulated molecular switch
+  that, in its GTP-bound state, engages downstream effectors to relay signals from
+  the cell surface. Its best-characterized physiological role is in the epidermis
+  (hypodermis), where GPA-12 signaling acts upstream of protein kinase C delta
+  (TPA-1) and a conserved p38 MAPK cassette (TIR-1, NSY-1, SEK-1, PMK-1) and the
+  STAT-like factor STA-2 to drive induction of antimicrobial peptide genes of the
+  NLP (nlp-29 cluster) and CNC families in response to fungal infection and
+  wounding. A constitutively active form (GPA-12 Q205L / G12QL) is sufficient to
+  drive constitutive antimicrobial peptide gene expression, and, when hyperactivated
+  more broadly, causes a developmental growth arrest through a pharyngeal-pumping
+  (feeding) defect that also depends on TPA-1. gpa-12 loss-of-function animals are
+  viable.
+references:
+- id: GO_REF:0000002
+  title: Gene Ontology annotation through association of InterPro records with GO
+    terms
+- id: GO_REF:0000033
+  title: Annotation inferences using phylogenetic trees
+- id: PMID:12646136
+  title: Hyperactivation of the G12-mediated signaling pathway in Caenorhabditis elegans
+    induces a developmental growth arrest via protein kinase C.
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Foundational characterization of gpa-12 as the C. elegans Galpha-12/13 homolog;
+      active G12QL causes growth arrest via a pharyngeal-pumping/feeding defect and
+      places TPA-1/PKC downstream of G12 signaling. Verified against the cached
+      abstract; this is also the IDA source for the cytoplasm/nucleus localization
+      annotations, whose primary data are in the full text (not in cache).
+- id: PMID:19380113
+  title: &#39;Antifungal innate immunity in C. elegans: PKCdelta links G protein signaling
+    and a conserved p38 MAPK cascade.&#39;
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Establishes that epidermal antifungal immunity (nlp-29 induction) requires G
+      protein signaling acting through PKCdelta (TPA-1) and the p38 MAPK cascade;
+      GPA-12 is the Galpha in this pathway. IMP source for the antifungal
+      innate immune response / defense response to fungus annotations.
+- id: PMID:22470487
+  title: The pseudokinase NIPI-4 is a novel regulator of antimicrobial peptide gene
+    expression.
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Full text available; epidermis-restricted active GPA-12* (Pcol-19::GPA-12*)
+      drives constitutive nlp/cnc antimicrobial peptide expression in a
+      nipi-4-dependent manner, and states GPA-12 (with the Gbeta RACK-1) is required
+      for wound/infection-induced signaling. IMP source for positive regulation of
+      gene expression and defense response to fungus.
+existing_annotations:
+- term:
+    id: GO:0003925
+    label: G protein activity
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Correct and core molecular function. GPA-12 is a heterotrimeric G protein alpha
+      subunit (Galpha-12/13 subfamily) that cycles between GTP- and GDP-bound states
+      to act as a signal-transducing molecular switch. GO:0003925 is the appropriate
+      MF for such subunits, and its behavior is supported experimentally in worm by
+      the constitutively active Q205L (catalytic-glutamine) mutant.
+    action: ACCEPT
+    reason: &gt;-
+      Best and most specific molecular-function term for a Galpha subunit; consistent
+      with family membership, intact G1-G5 motifs, and the behavior of activated
+      GPA-12.
+    supported_by:
+    - reference_id: PMID:12646136
+      supporting_text: &gt;-
+        We characterized a C. elegans Galpha subunit gene, gpa-12, which is a homolog
+        of mammalian G(12)/G(13)alpha, and found that animals defective in gpa-12 are
+        viable
+- term:
+    id: GO:0005737
+    label: cytoplasm
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: is_active_in
+  review:
+    summary: &gt;-
+      Phylogenetic (IBA) localization to cytoplasm, independently corroborated by the
+      experimental IDA cytoplasm annotation from PMID:12646136. This is a reasonable
+      functional cellular compartment for a peripheral, membrane-associated Galpha
+      subunit that cycles at the cytoplasmic face of the plasma membrane.
+    action: ACCEPT
+    reason: &gt;-
+      Consistent, independently corroborated cellular localization for a Galpha
+      subunit; accepted as the cellular compartment in which GPA-12 acts.
+- term:
+    id: GO:0007188
+    label: adenylate cyclase-modulating G protein-coupled receptor signaling pathway
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Over-propagation from the pan-Galpha PANTHER family node. Adenylate
+      cyclase/cAMP modulation is the defining function of the Gs (stimulatory) and Gi
+      (inhibitory) subfamilies, not of the Galpha-12/13 subfamily to which GPA-12
+      belongs. There is no evidence that GPA-12 modulates adenylate cyclase, and this
+      pathway type is biologically inappropriate for a G12/13 protein.
+    action: REMOVE
+    reason: &gt;-
+      Biologically incorrect for the G12/13 subfamily; the term propagated
+      electronically from Gs/Gi paralogs in the broad pan-Galpha tree and should not
+      transfer to GPA-12.
+    propagation_review:
+      root_cause: PROPAGATION_BAD
+      failure_modes:
+      - WRONG_ORTHOLOG_OR_PARALOG
+      - FUNCTIONAL_DIVERGENCE
+      source_entities:
+      - source_id: PANTHER:PTN000026392
+        source_label: pan-Galpha family node
+        source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
+- term:
+    id: GO:0007266
+    label: Rho protein signal transduction
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Canonical mammalian Galpha-12/13 signaling activates RhoGEFs to relay signals
+      through Rho GTPases, so this term is biologically apt at the family level and
+      propagates from the G12/13 node (mouse Gna12/Gna13). However, the Rho effector
+      arm has not been demonstrated for C. elegans GPA-12; the experimentally defined
+      worm effector arm runs through phospholipase (PLC-3) and PKCdelta (TPA-1).
+      Retained as a homology-based, non-core inference.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Homology-supported canonical G12/13 function, but not experimentally established
+      in worm, where the demonstrated downstream arm is PLC/PKCdelta rather than Rho.
+- term:
+    id: GO:0005834
+    label: heterotrimeric G-protein complex
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: part_of
+  review:
+    summary: &gt;-
+      Correct. As a Galpha subunit, GPA-12 assembles into a heterotrimeric G protein
+      (Galpha-beta-gamma) complex; in the epidermal immune pathway it partners with
+      the Gbeta RACK-1.
+    action: ACCEPT
+    reason: &gt;-
+      Accurate and well-supported complex membership for a Galpha subunit.
+    supported_by:
+    - reference_id: PMID:22470487
+      supporting_text: &gt;-
+        Wounding and infection require G-protein signaling, involving the Gα protein
+        GPA-12 and the Gß RACK-1, while infection specifically involves the
+        Tribbles-like kinase NIPI-3
+- term:
+    id: GO:0031526
+    label: brush border membrane
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: is_active_in
+  review:
+    summary: &gt;-
+      Over-specific location propagated from mammalian (rat) orthologs. Brush border
+      membrane is the plasma membrane of intestinal microvilli; GPA-12&#39;s demonstrated
+      site of action is the epidermis/hypodermis. There is no C. elegans evidence for
+      brush border localization.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      Narrow mammalian-tissue location transferred by phylogenetic inference; not
+      supported for the worm protein and inconsistent with its known site of action.
+    propagation_review:
+      root_cause: PROPAGATION_BAD
+      failure_modes:
+      - CONTEXT_OR_TISSUE_MISMATCH
+      - COMPARTMENT_OR_COMPLEX_MISMATCH
+      source_entities:
+      - source_id: PANTHER:PTN000026689
+        source_label: Galpha-12/13 node
+        source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
+- term:
+    id: GO:0031752
+    label: D5 dopamine receptor binding
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Hyper-specific molecular function propagated from a single mammalian ortholog
+      annotation. Binding to a D5 dopamine receptor is not a plausible or supported
+      activity for C. elegans GPA-12 (worms lack a D5 dopamine receptor ortholog),
+      and there is no worm evidence for it.
+    action: REMOVE
+    reason: &gt;-
+      Over-propagated, organism-specific receptor-binding annotation with no relevance
+      or evidence for the worm protein.
+    propagation_review:
+      root_cause: PROPAGATION_BAD
+      failure_modes:
+      - WRONG_ORTHOLOG_OR_PARALOG
+      - CONTEXT_OR_TISSUE_MISMATCH
+      source_entities:
+      - source_id: PANTHER:PTN000026689
+        source_label: Galpha-12/13 node
+        source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
+- term:
+    id: GO:0001664
+    label: G protein-coupled receptor binding
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Generic InterPro-based inference. Galpha subunits are activated by, and
+      physically couple to, GPCRs, so GPCR binding is a defensible general molecular
+      function. However, the specific cognate receptor for GPA-12 is not established,
+      so this remains a generic, non-core capability.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      True general Galpha property (more informative than &#39;protein binding&#39;) but
+      generic; the actual GPA-12 receptor is unknown.
+- term:
+    id: GO:0003924
+    label: GTPase activity
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Galpha subunits have intrinsic GTPase activity that terminates signaling by
+      returning the switch to the GDP-bound state. Correct for GPA-12, whose G-box
+      motifs are intact and whose catalytic-glutamine (Q205L) mutant behaves as a
+      GTP-hydrolysis-defective, constitutively active protein. The more specific
+      GO:0003925 (G protein activity) better captures the defining signaling-switch
+      role, so this generic GTPase term is retained as a supporting, non-core activity.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Correct enzymatic capability for a Galpha subunit, but a supporting activity
+      underlying the switch rather than the defining core function, which is better
+      represented by GO:0003925 (G protein activity).
+- term:
+    id: GO:0007165
+    label: signal transduction
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      High-level, generic biological process. True (GPA-12 is a signal transducer)
+      but far less informative than the specific GPCR-signaling and immune-signaling
+      processes it participates in.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Correct but uninformatively general; subsumed by more specific process terms.
+- term:
+    id: GO:0007186
+    label: G protein-coupled receptor signaling pathway
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Appropriate mechanistic process term: Galpha subunits are the canonical
+      transducers of GPCR signaling. This captures the pathway type through which
+      GPA-12 relays signals in the epidermis, even though the specific receptor is not
+      yet identified.
+    action: ACCEPT
+    reason: &gt;-
+      Accurate, mechanism-defining process for a Galpha subunit.
+- term:
+    id: GO:0007266
+    label: Rho protein signal transduction
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      InterPro-based duplicate of the IBA Rho protein signal transduction annotation,
+      reflecting the canonical G12/13 -&gt; RhoGEF -&gt; Rho effector arm. As with the IBA
+      version, this is homology-based and not experimentally demonstrated for worm
+      GPA-12.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Redundant with the IBA annotation; homology-supported canonical function not
+      demonstrated in worm.
+- term:
+    id: GO:0019001
+    label: guanyl nucleotide binding
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Correct supporting molecular function: GPA-12 binds guanine nucleotides
+      (GTP/GDP) via its intact G-box motifs. This underlies the G protein switch but
+      is a component capability rather than the core function.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Accurate binding activity underpinning the GTPase/G-protein switch; supporting
+      rather than core.
+- term:
+    id: GO:0031683
+    label: G-protein beta/gamma-subunit complex binding
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Correct: the Galpha subunit binds the Gbeta/gamma dimer to form the inactive
+      heterotrimer, releasing it upon GTP loading. Consistent with the curated GO-CAM
+      (gomodel:5b91dbd100002057), which models GPA-12&#39;s molecular function as
+      Gbeta/gamma-subunit complex binding, partnered with the Gbeta RACK-1.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Accurate Galpha-Gbetagamma interaction supporting heterotrimer assembly;
+      supporting rather than the core signaling function.
+- term:
+    id: GO:0010628
+    label: positive regulation of gene expression
+  evidence_type: IMP
+  original_reference_id: PMID:22470487
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Experimentally supported: epidermis-restricted active GPA-12* drives a marked
+      constitutive increase in antimicrobial peptide gene expression (nlp-29, nlp-31,
+      nlp-34 and cnc-1, cnc-4), an effect abolished in a nipi-4 mutant. This is the
+      transcriptional-induction readout of GPA-12&#39;s epidermal immune signaling.
+    action: ACCEPT
+    reason: &gt;-
+      Directly supported by loss/gain-of-function transcriptional data; captures
+      GPA-12&#39;s role in up-regulating immune-effector gene expression.
+    supported_by:
+    - reference_id: PMID:22470487
+      supporting_text: &gt;-
+        In uninfected transgenic worms carrying the Pcol-19::GPA-12* construct, we
+        observed a very marked increase in the expression of Pnlp-29::GFP in the
+        epidermis from the late L4 stage onwards
+    - reference_id: PMID:22470487
+      supporting_text: &gt;-
+        the transgenic strain exhibited an elevated constitutive expression of nlp-29,
+        nlp-31 and nlp-34, and cnc-1, cnc-4
+- term:
+    id: GO:0050832
+    label: defense response to fungus
+  evidence_type: IMP
+  original_reference_id: PMID:22470487
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Experimentally supported core biological process. GPA-12 signaling is required
+      for the epidermal antifungal defense program (nlp/cnc antimicrobial peptide
+      induction) against the natural fungal pathogen Drechmeria coniospora.
+    action: ACCEPT
+    reason: &gt;-
+      Well-supported IMP annotation reflecting GPA-12&#39;s core physiological role in
+      antifungal defense.
+    supported_by:
+    - reference_id: PMID:22470487
+      supporting_text: &gt;-
+        When we crossed the Pcol-19::GPA-12* transgene into nipi-4(fr106) mutant, the
+        elevated expression of the Pnlp-29::GFP reporter provoked by the active form of
+        GPA-12 was abrogated
+- term:
+    id: GO:0061760
+    label: antifungal innate immune response
+  evidence_type: IMP
+  original_reference_id: PMID:19380113
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Experimentally supported and the most specific immune process term for GPA-12.
+      Epidermal antifungal innate immunity (nlp-29 induction) requires G protein
+      signaling acting through PKCdelta and the p38 MAPK cascade, with GPA-12 as the
+      Galpha subunit; this is the same activity modeled in the curated GO-CAM
+      (gomodel:5b91dbd100002057).
+    action: ACCEPT
+    reason: &gt;-
+      Core, well-supported immune process; most specific and informative BP term for
+      this gene.
+    supported_by:
+    - reference_id: PMID:19380113
+      supporting_text: &gt;-
+        This involves G protein signaling and specific C-type phospholipases acting
+        upstream of PKCdelta
+    - reference_id: PMID:19380113
+      supporting_text: &gt;-
+        C. elegans PKC acts through the p38 MAPK pathway to regulate nlp-29
+- term:
+    id: GO:0005634
+    label: nucleus
+  evidence_type: IDA
+  original_reference_id: PMID:12646136
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      WormBase IDA nuclear localization from PMID:12646136. Nuclear localization is
+      unusual for a Galpha subunit, and the primary imaging data are in the full text,
+      which is not in the cache (abstract-only). Per curation guidance I do not
+      overrule an experimental IDA I cannot fully verify; I retain it as a non-core
+      localization and defer to the WormBase curator.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Experimental IDA from the curator (full text unavailable to verify); unusual for
+      a Galpha and not a core function, but not to be removed on incomplete evidence.
+- term:
+    id: GO:0005737
+    label: cytoplasm
+  evidence_type: IDA
+  original_reference_id: PMID:12646136
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      WormBase IDA cytoplasmic localization from PMID:12646136, consistent with the
+      expected peripheral/cytoplasmic disposition of a membrane-associated Galpha
+      subunit and with the IBA cytoplasm annotation. Accepted as the cellular
+      compartment in which GPA-12 acts.
+    action: ACCEPT
+    reason: &gt;-
+      Experimentally curated localization for a Galpha, corroborated by phylogenetic
+      inference; accepted as GPA-12&#39;s cellular compartment of action.
+- term:
+    id: GO:0050832
+    label: defense response to fungus
+  evidence_type: IMP
+  original_reference_id: PMID:19380113
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Experimentally supported core process (duplicate term with a distinct primary
+      reference). GPA-12 is required for the epidermal antifungal defense response, as
+      shown by its position upstream of PKCdelta and the p38 cascade controlling
+      nlp-29 induction after fungal infection.
+    action: ACCEPT
+    reason: &gt;-
+      Well-supported IMP annotation from the Ziegler et al. study; reinforces the core
+      antifungal-defense role.
+    supported_by:
+    - reference_id: PMID:19380113
+      supporting_text: &gt;-
+        This involves G protein signaling and specific C-type phospholipases acting
+        upstream of PKCdelta
+core_functions:
+- description: &gt;-
+    GPA-12 acts as a Galpha-12/13-type heterotrimeric G protein alpha subunit: a
+    GTP/GDP-regulated molecular switch that transduces cell-surface (GPCR-type)
+    signals in the C. elegans epidermis. Functioning upstream of PKCdelta (TPA-1) and
+    the conserved TIR-1 -&gt; NSY-1 -&gt; SEK-1 -&gt; PMK-1 (p38) MAPK cascade and the
+    STAT-like factor STA-2, GPA-12 signaling drives induction of NLP- and CNC-family
+    antimicrobial peptide genes in the antifungal innate immune response and after
+    wounding. It assembles into a heterotrimer with a Gbeta (RACK-1)/gamma dimer, and
+    an activated form (Q205L) is sufficient to drive the antimicrobial peptide program.
+  molecular_function:
+    id: GO:0003925
+    label: G protein activity
+  directly_involved_in:
+  - id: GO:0061760
+    label: antifungal innate immune response
+  - id: GO:0007186
+    label: G protein-coupled receptor signaling pathway
+  in_complex:
+    id: GO:0005834
+    label: heterotrimeric G-protein complex
+  locations:
+  - id: GO:0005737
+    label: cytoplasm
+  supported_by:
+  - reference_id: PMID:19380113
+    supporting_text: &gt;-
+      This involves G protein signaling and specific C-type phospholipases acting
+      upstream of PKCdelta
+  - reference_id: PMID:22470487
+    supporting_text: &gt;-
+      Wounding and infection require G-protein signaling, involving the Gα protein
+      GPA-12 and the Gß RACK-1, while infection specifically involves the
+      Tribbles-like kinase NIPI-3
+  - reference_id: PMID:12646136
+    supporting_text: &gt;-
+      We characterized a C. elegans Galpha subunit gene, gpa-12, which is a homolog of
+      mammalian G(12)/G(13)alpha, and found that animals defective in gpa-12 are viable
+knowledge_gaps:
+- gap_statement: &gt;-
+    The cognate receptor and activating input for GPA-12 are not biochemically
+    defined. It is unknown which cell-surface receptor couples to GPA-12 to initiate
+    epidermal immune signaling, what ligand/damage cue activates it, and whether
+    GPA-12 engages such a receptor directly.
+  boundary: &gt;-
+    Established: GPA-12 is a Galpha-12/13 subunit that acts upstream of PKCdelta
+    (TPA-1) and the p38 MAPK cascade to drive antimicrobial peptide expression after
+    fungal infection and wounding, and its activity is required for this response.
+    Unknown: the identity of the activating receptor and whether coupling is direct.
+  gap_kind:
+  - BIOLOGY
+  dark_aspect: RESIDUAL_SUBGAP
+  status: OPEN
+  significance: &gt;-
+    Identifying the receptor that switches on GPA-12 would define the sensing step of
+    epidermal surveillance immunity and connect damage/infection detection to the
+    p38/PMK-1 defense program.
+  provenance:
+  - reference_id: PMID:22470487
+    supporting_text: &gt;-
+      Our current understanding of both epidermal and intestinal innate immunity is
+      far from complete
+- gap_statement: &gt;-
+    The immediate downstream effector of GPA-12 is undetermined. Genetic epistasis
+    places GPA-12 upstream of phospholipase (PLC-3) and PKCdelta (TPA-1), but it is
+    not known whether GPA-12 directly activates a phospholipase, a RhoGEF/Rho module
+    (the canonical mammalian Galpha-12/13 effector arm), or another target.
+  boundary: &gt;-
+    Established: GPA-12/G-protein signaling acts genetically upstream of C-type
+    phospholipases and PKCdelta, and activated GPA-12 drives the p38-dependent
+    antimicrobial peptide program. Unknown: the direct biochemical effector; the
+    canonical G12/13 -&gt; RhoGEF -&gt; Rho arm has not been demonstrated in worm.
+  gap_kind:
+  - BIOLOGY
+  dark_aspect: MF_DARK
+  status: OPEN
+  significance: &gt;-
+    Whether worm GPA-12 signals through a Rho arm (like mammalian G12/13) or through a
+    phospholipase/PKCdelta arm (more Gq-like) determines how this subfamily was wired
+    into nematode epidermal immunity and would resolve an apparent divergence from the
+    mammalian paradigm.
+  provenance:
+  - reference_id: PMID:19380113
+    supporting_text: &gt;-
+      This involves G protein signaling and specific C-type phospholipases acting
+      upstream of PKCdelta
+- gap_statement: &gt;-
+    The full endogenous tissue and physiological repertoire of GPA-12 is unresolved.
+    Its immune requirement is epidermis/cell-type restricted, and hyperactive G12
+    separately perturbs pharyngeal pumping/feeding and growth, but why the immune
+    requirement is tissue-restricted and what other endogenous processes GPA-12
+    normally controls are not defined.
+  boundary: &gt;-
+    Established: active GPA-12 drives antimicrobial peptide expression in the
+    epidermis and, when broadly hyperactivated, causes a growth arrest via a
+    pharyngeal-pumping defect (with TPA-1 downstream); loss-of-function animals are
+    viable. Unknown: the complete set of tissues/behaviors in which endogenous GPA-12
+    acts, and the basis of its tissue-restricted immune role.
+  gap_kind:
+  - BIOLOGY
+  dark_aspect: BP_DARK
+  status: OPEN
+  significance: &gt;-
+    Mapping GPA-12&#39;s endogenous functions would distinguish its dedicated immune role
+    from its developmental/feeding role and clarify how one Galpha subunit is deployed
+    across contexts.
+  provenance:
+  - reference_id: PMID:12646136
+    supporting_text: &gt;-
+      Expression of activated GPA-12 (G(12)QL) results in a developmental growth arrest
+      caused by a feeding behavior defect that is due to a dramatic reduction in
+      pharyngeal pumping
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/genes/worm/hip-1/hip-1-ai-review.html
+++ b/genes/worm/hip-1/hip-1-ai-review.html
@@ -1,0 +1,3573 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>hip-1 - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        .propagation-review {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f8fafc;
+            border-left: 3px solid #64748b;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .propagation-title {
+            font-weight: 600;
+            color: #334155;
+            margin-bottom: 0.25rem;
+        }
+
+        .propagation-row {
+            margin-top: 0.25rem;
+        }
+
+        .propagation-source {
+            margin-top: 0.5rem;
+            padding-top: 0.5rem;
+            border-top: 1px solid #e5e7eb;
+        }
+
+        .propagation-source-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #1d4ed8;
+        }
+
+        .propagation-comment {
+            color: #4b5563;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>hip-1</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/G5EE04" target="_blank" class="term-link">
+                        G5EE04
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Caenorhabditis elegans</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-draft">
+                    DRAFT
+                </span>
+            </div>
+
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "hip-1";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="G5EE04" data-a="DESCRIPTION: hip-1 encodes the Caenorhabditis elegans ortholog ..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>hip-1 encodes the Caenorhabditis elegans ortholog of Hsp70-interacting protein (Hip/ST13), a member of the FAM10 family and a co-chaperone of the cytosolic Hsp70 (Hsc70) chaperone system. The protein has a modular architecture: an N-terminal dimerization domain (Hip_N) that drives homo-oligomerization into a tetramer, a central tetratricopeptide-repeat (TPR) region that binds the ATPase (nucleotide-binding) domain of Hsp70, and a C-terminal STI1/DP domain. Hip binds the ADP-bound state of Hsp70 and stabilizes it, slowing ADP release and prolonging the high-affinity association of Hsp70 with substrate; because Hip and nucleotide-exchange factors bind Hsp70 in a mutually exclusive manner, Hip acts as an attenuator of the Hsp70 reaction cycle that biases the system toward substrate holding and folding rather than release and degradation. Hip also has intrinsic holdase activity, binding non-native polypeptides to prevent their aggregation, but it lacks ATPase activity and cannot refold substrates on its own. In C. elegans, HIP-1 acts through Hsp70 to suppress proteotoxic aggregation in vivo, and it is predominantly cytosolic, consistent with a role in the cytosolic protein quality-control network. It is distinct from the C. elegans HOP/Stip1 ortholog sti-1, which occupies a different node of the Hsp70/Hsp90 system.</p>
+    </div>
+
+
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006457" target="_blank" class="term-link">
+                                    GO:0006457
+                                </a>
+                            </span>
+                            <span class="term-label">protein folding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="G5EE04" data-a="GO:0006457" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetically inferred biological process. HIP-1 is an Hsp70 co-chaperone that cooperates with Hsc70 in the folding of newly synthesized and non-native polypeptides; protein folding is the core process it participates in.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Consistent with the conserved FAM10/Hip co-chaperone role and with experimental evidence from orthologs that Hip cooperates with Hsc70 in polypeptide folding and plays a critical role in protein folding in the eukaryotic cytoplasm.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/8999928" target="_blank" class="term-link">
+                                        PMID:8999928
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The homo-oligomeric Hip protein cooperates with the 70-kDa heat shock cognate Hsc70 in the folding of newly synthesized polypeptide chains</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9183013" target="_blank" class="term-link">
+                                        PMID:9183013
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">play a critical role in protein folding in the eukaryotic cytoplasm</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030544" target="_blank" class="term-link">
+                                    GO:0030544
+                                </a>
+                            </span>
+                            <span class="term-label">Hsp70 protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="G5EE04" data-a="GO:0030544" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Core, defining molecular function of a Hip-family co-chaperone: HIP-1 binds the N-terminal ATPase (nucleotide-binding) domain of Hsp70/Hsc70, specifically in the ADP state, and stabilizes the high substrate-affinity conformation.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> This is the informative, partner-specific molecular function of the protein and is supported by biochemical mapping in orthologs showing Hip binds the Hsc70 ATPase domain exclusively and by structural work showing it brackets the ATPase domain to lock in ADP.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9528774" target="_blank" class="term-link">
+                                        PMID:9528774
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Hip interacts exclusively with the amino-terminal ATPase domain of Hsc70</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/7585962" target="_blank" class="term-link">
+                                        PMID:7585962
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">One Hip oligomer binds the ATPase domains of at least two Hsc70 molecules</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005634" target="_blank" class="term-link">
+                                    GO:0005634
+                                </a>
+                            </span>
+                            <span class="term-label">nucleus</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000117
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-remove">
+                            REMOVE
+                        </span>
+                        <span class="vote-buttons" data-g="G5EE04" data-a="GO:0005634" data-r="GO_REF:0000117" data-act="REMOVE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic (ARBA machine-learning) cellular-component annotation with no experimental support. Hip/ST13 is an established cytosolic co-chaperone of the cytosolic Hsp70 machinery, and there is no evidence for nuclear localization of C. elegans HIP-1.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Over-propagated electronic inference that conflicts with the well-established cytosolic biology of Hip-family co-chaperones; not supported by any experimental or phylogenetic evidence for this gene.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0046983" target="_blank" class="term-link">
+                                    GO:0046983
+                                </a>
+                            </span>
+                            <span class="term-label">protein dimerization activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="G5EE04" data-a="GO:0046983" data-r="GO_REF:0000002" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> InterPro-derived (IPR034649, Hip_N) molecular function. HIP-1 genuinely homo-oligomerizes (dimer of dimers / tetramer) through its N-terminal Hip_N domain, which provides avidity for binding multiple Hsp70 molecules.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Self-association is real and functionally relevant but is a structural property rather than the informative core molecular function; retained as non-core. The N-terminal oligomerization determinant and the tetrameric state are documented experimentally in orthologs.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/8999928" target="_blank" class="term-link">
+                                        PMID:8999928
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">a domain required for homo-oligomerization was identified at the extreme amino terminus of Hip</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9183013" target="_blank" class="term-link">
+                                        PMID:9183013
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">the chaperone forms a tetramer similar to what has been reported for the native protein from rat liver cytosol</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0070013" target="_blank" class="term-link">
+                                    GO:0070013
+                                </a>
+                            </span>
+                            <span class="term-label">intracellular organelle lumen</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000117
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-remove">
+                            REMOVE
+                        </span>
+                        <span class="vote-buttons" data-g="G5EE04" data-a="GO:0070013" data-r="GO_REF:0000117" data-act="REMOVE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic (ARBA machine-learning) cellular-component annotation with no experimental support and inconsistent with the cytosolic localization of Hip-family co-chaperones.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Over-propagated electronic inference; an organelle-lumen location is not supported by any experimental or phylogenetic evidence for HIP-1 and conflicts with its cytosolic function.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1902494" target="_blank" class="term-link">
+                                    GO:1902494
+                                </a>
+                            </span>
+                            <span class="term-label">catalytic complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000117
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="G5EE04" data-a="GO:1902494" data-r="GO_REF:0000117" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic (ARBA machine-learning) annotation placing HIP-1 in a catalytic complex. HIP-1 itself is non-catalytic (no ATPase activity); it transiently associates with the catalytic Hsp70 ATPase, but &#34;catalytic complex&#34; is generic and mischaracterizes HIP-1&#39;s own role.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Uninformative and potentially misleading: HIP-1 does not catalyze a reaction and is not a stable structural subunit of a defined catalytic complex; its interaction with Hsp70 is transient and regulatory.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9183013" target="_blank" class="term-link">
+                                        PMID:9183013
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The recombinant form of Hip did not catalyze the hydrolysis of ATP and ATP analogs</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005783" target="_blank" class="term-link">
+                                    GO:0005783
+                                </a>
+                            </span>
+                            <span class="term-label">endoplasmic reticulum</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">HDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/21611156" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:21611156
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Determining the sub-cellular localization of proteins within...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="G5EE04" data-a="GO:0005783" data-r="PMID:21611156" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> High-throughput direct-assay localization from a body-wall-muscle GFP-localizome: T12D8.8::GFP fell in category 6, which includes the ER/SR alongside dense bodies and the M-line/thick filaments.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Experimental (HDA) but from muscle-specific overexpression of a C-terminally GFP-tagged protein, which the authors explicitly caution may perturb localization; retained as a non-core, muscle-context localization rather than the core cytosolic site of action.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/21611156" target="_blank" class="term-link">
+                                        PMID:21611156
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">They appear to be in the dense bodies, M-line and/or thick filaments, as well as the ER or SR</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/21611156" target="_blank" class="term-link">
+                                        PMID:21611156
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">the presence or perhaps over expression of the GFP-tagged protein may be disruptive</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030017" target="_blank" class="term-link">
+                                    GO:0030017
+                                </a>
+                            </span>
+                            <span class="term-label">sarcomere</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">HDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/21611156" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:21611156
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Determining the sub-cellular localization of proteins within...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="G5EE04" data-a="GO:0030017" data-r="PMID:21611156" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> High-throughput GFP-localizome placing T12D8.8::GFP at sarcomeric structures (M-line/thick filaments) in body-wall muscle (category 6).
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Experimental (HDA) but from muscle overexpression of a GFP fusion with acknowledged tagging/overexpression caveats; a genuine sarcomeric quality-control role is biologically plausible for a chaperone but unconfirmed for HIP-1, so kept as non-core.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/21611156" target="_blank" class="term-link">
+                                        PMID:21611156
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">They appear to be in the dense bodies, M-line and/or thick filaments, as well as the ER or SR</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0055120" target="_blank" class="term-link">
+                                    GO:0055120
+                                </a>
+                            </span>
+                            <span class="term-label">striated muscle dense body</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">HDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/21611156" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:21611156
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Determining the sub-cellular localization of proteins within...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="G5EE04" data-a="GO:0055120" data-r="PMID:21611156" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> High-throughput GFP-localizome placing T12D8.8::GFP at the dense body (Z-disk analog) in body-wall muscle (category 6).
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Experimental (HDA) but from muscle overexpression of a GFP fusion with acknowledged tagging/overexpression caveats; retained as a non-core, muscle-context localization rather than the core cytosolic site of action.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/21611156" target="_blank" class="term-link">
+                                        PMID:21611156
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">They appear to be in the dense bodies, M-line and/or thick filaments, as well as the ER or SR</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
+                                    GO:0005829
+                                </a>
+                            </span>
+                            <span class="term-label">cytosol</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ISS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/9183013" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:9183013
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Characterization of the molecular-chaperone function of the ...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-new">
+                            NEW
+                        </span>
+                        <span class="vote-buttons" data-g="G5EE04" data-a="GO:0005829" data-r="PMID:9183013" data-act="NEW">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Proposed core localization. Hip/ST13 orthologs are predominantly cytosolic co-chaperones of the cytosolic Hsp70 machinery, and worm HIP-1 acts through Hsp70 in the cytosol; the cytosol is inferred as the primary site of action (the muscle GFP-overexpression pattern notwithstanding).
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Not present in GOA but strongly supported by ortholog localization (native Hip purifies from cytosol) and by the cytosolic Hsp70-dependent proteostasis role demonstrated in the worm.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9183013" target="_blank" class="term-link">
+                                        PMID:9183013
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">the native protein from rat liver cytosol</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051082" target="_blank" class="term-link">
+                                    GO:0051082
+                                </a>
+                            </span>
+                            <span class="term-label">unfolded protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ISS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/9183013" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:9183013
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Characterization of the molecular-chaperone function of the ...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-new">
+                            NEW
+                        </span>
+                        <span class="vote-buttons" data-g="G5EE04" data-a="GO:0051082" data-r="PMID:9183013" data-act="NEW">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Proposed molecular function. HIP-1 has intrinsic holdase activity, binding non-native/unfolded polypeptides to prevent aggregation, independent of the Hsp70 ATP cycle, as shown for the ortholog.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Not present in GOA but experimentally demonstrated for the ortholog (specific binding to reduced, carboxymethylated alpha-lactalbumin but not the native form); an informative MF complementing the Hsp70-binding activity.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9183013" target="_blank" class="term-link">
+                                        PMID:9183013
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The role of Hip as a molecular chaperone has been confirmed by its ability to strongly bind to the reduced, carboxymethylated form of alpha-lactalbumin</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1903334" target="_blank" class="term-link">
+                                    GO:1903334
+                                </a>
+                            </span>
+                            <span class="term-label">positive regulation of protein folding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ISS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/23812373" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:23812373
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Structure and function of Hip, an attenuator of the Hsp70 ch...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-new">
+                            NEW
+                        </span>
+                        <span class="vote-buttons" data-g="G5EE04" data-a="GO:1903334" data-r="PMID:23812373" data-act="NEW">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Proposed biological process. By stabilizing the ADP-bound state and attenuating the Hsp70 cycle, HIP-1 biases the chaperone system toward productive substrate holding and folding and enhances aggregation prevention by Hsp70.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Not present in GOA but follows directly from the attenuator mechanism and the in vivo anti-aggregation phenotype; captures the regulatory direction of HIP-1&#39;s effect on folding.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/23812373" target="_blank" class="term-link">
+                                        PMID:23812373
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">This mechanism explains how Hip enhances aggregation prevention by Hsp70</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>HIP-1 is a co-chaperone of the cytosolic Hsp70 (Hsc70) system. It binds the ATPase/nucleotide-binding domain of Hsp70 and stabilizes the ADP-bound, high substrate-affinity state, forming a bracket that locks ADP in the cleft and, because it is mutually exclusive with nucleotide-exchange factors, attenuates the Hsp70 reaction cycle so that substrates are held and folded rather than prematurely released. In C. elegans this activity suppresses proteotoxic aggregation in an Hsp70-dependent manner.</h3>
+                <span class="vote-buttons" data-g="G5EE04" data-a="FUNCTION: HIP-1 is a co-chaperone of the cytosolic Hsp70 (Hs..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030544" target="_blank" class="term-link">
+                            Hsp70 protein binding
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006457" target="_blank" class="term-link">
+                                protein folding
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1903334" target="_blank" class="term-link">
+                                positive regulation of protein folding
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
+                                cytosol
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/23812373" target="_blank" class="term-link">
+                                PMID:23812373
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">to form a bracket that locks ADP in the binding cleft</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/19875982" target="_blank" class="term-link">
+                                PMID:19875982
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">the hypothesis that it might do so also in vivo is supported by studies of a Caenorhabditis elegans model of alphaSyn aggregation</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>Independent of the Hsp70 cycle, HIP-1 has intrinsic holdase (chaperone) activity: it binds non-native/unfolded polypeptides to prevent their aggregation. It has no ATPase activity and cannot refold substrates on its own, and it homo-oligomerizes via its N-terminal Hip_N domain into a tetramer, giving avidity for multiple Hsp70 molecules.</h3>
+                <span class="vote-buttons" data-g="G5EE04" data-a="FUNCTION: Independent of the Hsp70 cycle, HIP-1 has intrinsi..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051082" target="_blank" class="term-link">
+                            unfolded protein binding
+                        </a>
+                    </span>
+                </div>
+
+
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
+                                cytosol
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/9183013" target="_blank" class="term-link">
+                                PMID:9183013
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">The role of Hip as a molecular chaperone has been confirmed by its ability to strongly bind to the reduced, carboxymethylated form of alpha-lactalbumin</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000002.md" target="_blank" class="term-link">
+                            GO_REF:0000002
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation through association of InterPro records with GO terms</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
+                            GO_REF:0000033
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Annotation inferences using phylogenetic trees</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000117.md" target="_blank" class="term-link">
+                            GO_REF:0000117
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Electronic Gene Ontology annotations created by ARBA machine learning models</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/7585962" target="_blank" class="term-link">
+                            PMID:7585962
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Hip, a novel cochaperone involved in the eukaryotic Hsc70/Hsp40 reaction cycle.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/8999928" target="_blank" class="term-link">
+                            PMID:8999928
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Characterization of functional domains of the eukaryotic co-chaperone Hip.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/9528774" target="_blank" class="term-link">
+                            PMID:9528774
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">The carboxy-terminal domain of Hsc70 provides binding sites for a distinct set of chaperone cofactors.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/9183013" target="_blank" class="term-link">
+                            PMID:9183013
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Characterization of the molecular-chaperone function of the heat-shock-cognate-70-interacting protein.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/23812373" target="_blank" class="term-link">
+                            PMID:23812373
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Structure and function of Hip, an attenuator of the Hsp70 chaperone cycle.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/19875982" target="_blank" class="term-link">
+                            PMID:19875982
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Chaperone proteostasis in Parkinson&#39;s disease: stabilization of the Hsp70/alpha-synuclein complex by Hip.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/21611156" target="_blank" class="term-link">
+                            PMID:21611156
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Determining the sub-cellular localization of proteins within Caenorhabditis elegans body wall muscle.</div>
+
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Questions for Experts</h2>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Which endogenous C. elegans proteins are obligate HIP-1 clients, and does HIP-1 loss produce a phenotype (development, lifespan, proteotoxic-stress resistance, muscle maintenance) under normal conditions?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="G5EE04" data-a="Q: Which endogenous C. elegans proteins are obligate ..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Does endogenous HIP-1 localize to the cytosol in most tissues, and is the muscle sarcomeric/ER pattern seen on overexpression a genuine site of function?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="G5EE04" data-a="Q: Does endogenous HIP-1 localize to the cytosol in m..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Experiments</h2>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Generate a hip-1 loss-of-function allele (deletion or auxin-inducible degron) and phenotype development, brood size, lifespan, thermotolerance, and heat/proteotoxic stress resistance, with and without sti-1/HOP and hsp-90 co-depletion to test redundancy in the chaperone network.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: HIP-1 buffers proteotoxic stress by stabilizing Hsp70-substrate complexes on endogenous clients.</em></p>
+
+
+                    <p style="margin-top: 0.5rem;">Type: genetics / phenotyping</p>
+
+                </div>
+                <span class="vote-buttons" data-g="G5EE04" data-a="EXPERIMENT: Generate a hip-1 loss-of-function allele (deletion..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Immunoprecipitate CRISPR-tagged endogenous HIP-1 (and its Hsp70 partner HSP-1) from staged worms and identify co-purifying substrates by mass spectrometry, comparing basal and heat-stressed conditions.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: HIP-1 has a defined set of endogenous folding clients in the worm.</em></p>
+
+
+                    <p style="margin-top: 0.5rem;">Type: interaction proteomics</p>
+
+                </div>
+                <span class="vote-buttons" data-g="G5EE04" data-a="EXPERIMENT: Immunoprecipitate CRISPR-tagged endogenous HIP-1 (..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Knowledge Gaps</h2>
+        <p style="color: #555; font-size: 0.92rem; margin-top: -0.3rem;">
+            What is <em>not</em> known — curated, literature-grounded statements of the open
+            unknowns (the inverse of core functions).
+        </p>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The endogenous physiological clients/substrates of C. elegans HIP-1, and the loss-of-function phenotype of hip-1 under normal (non-transgenic) conditions, are undefined. The only direct in vivo worm evidence uses an overexpressed heterologous aggregation reporter (human alpha-synuclein), so it does not reveal which native worm proteins depend on HIP-1 or what its loss does to development, lifespan, or stress resistance.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">RESIDUAL_SUBGAP</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> The conserved molecular mechanism is solid (HIP-1 binds the Hsp70 ADP state, attenuates the chaperone cycle, and has holdase activity) and genetic epistasis in the worm shows HIP-1 acts through Hsp70. What is unknown is the native client set and the organismal phenotype of HIP-1 loss.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Without native clients or a described phenotype, HIP-1&#39;s dedicated biological role in the worm cannot be separated from redundant, buffered co-chaperone functions (the sti-1/HOP and Hsp90 arms), leaving its importance for proteostasis in the intact animal unquantified.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Phenotype a hip-1 deletion/RNAi allele across development, lifespan, and proteotoxic-stress paradigms, and identify endogenous clients by immunoprecipitation-mass spectrometry of tagged endogenous HIP-1.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"the hypothesis that it might do so also in vivo is supported by studies of a Caenorhabditis elegans model of alphaSyn aggregation"</em> — PMID:19875982</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> Where endogenous HIP-1 acts in the C. elegans cell is not directly measured. Cytosolic localization is inferred from mammalian orthologs, and the only worm localization data come from muscle-specific GFP overexpression that placed the protein at dense bodies, the M-line/thick filaments, and the ER/SR; whether HIP-1 has a genuine sarcomeric/muscle quality-control role is unconfirmed.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">CC_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> Mammalian Hip/ST13 is firmly cytosolic. The worm GFP-overexpression screen reported a muscle sarcomeric/ER pattern for T12D8.8, but with explicit tagging/overexpression caveats and no endogenous-localization confirmation.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Distinguishing a general cytosolic role from a dedicated sarcomeric/muscle quality-control function would clarify whether HIP-1 contributes to muscle protein maintenance, a tissue where chaperone machinery is known to service the contractile apparatus.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> CRISPR endogenous tagging of hip-1 followed by in vivo imaging across tissues, and tissue-specific rescue/depletion to test a muscle-autonomous requirement.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"the presence or perhaps over expression of the GFP-tagged protein may be disruptive"</em> — PMID:21611156</li>
+
+            </ul>
+
+
+        </div>
+
+    </div>
+
+
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Deep Research Sections -->
+
+    <div class="section">
+        <h2 class="section-title">Deep Research</h2>
+
+        <details class="deep-research-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; gap: 1rem;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Falcon</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(hip-1-deep-research-falcon.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="G5EE04" data-a="DEEP_RESEARCH: Falcon" data-r="" data-act="DEEP_RESEARCH" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This deep research is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This deep research needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+
+                <div class="report-meta">
+
+                    <span class="report-meta-text">Comprehensive Research Report: *C. elegans* hip-1 (T12D8.8) — An Hsp70 Co-chaperone of the Hip/ST13 Family</span>
+
+
+                    <span class="report-badge">Falcon</span>
+
+
+                    <span class="report-badge">Edison Scientific Literature</span>
+
+
+                    <span class="report-badge">30 citations</span>
+
+
+                    <span class="report-badge">2 artifacts</span>
+
+
+                    <span class="report-meta-text">2026-07-03T21:37:11.439955</span>
+
+
+
+                </div>
+
+
+                <div class="artifact-list">
+
+
+
+                    <div class="artifact-link">
+                        <a href="hip-1-deep-research-falcon_artifacts/artifact-00.md" class="term-link">Edison artifact artifact-00</a>
+                        <span>(text/markdown)</span>
+                    </div>
+
+
+
+
+                    <div class="artifact-link">
+                        <a href="hip-1-deep-research-falcon_artifacts/artifact-01.md" class="term-link">Edison artifact artifact-01</a>
+                        <span>(text/markdown)</span>
+                    </div>
+
+
+                </div>
+
+                <p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h1 id="comprehensive-research-report-c-elegans-hip-1-t12d88-an-hsp70-co-chaperone-of-the-hipst13-family">Comprehensive Research Report: <em>C. elegans</em> hip-1 (T12D8.8) — An Hsp70 Co-chaperone of the Hip/ST13 Family</h1>
+<h2 id="1-gene-identity-and-nomenclature">1. Gene Identity and Nomenclature</h2>
+<p>The <em>C. elegans</em> gene <strong>hip-1</strong> (systematic name T12D8.8; UniProt accession G5EE04) encodes an STI1 domain-containing protein that is the nematode ortholog of mammalian <strong>Hip</strong> (Hsp70-interacting protein), also known as <strong>ST13</strong> (Suppressor of Tumorigenicity 13) or <strong>p48</strong> (shi2007whatweknow pages 1-2). It is important to distinguish this protein from the <em>C. elegans</em> <strong>sti-1</strong> gene, which encodes the ortholog of HOP (Hsp70–Hsp90 organizing protein) — a related but functionally distinct co-chaperone (song2009c.eleganssti1 pages 8-9). While both Hip and Hop share STI1-type domains, they occupy different positions in the Hsp70 chaperone network. HIP-1 belongs to the <strong>FAM10 protein family</strong>, which is the gene family designation for ST13/Hip orthologs across eukaryotes (shi2007whatweknow pages 1-2). The protein is conserved across animals, plants, and protozoa, though notably absent from <em>Saccharomyces cerevisiae</em> and other fungi (li2013structureandfunction pages 31-35).</p>
+<h2 id="2-protein-function-hsp70-co-chaperone-activity">2. Protein Function: Hsp70 Co-chaperone Activity</h2>
+<h3 id="21-primary-molecular-function">2.1 Primary Molecular Function</h3>
+<p>HIP-1 functions as a <strong>co-chaperone of the Hsp70 family of molecular chaperones</strong>. Its primary biochemical activity is to <strong>stabilize the ADP-bound state of Hsp70</strong>, thereby prolonging Hsp70–substrate complexes and preventing premature substrate release (leak2014heatshockproteins pages 4-5, shi2007whatweknow pages 2-4). In mammalian systems, Hip binds to the nucleotide-binding domain (NBD/ATPase domain) of Hsp70 specifically when Hsp70 is in the ADP-bound conformation, with a dissociation constant (K_D) of approximately 8–10 µM (li2013structureandfunction pages 82-86, li2013structureandfunction pages 121-125). One Hip dimer binds two Hsp70 molecules (li2013structureandfunction pages 82-86).</p>
+<p>Structurally, Hip's TPR domain forms a <strong>"bracket" over the nucleotide-binding cleft of Hsp70</strong>, dampening dynamic movement of subdomain IIB and slowing ADP dissociation (li2013structureandfunction pages 121-125, karunanayake2021cytosolicproteinquality pages 8-10). This mechanism locks Hsp70 in its high-affinity substrate-binding state (the "closed lid" state), effectively <strong>attenuating the Hsp70 chaperone cycle</strong> and extending the dwell time of substrates on the chaperone (li2013structureandfunction pages 31-35, li2013structureandfunction pages 125-129).</p>
+<p>Hip also possesses <strong>intrinsic holdase activity</strong>: it can bind unfolded proteins and prevent their aggregation independently of Hsp70, though it cannot fold substrates on its own and has no ATPase activity (li2013structureandfunction pages 31-35, velten2002domainstructureof pages 7-7, velten2002domainstructureof pages 5-7).</p>
+<h3 id="22-role-in-protein-folding-vs-degradation-decisions">2.2 Role in Protein Folding vs. Degradation Decisions</h3>
+<p>Hip functions as a <strong>pro-folding co-chaperone</strong> that biases the Hsp70 system toward protein refolding rather than degradation. It competes with the nucleotide exchange factor <strong>BAG-1</strong> for binding to the Hsp70 ATPase domain (shi2007whatweknow pages 2-4, leak2014heatshockproteins pages 4-5, li2013structureandfunction pages 31-35). While Hip stabilizes Hsp70–substrate complexes to promote refolding, BAG-1 stimulates ADP release and substrate dissociation, which can route substrates toward proteasomal degradation. Under normal cellular conditions, Hip is typically 5–10 times more abundant than BAG-1 or BAG-2, favoring the folding pathway (arndt2007tobeor pages 6-8). Importantly, Hip is not found in complexes with CHIP (the E3 ubiquitin ligase that links Hsp70 to the proteasome), suggesting steric incompatibility between the pro-folding (Hip) and pro-degradation (CHIP) co-chaperone pathways on Hsp70 (arndt2007tobeor pages 6-8).</p>
+<h2 id="3-domain-architecture">3. Domain Architecture</h2>
+<p>The conserved domain architecture of HIP-1 inferred from the UniProt annotation and detailed structural studies of mammalian Hip is summarized below:</p>
+<table>
+<thead>
+<tr>
+<th>Domain name</th>
+<th>InterPro ID</th>
+<th style="text-align: right;">Approximate residue positions in mammalian Hip/ST13</th>
+<th>Known function</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Hip_N</td>
+<td>IPR034649</td>
+<td style="text-align: right;">1–44</td>
+<td>N-terminal dimerization domain; forms a stable Hip dimer that supports avid Hsp70 binding and co-chaperone function (li2013structureandfunction pages 31-35, li2013structureandfunction pages 35-39)</td>
+</tr>
+<tr>
+<td>STI1_HS-bd</td>
+<td>IPR006636</td>
+<td style="text-align: right;">~113–214</td>
+<td>TPR-containing Hsp70-binding module; binds the Hsp70 nucleotide-binding/ATPase domain preferentially in the ADP-bound state and stabilizes Hsp70-substrate complexes by slowing ADP release (li2013structureandfunction pages 31-35, li2013structureandfunction pages 121-125, shi2007whatweknow pages 1-2)</td>
+</tr>
+<tr>
+<td>TPR repeat</td>
+<td>IPR019734</td>
+<td style="text-align: right;">within ~113–214</td>
+<td>Repeated tetratricopeptide motifs that build the Hsp70-binding scaffold; mediate protein–protein interaction with Hsp70 and contribute to attenuation of the Hsp70 chaperone cycle (li2013structureandfunction pages 35-39, li2013structureandfunction pages 121-125)</td>
+</tr>
+<tr>
+<td>TPR-like helical domain superfamily</td>
+<td>IPR011990</td>
+<td style="text-align: right;">within ~113–214</td>
+<td>Helical superstructure underlying the TPR region; provides the structural scaffold for docking onto Hsp70’s nucleotide-binding domain and forming the “bracket” that stabilizes the ADP-bound conformation (li2013structureandfunction pages 121-125, karunanayake2021cytosolicproteinquality pages 8-10)</td>
+</tr>
+<tr>
+<td>GGMP repeat region</td>
+<td>—</td>
+<td style="text-align: right;">~278–311</td>
+<td>Flexible repeat-rich region with seven imperfect GGMP tetrapeptide repeats; precise role remains unresolved, but it is part of the conserved C-terminal region associated with Hip function in substrate/chaperone complexes (li2013structureandfunction pages 35-39, velten2002domainstructureof pages 5-7)</td>
+</tr>
+<tr>
+<td>STI1/HOP_DP</td>
+<td>IPR041243</td>
+<td style="text-align: right;">~312–368</td>
+<td>C-terminal DP domain; contains hydrophobic grooves implicated in binding non-native substrate segments and is important for substrate/client handling and conformational maturation in vivo (li2013structureandfunction pages 31-35, li2013structureandfunction pages 35-39, li2013structureandfunction pages 121-125)</td>
+</tr>
+</tbody>
+</table>
+<p><em>Table: This table summarizes the conserved domain architecture of C. elegans HIP-1/T12D8.8 inferred from UniProt domain calls and mechanistic studies of mammalian Hip/ST13. It is useful for mapping sequence features to likely co-chaperone functions in Hsp70-dependent proteostasis.</em></p>
+<p>The multi-domain organization is connected by long, negatively charged, disordered linkers that provide conformational flexibility, allowing Hip to recognize diverse Hsp70–substrate complexes (li2013structureandfunction pages 121-125). The N-terminal dimerization domain forms a compact α-helical dimer with slow subunit exchange (half-time ~6 hours), which is essential for avidity-based binding to multiple Hsp70 molecules simultaneously (li2013structureandfunction pages 35-39, li2013structureandfunction pages 125-129). The two-domain structural organization (an elongated N-terminal dimeric domain and a globular C-terminal domain) was also confirmed by limited proteolysis and biophysical characterization (velten2002domainstructureof pages 7-7, velten2002domainstructureof pages 5-7).</p>
+<h2 id="4-subcellular-localization">4. Subcellular Localization</h2>
+<p>Hip/ST13 is predominantly a <strong>cytosolic protein</strong>. Studies in mammalian cells demonstrate that Hip shows a <strong>uniform distribution throughout the cytoplasm</strong>, with an estimated concentration in reticulocyte lysate of approximately 1 µM (shi2007whatweknow pages 1-2, wu2019acytosolicchaperone pages 2-3, li2013structureandfunction pages 31-35). Immunostaining confirms cytosolic localization distinct from ER-associated punctate patterns (wu2019acytosolicchaperone pages 2-3). This cytoplasmic localization is consistent with its function as a co-chaperone of the cytosolic Hsp70 machinery. By inference, <em>C. elegans</em> HIP-1 is predicted to similarly function in the cytosol, where it can engage the nematode Hsp70 homologs (such as HSP-1) in their chaperone cycles.</p>
+<h2 id="5-biological-roles-and-experimental-evidence-in-c-elegans">5. Biological Roles and Experimental Evidence in <em>C. elegans</em></h2>
+<h3 id="51-proteostasis-and-synuclein-aggregation">5.1 Proteostasis and α-Synuclein Aggregation</h3>
+<p>The most direct experimental evidence for <em>C. elegans</em> HIP-1 function comes from a landmark study by Roodveldt et al. (2009) using a transgenic worm model expressing α-synuclein-YFP in body wall muscle cells. Key findings include:</p>
+<ul>
+<li>
+<p><strong>RNAi knockdown of hip-1 (T12D8.8) significantly increased the number of α-synuclein inclusions by 2.3-fold</strong> (P &lt; 0.0001), demonstrating that HIP-1 is required for suppression of α-synuclein aggregation in vivo (roodveldt2009chaperoneproteostasisin pages 6-8, roodveldt2009chaperoneproteostasisin pages 8-10).</p>
+</li>
+<li>
+<p><strong>Double knockdown of hsp-70 (C12C8.1) and hip-1 reduced inclusions by approximately 60%</strong> compared to single hip-1 knockdown, reaching a level similar to hsp-70 knockdown alone (roodveldt2009chaperoneproteostasisin pages 8-10, roodveldt2009chaperoneproteostasisin pages 10-10). This provides strong genetic evidence that HIP-1 acts <strong>through and with Hsp70</strong> in an epistatic relationship, functioning upstream of Hsp70 to modulate its anti-aggregation activity.</p>
+</li>
+<li>
+<p><strong>In vitro reconstitution</strong> showed that addition of Hip to Hsp70 in the presence of ATP <strong>completely suppressed the conversion of α-synuclein into amyloid species</strong>, maintaining both Hsp70 and α-synuclein in solution (roodveldt2009chaperoneproteostasisin pages 6-8). Hip alone did not inhibit fibril formation, confirming that its anti-amyloidogenic activity is mediated through Hsp70 (roodveldt2009chaperoneproteostasisin pages 6-8).</p>
+</li>
+</ul>
+<p>The mechanistic model posits that without Hip, the ADP-bound Hsp70/α-synuclein complex can co-aggregate, depleting functional Hsp70 from solution and allowing rapid α-synuclein fibril formation. Hip stabilizes the ADP-Hsp70 complex and maintains Hsp70 in solution, thereby sustaining chaperone-mediated inhibition of amyloid pathways (roodveldt2009chaperoneproteostasisin pages 8-10, roodveldt2009chaperoneproteostasisin pages 10-10).</p>
+<h3 id="52-chaperone-network-context-in-c-elegans">5.2 Chaperone Network Context in <em>C. elegans</em></h3>
+<p>The <em>C. elegans</em> chaperone network includes a separate co-chaperone, STI-1, which is the ortholog of mammalian HOP/Stip1 and mediates client transfer from Hsp70 to Hsp90 (song2009c.eleganssti1 pages 8-9). CeSTI-1 is involved in aging and thermotolerance, with loss of function shortening lifespan by 68–77% at different temperatures (song2009c.eleganssti1 pages 8-9). HIP-1 and STI-1 thus occupy complementary roles in the nematode proteostasis network: HIP-1 stabilizes Hsp70–substrate complexes to promote the holding/folding function, while STI-1 facilitates substrate transfer between the Hsp70 and Hsp90 systems.</p>
+<h2 id="6-emerging-roles-mitochondrial-precursor-import">6. Emerging Roles: Mitochondrial Precursor Import</h2>
+<p>A recent study (Juszkiewicz et al., 2025) has identified a previously unappreciated function for St13/Hip in <strong>mitochondrial precursor protein import</strong>. St13 directly engages <strong>mitochondrial targeting signals (MTS)</strong> through the hydrophobic groove of its STI1 domain, accommodating the hydrophobic face of amphipathic MTS helices (juszkiewicz2025mechanismofchaperone pages 9-10). Upon emergence of the precursor polypeptide from the ribosome, St13 recruits and facilitates loading of Hsc70 onto the precursor, stabilizing Hsc70's ADP-bound state and maintaining the precursor in an unfolded, import-competent state (juszkiewicz2025mechanismofchaperone pages 9-10, juszkiewicz2025mechanismofchaperone pages 7-9). St13 also facilitates recruitment of the Stip1-Hsp90 system to these precursors (juszkiewicz2025mechanismofchaperone pages 7-9). The authors propose that St13 is the long-sought "presequence binding factor" (PBF), a ~50 kDa protein previously identified in early studies as interacting with mitochondrial presequences (juszkiewicz2025mechanismofchaperone pages 9-10). During mitochondrial import stress, this interaction becomes particularly important for buffering precursor degradation and preserving import competence (juszkiewicz2025mechanismofchaperone pages 1-2). This finding suggests that <em>C. elegans</em> HIP-1, by domain conservation, may similarly participate in mitochondrial protein biogenesis.</p>
+<h2 id="7-summary-of-key-evidence">7. Summary of Key Evidence</h2>
+<table>
+<thead>
+<tr>
+<th>Study/Reference</th>
+<th>Experimental approach</th>
+<th>Key finding</th>
+<th>Functional implication</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Roodveldt et al., 2009, <em>EMBO Journal</em></td>
+<td>RNAi knockdown of <strong>hip-1/T12D8.8</strong> in a transgenic <em>C. elegans</em> α-synuclein-YFP inclusion model; confocal quantification of inclusions in young adults</td>
+<td><strong>hip-1 RNAi increased α-synuclein inclusions 2.3-fold</strong> relative to control (<strong>P</strong>&lt;0.0001) (roodveldt2009chaperoneproteostasisin pages 6-8, roodveldt2009chaperoneproteostasisin pages 8-10)</td>
+<td>hip-1 is required in vivo to suppress proteotoxic α-synuclein aggregation and supports proteostasis in the worm cytosol (roodveldt2009chaperoneproteostasisin pages 6-8, roodveldt2009chaperoneproteostasisin pages 10-10)</td>
+</tr>
+<tr>
+<td>Roodveldt et al., 2009, <em>EMBO Journal</em></td>
+<td>Double RNAi knockdown of <strong>hsp70 (C12C8.1) + hip-1 (T12D8.8)</strong> in the same <em>C. elegans</em> α-synuclein model</td>
+<td>Double knockdown <strong>reduced inclusions by ~60% compared with hip-1 knockdown alone</strong>, approaching the hsp70-knockdown phenotype (roodveldt2009chaperoneproteostasisin pages 8-10, roodveldt2009chaperoneproteostasisin pages 10-10)</td>
+<td>Provides genetic evidence that hip-1 acts <strong>through/with Hsp70</strong>, functioning upstream to modulate Hsp70-dependent anti-aggregation activity (roodveldt2009chaperoneproteostasisin pages 8-10)</td>
+</tr>
+<tr>
+<td>Roodveldt et al., 2009, <em>EMBO Journal</em></td>
+<td>In vitro α-synuclein aggregation assay with purified proteins; ThT fluorescence, TEM, and solubility analysis in the presence of <strong>Hip + Hsp70 + ATP</strong></td>
+<td>Addition of <strong>Hip to Hsp70 in the presence of ATP completely suppressed conversion of α-synuclein into amyloid species</strong> and maintained Hsp70 and α-synuclein in soluble form (roodveldt2009chaperoneproteostasisin pages 6-8, roodveldt2009chaperoneproteostasisin pages 1-2)</td>
+<td>hip-1/Hip is an <strong>Hsp70 co-chaperone</strong> that prevents Hsp70 co-aggregation and stabilizes anti-amyloid chaperone function under ATP-turnover conditions (roodveldt2009chaperoneproteostasisin pages 6-8, roodveldt2009chaperoneproteostasisin pages 8-10)</td>
+</tr>
+<tr>
+<td>Li et al., 2013, <em>Nature Structural &amp; Molecular Biology</em></td>
+<td>Structural and biochemical characterization of mammalian Hip/ST13, including domain mapping and Hsp70-binding analysis</td>
+<td>Hip’s <strong>TPR domain binds the Hsp70 nucleotide-binding domain (NBD)</strong> and forms a <strong>bracket over the nucleotide-binding cleft</strong>, stabilizing the <strong>ADP-bound</strong> state; Hip preferentially binds ADP-Hsp70 (KD ~8–10 µM) (li2013structureandfunction pages 121-125, li2013structureandfunction pages 82-86)</td>
+<td>Explains the likely molecular mechanism of worm hip-1: a conserved Hip-family co-chaperone that <strong>slows ADP release, prolongs substrate holding, and prevents premature substrate release</strong> (li2013structureandfunction pages 31-35, li2013structureandfunction pages 121-125)</td>
+</tr>
+<tr>
+<td>Juszkiewicz et al., 2025, <em>Molecular Biology of the Cell</em></td>
+<td>Biochemical and mechanistic analysis of St13 on mitochondrial precursor proteins and mitochondrial targeting signals (MTSs)</td>
+<td><strong>St13 directly engages mitochondrial targeting signals</strong> via its STI1 domain hydrophobic groove and recruits/retains <strong>Hsc70/Hsp90</strong> on precursors to maintain import competence (juszkiewicz2025mechanismofchaperone pages 9-10, juszkiewicz2025mechanismofchaperone pages 7-9, juszkiewicz2025mechanismofchaperone pages 1-2)</td>
+<td>Expands Hip-family function beyond generic proteostasis: hip-1-like proteins can act in <strong>mitochondrial precursor triage/import competence</strong>, suggesting additional conserved roles for worm hip-1 inferred from domain architecture (juszkiewicz2025mechanismofchaperone pages 9-10, juszkiewicz2025mechanismofchaperone pages 1-2)</td>
+</tr>
+</tbody>
+</table>
+<p><em>Table: This table summarizes the main experimental findings supporting functional annotation of C. elegans hip-1 and its orthologous Hip/ST13 mechanism. It links worm genetic evidence to conserved biochemical and structural studies that explain how HIP-1 acts as an Hsp70 co-chaperone.</em></p>
+<h2 id="8-conclusions">8. Conclusions</h2>
+<p><em>C. elegans</em> <strong>hip-1</strong> (T12D8.8, UniProt G5EE04) encodes a cytosolic co-chaperone of the Hip/ST13/FAM10 family that functions as a critical regulator of Hsp70 chaperone activity. Its primary molecular function is to <strong>stabilize the ADP-bound state of Hsp70</strong>, prolonging substrate engagement and promoting protein folding over degradation. The protein achieves this through a conserved multi-domain architecture comprising an N-terminal dimerization domain (Hip_N), a central TPR domain that binds the Hsp70 ATPase domain, and a C-terminal DP domain involved in substrate interactions. Direct experimental evidence in <em>C. elegans</em> demonstrates that HIP-1 is essential for suppressing α-synuclein aggregation in an Hsp70-dependent manner (roodveldt2009chaperoneproteostasisin pages 6-8, roodveldt2009chaperoneproteostasisin pages 8-10). The protein functions in the cytosol where it participates in general proteostasis and, based on recent evidence from the conserved mammalian ortholog, may also play a role in maintaining mitochondrial precursor import competence (juszkiewicz2025mechanismofchaperone pages 9-10, juszkiewicz2025mechanismofchaperone pages 7-9). HIP-1 represents a key node in the <em>C. elegans</em> cytosolic protein quality control network, operating alongside but distinct from other co-chaperones such as STI-1/HOP and CHIP in directing client protein fate decisions.</p>
+<p>References</p>
+<ol>
+<li>
+<p>(shi2007whatweknow pages 1-2): Zheng-zheng Shi, Jia-wei Zhang, and Shu Zheng. What we know about st13, a co-factor of heat shock protein, or a tumor suppressor? Journal of Zhejiang University SCIENCE B, 8:170-176, Mar 2007. URL: https://doi.org/10.1631/jzus.2007.b0170, doi:10.1631/jzus.2007.b0170. This article has 59 citations.</p>
+</li>
+<li>
+<p>(song2009c.eleganssti1 pages 8-9): Hyun-Ok Song, Wonhae Lee, Kiyoung An, Hye-suk Lee, Jeong Hoon Cho, Zee-Yong Park, and Joohong Ahnn. C. elegans sti-1, the homolog of sti1/hop, is involved in aging and stress response. Journal of molecular biology, 390 4:604-17, Jul 2009. URL: https://doi.org/10.1016/j.jmb.2009.05.035, doi:10.1016/j.jmb.2009.05.035. This article has 68 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(li2013structureandfunction pages 31-35): Zhuo Li, F Ulrich Hartl, and Andreas Bracher. Structure and function of hip, an attenuator of the hsp70 chaperone cycle. Nature Structural &amp;Molecular Biology, 20:929-935, Jun 2013. URL: https://doi.org/10.1038/nsmb.2608, doi:10.1038/nsmb.2608. This article has 97 citations.</p>
+</li>
+<li>
+<p>(leak2014heatshockproteins pages 4-5): Rehana K. Leak. Heat shock proteins in neurodegenerative disorders and aging. Journal of Cell Communication and Signaling, 8:293-310, Sep 2014. URL: https://doi.org/10.1007/s12079-014-0243-9, doi:10.1007/s12079-014-0243-9. This article has 226 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(shi2007whatweknow pages 2-4): Zheng-zheng Shi, Jia-wei Zhang, and Shu Zheng. What we know about st13, a co-factor of heat shock protein, or a tumor suppressor? Journal of Zhejiang University SCIENCE B, 8:170-176, Mar 2007. URL: https://doi.org/10.1631/jzus.2007.b0170, doi:10.1631/jzus.2007.b0170. This article has 59 citations.</p>
+</li>
+<li>
+<p>(li2013structureandfunction pages 82-86): Zhuo Li, F Ulrich Hartl, and Andreas Bracher. Structure and function of hip, an attenuator of the hsp70 chaperone cycle. Nature Structural &amp;Molecular Biology, 20:929-935, Jun 2013. URL: https://doi.org/10.1038/nsmb.2608, doi:10.1038/nsmb.2608. This article has 97 citations.</p>
+</li>
+<li>
+<p>(li2013structureandfunction pages 121-125): Zhuo Li, F Ulrich Hartl, and Andreas Bracher. Structure and function of hip, an attenuator of the hsp70 chaperone cycle. Nature Structural &amp;Molecular Biology, 20:929-935, Jun 2013. URL: https://doi.org/10.1038/nsmb.2608, doi:10.1038/nsmb.2608. This article has 97 citations.</p>
+</li>
+<li>
+<p>(karunanayake2021cytosolicproteinquality pages 8-10): Chamithi Karunanayake and Richard C Page. Cytosolic protein quality control machinery: interactions of hsp70 with a network of co-chaperones and substrates. Experimental Biology and Medicine, 246:1419-1434, Mar 2021. URL: https://doi.org/10.1177/1535370221999812, doi:10.1177/1535370221999812. This article has 21 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(li2013structureandfunction pages 125-129): Zhuo Li, F Ulrich Hartl, and Andreas Bracher. Structure and function of hip, an attenuator of the hsp70 chaperone cycle. Nature Structural &amp;Molecular Biology, 20:929-935, Jun 2013. URL: https://doi.org/10.1038/nsmb.2608, doi:10.1038/nsmb.2608. This article has 97 citations.</p>
+</li>
+<li>
+<p>(velten2002domainstructureof pages 7-7): Marion Velten, Nathalie Gomez-Vrielynck, Alain Chaffotte, and Moncef M. Ladjimi. Domain structure of the hsc70 cochaperone, hip*. The Journal of Biological Chemistry, 277:259-266, Jan 2002. URL: https://doi.org/10.1074/jbc.m106881200, doi:10.1074/jbc.m106881200. This article has 30 citations.</p>
+</li>
+<li>
+<p>(velten2002domainstructureof pages 5-7): Marion Velten, Nathalie Gomez-Vrielynck, Alain Chaffotte, and Moncef M. Ladjimi. Domain structure of the hsc70 cochaperone, hip*. The Journal of Biological Chemistry, 277:259-266, Jan 2002. URL: https://doi.org/10.1074/jbc.m106881200, doi:10.1074/jbc.m106881200. This article has 30 citations.</p>
+</li>
+<li>
+<p>(arndt2007tobeor pages 6-8): V. Arndt, Christian Rogon, and J. Höhfeld. To be, or not to be — molecular chaperones in protein degradation. Cellular and Molecular Life Sciences, 64:2525-2541, Jun 2007. URL: https://doi.org/10.1007/s00018-007-7188-6, doi:10.1007/s00018-007-7188-6. This article has 248 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(li2013structureandfunction pages 35-39): Zhuo Li, F Ulrich Hartl, and Andreas Bracher. Structure and function of hip, an attenuator of the hsp70 chaperone cycle. Nature Structural &amp;Molecular Biology, 20:929-935, Jun 2013. URL: https://doi.org/10.1038/nsmb.2608, doi:10.1038/nsmb.2608. This article has 97 citations.</p>
+</li>
+<li>
+<p>(wu2019acytosolicchaperone pages 2-3): Yang Wu, Jingzi Zhang, Lei Fang, Hon Cheung Lee, and Yong Juan Zhao. A cytosolic chaperone complex controls folding and degradation of type iii cd38. Journal of Biological Chemistry, 294:4247-4258, Mar 2019. URL: https://doi.org/10.1074/jbc.ra118.005844, doi:10.1074/jbc.ra118.005844. This article has 15 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(roodveldt2009chaperoneproteostasisin pages 6-8): Cintia Roodveldt, Carlos W Bertoncini, August Andersson, Annemieke T van der Goot, Shang-Te Hsu, Rafael Fernández-Montesinos, Jannie de Jong, Tjakko J van Ham, Ellen A Nollen, David Pozo, John Christodoulou, and Christopher M Dobson. Chaperone proteostasis in parkinson's disease: stabilization of the hsp70/α‐synuclein complex by hip. The EMBO Journal, 28:3758-3770, Dec 2009. URL: https://doi.org/10.1038/emboj.2009.298, doi:10.1038/emboj.2009.298. This article has 151 citations.</p>
+</li>
+<li>
+<p>(roodveldt2009chaperoneproteostasisin pages 8-10): Cintia Roodveldt, Carlos W Bertoncini, August Andersson, Annemieke T van der Goot, Shang-Te Hsu, Rafael Fernández-Montesinos, Jannie de Jong, Tjakko J van Ham, Ellen A Nollen, David Pozo, John Christodoulou, and Christopher M Dobson. Chaperone proteostasis in parkinson's disease: stabilization of the hsp70/α‐synuclein complex by hip. The EMBO Journal, 28:3758-3770, Dec 2009. URL: https://doi.org/10.1038/emboj.2009.298, doi:10.1038/emboj.2009.298. This article has 151 citations.</p>
+</li>
+<li>
+<p>(roodveldt2009chaperoneproteostasisin pages 10-10): Cintia Roodveldt, Carlos W Bertoncini, August Andersson, Annemieke T van der Goot, Shang-Te Hsu, Rafael Fernández-Montesinos, Jannie de Jong, Tjakko J van Ham, Ellen A Nollen, David Pozo, John Christodoulou, and Christopher M Dobson. Chaperone proteostasis in parkinson's disease: stabilization of the hsp70/α‐synuclein complex by hip. The EMBO Journal, 28:3758-3770, Dec 2009. URL: https://doi.org/10.1038/emboj.2009.298, doi:10.1038/emboj.2009.298. This article has 151 citations.</p>
+</li>
+<li>
+<p>(juszkiewicz2025mechanismofchaperone pages 9-10): Szymon Juszkiewicz, Sew-Yeu Peak-Chew, and Ramanujan S. Hegde. Mechanism of chaperone recruitment and retention on mitochondrial precursors. Molecular Biology of the Cell, Jan 2025. URL: https://doi.org/10.1091/mbc.e25-01-0035, doi:10.1091/mbc.e25-01-0035. This article has 21 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(juszkiewicz2025mechanismofchaperone pages 7-9): Szymon Juszkiewicz, Sew-Yeu Peak-Chew, and Ramanujan S. Hegde. Mechanism of chaperone recruitment and retention on mitochondrial precursors. Molecular Biology of the Cell, Jan 2025. URL: https://doi.org/10.1091/mbc.e25-01-0035, doi:10.1091/mbc.e25-01-0035. This article has 21 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(juszkiewicz2025mechanismofchaperone pages 1-2): Szymon Juszkiewicz, Sew-Yeu Peak-Chew, and Ramanujan S. Hegde. Mechanism of chaperone recruitment and retention on mitochondrial precursors. Molecular Biology of the Cell, Jan 2025. URL: https://doi.org/10.1091/mbc.e25-01-0035, doi:10.1091/mbc.e25-01-0035. This article has 21 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(roodveldt2009chaperoneproteostasisin pages 1-2): Cintia Roodveldt, Carlos W Bertoncini, August Andersson, Annemieke T van der Goot, Shang-Te Hsu, Rafael Fernández-Montesinos, Jannie de Jong, Tjakko J van Ham, Ellen A Nollen, David Pozo, John Christodoulou, and Christopher M Dobson. Chaperone proteostasis in parkinson's disease: stabilization of the hsp70/α‐synuclein complex by hip. The EMBO Journal, 28:3758-3770, Dec 2009. URL: https://doi.org/10.1038/emboj.2009.298, doi:10.1038/emboj.2009.298. This article has 151 citations.</p>
+</li>
+</ol>
+<h2 id="artifacts">Artifacts</h2>
+<ul>
+<li><a href="hip-1-deep-research-falcon_artifacts/artifact-00.md">Edison artifact artifact-00</a></li>
+<li><a href="hip-1-deep-research-falcon_artifacts/artifact-01.md">Edison artifact artifact-01</a></li>
+</ul>
+<h2 id="citations">Citations</h2>
+<ol>
+<li>shi2007whatweknow pages 1-2</li>
+<li>li2013structureandfunction pages 31-35</li>
+<li>li2013structureandfunction pages 82-86</li>
+<li>arndt2007tobeor pages 6-8</li>
+<li>li2013structureandfunction pages 121-125</li>
+<li>wu2019acytosolicchaperone pages 2-3</li>
+<li>roodveldt2009chaperoneproteostasisin pages 6-8</li>
+<li>juszkiewicz2025mechanismofchaperone pages 9-10</li>
+<li>juszkiewicz2025mechanismofchaperone pages 7-9</li>
+<li>juszkiewicz2025mechanismofchaperone pages 1-2</li>
+<li>roodveldt2009chaperoneproteostasisin pages 8-10</li>
+<li>leak2014heatshockproteins pages 4-5</li>
+<li>shi2007whatweknow pages 2-4</li>
+<li>karunanayake2021cytosolicproteinquality pages 8-10</li>
+<li>li2013structureandfunction pages 125-129</li>
+<li>velten2002domainstructureof pages 7-7</li>
+<li>velten2002domainstructureof pages 5-7</li>
+<li>li2013structureandfunction pages 35-39</li>
+<li>roodveldt2009chaperoneproteostasisin pages 10-10</li>
+<li>roodveldt2009chaperoneproteostasisin pages 1-2</li>
+<li>https://doi.org/10.1631/jzus.2007.b0170,</li>
+<li>https://doi.org/10.1016/j.jmb.2009.05.035,</li>
+<li>https://doi.org/10.1038/nsmb.2608,</li>
+<li>https://doi.org/10.1007/s12079-014-0243-9,</li>
+<li>https://doi.org/10.1177/1535370221999812,</li>
+<li>https://doi.org/10.1074/jbc.m106881200,</li>
+<li>https://doi.org/10.1007/s00018-007-7188-6,</li>
+<li>https://doi.org/10.1074/jbc.ra118.005844,</li>
+<li>https://doi.org/10.1038/emboj.2009.298,</li>
+<li>https://doi.org/10.1091/mbc.e25-01-0035,</li>
+</ol>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(hip-1-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="G5EE04" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="hip-1-c-elegans-research-notes">hip-1 (C. elegans) — research notes</h1>
+<p>UniProt: G5EE04 (G5EE04_CAEEL). WormBase: WBGene00011735 / T12D8.8. Chromosome III.<br />
+Gene symbol: hip-1. Product: STI1 domain-containing protein = <strong>Hsc70-interacting protein (HIP)</strong>,<br />
+ortholog of mammalian <strong>Hip/ST13</strong> (FAM10 family). Evidence at protein level (PE1; PeptideAtlas).</p>
+<h2 id="identity-confirmation-task-sanity-check">Identity confirmation (task sanity check)</h2>
+<p>The UniProt record IS the HSP70-interacting co-chaperone, not an unrelated gene:<br />
+- UniProt FUNCTION (ARBA): "One HIP oligomer binds the ATPase domains of at least two HSC70<br />
+  molecules dependent on activation of the HSC70 ATPase by HSP40. Stabilizes the ADP state of<br />
+  HSC70 that has a high affinity for substrate protein."<br />
+- Domain architecture matches Hip/ST13: Hip_N (IPR034649, N-terminal dimerization), STI1/HOP_DP<br />
+  (IPR041243, C-terminal DP domain), STI1_HS-bd (IPR006636), TPR repeats (IPR019734), TPR-like<br />
+  helical superfamily (IPR011990); Pfam HipN (PF18253), STI1-HOP_DP (PF17830), TPR_16 (PF13432);<br />
+  SMART STI1 + 3×TPR.<br />
+- PANTHER PTHR45883 "HSC70-INTERACTING PROTEIN" (subfamily SF2). "Belongs to the FAM10 family."<br />
+- NOTE: distinct from C. elegans <strong>sti-1</strong> (the HOP/Stip1 ortholog); both carry STI1-type domains<br />
+  but occupy different positions in the Hsp70/Hsp90 network<br />
+  [file:worm/hip-1/hip-1-deep-research-falcon.md "It is important to distinguish this protein from<br />
+  the <em>C. elegans</em> <strong>sti-1</strong> gene, which encodes the ortholog of HOP"].</p>
+<h2 id="known-well-established-conserved-biochemistry-from-mammalian-orthologs">KNOWN (well-established, conserved biochemistry from mammalian orthologs)</h2>
+<ul>
+<li><strong>Hsp70/Hsc70 co-chaperone; binds the ATPase (nucleotide-binding) domain.</strong> Hip is a TPR<br />
+  protein that binds the N-terminal ATPase domain of Hsc70<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/7585962" title="One Hip oligomer binds the ATPase domains of at least two Hsc70 molecules   dependent on activation of the Hsc70 ATPase by Hsp40.">PMID:7585962</a>. Binding is exclusive to the ATPase<br />
+  domain <a href="https://pubmed.ncbi.nlm.nih.gov/9528774" title="Hip interacts exclusively with the amino-terminal ATPase domain of Hsc70.">PMID:9528774</a>,<br />
+  which is separate from the Hsp40/Hop sites <a href="https://pubmed.ncbi.nlm.nih.gov/9528774" title="Hsc70 possesses separate nonoverlapping   binding sites for Hsp40, Hip, and Hop.">PMID:9528774</a>.</li>
+<li><strong>Stabilizes the ADP-bound (high substrate-affinity) state of Hsp70 — an "attenuator" of the<br />
+  cycle.</strong> <a href="https://pubmed.ncbi.nlm.nih.gov/7585962" title="Hip stabilizes the ADP state of Hsc70 that has a high affinity for   substrate protein.">PMID:7585962</a>. Structurally, the TPR core forms a bracket over the ATPase domain that<br />
+  locks ADP in <a href="https://pubmed.ncbi.nlm.nih.gov/23812373" title="the TPR core of Hip interacts with the Hsp70 ATPase domain through   an extensive interface, to form a bracket that locks ADP in the binding cleft.">PMID:23812373</a>. Hip and<br />
+  nucleotide-exchange factors (NEFs, e.g. BAG-1) compete: <a href="https://pubmed.ncbi.nlm.nih.gov/23812373" title="Hip and NEF binding to   Hsp70 are mutually exclusive, and thus Hip attenuates active cycling of Hsp70-substrate   complexes.">PMID:23812373</a>. Thus Hip biases the system toward folding/holding over release/degradation.</li>
+<li><strong>Domain-specific binding via the TPR domain.</strong> <a href="https://pubmed.ncbi.nlm.nih.gov/8999928" title="the Hsc70-binding site of Hip was   mapped to a domain comprising multiple tetratricopeptide repeats and flanking charged   alpha-helices.">PMID:8999928</a>.</li>
+<li><strong>Homo-oligomerizes (tetramer / dimer of dimers) via an N-terminal domain.</strong> <a href="https://pubmed.ncbi.nlm.nih.gov/8999928" title="a domain required for homo-oligomerization was identified at the extreme amino terminus of Hip.">PMID:8999928</a><br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/9183013" title="the chaperone forms a tetramer similar to what has been reported for the native   protein from rat liver cytosol">PMID:9183013</a>. Self-association gives avidity for multiple Hsp70 molecules.</li>
+<li><strong>Intrinsic holdase activity but no independent foldase / no ATPase.</strong> Binds non-native protein<br />
+  but cannot refold it and does not hydrolyze ATP [PMID:9183013 "The role of Hip as a molecular<br />
+  chaperone has been confirmed by its ability to strongly bind to the reduced, carboxymethylated<br />
+  form of alpha-lactalbumin."; "Hip inhibited the refolding of alkaline phosphatase and malic<br />
+  dehydrogenase. Inhibition occurred at near stoichiometric levels of Hip and could not be reversed<br />
+  by the addition of ATP."]. In the context of the Hsp70 cycle this "holdase" behavior translates<br />
+  into anti-aggregation, not refolding-inhibition.</li>
+<li><strong>Cooperates with Hsc70 in folding of nascent chains and conformational maturation of signaling<br />
+  clients</strong> <a href="https://pubmed.ncbi.nlm.nih.gov/8999928" title="The homo-oligomeric Hip protein cooperates with the 70-kDa heat shock   cognate Hsc70 in the folding of newly synthesized polypeptide chains and in the conformational   regulation of signaling molecules known to interact with Hsc70 and Hsp90.">PMID:8999928</a>.</li>
+<li><strong>Cytosolic</strong> co-chaperone of the cytosolic Hsp70 machinery (mammalian immunolocalization; falcon)<br />
+  [file:worm/hip-1/hip-1-deep-research-falcon.md "Hip/ST13 is predominantly a <strong>cytosolic<br />
+  protein</strong>"].</li>
+</ul>
+<h2 id="known-c-elegans-specific-in-vivo">KNOWN (C. elegans-specific, in vivo)</h2>
+<ul>
+<li><strong>HIP-1 (T12D8.8) suppresses α-synuclein aggregation in an Hsp70-dependent manner in vivo.</strong><br />
+  Roodveldt et al. 2009 used a transgenic worm αSyn-aggregation model and RNAi.<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/19875982" title="Such a co-aggregation phenomenon can be prevented in vitro by the co-chaperone   Hip (ST13), and the hypothesis that it might do so also in vivo is supported by studies of a   Caenorhabditis elegans model of αSyn aggregation.">PMID:19875982</a><br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/19875982" title="our results with an in vivo αSyn aggregation model of C. elegans strongly support   the hypothesis derived from the in vitro experiments, indicating that Hip is indeed required for   suppression of αSyn inclusion formation in an Hsp70-dependent manner">PMID:19875982</a>.<br />
+  Genetic epistasis: knocking down Hip alone gave MORE inclusions than knocking down Hip+Hsp70<br />
+  together — i.e. Hip acts through Hsp70<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/19875982" title="The observation in our C. elegans model that the absence of Hip alone could give   rise to more inclusions than when both Hip and Hsp70 are absent is consistent with a scenario in   which there is a redundancy of chaperone pathways">PMID:19875982</a>.<br />
+  Falcon summary of the same figures (paraphrase, cite primary for verbatim): hip-1 RNAi increased<br />
+  αSyn inclusions ~2.3-fold; double hsp-70+hip-1 RNAi reduced inclusions ~60% vs hip-1 alone<br />
+  [file:worm/hip-1/hip-1-deep-research-falcon.md].</li>
+<li><strong>Muscle localization (moderate/high-throughput GFP overexpression screen).</strong> T12D8.8::GFP driven<br />
+  by a muscle-specific promoter localized to category 6 = dense bodies, thick filaments/M-lines, and<br />
+  ER/SR <a href="https://pubmed.ncbi.nlm.nih.gov/21611156" title="The GFP-tagged proteins in category 6 are located in several places   throughout the cell. They appear to be in the dense bodies, M-line and/or thick filaments, as well   as the ER or SR">PMID:21611156</a>. This is the source of the GO HDA CC annotations (GO:0005783 ER, GO:0030017<br />
+  sarcomere, GO:0055120 striated muscle dense body). The authors explicitly caution that C-terminal<br />
+  GFP tagging + overexpression can perturb localization<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/21611156" title="the presence or perhaps over expression of the GFP-tagged protein may be   disruptive">PMID:21611156</a> — so these muscle localizations are treated as non-core relative to the cytosol.<br />
+  (Biologically, chaperone machinery does associate with the Z-disk/dense body for sarcomeric<br />
+  protein quality control, so a genuine muscle-QC role is plausible but unconfirmed for HIP-1.)</li>
+</ul>
+<h2 id="not-known-dark-worm-specific">NOT known / dark (worm-specific)</h2>
+<ul>
+<li><strong>Endogenous physiological clients/substrates of C. elegans HIP-1 are unidentified.</strong> All in vivo<br />
+  worm evidence uses a heterologous, overexpressed aggregation-prone reporter (human α-synuclein);<br />
+  the native folding clients that require HIP-1 in the worm are undefined.</li>
+<li><strong>Loss-of-function phenotype under normal (non-transgenic) conditions is undescribed</strong> — no<br />
+  reported hip-1 mutant phenotype for development, lifespan, stress resistance, or muscle<br />
+  maintenance. (Contrast the HOP ortholog sti-1, whose loss shortens lifespan<br />
+  [file:worm/hip-1/hip-1-deep-research-falcon.md].)</li>
+<li><strong>Native subcellular localization of endogenous HIP-1 in the worm is not directly measured</strong><br />
+  (only overexpression GFP in muscle). Cytosol is inferred from orthologs.</li>
+<li>Whether the recently proposed mammalian St13 role in <strong>mitochondrial precursor import</strong> (Juszkiewicz<br />
+  et al. 2025, MBoC) is conserved in the worm is untested<br />
+  [file:worm/hip-1/hip-1-deep-research-falcon.md].</li>
+</ul>
+<h2 id="goa-annotation-set-9-rows-review-plan">GOA annotation set (9 rows) — review plan</h2>
+<ol>
+<li>GO:0006457 protein folding — IBA (GO_REF:0000033) — ACCEPT (core BP).</li>
+<li>GO:0030544 Hsp70 protein binding — IBA (GO_REF:0000033) — ACCEPT (core, defining MF).</li>
+<li>GO:0005634 nucleus — IEA (ARBA GO_REF:0000117) — REMOVE (unsupported ML CC; Hip is cytosolic).</li>
+<li>GO:0046983 protein dimerization activity — IEA (InterPro GO_REF:0000002) — MARK_AS_OVER_ANNOTATED<br />
+   (self-association is a structural property, not the informative MF; real but not core).</li>
+<li>GO:0070013 intracellular organelle lumen — IEA (ARBA GO_REF:0000117) — REMOVE (unsupported ML CC).</li>
+<li>GO:1902494 catalytic complex — IEA (ARBA GO_REF:0000117) — MARK_AS_OVER_ANNOTATED (generic;<br />
+   Hip itself is non-catalytic; binds catalytic Hsp70 but "catalytic complex" is uninformative).</li>
+<li>GO:0005783 endoplasmic reticulum — HDA (PMID:21611156) — KEEP_AS_NON_CORE (muscle overexpression).</li>
+<li>GO:0030017 sarcomere — HDA (PMID:21611156) — KEEP_AS_NON_CORE (muscle overexpression).</li>
+<li>GO:0055120 striated muscle dense body — HDA (PMID:21611156) — KEEP_AS_NON_CORE (muscle overexpr.).</li>
+</ol>
+<p>Core MF = GO:0030544 Hsp70 protein binding; core BP = GO:0006457 protein folding + GO:1903334<br />
+positive regulation of protein folding; core CC = GO:0005829 cytosol.</p>
+<h2 id="final-review-decisions-completed">Final review decisions (completed)</h2>
+<p>All 9 GOA annotations resolved; 3 NEW proposed annotations added. Every supporting_text<br />
+was grep/normalization-verified as a verbatim substring of the cached publication.</p>
+<ul>
+<li>GO:0006457 protein folding (IBA) — ACCEPT (core BP).</li>
+<li>GO:0030544 Hsp70 protein binding (IBA) — ACCEPT (core, defining MF).</li>
+<li>GO:0005634 nucleus (IEA/ARBA) — REMOVE (unsupported ML CC; Hip is cytosolic).</li>
+<li>GO:0046983 protein dimerization activity (IEA/InterPro) — KEEP_AS_NON_CORE (revised<br />
+  from the earlier MARK_AS_OVER_ANNOTATED plan: homo-oligomerization is experimentally<br />
+  real [PMID:8999928, PMID:9183013] and functionally relevant for avidity, so it is a<br />
+  correct non-core MF rather than an over-annotation).</li>
+<li>GO:0070013 intracellular organelle lumen (IEA/ARBA) — REMOVE (unsupported ML CC).</li>
+<li>GO:1902494 catalytic complex (IEA/ARBA) — MARK_AS_OVER_ANNOTATED (HIP-1 is itself<br />
+  non-catalytic <a href="https://pubmed.ncbi.nlm.nih.gov/9183013" title="did not catalyze the hydrolysis of ATP">PMID:9183013</a>).</li>
+<li>GO:0005783 ER / GO:0030017 sarcomere / GO:0055120 dense body (HDA, PMID:21611156) —<br />
+  KEEP_AS_NON_CORE (muscle GFP overexpression; authors caution tagging may be disruptive).</li>
+<li>NEW GO:0005829 cytosol (ISS) — core site of action, inferred from orthologs.</li>
+<li>NEW GO:0051082 unfolded protein binding (ISS) — intrinsic holdase activity.</li>
+<li>NEW GO:1903334 positive regulation of protein folding (ISS) — attenuator mechanism<br />
+  biases folding <a href="https://pubmed.ncbi.nlm.nih.gov/23812373" title="enhances aggregation prevention by Hsp70">PMID:23812373</a>.</li>
+</ul>
+<p>Knowledge gaps recorded (top-level): (1) endogenous worm clients + LoF phenotype are<br />
+undefined (only a heterologous overexpressed αSyn reporter was assayed in vivo)<br />
+[RESIDUAL_SUBGAP]; (2) native subcellular localization of endogenous HIP-1 unmeasured;<br />
+worm data are muscle GFP-overexpression only [CC_DARK].</p>
+<p>Note: the "no annotation references the deep research file" validation WARNING is left<br />
+unresolved because the pre-edit hook resolves <code>file:</code> references against a temp-dir copy<br />
+and cannot see the (real, present) falcon file; this is a non-blocking warning only.</p>
+<h2 id="references-with-pmids-all-cached-in-publications">References with PMIDs (all cached in publications/)</h2>
+<ul>
+<li>PMID:7585962 Höhfeld et al. 1995 Cell — original Hip; ADP-state stabilization (abstract-only).</li>
+<li>PMID:8999928 Irmer &amp; Höhfeld 1997 JBC — TPR = Hsc70-binding site; N-term oligomerization.</li>
+<li>PMID:9528774 Demand et al. 1998 MCB — Hip binds ATPase domain exclusively; separate cofactor sites.</li>
+<li>PMID:9183013 Bruce &amp; Churchich 1997 EJB — tetramer; holdase; no ATPase; no independent foldase.</li>
+<li>PMID:23812373 Li, Hartl &amp; Bracher 2013 NSMB — crystal structures; bracket locks ADP; NEF-exclusive.</li>
+<li>PMID:19875982 Roodveldt et al. 2009 EMBO J — C. elegans αSyn model; Hip required Hsp70-dependently.</li>
+<li>PMID:21611156 Meissner et al. 2011 PLoS One — body-wall-muscle GFP localizome (T12D8.8 category 6).</li>
+</ul>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: G5EE04
+gene_symbol: hip-1
+product_type: PROTEIN
+status: DRAFT
+taxon:
+  id: NCBITaxon:6239
+  label: Caenorhabditis elegans
+description: &gt;-
+  hip-1 encodes the Caenorhabditis elegans ortholog of Hsp70-interacting protein
+  (Hip/ST13), a member of the FAM10 family and a co-chaperone of the cytosolic
+  Hsp70 (Hsc70) chaperone system. The protein has a modular architecture: an
+  N-terminal dimerization domain (Hip_N) that drives homo-oligomerization into a
+  tetramer, a central tetratricopeptide-repeat (TPR) region that binds the ATPase
+  (nucleotide-binding) domain of Hsp70, and a C-terminal STI1/DP domain. Hip binds
+  the ADP-bound state of Hsp70 and stabilizes it, slowing ADP release and prolonging
+  the high-affinity association of Hsp70 with substrate; because Hip and
+  nucleotide-exchange factors bind Hsp70 in a mutually exclusive manner, Hip acts as
+  an attenuator of the Hsp70 reaction cycle that biases the system toward substrate
+  holding and folding rather than release and degradation. Hip also has intrinsic
+  holdase activity, binding non-native polypeptides to prevent their aggregation, but
+  it lacks ATPase activity and cannot refold substrates on its own. In C. elegans,
+  HIP-1 acts through Hsp70 to suppress proteotoxic aggregation in vivo, and it is
+  predominantly cytosolic, consistent with a role in the cytosolic protein
+  quality-control network. It is distinct from the C. elegans HOP/Stip1 ortholog
+  sti-1, which occupies a different node of the Hsp70/Hsp90 system.
+references:
+- id: GO_REF:0000002
+  title: Gene Ontology annotation through association of InterPro records with GO
+    terms
+  findings: []
+- id: GO_REF:0000033
+  title: Annotation inferences using phylogenetic trees
+  findings: []
+- id: GO_REF:0000117
+  title: Electronic Gene Ontology annotations created by ARBA machine learning models
+  findings: []
+- id: PMID:7585962
+  title: Hip, a novel cochaperone involved in the eukaryotic Hsc70/Hsp40 reaction cycle.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Original characterization of Hip. PubMed-verified. Establishes that one Hip
+      oligomer binds the ATPase domains of Hsc70 and stabilizes the ADP (high
+      substrate-affinity) state. Mechanism is on the mammalian ortholog; conserved
+      in the FAM10 family to which C. elegans HIP-1 belongs. Abstract-only in cache.
+- id: PMID:8999928
+  title: Characterization of functional domains of the eukaryotic co-chaperone Hip.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PubMed-verified. Maps the Hsc70-binding site to the TPR domain and the
+      homo-oligomerization determinant to the extreme N terminus; supports the
+      folding/co-chaperone role. Mammalian ortholog; abstract-only in cache.
+- id: PMID:9528774
+  title: The carboxy-terminal domain of Hsc70 provides binding sites for a distinct
+    set of chaperone cofactors.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PubMed-verified. Shows Hip binds exclusively the amino-terminal ATPase domain
+      of Hsc70 and that Hsc70 has separate nonoverlapping sites for Hsp40, Hip and
+      Hop, and that Hip and BAG-1 compete. Directly supports the Hsp70-binding MF.
+- id: PMID:9183013
+  title: Characterization of the molecular-chaperone function of the heat-shock-cognate-70-interacting
+    protein.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PubMed-verified. Recombinant Hip forms a tetramer, has intrinsic holdase
+      activity (binds reduced carboxymethylated alpha-lactalbumin), does not
+      hydrolyze ATP, and cannot refold substrates on its own. Anchors the holdase MF
+      and the non-catalytic character.
+- id: PMID:23812373
+  title: Structure and function of Hip, an attenuator of the Hsp70 chaperone cycle.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PubMed-verified. Crystal structures show the TPR core forms a bracket over the
+      Hsp70 ATPase domain that locks ADP in the cleft, and that Hip and NEF binding
+      are mutually exclusive, so Hip attenuates the cycle. Defines the mechanism of
+      the Hsp70-binding MF.
+- id: PMID:19875982
+  title: &#34;Chaperone proteostasis in Parkinson&#39;s disease: stabilization of the Hsp70/alpha-synuclein
+    complex by Hip.&#34;
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PubMed-verified; full text available. The only study with direct in vivo
+      C. elegans evidence: hip-1 (T12D8.8) RNAi increases alpha-synuclein inclusions
+      and epistasis shows HIP-1 acts through Hsp70. Uses a heterologous overexpressed
+      alpha-synuclein reporter, so it does not identify endogenous worm clients.
+- id: PMID:21611156
+  title: Determining the sub-cellular localization of proteins within Caenorhabditis
+    elegans body wall muscle.
+  findings: []
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PubMed-verified. High-throughput body-wall-muscle GFP-localizome; T12D8.8::GFP
+      is in category 6 (dense bodies, M-line/thick filaments, ER/SR). Source of the
+      three HDA muscle CC annotations. Authors explicitly caution that C-terminal GFP
+      tagging and overexpression may perturb localization, so these are non-core.
+existing_annotations:
+- term:
+    id: GO:0006457
+    label: protein folding
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Phylogenetically inferred biological process. HIP-1 is an Hsp70 co-chaperone
+      that cooperates with Hsc70 in the folding of newly synthesized and non-native
+      polypeptides; protein folding is the core process it participates in.
+    action: ACCEPT
+    reason: &gt;-
+      Consistent with the conserved FAM10/Hip co-chaperone role and with experimental
+      evidence from orthologs that Hip cooperates with Hsc70 in polypeptide folding
+      and plays a critical role in protein folding in the eukaryotic cytoplasm.
+    supported_by:
+    - reference_id: PMID:8999928
+      supporting_text: &gt;-
+        The homo-oligomeric Hip protein cooperates with the 70-kDa heat shock cognate
+        Hsc70 in the folding of newly synthesized polypeptide chains
+    - reference_id: PMID:9183013
+      supporting_text: play a critical role in protein folding in the eukaryotic cytoplasm
+- term:
+    id: GO:0030544
+    label: Hsp70 protein binding
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Core, defining molecular function of a Hip-family co-chaperone: HIP-1 binds the
+      N-terminal ATPase (nucleotide-binding) domain of Hsp70/Hsc70, specifically in
+      the ADP state, and stabilizes the high substrate-affinity conformation.
+    action: ACCEPT
+    reason: &gt;-
+      This is the informative, partner-specific molecular function of the protein and
+      is supported by biochemical mapping in orthologs showing Hip binds the Hsc70
+      ATPase domain exclusively and by structural work showing it brackets the ATPase
+      domain to lock in ADP.
+    supported_by:
+    - reference_id: PMID:9528774
+      supporting_text: Hip interacts exclusively with the amino-terminal ATPase domain of Hsc70
+    - reference_id: PMID:7585962
+      supporting_text: &gt;-
+        One Hip oligomer binds the ATPase domains of at least two Hsc70 molecules
+- term:
+    id: GO:0005634
+    label: nucleus
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000117
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Electronic (ARBA machine-learning) cellular-component annotation with no
+      experimental support. Hip/ST13 is an established cytosolic co-chaperone of the
+      cytosolic Hsp70 machinery, and there is no evidence for nuclear localization of
+      C. elegans HIP-1.
+    action: REMOVE
+    reason: &gt;-
+      Over-propagated electronic inference that conflicts with the well-established
+      cytosolic biology of Hip-family co-chaperones; not supported by any experimental
+      or phylogenetic evidence for this gene.
+- term:
+    id: GO:0046983
+    label: protein dimerization activity
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: enables
+  review:
+    summary: &gt;-
+      InterPro-derived (IPR034649, Hip_N) molecular function. HIP-1 genuinely
+      homo-oligomerizes (dimer of dimers / tetramer) through its N-terminal Hip_N
+      domain, which provides avidity for binding multiple Hsp70 molecules.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Self-association is real and functionally relevant but is a structural property
+      rather than the informative core molecular function; retained as non-core. The
+      N-terminal oligomerization determinant and the tetrameric state are documented
+      experimentally in orthologs.
+    supported_by:
+    - reference_id: PMID:8999928
+      supporting_text: &gt;-
+        a domain required for homo-oligomerization was identified at the extreme amino
+        terminus of Hip
+    - reference_id: PMID:9183013
+      supporting_text: &gt;-
+        the chaperone forms a tetramer similar to what has been reported for the native
+        protein from rat liver cytosol
+- term:
+    id: GO:0070013
+    label: intracellular organelle lumen
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000117
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Electronic (ARBA machine-learning) cellular-component annotation with no
+      experimental support and inconsistent with the cytosolic localization of
+      Hip-family co-chaperones.
+    action: REMOVE
+    reason: &gt;-
+      Over-propagated electronic inference; an organelle-lumen location is not
+      supported by any experimental or phylogenetic evidence for HIP-1 and conflicts
+      with its cytosolic function.
+- term:
+    id: GO:1902494
+    label: catalytic complex
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000117
+  qualifier: part_of
+  review:
+    summary: &gt;-
+      Electronic (ARBA machine-learning) annotation placing HIP-1 in a catalytic
+      complex. HIP-1 itself is non-catalytic (no ATPase activity); it transiently
+      associates with the catalytic Hsp70 ATPase, but &#34;catalytic complex&#34; is generic
+      and mischaracterizes HIP-1&#39;s own role.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      Uninformative and potentially misleading: HIP-1 does not catalyze a reaction and
+      is not a stable structural subunit of a defined catalytic complex; its
+      interaction with Hsp70 is transient and regulatory.
+    supported_by:
+    - reference_id: PMID:9183013
+      supporting_text: &gt;-
+        The recombinant form of Hip did not catalyze the hydrolysis of ATP and ATP
+        analogs
+- term:
+    id: GO:0005783
+    label: endoplasmic reticulum
+  evidence_type: HDA
+  original_reference_id: PMID:21611156
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      High-throughput direct-assay localization from a body-wall-muscle GFP-localizome:
+      T12D8.8::GFP fell in category 6, which includes the ER/SR alongside dense bodies
+      and the M-line/thick filaments.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Experimental (HDA) but from muscle-specific overexpression of a C-terminally
+      GFP-tagged protein, which the authors explicitly caution may perturb
+      localization; retained as a non-core, muscle-context localization rather than the
+      core cytosolic site of action.
+    supported_by:
+    - reference_id: PMID:21611156
+      supporting_text: &gt;-
+        They appear to be in the dense bodies, M-line and/or thick filaments, as well
+        as the ER or SR
+    - reference_id: PMID:21611156
+      supporting_text: the presence or perhaps over expression of the GFP-tagged protein may be disruptive
+- term:
+    id: GO:0030017
+    label: sarcomere
+  evidence_type: HDA
+  original_reference_id: PMID:21611156
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      High-throughput GFP-localizome placing T12D8.8::GFP at sarcomeric structures
+      (M-line/thick filaments) in body-wall muscle (category 6).
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Experimental (HDA) but from muscle overexpression of a GFP fusion with
+      acknowledged tagging/overexpression caveats; a genuine sarcomeric
+      quality-control role is biologically plausible for a chaperone but unconfirmed
+      for HIP-1, so kept as non-core.
+    supported_by:
+    - reference_id: PMID:21611156
+      supporting_text: &gt;-
+        They appear to be in the dense bodies, M-line and/or thick filaments, as well
+        as the ER or SR
+- term:
+    id: GO:0055120
+    label: striated muscle dense body
+  evidence_type: HDA
+  original_reference_id: PMID:21611156
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      High-throughput GFP-localizome placing T12D8.8::GFP at the dense body (Z-disk
+      analog) in body-wall muscle (category 6).
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Experimental (HDA) but from muscle overexpression of a GFP fusion with
+      acknowledged tagging/overexpression caveats; retained as a non-core,
+      muscle-context localization rather than the core cytosolic site of action.
+    supported_by:
+    - reference_id: PMID:21611156
+      supporting_text: &gt;-
+        They appear to be in the dense bodies, M-line and/or thick filaments, as well
+        as the ER or SR
+- term:
+    id: GO:0005829
+    label: cytosol
+  evidence_type: ISS
+  original_reference_id: PMID:9183013
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Proposed core localization. Hip/ST13 orthologs are predominantly cytosolic
+      co-chaperones of the cytosolic Hsp70 machinery, and worm HIP-1 acts through
+      Hsp70 in the cytosol; the cytosol is inferred as the primary site of action
+      (the muscle GFP-overexpression pattern notwithstanding).
+    action: NEW
+    reason: &gt;-
+      Not present in GOA but strongly supported by ortholog localization (native Hip
+      purifies from cytosol) and by the cytosolic Hsp70-dependent proteostasis role
+      demonstrated in the worm.
+    supported_by:
+    - reference_id: PMID:9183013
+      supporting_text: the native protein from rat liver cytosol
+- term:
+    id: GO:0051082
+    label: unfolded protein binding
+  evidence_type: ISS
+  original_reference_id: PMID:9183013
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Proposed molecular function. HIP-1 has intrinsic holdase activity, binding
+      non-native/unfolded polypeptides to prevent aggregation, independent of the
+      Hsp70 ATP cycle, as shown for the ortholog.
+    action: NEW
+    reason: &gt;-
+      Not present in GOA but experimentally demonstrated for the ortholog (specific
+      binding to reduced, carboxymethylated alpha-lactalbumin but not the native
+      form); an informative MF complementing the Hsp70-binding activity.
+    supported_by:
+    - reference_id: PMID:9183013
+      supporting_text: &gt;-
+        The role of Hip as a molecular chaperone has been confirmed by its ability to
+        strongly bind to the reduced, carboxymethylated form of alpha-lactalbumin
+- term:
+    id: GO:1903334
+    label: positive regulation of protein folding
+  evidence_type: ISS
+  original_reference_id: PMID:23812373
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Proposed biological process. By stabilizing the ADP-bound state and attenuating
+      the Hsp70 cycle, HIP-1 biases the chaperone system toward productive substrate
+      holding and folding and enhances aggregation prevention by Hsp70.
+    action: NEW
+    reason: &gt;-
+      Not present in GOA but follows directly from the attenuator mechanism and the
+      in vivo anti-aggregation phenotype; captures the regulatory direction of HIP-1&#39;s
+      effect on folding.
+    supported_by:
+    - reference_id: PMID:23812373
+      supporting_text: This mechanism explains how Hip enhances aggregation prevention by Hsp70
+core_functions:
+- description: &gt;-
+    HIP-1 is a co-chaperone of the cytosolic Hsp70 (Hsc70) system. It binds the
+    ATPase/nucleotide-binding domain of Hsp70 and stabilizes the ADP-bound, high
+    substrate-affinity state, forming a bracket that locks ADP in the cleft and,
+    because it is mutually exclusive with nucleotide-exchange factors, attenuates the
+    Hsp70 reaction cycle so that substrates are held and folded rather than
+    prematurely released. In C. elegans this activity suppresses proteotoxic
+    aggregation in an Hsp70-dependent manner.
+  supported_by:
+  - reference_id: PMID:23812373
+    supporting_text: to form a bracket that locks ADP in the binding cleft
+  - reference_id: PMID:19875982
+    supporting_text: &gt;-
+      the hypothesis that it might do so also in vivo is supported by studies of a
+      Caenorhabditis elegans model of alphaSyn aggregation
+  molecular_function:
+    id: GO:0030544
+    label: Hsp70 protein binding
+  directly_involved_in:
+  - id: GO:0006457
+    label: protein folding
+  - id: GO:1903334
+    label: positive regulation of protein folding
+  locations:
+  - id: GO:0005829
+    label: cytosol
+- description: &gt;-
+    Independent of the Hsp70 cycle, HIP-1 has intrinsic holdase (chaperone) activity:
+    it binds non-native/unfolded polypeptides to prevent their aggregation. It has no
+    ATPase activity and cannot refold substrates on its own, and it homo-oligomerizes
+    via its N-terminal Hip_N domain into a tetramer, giving avidity for multiple Hsp70
+    molecules.
+  supported_by:
+  - reference_id: PMID:9183013
+    supporting_text: &gt;-
+      The role of Hip as a molecular chaperone has been confirmed by its ability to
+      strongly bind to the reduced, carboxymethylated form of alpha-lactalbumin
+  molecular_function:
+    id: GO:0051082
+    label: unfolded protein binding
+  locations:
+  - id: GO:0005829
+    label: cytosol
+knowledge_gaps:
+- gap_statement: &gt;-
+    The endogenous physiological clients/substrates of C. elegans HIP-1, and the
+    loss-of-function phenotype of hip-1 under normal (non-transgenic) conditions, are
+    undefined. The only direct in vivo worm evidence uses an overexpressed
+    heterologous aggregation reporter (human alpha-synuclein), so it does not reveal
+    which native worm proteins depend on HIP-1 or what its loss does to development,
+    lifespan, or stress resistance.
+  boundary: &gt;-
+    The conserved molecular mechanism is solid (HIP-1 binds the Hsp70 ADP state,
+    attenuates the chaperone cycle, and has holdase activity) and genetic epistasis in
+    the worm shows HIP-1 acts through Hsp70. What is unknown is the native client set
+    and the organismal phenotype of HIP-1 loss.
+  gap_kind:
+  - BIOLOGY
+  dark_aspect: RESIDUAL_SUBGAP
+  status: OPEN
+  significance: &gt;-
+    Without native clients or a described phenotype, HIP-1&#39;s dedicated biological role
+    in the worm cannot be separated from redundant, buffered co-chaperone functions
+    (the sti-1/HOP and Hsp90 arms), leaving its importance for proteostasis in the
+    intact animal unquantified.
+  resolution: &gt;-
+    Phenotype a hip-1 deletion/RNAi allele across development, lifespan, and
+    proteotoxic-stress paradigms, and identify endogenous clients by
+    immunoprecipitation-mass spectrometry of tagged endogenous HIP-1.
+  provenance:
+  - reference_id: PMID:19875982
+    supporting_text: &gt;-
+      the hypothesis that it might do so also in vivo is supported by studies of a
+      Caenorhabditis elegans model of alphaSyn aggregation
+- gap_statement: &gt;-
+    Where endogenous HIP-1 acts in the C. elegans cell is not directly measured.
+    Cytosolic localization is inferred from mammalian orthologs, and the only worm
+    localization data come from muscle-specific GFP overexpression that placed the
+    protein at dense bodies, the M-line/thick filaments, and the ER/SR; whether HIP-1
+    has a genuine sarcomeric/muscle quality-control role is unconfirmed.
+  boundary: &gt;-
+    Mammalian Hip/ST13 is firmly cytosolic. The worm GFP-overexpression screen
+    reported a muscle sarcomeric/ER pattern for T12D8.8, but with explicit
+    tagging/overexpression caveats and no endogenous-localization confirmation.
+  gap_kind:
+  - BIOLOGY
+  dark_aspect: CC_DARK
+  status: OPEN
+  significance: &gt;-
+    Distinguishing a general cytosolic role from a dedicated sarcomeric/muscle
+    quality-control function would clarify whether HIP-1 contributes to muscle protein
+    maintenance, a tissue where chaperone machinery is known to service the
+    contractile apparatus.
+  resolution: &gt;-
+    CRISPR endogenous tagging of hip-1 followed by in vivo imaging across tissues, and
+    tissue-specific rescue/depletion to test a muscle-autonomous requirement.
+  provenance:
+  - reference_id: PMID:21611156
+    supporting_text: the presence or perhaps over expression of the GFP-tagged protein may be disruptive
+proposed_new_terms: []
+suggested_questions:
+- question: &gt;-
+    Which endogenous C. elegans proteins are obligate HIP-1 clients, and does HIP-1
+    loss produce a phenotype (development, lifespan, proteotoxic-stress resistance,
+    muscle maintenance) under normal conditions?
+  experts: []
+- question: &gt;-
+    Does endogenous HIP-1 localize to the cytosol in most tissues, and is the muscle
+    sarcomeric/ER pattern seen on overexpression a genuine site of function?
+  experts: []
+suggested_experiments:
+- hypothesis: &gt;-
+    HIP-1 buffers proteotoxic stress by stabilizing Hsp70-substrate complexes on
+    endogenous clients.
+  description: &gt;-
+    Generate a hip-1 loss-of-function allele (deletion or auxin-inducible degron) and
+    phenotype development, brood size, lifespan, thermotolerance, and heat/proteotoxic
+    stress resistance, with and without sti-1/HOP and hsp-90 co-depletion to test
+    redundancy in the chaperone network.
+  experiment_type: genetics / phenotyping
+- hypothesis: &gt;-
+    HIP-1 has a defined set of endogenous folding clients in the worm.
+  description: &gt;-
+    Immunoprecipitate CRISPR-tagged endogenous HIP-1 (and its Hsp70 partner HSP-1)
+    from staged worms and identify co-purifying substrates by mass spectrometry,
+    comparing basal and heat-stressed conditions.
+  experiment_type: interaction proteomics
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/genes/worm/hsp-110/hsp-110-ai-review.html
+++ b/genes/worm/hsp-110/hsp-110-ai-review.html
@@ -1,0 +1,3489 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>hsp-110 - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        .propagation-review {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f8fafc;
+            border-left: 3px solid #64748b;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .propagation-title {
+            font-weight: 600;
+            color: #334155;
+            margin-bottom: 0.25rem;
+        }
+
+        .propagation-row {
+            margin-top: 0.25rem;
+        }
+
+        .propagation-source {
+            margin-top: 0.5rem;
+            padding-top: 0.5rem;
+            border-top: 1px solid #e5e7eb;
+        }
+
+        .propagation-source-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #1d4ed8;
+        }
+
+        .propagation-comment {
+            color: #4b5563;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>hsp-110</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/Q05036" target="_blank" class="term-link">
+                        Q05036
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Caenorhabditis elegans</span>
+            </div>
+
+
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "hsp-110";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="Q05036" data-a="DESCRIPTION: hsp-110 (ORF C30C11.4) encodes the C. elegans memb..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>hsp-110 (ORF C30C11.4) encodes the C. elegans member of the HSP110/HSPH subfamily of the Hsp70 chaperone superfamily, orthologous to yeast Sse1/Sse2 and human HSPH1/HSPA4/ HSPA4L (apg-1). Like other HSP110 proteins it is a cytosolic, ATP-binding relative of Hsp70 that acts as a nucleotide-exchange factor (NEF) for canonical Hsp70 chaperones: its ATP-loaded nucleotide-binding domain, together with a three-helix-bundle domain, clamps the Hsp70 nucleotide-binding domain and drives ADP release, resetting the Hsp70 ATPase/folding cycle. Unlike canonical Hsp70s, HSP110 does not depend on its own ATP hydrolysis for this activity and can additionally bind non-native polypeptides directly (holdase activity). In C. elegans, HSP-110 operates within the cytosolic chaperone and disaggregation network together with Hsp70 and Hsp40/DnaJ partners to limit the accumulation of misfolded, aggregation-prone proteins; loss of HSP-110 increases aggregation of a misfolding-prone protein in neurons. As an HSF-1-regulated heat-shock protein it also contributes to stress resistance and to the extended lifespan of insulin/IGF-1-signaling mutants.</p>
+    </div>
+
+
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000774" target="_blank" class="term-link">
+                                    GO:0000774
+                                </a>
+                            </span>
+                            <span class="term-label">adenyl-nucleotide exchange factor activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q05036" data-a="GO:0000774" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Core molecular function. HSP-110 is the C. elegans HSP110-family nucleotide-exchange factor for Hsp70. This IBA is well grounded: the phylogenetic reference set includes yeast Sse1/Sse2 and human HSPH1, for which NEF activity is directly established.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> HSP110 proteins are the principal cytosolic NEFs for Hsp70; the ATP-loaded HSP110 NBD engages the Hsp70 NBD and drives ADP release. This is the defining, informative molecular function of the gene and should be retained as core.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/16688211" target="_blank" class="term-link">
+                                        PMID:16688211
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">acts as an efficient nucleotide exchange factor (NEF) for both yeast cytosolic Hsp70s, Ssa1p and Ssb1p. The mechanism involves formation of a stable nucleotide-sensitive complex, but does not require ATP hydrolysis by Sse1p</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/18555782" target="_blank" class="term-link">
+                                        PMID:18555782
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">the NBD of Sse1p is ATP bound, and together with the 3HBD it embraces the NBD of Hsp70, inducing opening and the release of bound ADP from Hsp70. Mutations that abolish NEF activity are lethal, thus defining nucleotide exchange on Hsp70 as an essential function of Sse1p</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005634" target="_blank" class="term-link">
+                                    GO:0005634
+                                </a>
+                            </span>
+                            <span class="term-label">nucleus</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q05036" data-a="GO:0005634" data-r="GO_REF:0000033" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetically propagated nuclear localization. HSP110-family proteins are primarily cytosolic; some mammalian HSPH1 can partition to the nucleus, but there is no direct C. elegans evidence for a nuclear pool of HSP-110.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Retain as a possible minor/shuttling location inherited from the family tree, but it is not the site of the core function; the cytosol is where HSP-110 acts on Hsp70.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006457" target="_blank" class="term-link">
+                                    GO:0006457
+                                </a>
+                            </span>
+                            <span class="term-label">protein folding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q05036" data-a="GO:0006457" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> HSP-110 participates in the cytosolic protein-folding process as the Hsp70 NEF; its NEF activity stimulates Hsp70-mediated refolding of denatured substrates.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Valid and central biological process for an Hsp70 co-chaperone/NEF; consistent with the experimental IMP protein-folding annotation from the worm and with the conserved family mechanism.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/16688211" target="_blank" class="term-link">
+                                        PMID:16688211
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The NEF activity of Sse1p stimulates in vitro Ssa1p-mediated refolding of thermally denatured luciferase</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
+                                    GO:0005829
+                                </a>
+                            </span>
+                            <span class="term-label">cytosol</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q05036" data-a="GO:0005829" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Core location. HSP110 proteins are cytosolic Hsp70 relatives, and the worm HSP-110 acts on cytosolic Hsp70.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The cytosol is the compartment where HSP-110 performs its NEF function; well supported at the family level and consistent with worm proteostasis assays in cytoplasm.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/16688211" target="_blank" class="term-link">
+                                        PMID:16688211
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The Hsp110 proteins, exclusively found in the eukaryotic cytosol</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005524" target="_blank" class="term-link">
+                                    GO:0005524
+                                </a>
+                            </span>
+                            <span class="term-label">ATP binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q05036" data-a="GO:0005524" data-r="GO_REF:0000002" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> HSP-110 retains the Hsp70-family nucleotide-binding domain and binds ATP; ATP loading of its NBD is functionally required for NEF activity (the ATP-bound NBD clamps the Hsp70 NBD to release ADP).
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> ATP/adenyl-nucleotide binding is genuine and mechanistically essential for HSP-110 NEF function, not a spurious fold-based call.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/18555782" target="_blank" class="term-link">
+                                        PMID:18555782
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">the NBD of Sse1p is ATP bound, and together with the 3HBD it embraces the NBD of Hsp70, inducing opening and the release of bound ADP from Hsp70</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006950" target="_blank" class="term-link">
+                                    GO:0006950
+                                </a>
+                            </span>
+                            <span class="term-label">response to stress</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000117
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q05036" data-a="GO:0006950" data-r="GO_REF:0000117" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Generic stress-response term from ARBA. HSP-110 is a heat-shock protein and HSF-1 transcriptional target, so involvement in the stress response is correct but uninformatively broad relative to the specific proteostasis roles captured elsewhere.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> True but too general; the specific and better-supported terms (response to topologically incorrect protein, protein folding) convey the actual role. Keep as a broad, non-core annotation.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016887" target="_blank" class="term-link">
+                                    GO:0016887
+                                </a>
+                            </span>
+                            <span class="term-label">ATP hydrolysis activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q05036" data-a="GO:0016887" data-r="GO_REF:0000002" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Propagated from the generic Hsp70 ATPase fold. HSP110-family proteins have only weak, atypical ATPase activity, and their defining NEF mechanism explicitly does NOT require ATP hydrolysis by HSP110; HSP110 also does not use the canonical Hsp70 nucleotide-driven allosteric cycle.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The term is not categorically impossible (HSP110 binds and may slowly turn over ATP), but attributing a functional ATP hydrolysis activity over-states the biochemistry: it is an electronic call from the shared Hsp70 domain, whereas the characterized HSP110 role is NEF and holdase, with ATP binding (not hydrolysis) being the load-bearing property. Flag as likely over-annotation rather than remove outright.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/16688211" target="_blank" class="term-link">
+                                        PMID:16688211
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The mechanism involves formation of a stable nucleotide-sensitive complex, but does not require ATP hydrolysis by Sse1p</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/18555782" target="_blank" class="term-link">
+                                        PMID:18555782
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">does not employ the nucleotide-dependent allostery and peptide-binding mode of canonical Hsp70s</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006457" target="_blank" class="term-link">
+                                    GO:0006457
+                                </a>
+                            </span>
+                            <span class="term-label">protein folding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/22242008" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:22242008
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    A genetic screening strategy identifies novel regulators of ...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q05036" data-a="GO:0006457" data-r="PMID:22242008" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Experimental WormBase annotation. In a genome-wide RNAi screen, C30C11.4 (hsp-110) was one of six chaperone-class genes among the polyglutamine (Q35/Q37) aggregation modifiers (a Class A strong modifier), linking it to the muscle-cell protein-folding environment.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Experimental (IMP) annotation supported by the screen; consistent with HSP-110&#39;s role as an Hsp70 NEF in cytosolic protein folding. Deferred to the WormBase curator who assessed the full dataset.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/22242008" target="_blank" class="term-link">
+                                        PMID:22242008
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">F08H9.3; cyn-11; cyn-12; C30C11.4; dnj-22; phb-2</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0035966" target="_blank" class="term-link">
+                                    GO:0035966
+                                </a>
+                            </span>
+                            <span class="term-label">response to topologically incorrect protein</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/19165329" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:19165329
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    An ALS-linked mutant SOD1 produces a locomotor defect associ...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q05036" data-a="GO:0035966" data-r="PMID:19165329" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Experimental WormBase annotation and a core biological role. RNAi and the gk533 loss-of-function allele of hsp-110/C30C11.4 strongly increase aggregation of neuronally expressed misfolding-prone mutant human SOD1(G85R); HSP-110 acts here with an Hsp70 (stc-1) and a DnaJ (dnj-19), i.e. the metazoan Hsp70-Hsp40-Hsp110 anti-aggregation machinery.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Directly supported experimental annotation for this gene; captures HSP-110&#39;s in vivo function in handling misfolded (topologically incorrect) proteins.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/19165329" target="_blank" class="term-link">
+                                        PMID:19165329
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">including an Hsp110 (C30C11.4), a DnaJ (A2) (dnj-19), an Hsp70 (stc-1), and a neuron specific Hsp16 (F08H9.4)</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/19165329" target="_blank" class="term-link">
+                                        PMID:19165329
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Three of these were validated as strongly increasing aggregation when mutant alleles were crossed with G85R-YFP</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008340" target="_blank" class="term-link">
+                                    GO:0008340
+                                </a>
+                            </span>
+                            <span class="term-label">determination of adult lifespan</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IGI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/14668486" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:14668486
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Regulation of longevity in Caenorhabditis elegans by heat sh...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q05036" data-a="GO:0008340" data-r="PMID:14668486" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Experimental IGI annotation. HSF-1-target molecular chaperones, when down-regulated, shorten the extended lifespan of long-lived insulin/IGF-1-signaling mutants; the WormBase annotation records a genetic interaction of hsp-110 with age-1 (WBGene00000090). This is a pleiotropic, downstream organismal consequence of HSP-110&#39;s chaperone activity rather than its core molecular function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Retain as a genuine experimental (genetic-interaction) annotation - do not remove - but classify as non-core: lifespan determination reflects HSP-110&#39;s contribution to the proteostasis/stress network, not a distinct molecular activity. Cached reference is abstract-only; deferred to the WormBase curator who read the full text.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/14668486" target="_blank" class="term-link">
+                                        PMID:14668486
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Down-regulation of individual molecular chaperones, transcriptional targets of HSF-1, also decreased longevity of long-lived mutant but not wild-type animals</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051082" target="_blank" class="term-link">
+                                    GO:0051082
+                                </a>
+                            </span>
+                            <span class="term-label">unfolded protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ISS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/18555782" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:18555782
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Structural basis for the cooperation of Hsp70 and Hsp110 cha...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-new">
+                            NEW
+                        </span>
+                        <span class="vote-buttons" data-g="Q05036" data-a="GO:0051082" data-r="PMID:18555782" data-act="NEW">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Proposed molecular function not currently in GOA. In addition to nucleotide exchange, HSP110-family proteins bind non-native polypeptides directly (holdase activity), and in the worm HSP-110 loss increases aggregation of misfolding-prone SOD1 in neurons - consistent with a substrate-binding contribution to keeping clients soluble for Hsp70.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Captures HSP-110&#39;s substrate-binding/holdase arm, complementing its NEF activity; more informative than a generic protein-binding term and grounded in the family structure plus the in vivo anti-aggregation phenotype.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/18555782" target="_blank" class="term-link">
+                                        PMID:18555782
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">direct interactions of substrate with Sse1p may support Hsp70-assisted protein folding in a cooperative process</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>Cytosolic HSP110-family nucleotide-exchange factor (NEF) for Hsp70. The ATP-loaded HSP-110 nucleotide-binding domain, together with its three-helix-bundle domain, clamps the Hsp70 nucleotide-binding domain and triggers ADP release, resetting the Hsp70 ATPase/folding cycle. This conserved HSP110 activity (yeast Sse1 to human HSPH1) is the defining molecular function of HSP-110 and drives Hsp70-dependent (re)folding in the cytosol.</h3>
+                <span class="vote-buttons" data-g="Q05036" data-a="FUNCTION: Cytosolic HSP110-family nucleotide-exchange factor..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000774" target="_blank" class="term-link">
+                            adenyl-nucleotide exchange factor activity
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006457" target="_blank" class="term-link">
+                                protein folding
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
+                                cytosol
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/16688211" target="_blank" class="term-link">
+                                PMID:16688211
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">acts as an efficient nucleotide exchange factor (NEF) for both yeast cytosolic Hsp70s, Ssa1p and Ssb1p. The mechanism involves formation of a stable nucleotide-sensitive complex, but does not require ATP hydrolysis by Sse1p</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/18555782" target="_blank" class="term-link">
+                                PMID:18555782
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">nucleotide exchange factors (NEFs) that remove ADP from Hsp70</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>Direct binding of non-native/unfolded polypeptides (holdase arm). Beyond nucleotide exchange, HSP-110 can engage substrate directly, cooperating with Hsp70 to keep aggregation-prone clients soluble; in the worm, loss of HSP-110 increases aggregation of misfolding-prone SOD1 in neurons, consistent with a substrate-holding/anti-aggregation contribution alongside its Hsp70 and Hsp40 partners.</h3>
+                <span class="vote-buttons" data-g="Q05036" data-a="FUNCTION: Direct binding of non-native/unfolded polypeptides..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051082" target="_blank" class="term-link">
+                            unfolded protein binding
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0035966" target="_blank" class="term-link">
+                                response to topologically incorrect protein
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
+                                cytosol
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/18555782" target="_blank" class="term-link">
+                                PMID:18555782
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">direct interactions of substrate with Sse1p may support Hsp70-assisted protein folding in a cooperative process</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/19165329" target="_blank" class="term-link">
+                                PMID:19165329
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">including an Hsp110 (C30C11.4), a DnaJ (A2) (dnj-19), an Hsp70 (stc-1), and a neuron specific Hsp16 (F08H9.4)</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000002.md" target="_blank" class="term-link">
+                            GO_REF:0000002
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation through association of InterPro records with GO terms</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
+                            GO_REF:0000033
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Annotation inferences using phylogenetic trees</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000117.md" target="_blank" class="term-link">
+                            GO_REF:0000117
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Electronic Gene Ontology annotations created by ARBA machine learning models</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/14668486" target="_blank" class="term-link">
+                            PMID:14668486
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Regulation of longevity in Caenorhabditis elegans by heat shock factor and molecular chaperones.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/19165329" target="_blank" class="term-link">
+                            PMID:19165329
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">An ALS-linked mutant SOD1 produces a locomotor defect associated with aggregation and synaptic dysfunction when expressed in neurons of Caenorhabditis elegans.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/22242008" target="_blank" class="term-link">
+                            PMID:22242008
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">A genetic screening strategy identifies novel regulators of the proteostasis network.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/16688211" target="_blank" class="term-link">
+                            PMID:16688211
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Chaperone network in the yeast cytosol: Hsp110 is revealed as an Hsp70 nucleotide exchange factor.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/18555782" target="_blank" class="term-link">
+                            PMID:18555782
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Structural basis for the cooperation of Hsp70 and Hsp110 chaperones in protein folding.</div>
+
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Questions for Experts</h2>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Which C. elegans Hsp70 (HSP-1, STC-1, or HSP-70) and which J-domain/Hsp40 proteins form the physiological HSP-110-dependent disaggregation machine in each tissue?</p>
+
+                    <p style="margin-top: 0.5rem;"><em>Suggested experts: C. elegans proteostasis biologists, Hsp70/Hsp110 chaperone biochemists</em></p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q05036" data-a="Q: Which C. elegans Hsp70 (HSP-1, STC-1, or HSP-70) a..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Is HSP-110 required to dissolve pre-formed aggregates, or only to prevent their formation, in worm neurons and muscle?</p>
+
+                    <p style="margin-top: 0.5rem;"><em>Suggested experts: Protein-aggregation/disaggregase biologists</em></p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q05036" data-a="Q: Is HSP-110 required to dissolve pre-formed aggrega..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Experiments</h2>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Affinity-purify endogenously tagged HSP-110 from C. elegans lysate and identify Hsp70, Hsp40/J-protein, and client partners to define the worm disaggregation network and native substrates.</p>
+
+
+
+                    <p style="margin-top: 0.5rem;">Type: Affinity purification / mass spectrometry</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q05036" data-a="EXPERIMENT: Affinity-purify endogenously tagged HSP-110 from C..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Engineer NEF-dead, ATPase-dead, and substrate-binding-dead hsp-110 alleles and test each for rescue of aggregation/disaggregation and lifespan phenotypes to dissect which molecular property (nucleotide exchange, ATP hydrolysis, holdase) is required in vivo.</p>
+
+
+
+                    <p style="margin-top: 0.5rem;">Type: Separation-of-function genetics</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q05036" data-a="EXPERIMENT: Engineer NEF-dead, ATPase-dead, and substrate-bind..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Reconstitute disaggregation of aggregated model substrates with purified worm HSP-110, Hsp70, and Hsp40 to test whether HSP-110 is required and rate-limiting for the reaction.</p>
+
+
+
+                    <p style="margin-top: 0.5rem;">Type: In vitro disaggregation reconstitution</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q05036" data-a="EXPERIMENT: Reconstitute disaggregation of aggregated model su..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Knowledge Gaps</h2>
+        <p style="color: #555; font-size: 0.92rem; margin-top: -0.3rem;">
+            What is <em>not</em> known — curated, literature-grounded statements of the open
+            unknowns (the inverse of core functions).
+        </p>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> Whether C. elegans HSP-110 is genetically and biochemically required for Hsp70/Hsp40-mediated protein DISAGGREGATION in vivo, and the identity of its physiological worm Hsp70 (HSP-1 vs STC-1 vs HSP-70) and J-protein/Hsp40 partners in that reaction, are undetermined.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">RESIDUAL_SUBGAP</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> It is established that HSP-110 is an HSP110-family Hsp70 NEF (conserved from yeast Sse1 to human HSPH1) and that in neurons its loss (RNAi and the gk533 allele) increases aggregation of misfolding-prone SOD1 alongside an Hsp70 (stc-1) and a DnaJ (dnj-19). What is NOT established for the worm is a reconstituted or genetically defined Hsp70-Hsp40-Hsp110 disaggregase, its obligate partner set, and whether HSP-110 is required for active dissolution of pre-formed aggregates (as opposed to preventing their formation).</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Metazoan protein disaggregation depends on a cooperative Hsp70-Hsp40-Hsp110 system. Defining the worm partners and the requirement for HSP-110 would connect its molecular NEF activity to organismal proteostasis and neuroprotection, and clarify which chaperone axis to target in C. elegans neurodegeneration models.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Tissue-specific hsp-110 loss-of-function combined with aggregation/disaggregation reporters and photoconvertible aggregation-clearance assays; affinity-purification/mass-spectrometry of tagged HSP-110 from worm lysate to define Hsp70/J-protein partners; in vitro reconstitution of a worm disaggregase.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"including an Hsp110 (C30C11.4), a DnaJ (A2) (dnj-19), an Hsp70 (stc-1), and a neuron specific Hsp16 (F08H9.4)"</em> — PMID:19165329</li>
+
+                <li><em>"This is the first report of a nucleotide exchange activity for the Hsp110 class of proteins"</em> — PMID:16688211</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The endogenous C. elegans client repertoire of HSP-110 is undefined: which native metastable proteins depend on HSP-110 NEF/holdase activity, and in which tissues, is unknown.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">RESIDUAL_SUBGAP</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> HSP-110 demonstrably modifies aggregation of heterologous, aggregation-prone reporters (polyglutamine and mutant human SOD1) and, at the family level, HSP110 NEF activity stimulates Hsp70-mediated refolding of denatured model substrates such as luciferase. No endogenous physiological worm client of HSP-110 has been mapped.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Client identity determines where HSP-110 activity is rate-limiting for proteostasis and which phenotypes (muscle, neuron, germline, aging) are mechanistically downstream of the NEF function.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Chaperone-client capture (e.g. interactomics of tagged HSP-110, or aggregate proteomics in hsp-110 loss-of-function) to enumerate native substrates.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"F08H9.3; cyn-11; cyn-12; C30C11.4; dnj-22; phb-2"</em> — PMID:22242008</li>
+
+                <li><em>"The NEF activity of Sse1p stimulates in vitro Ssa1p-mediated refolding of thermally denatured luciferase"</em> — PMID:16688211</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> Whether HSP-110&#39;s own weak/atypical ATPase activity, and any Hsp70-independent holdase function, have a physiological role in C. elegans is untested.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">MF_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> The defining HSP110 NEF mechanism requires ATP BINDING but not ATP hydrolysis by HSP110, and HSP110 does not use the canonical Hsp70 nucleotide-driven allosteric peptide-binding cycle; direct substrate binding by Hsp110 has been observed in vitro. The in vivo relevance of HSP-110 ATP hydrolysis and of a standalone holdase mode in the worm has not been probed.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Resolving this would settle whether the IEA-propagated ATP hydrolysis activity is functionally meaningful for HSP-110 or a fold-based over-annotation, and whether HSP-110 contributes to proteostasis independently of Hsp70.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Structure-guided separation-of-function alleles (NEF-dead vs ATPase-dead vs substrate-binding-dead) tested for rescue of hsp-110 proteostasis phenotypes in vivo, plus in vitro ATPase and holdase assays on purified worm HSP-110.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"does not require ATP hydrolysis by Sse1p"</em> — PMID:16688211</li>
+
+                <li><em>"does not employ the nucleotide-dependent allostery and peptide-binding mode of canonical Hsp70s"</em> — PMID:18555782</li>
+
+            </ul>
+
+
+        </div>
+
+    </div>
+
+
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Deep Research Sections -->
+
+    <div class="section">
+        <h2 class="section-title">Deep Research</h2>
+
+        <details class="deep-research-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; gap: 1rem;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Falcon</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(hsp-110-deep-research-falcon.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="Q05036" data-a="DEEP_RESEARCH: Falcon" data-r="" data-act="DEEP_RESEARCH" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This deep research is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This deep research needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+
+                <div class="report-meta">
+
+                    <span class="report-meta-text">Comprehensive Research Report: *C. elegans* hsp-110 (C30C11.4, UniProt Q05036)</span>
+
+
+                    <span class="report-badge">Falcon</span>
+
+
+                    <span class="report-badge">Edison Scientific Literature</span>
+
+
+                    <span class="report-badge">23 citations</span>
+
+
+                    <span class="report-badge">1 artifacts</span>
+
+
+                    <span class="report-meta-text">2026-07-04T15:00:29.869511</span>
+
+
+
+                </div>
+
+
+                <div class="artifact-list">
+
+
+
+                    <div class="artifact-link">
+                        <a href="hsp-110-deep-research-falcon_artifacts/artifact-00.md" class="term-link">Edison artifact artifact-00</a>
+                        <span>(text/markdown)</span>
+                    </div>
+
+
+                </div>
+
+                <p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h1 id="comprehensive-research-report-c-elegans-hsp-110-c30c114-uniprot-q05036">Comprehensive Research Report: <em>C. elegans</em> hsp-110 (C30C11.4, UniProt Q05036)</h1>
+<h2 id="1-gene-identity-and-protein-classification">1. Gene Identity and Protein Classification</h2>
+<p>The <em>C. elegans</em> gene <strong>hsp-110</strong> (systematic name C30C11.4; UniProt accession Q05036) encodes <strong>Heat Shock Protein 110</strong>, a member of the HSP70 superfamily belonging to the HSP110/Grp170 subfamily. The <em>C. elegans</em> genome encodes three Hsp70-related putative nucleotide exchange factors (NEFs): two ER-localized Grp170 family members and a <strong>single cytosolic HSP110 member</strong>, which is C30C11.4/HSP-110 (rampelt2012metazoanhsp70machines pages 8-9, tittelmeier2020thehsp110hsp70disaggregation pages 2-4). This makes HSP-110 the sole cytosolic HSP110-type NEF in the nematode, underscoring its non-redundant importance in cytoplasmic protein quality control.</p>
+<h2 id="2-domain-architecture-and-structural-features">2. Domain Architecture and Structural Features</h2>
+<p>HSP-110 shares the core domain organization of canonical Hsp70 proteins but with distinguishing features. It contains an <strong>N-terminal nucleotide-binding domain (NBD)</strong>, a <strong>β-sandwich peptide-binding domain (PBD-β)</strong>, and an <strong>α-helical bundle domain (PBD-α)</strong>, along with longer insertions and C-terminal extensions relative to canonical Hsp70 (bracher2015thenucleotideexchange pages 2-4). A particularly notable structural feature is a <strong>negatively charged ~100-residue acidic insertion loop</strong> located between strands 7 and 8 of the β-sandwich subdomain, which is unique to the HSP110 family (sousa2014structuralmechanismsof pages 3-4). Additionally, the interdomain linker between the NBD and the substrate-binding domain is <strong>charged rather than hydrophobic</strong>, further distinguishing HSP-110 from canonical Hsp70 proteins (yakubu2018rolesofthe pages 1-3).</p>
+<h2 id="3-primary-molecular-function-nucleotide-exchange-factor-for-hsp70">3. Primary Molecular Function: Nucleotide Exchange Factor for Hsp70</h2>
+<p>The primary biochemical function of HSP-110 is to serve as a <strong>nucleotide exchange factor (NEF) for Hsp70/Hsc70 chaperones</strong>. HSP-110 catalyzes the release of ADP from Hsp70, allowing ATP to rebind and thereby triggering substrate release from the Hsp70 peptide-binding cleft (sousa2014structuralmechanismsof pages 3-4, rampelt2012metazoanhsp70machines pages 1-2). This NEF activity is the most potent among eukaryotic cytosolic Hsp70 NEFs, making HSP110 proteins the dominant regulators of the Hsp70 chaperone cycle in the cytosol (sousa2014structuralmechanismsof pages 3-4).</p>
+<h3 id="mechanism-of-nucleotide-exchange">Mechanism of Nucleotide Exchange</h3>
+<p>Structural studies of the yeast ortholog Sse1 (in complex with Ssa1/Hsp70) have revealed the molecular mechanism of HSP110-mediated nucleotide exchange. The NBDs of HSP110 and Hsp70 face each other asymmetrically, forming extensive contacts between opposite NBD lobes (andreasson2008insightsintothe pages 1-2). A critical second contact involves the protruding C-terminal β-helical subdomain of HSP110 interacting with the periphery of Hsp70 NBD lobe II. The α-helix bundle domain of HSP110 fixes the Hsp70 NBD in an open conformation through highly conserved contacts (bracher2015thenucleotideexchange pages 2-4). This causes <strong>lobe displacement or rotation in the Hsp70 NBD</strong>, reducing Hsp70's affinity for ADP and enabling nucleotide exchange (yakubu2018rolesofthe pages 3-4). Importantly, <strong>ATP binding to the HSP110 NBD is required for complex formation with Hsp70, but ATP hydrolysis by HSP110 is not essential</strong> for its NEF function—ATPase-deficient HSP110 mutants can still rescue lethality from HSP110 deletion (yakubu2018rolesofthe pages 1-3, bracher2015thenucleotideexchange pages 2-4).</p>
+<h3 id="additional-chaperone-activity">Additional Chaperone Activity</h3>
+<p>Beyond its NEF function, HSP-110 also acts as a <strong>passive chaperone ("holdase")</strong> capable of recognizing and binding unfolded or partially folded polypeptides to prevent their aggregation, without requiring energy input (yakubu2018rolesofthe pages 3-4). HSP110 displays faster binding kinetics and a preference for aromatic residue-rich peptides, in contrast to Hsp70's preference for aliphatic sequences (sousa2014structuralmechanismsof pages 3-4). However, in the context of protein disaggregation, the holdase function of HSP110 appears dispensable—studies using yeast Hsp110 mutants with partially inactivated substrate-binding domains showed no detrimental effect on disaggregation activity (yakubu2018rolesofthe pages 4-6).</p>
+<h2 id="4-role-in-the-metazoan-protein-disaggregation-pathway">4. Role in the Metazoan Protein Disaggregation Pathway</h2>
+<p>HSP-110's most critical physiological role is as an essential component of the <strong>metazoan Hsp70-based protein disaggregation machinery</strong>. Unlike bacteria, fungi, and plants, which employ dedicated AAA+ ATPase Hsp100/Hsp104 disaggregases, metazoan organisms (including <em>C. elegans</em>) lack cytosolic Hsp100 homologs and instead rely on a tripartite chaperone system comprising <strong>Hsp70 (HSC70), J-domain proteins (Hsp40s), and HSP110</strong> to solubilize protein aggregates (rampelt2012metazoanhsp70machines pages 1-2).</p>
+<h3 id="mechanistic-steps-in-disaggregation">Mechanistic Steps in Disaggregation</h3>
+<p>The disaggregation cycle operates as follows:</p>
+<ol>
+<li>
+<p><strong>Aggregate recognition and Hsp70 recruitment</strong>: J-domain proteins (JDPs) of class A and class B recognize and target aggregated protein substrates, recruiting Hsp70 to the aggregate surface (nillegoda2015metazoanhsp70basedprotein pages 2-4, kirstein2017invivoproperties pages 1-1).</p>
+</li>
+<li>
+<p><strong>Hsp70 activation</strong>: JDPs stimulate Hsp70 ATPase activity, locking Hsp70 in its ADP-bound, high-affinity substrate-binding state on the aggregate.</p>
+</li>
+<li>
+<p><strong>HSP110-mediated nucleotide exchange</strong>: HSP110 is recruited to Hsp70 at the aggregate surface and catalyzes ADP-to-ATP exchange, which triggers substrate release and resets Hsp70 for another binding cycle (sztangierska2024earlystepsof pages 1-2).</p>
+</li>
+<li>
+<p><strong>Aggregate remodeling</strong>: Repeated cycles of Hsp70 binding and release, powered by HSP110-mediated nucleotide exchange, generate mechanical forces that extract polypeptides from aggregates. This may operate through an <strong>entropic pulling</strong> mechanism, where the bulky HSP110–Hsp70 complex transiently increases the effective volume near the aggregate, amplifying the unfolding/pulling forces (rebeaud2025ishsp110boosting pages 1-4).</p>
+</li>
+<li>
+<p><strong>Substrate refolding or degradation</strong>: Released polypeptides are either refolded by the Hsp70 system or handed off to degradation pathways.</p>
+</li>
+</ol>
+<p>Recent work (2024) has demonstrated that HSP110 plays a <strong>major role at the initial stages of disaggregation</strong>, catalyzing the recruitment of thick Hsp70 assemblies onto aggregate surfaces, which converts large aggregates into smaller species more readily processed by chaperones (sztangierska2024earlystepsof pages 1-2). HSP110's stimulation of Hsp70 is substantially stronger when working with <strong>class B J-domain proteins</strong> compared to class A, and this interaction requires the Hsp70 EEVD motif. Notably, HSP110 can also <strong>disrupt JDP-Hsp70 interactions</strong>, which may improve disaggregation efficiency but can inhibit activity if HSP110 concentrations exceed optimal sub-stoichiometric levels (sztangierska2024earlystepsof pages 1-2). This finding highlights that balanced interplay between the co-chaperones and Hsp70 is critical for effective disaggregation.</p>
+<h2 id="5-subcellular-localization">5. Subcellular Localization</h2>
+<p>HSP-110 is identified as the <strong>sole cytosolic HSP110-type nucleotide exchange factor</strong> in <em>C. elegans</em> (tittelmeier2020thehsp110hsp70disaggregation pages 2-4). Its primary site of function is the <strong>cytoplasm</strong>, where it supports the Hsp70-based disaggregation machinery. Studies in yeast have demonstrated that the orthologous Hsp110 proteins (Sse1/Sse2) function in both the cytosol and nucleus, and that tethering Hsp110 away from either compartment impairs disaggregation in that location (kaimal2017coordinatedhsp110and pages 15-18). By analogy, <em>C. elegans</em> HSP-110 likely operates in both the cytoplasm and nucleus, though direct nuclear localization data in the worm are limited. The ER-localized Grp170 family members serve as the HSP70 NEFs in the endoplasmic reticulum, functionally complementing HSP-110 in that compartment (rampelt2012metazoanhsp70machines pages 8-9).</p>
+<h2 id="6-in-vivo-evidence-from-c-elegans">6. In Vivo Evidence from <em>C. elegans</em></h2>
+<h3 id="61-essentiality">6.1 Essentiality</h3>
+<p>Complete <strong>hsp-110 knockout is lethal</strong> in <em>C. elegans</em>, demonstrating its essential role in normal cellular function (tittelmeier2020thehsp110hsp70disaggregation pages 2-4). Systemic RNAi knockdown also affects growth, development, and fertility (tittelmeier2020thehsp110hsp70disaggregation pages 2-4).</p>
+<h3 id="62-protein-disaggregation-in-vivo">6.2 Protein Disaggregation In Vivo</h3>
+<p>The landmark study by Rampelt et al. (2012) provided direct in vivo evidence for HSP-110's role in protein disaggregation using transgenic <em>C. elegans</em> expressing luciferase-YFP in muscle cells as an aggregation sensor. After heat shock (1 hour at 35°C), luciferase-YFP formed aggregated foci. In control animals, these aggregates were completely resolved within 24 hours of recovery at 20°C. However, in animals where <strong>hsp-110 was knocked down by RNAi, the aggregated luciferase foci persisted and remained insoluble and immobile</strong> at both 12 and 24 hours post-heat shock (rampelt2012metazoanhsp70machines pages 9-10, rampelt2012metazoanhsp70machines pages 8-9). Critically, knockdown of the alternative NEF <strong>bag-1</strong> did not impair aggregate solubilization, demonstrating the <strong>non-redundant, specialized role</strong> of HSP-110 in the disaggregation machinery (rampelt2012metazoanhsp70machines pages 10-11, rampelt2012metazoanhsp70machines pages 9-10).</p>
+<h3 id="63-lifespan-and-stress-recovery">6.3 Lifespan and Stress Recovery</h3>
+<p>Under normal growth conditions at 20°C, hsp-110 RNAi causes only a <strong>modest lifespan reduction of 1–2 days</strong>. However, following heat shock, hsp-110-depleted animals exhibit a <strong>dramatic lifespan reduction of approximately 4.5 days</strong> compared to controls (rampelt2012metazoanhsp70machines pages 9-10). This indicates that HSP-110 becomes especially critical under conditions of high protein aggregation load, consistent with its role in the disaggregation pathway (rampelt2012metazoanhsp70machines pages 9-10).</p>
+<h3 id="64-role-in-amyloid-processing-a-double-edged-sword">6.4 Role in Amyloid Processing: A Double-Edged Sword</h3>
+<p>A pivotal study by Tittelmeier et al. (2020) revealed that the HSP-110/HSP70 disaggregation system is a <strong>"double-edged sword"</strong> in the context of amyloid disease models. While HSP-110 depletion impaired general proteostasis (preventing resolubilization of amorphous aggregates and compromising cellular folding capacity), it paradoxically <strong>reduced α-synuclein foci formation, cell-to-cell transmission, and toxicity</strong> in <em>C. elegans</em> disease models (tittelmeier2020thehsp110hsp70disaggregation pages 1-2, tittelmeier2020thehsp110hsp70disaggregation pages 4-5). Specifically:</p>
+<ul>
+<li>HSP-110 knockdown significantly reduced cytosolic α-synuclein and polyQ (Q35) aggregate foci and correspondingly reduced toxicity as measured by motility assays (tittelmeier2020thehsp110hsp70disaggregation pages 4-5).</li>
+<li>Intercellular transmission of α-synuclein between muscle and hypodermal cells was impaired—protein transfer was detected in only <strong>50% of hsp-110 knockdown animals</strong> on days 5–6 compared to <strong>90% in wild-type</strong> animals (tittelmeier2020thehsp110hsp70disaggregation pages 4-5).</li>
+<li>The HSP-110 knockdown did not activate compensatory stress responses (HSF-1/DAF-16), and total substrate protein levels remained unchanged (tittelmeier2020thehsp110hsp70disaggregation pages 4-5).</li>
+</ul>
+<p>These findings demonstrate that the HSP70 disaggregation activity, while essential for maintaining cellular proteostasis, is also involved in generating <strong>toxic, spreading-competent amyloid species</strong> through fibril fragmentation, which can seed further polymerization and prion-like propagation (tittelmeier2020thehsp110hsp70disaggregation pages 6-9, tittelmeier2020thehsp110hsp70disaggregation pages 2-4).</p>
+<h3 id="65-age-dependent-effects">6.5 Age-Dependent Effects</h3>
+<p>HSP-110 knockdown shows complex age-dependent phenotypes. In young animals, HSP-110 depletion provides some tolerance to α-synuclein and polyQ toxicity. However, during aging, HSP-110-depleted animals show <strong>accelerated decline in motility</strong> compared to controls, likely due to progressive proteostasis collapse (tittelmeier2020thehsp110hsp70disaggregation pages 6-9). Age-dependent protein aggregation (measured by FlucSM foci) forms more rapidly in HSP-110 knockdown backgrounds, and the protective effects observed in younger animals are lost with age (tittelmeier2020thehsp110hsp70disaggregation pages 6-9).</p>
+<h2 id="7-cooperative-network-with-j-domain-proteins">7. Cooperative Network with J-Domain Proteins</h2>
+<p>In vivo studies in <em>C. elegans</em> have revealed that HSP-110 functions within a broader <strong>cooperative J-protein network</strong>. Class A and class B J-proteins (JDPs) form a flexible interactive network that relocalizes to protein aggregates upon heat shock and preferentially recruits constitutive Hsc70 for disaggregation (kirstein2017invivoproperties pages 1-1). This cooperation between J-protein classes is required for organismal health, promoting thermotolerance, maintenance of fecundity, and extended viability after heat stress (kirstein2017invivoproperties pages 7-8). Disruption of these cooperative interactions exacerbates age-dependent aggregation of polyQ proteins (kirstein2017invivoproperties pages 7-8).</p>
+<h2 id="8-evolutionary-context">8. Evolutionary Context</h2>
+<p>HSP-110 represents a distinct evolutionary branch of the Hsp70 superfamily that has acquired specialized NEF function. In metazoan lineages that lost cytosolic Hsp100/Hsp104 disaggregases, the Hsp70-JDP-Hsp110 system became the <strong>primary disaggregation machinery</strong> (rampelt2012metazoanhsp70machines pages 1-2). This evolutionary transition underscores the importance of HSP-110 as a critical adaptation enabling metazoan cells to maintain proteostasis without dedicated AAA+ disaggregases. The system achieves disaggregation through a fundamentally different mechanism—iterative Hsp70 cycling powered by HSP110 NEF activity—rather than the threading mechanism employed by Hsp104 ring hexamers (torrente2013themetazoanprotein pages 4-5).</p>
+<h2 id="9-summary">9. Summary</h2>
+<p>The following table provides a comprehensive overview of the key functional attributes of <em>C. elegans</em> hsp-110:</p>
+<table>
+<thead>
+<tr>
+<th>Feature</th>
+<th>Detail</th>
+<th>Key Reference</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Gene identity</td>
+<td><strong>hsp-110</strong> corresponds to <strong>C30C11.4</strong> in <strong>Caenorhabditis elegans</strong> and encodes the organism’s <strong>single cytosolic HSP110-type nucleotide exchange factor (NEF)</strong> for HSP70; this matches the UniProt entry Q05036 and distinguishes it from two ER-localized Grp170 family members.</td>
+<td>(rampelt2012metazoanhsp70machines pages 8-9, tittelmeier2020thehsp110hsp70disaggregation pages 2-4)</td>
+</tr>
+<tr>
+<td>Protein family</td>
+<td>HSP-110 belongs to the <strong>HSP70 superfamily / HSP110 subfamily</strong>. Like other HSP110 proteins, it contains an <strong>N-terminal nucleotide-binding domain</strong>, <strong>β-sandwich peptide-binding domain</strong>, and <strong>α-helical bundle</strong>, with characteristic insertions including an acidic loop that distinguishes HSP110 proteins from canonical HSP70s.</td>
+<td>(yakubu2018rolesofthe pages 1-3, bracher2015thenucleotideexchange pages 2-4, sousa2014structuralmechanismsof pages 3-4, yakubu2018rolesofthe pages 11-12)</td>
+</tr>
+<tr>
+<td>Primary molecular function</td>
+<td>The best-supported primary function is to act as a <strong>nucleotide exchange factor for HSP70/HSC70</strong>, promoting <strong>ADP release and ATP rebinding</strong> on HSP70 and thereby enabling substrate release and repeated chaperone cycles during protein quality control. In metazoan disaggregation, this NEF activity is the key catalytic contribution of HSP110.</td>
+<td>(sousa2014structuralmechanismsof pages 3-4, yakubu2018rolesofthe pages 1-3, yakubu2018rolesofthe pages 3-4, rampelt2012metazoanhsp70machines pages 1-2)</td>
+</tr>
+<tr>
+<td>Biochemical role in disaggregation</td>
+<td>HSP-110 is essential for the <strong>HSP70-HSP40-HSP110 disaggregase system</strong> that solubilizes and reactivates aggregated proteins after stress. Direct work in C. elegans showed that HSP-110 is required for clearing heat-induced luciferase aggregates in vivo.</td>
+<td>(rampelt2012metazoanhsp70machines pages 10-11, rampelt2012metazoanhsp70machines pages 9-10, rampelt2012metazoanhsp70machines pages 8-9)</td>
+</tr>
+<tr>
+<td>ATP dependence / mechanism</td>
+<td>Structural and biochemical studies of the HSP110 family show that <strong>ATP binding to HSP110 is required for productive interaction with HSP70</strong>, whereas <strong>ATP hydrolysis by HSP110 is not essential</strong> for its NEF function. HSP110 opens the HSP70 NBD through extensive NBD-NBD contacts and associated conformational changes.</td>
+<td>(yakubu2018rolesofthe pages 1-3, bracher2015thenucleotideexchange pages 2-4, andreasson2008insightsintothe pages 1-2)</td>
+</tr>
+<tr>
+<td>Additional chaperone properties</td>
+<td>Beyond NEF activity, HSP110 family proteins can function as <strong>holdase chaperones</strong> that bind unfolded proteins and help prevent aggregation, though in disaggregation assays the central requirement is still the HSP70-directed NEF activity.</td>
+<td>(yakubu2018rolesofthe pages 3-4, sousa2014structuralmechanismsof pages 3-4, yakubu2018rolesofthe pages 4-6)</td>
+</tr>
+<tr>
+<td>Subcellular localization</td>
+<td>In C. elegans, HSP-110 is identified as the <strong>sole cytosolic HSP110-type NEF</strong>. Available direct evidence supports <strong>cytosolic function</strong>, especially in muscle-cell proteostasis assays; by analogy with other eukaryotic HSP110 systems, related proteins can support disaggregation in both cytosol and nucleus, but C. elegans-specific nuclear localization evidence is limited.</td>
+<td>(tittelmeier2020thehsp110hsp70disaggregation pages 2-4, kaimal2017coordinatedhsp110and pages 15-18)</td>
+</tr>
+<tr>
+<td>Key interacting partners</td>
+<td>Core functional partners are <strong>HSP70/HSC70</strong> and <strong>J-domain proteins (HSP40s)</strong>. The disaggregation machinery depends on cooperation between HSP110 and HSP70, while class A and class B J-proteins target aggregates and help recruit/activate HSP70 for extraction and refolding cycles.</td>
+<td>(kirstein2017invivoproperties pages 1-1, rampelt2012metazoanhsp70machines pages 9-10, rampelt2012metazoanhsp70machines pages 1-2, nillegoda2015metazoanhsp70basedprotein pages 2-4, sztangierska2024earlystepsof pages 1-2)</td>
+</tr>
+<tr>
+<td>Pathway involvement</td>
+<td>hsp-110 functions in the <strong>cytosolic proteostasis network</strong>, specifically the <strong>metazoan HSP70-based protein disaggregation pathway</strong> that responds to heat stress, age-associated aggregation, and misfolded proteins. It is part of stress-recovery and aggregate-clearance pathways rather than a classic signaling enzyme pathway.</td>
+<td>(kirstein2017invivoproperties pages 1-1, rampelt2012metazoanhsp70machines pages 9-10, rampelt2012metazoanhsp70machines pages 1-2)</td>
+</tr>
+<tr>
+<td>Relationship to heat stress</td>
+<td>In worms subjected to heat shock, HSP-110 is required for efficient <strong>recovery from proteotoxic stress</strong>. Loss of HSP-110 leaves heat-induced aggregates persistent and insoluble, indicating failure of post-stress protein recovery.</td>
+<td>(rampelt2012metazoanhsp70machines pages 1-2, rampelt2012metazoanhsp70machines pages 9-10, rampelt2012metazoanhsp70machines pages 8-9)</td>
+</tr>
+<tr>
+<td>Loss-of-function phenotype: viability</td>
+<td><strong>Complete hsp-110 knockout is lethal</strong>, indicating an essential housekeeping role in proteostasis. More moderate systemic RNAi knockdown also affects growth, development, and fertility.</td>
+<td>(tittelmeier2020thehsp110hsp70disaggregation pages 2-4)</td>
+</tr>
+<tr>
+<td>Loss-of-function phenotype: aggregate clearance</td>
+<td>RNAi depletion of hsp-110 causes a strong defect in <strong>resolubilization of heat-induced luciferase aggregates</strong> in vivo; aggregates persist at 12–24 h after heat shock instead of clearing during recovery.</td>
+<td>(rampelt2012metazoanhsp70machines pages 9-10, rampelt2012metazoanhsp70machines pages 8-9)</td>
+</tr>
+<tr>
+<td>Loss-of-function phenotype: lifespan after stress</td>
+<td>Under normal conditions, hsp-110 knockdown causes only a modest lifespan decrease, but after heat shock it causes a <strong>dramatic shortening of lifespan (~4.5 days)</strong>, indicating that HSP-110 becomes especially critical under high aggregation load.</td>
+<td>(rampelt2012metazoanhsp70machines pages 9-10)</td>
+</tr>
+<tr>
+<td>Loss-of-function phenotype: amyloid models</td>
+<td>In contrast to its protective role in general proteostasis, HSP-110 depletion can <strong>reduce α-synuclein and polyQ foci formation, spreading, and toxicity</strong> in worm disease models, showing that the disaggregase can be a <strong>double-edged sword</strong> by generating toxic amyloid-competent species while still supporting overall protein homeostasis.</td>
+<td>(tittelmeier2020thehsp110hsp70disaggregation pages 6-9, tittelmeier2020thehsp110hsp70disaggregation pages 4-5, tittelmeier2020thehsp110hsp70disaggregation pages 1-2)</td>
+</tr>
+<tr>
+<td>Expert interpretation</td>
+<td>Authoritative reviews and mechanistic papers converge on the view that HSP110 is the <strong>major metazoan HSP70 NEF</strong> and a central amplifier of disaggregation capacity, acting early in aggregate processing and enabling efficient HSP70 cycling on difficult aggregate substrates.</td>
+<td>(yakubu2018rolesofthe pages 4-6, nillegoda2015metazoanhsp70basedprotein pages 2-4, sztangierska2024earlystepsof pages 1-2)</td>
+</tr>
+</tbody>
+</table>
+<p><em>Table: This table summarizes the core functional annotation of C. elegans hsp-110/C30C11.4, including identity, molecular role, localization, partners, phenotypes, and pathway context. It is useful as a concise evidence-backed overview for gene annotation and literature review.</em></p>
+<p>In conclusion, <em>C. elegans</em> HSP-110 (C30C11.4) is a cytosolic nucleotide exchange factor for Hsp70 that is essential for metazoan protein disaggregation. Its primary biochemical activity is catalyzing ADP release from Hsp70, enabling the iterative chaperone cycling required to extract and resolubilize aggregated proteins. HSP-110 is the sole cytosolic member of the HSP110 family in <em>C. elegans</em>, and its complete loss is lethal. Under proteotoxic stress conditions, HSP-110 is indispensable for aggregate clearance and organismal survival, while its activity in processing amyloid substrates represents a double-edged sword—essential for general proteostasis but also capable of generating toxic, spreading-competent amyloid species.</p>
+<p>References</p>
+<ol>
+<li>
+<p>(rampelt2012metazoanhsp70machines pages 8-9): Heike Rampelt, Janine Kirstein-Miles, Nadinath B Nillegoda, Kang Chi, Sebastian R Scholz, Richard I Morimoto, and Bernd Bukau. Metazoan hsp70 machines use hsp110 to power protein disaggregation. The EMBO Journal, 31:4221-4235, Nov 2012. URL: https://doi.org/10.1038/emboj.2012.264, doi:10.1038/emboj.2012.264. This article has 383 citations.</p>
+</li>
+<li>
+<p>(tittelmeier2020thehsp110hsp70disaggregation pages 2-4): Jessica Tittelmeier, Carl Alexander Sandhof, Heidrun Maja Ries, Silke Druffel‐Augustin, Axel Mogk, Bernd Bukau, and Carmen Nussbaum‐Krammer. The hsp110/hsp70 disaggregation system generates spreading‐competent toxic α‐synuclein species. The EMBO Journal, May 2020. URL: https://doi.org/10.15252/embj.2019103954, doi:10.15252/embj.2019103954. This article has 119 citations.</p>
+</li>
+<li>
+<p>(bracher2015thenucleotideexchange pages 2-4): Andreas Bracher and Jacob Verghese. The nucleotide exchange factors of hsp70 molecular chaperones. Frontiers in Molecular Biosciences, Apr 2015. URL: https://doi.org/10.3389/fmolb.2015.00010, doi:10.3389/fmolb.2015.00010. This article has 299 citations.</p>
+</li>
+<li>
+<p>(sousa2014structuralmechanismsof pages 3-4): Rui Sousa. Structural mechanisms of chaperone mediated protein disaggregation. Frontiers in Molecular Biosciences, Sep 2014. URL: https://doi.org/10.3389/fmolb.2014.00012, doi:10.3389/fmolb.2014.00012. This article has 42 citations.</p>
+</li>
+<li>
+<p>(yakubu2018rolesofthe pages 1-3): Unekwu M. Yakubu and Kevin A. Morano. Roles of the nucleotide exchange factor and chaperone hsp110 in cellular proteostasis and diseases of protein misfolding. Biological Chemistry, 399:1215-1221, Sep 2018. URL: https://doi.org/10.1515/hsz-2018-0209, doi:10.1515/hsz-2018-0209. This article has 41 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(rampelt2012metazoanhsp70machines pages 1-2): Heike Rampelt, Janine Kirstein-Miles, Nadinath B Nillegoda, Kang Chi, Sebastian R Scholz, Richard I Morimoto, and Bernd Bukau. Metazoan hsp70 machines use hsp110 to power protein disaggregation. The EMBO Journal, 31:4221-4235, Nov 2012. URL: https://doi.org/10.1038/emboj.2012.264, doi:10.1038/emboj.2012.264. This article has 383 citations.</p>
+</li>
+<li>
+<p>(andreasson2008insightsintothe pages 1-2): Claes Andréasson, Jocelyne Fiaux, Heike Rampelt, Silke Druffel-Augustin, and Bernd Bukau. Insights into the structural dynamics of the hsp110–hsp70 interaction reveal the mechanism for nucleotide exchange activity. Proceedings of the National Academy of Sciences, 105:16519-16524, Oct 2008. URL: https://doi.org/10.1073/pnas.0804187105, doi:10.1073/pnas.0804187105. This article has 107 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(yakubu2018rolesofthe pages 3-4): Unekwu M. Yakubu and Kevin A. Morano. Roles of the nucleotide exchange factor and chaperone hsp110 in cellular proteostasis and diseases of protein misfolding. Biological Chemistry, 399:1215-1221, Sep 2018. URL: https://doi.org/10.1515/hsz-2018-0209, doi:10.1515/hsz-2018-0209. This article has 41 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(yakubu2018rolesofthe pages 4-6): Unekwu M. Yakubu and Kevin A. Morano. Roles of the nucleotide exchange factor and chaperone hsp110 in cellular proteostasis and diseases of protein misfolding. Biological Chemistry, 399:1215-1221, Sep 2018. URL: https://doi.org/10.1515/hsz-2018-0209, doi:10.1515/hsz-2018-0209. This article has 41 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(nillegoda2015metazoanhsp70basedprotein pages 2-4): Nadinath B. Nillegoda and Bernd Bukau. Metazoan hsp70-based protein disaggregases: emergence and mechanisms. Frontiers in Molecular Biosciences, Oct 2015. URL: https://doi.org/10.3389/fmolb.2015.00057, doi:10.3389/fmolb.2015.00057. This article has 149 citations.</p>
+</li>
+<li>
+<p>(kirstein2017invivoproperties pages 1-1): Janine Kirstein, Kristin Arnsburg, Annika Scior, Anna Szlachcic, D. Lys Guilbride, Richard I. Morimoto, Bernd Bukau, and Nadinath B. Nillegoda. In vivo properties of the disaggregase function of j‐proteins and hsc70 in caenorhabditis elegans stress and aging. Aging Cell, 16:1414-1424, Oct 2017. URL: https://doi.org/10.1111/acel.12686, doi:10.1111/acel.12686. This article has 87 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(sztangierska2024earlystepsof pages 1-2): Wiktoria Sztangierska, Hubert Wyszkowski, Maria Pokornowska, Klaudia Kochanowicz, Michał Rychłowski, Krzysztof Liberek, and Agnieszka Kłosowska. Early steps of protein disaggregation by hsp70 chaperone and class b j-domain proteins are shaped by hsp110. Sep 2024. URL: https://doi.org/10.7554/elife.94795.2, doi:10.7554/elife.94795.2. This article has 24 citations.</p>
+</li>
+<li>
+<p>(rebeaud2025ishsp110boosting pages 1-4): Mathieu E. Rebeaud, Bruno Fauvet, Paolo De Los Rios, and Pierre Goloubinoff. Is hsp110 boosting the basal disaggregation activity hsp70 by enhanced entropic pulling strokes? bioRxiv, Apr 2025. URL: https://doi.org/10.1101/2025.04.01.646638, doi:10.1101/2025.04.01.646638. This article has 0 citations.</p>
+</li>
+<li>
+<p>(kaimal2017coordinatedhsp110and pages 15-18): Jayasankar Mohanakrishnan Kaimal, Ganapathi Kandasamy, Fabian Gasser, and Claes Andréasson. Coordinated hsp110 and hsp104 activities power protein disaggregation in <i>saccharomyces cerevisiae</i>. Molecular and Cellular Biology, Jun 2017. URL: https://doi.org/10.1128/mcb.00027-17, doi:10.1128/mcb.00027-17. This article has 95 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(rampelt2012metazoanhsp70machines pages 9-10): Heike Rampelt, Janine Kirstein-Miles, Nadinath B Nillegoda, Kang Chi, Sebastian R Scholz, Richard I Morimoto, and Bernd Bukau. Metazoan hsp70 machines use hsp110 to power protein disaggregation. The EMBO Journal, 31:4221-4235, Nov 2012. URL: https://doi.org/10.1038/emboj.2012.264, doi:10.1038/emboj.2012.264. This article has 383 citations.</p>
+</li>
+<li>
+<p>(rampelt2012metazoanhsp70machines pages 10-11): Heike Rampelt, Janine Kirstein-Miles, Nadinath B Nillegoda, Kang Chi, Sebastian R Scholz, Richard I Morimoto, and Bernd Bukau. Metazoan hsp70 machines use hsp110 to power protein disaggregation. The EMBO Journal, 31:4221-4235, Nov 2012. URL: https://doi.org/10.1038/emboj.2012.264, doi:10.1038/emboj.2012.264. This article has 383 citations.</p>
+</li>
+<li>
+<p>(tittelmeier2020thehsp110hsp70disaggregation pages 1-2): Jessica Tittelmeier, Carl Alexander Sandhof, Heidrun Maja Ries, Silke Druffel‐Augustin, Axel Mogk, Bernd Bukau, and Carmen Nussbaum‐Krammer. The hsp110/hsp70 disaggregation system generates spreading‐competent toxic α‐synuclein species. The EMBO Journal, May 2020. URL: https://doi.org/10.15252/embj.2019103954, doi:10.15252/embj.2019103954. This article has 119 citations.</p>
+</li>
+<li>
+<p>(tittelmeier2020thehsp110hsp70disaggregation pages 4-5): Jessica Tittelmeier, Carl Alexander Sandhof, Heidrun Maja Ries, Silke Druffel‐Augustin, Axel Mogk, Bernd Bukau, and Carmen Nussbaum‐Krammer. The hsp110/hsp70 disaggregation system generates spreading‐competent toxic α‐synuclein species. The EMBO Journal, May 2020. URL: https://doi.org/10.15252/embj.2019103954, doi:10.15252/embj.2019103954. This article has 119 citations.</p>
+</li>
+<li>
+<p>(tittelmeier2020thehsp110hsp70disaggregation pages 6-9): Jessica Tittelmeier, Carl Alexander Sandhof, Heidrun Maja Ries, Silke Druffel‐Augustin, Axel Mogk, Bernd Bukau, and Carmen Nussbaum‐Krammer. The hsp110/hsp70 disaggregation system generates spreading‐competent toxic α‐synuclein species. The EMBO Journal, May 2020. URL: https://doi.org/10.15252/embj.2019103954, doi:10.15252/embj.2019103954. This article has 119 citations.</p>
+</li>
+<li>
+<p>(kirstein2017invivoproperties pages 7-8): Janine Kirstein, Kristin Arnsburg, Annika Scior, Anna Szlachcic, D. Lys Guilbride, Richard I. Morimoto, Bernd Bukau, and Nadinath B. Nillegoda. In vivo properties of the disaggregase function of j‐proteins and hsc70 in caenorhabditis elegans stress and aging. Aging Cell, 16:1414-1424, Oct 2017. URL: https://doi.org/10.1111/acel.12686, doi:10.1111/acel.12686. This article has 87 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(torrente2013themetazoanprotein pages 4-5): Mariana P Torrente and James Shorter. The metazoan protein disaggregase and amyloid depolymerase system. Prion, 7:457-463, Nov 2013. URL: https://doi.org/10.4161/pri.27531, doi:10.4161/pri.27531. This article has 92 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(yakubu2018rolesofthe pages 11-12): Unekwu M. Yakubu and Kevin A. Morano. Roles of the nucleotide exchange factor and chaperone hsp110 in cellular proteostasis and diseases of protein misfolding. Biological Chemistry, 399:1215-1221, Sep 2018. URL: https://doi.org/10.1515/hsz-2018-0209, doi:10.1515/hsz-2018-0209. This article has 41 citations and is from a peer-reviewed journal.</p>
+</li>
+</ol>
+<h2 id="artifacts">Artifacts</h2>
+<ul>
+<li><a href="hsp-110-deep-research-falcon_artifacts/artifact-00.md">Edison artifact artifact-00</a></li>
+</ul>
+<h2 id="citations">Citations</h2>
+<ol>
+<li>bracher2015thenucleotideexchange pages 2-4</li>
+<li>sousa2014structuralmechanismsof pages 3-4</li>
+<li>yakubu2018rolesofthe pages 1-3</li>
+<li>andreasson2008insightsintothe pages 1-2</li>
+<li>yakubu2018rolesofthe pages 3-4</li>
+<li>yakubu2018rolesofthe pages 4-6</li>
+<li>sztangierska2024earlystepsof pages 1-2</li>
+<li>kirstein2017invivoproperties pages 1-1</li>
+<li>kirstein2017invivoproperties pages 7-8</li>
+<li>torrente2013themetazoanprotein pages 4-5</li>
+<li>yakubu2018rolesofthe pages 11-12</li>
+<li>https://doi.org/10.1038/emboj.2012.264,</li>
+<li>https://doi.org/10.15252/embj.2019103954,</li>
+<li>https://doi.org/10.3389/fmolb.2015.00010,</li>
+<li>https://doi.org/10.3389/fmolb.2014.00012,</li>
+<li>https://doi.org/10.1515/hsz-2018-0209,</li>
+<li>https://doi.org/10.1073/pnas.0804187105,</li>
+<li>https://doi.org/10.3389/fmolb.2015.00057,</li>
+<li>https://doi.org/10.1111/acel.12686,</li>
+<li>https://doi.org/10.7554/elife.94795.2,</li>
+<li>https://doi.org/10.1101/2025.04.01.646638,</li>
+<li>https://doi.org/10.1128/mcb.00027-17,</li>
+<li>https://doi.org/10.4161/pri.27531,</li>
+</ol>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(hsp-110-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="Q05036" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="hsp-110-c-elegans-research-notes">hsp-110 (C. elegans) — research notes</h1>
+<p>Gene: <strong>hsp-110</strong> / ORF <strong>C30C11.4</strong> / WormBase <strong>WBGene00016250</strong><br />
+UniProt: <strong>Q05036</strong> (HS110_CAEEL), 776 aa, chromosome III.<br />
+Product: Heat shock protein 110 (HSP110 / HSPH-family Hsp70 relative).</p>
+<h2 id="identity-family-known">Identity / family (KNOWN)</h2>
+<ul>
+<li>UniProt: "Belongs to the heat shock protein 70 family" (SIMILARITY, ECO:0000305). Domain<br />
+  architecture is the canonical Hsp70 fold: N-terminal actin-like ATPase nucleotide-binding<br />
+  domain (NBD; CDD cd10228 <code>ASKHA_NBD_HSP70_HSPA4_like</code>, InterPro IPR043129) + Hsp70<br />
+  substrate/peptide-binding-like domain (IPR029047) + Hsp70 C-terminal subdomain (IPR029048)<br />
+  [file:worm/hsp-110/hsp-110-uniprot.txt].</li>
+<li>This is the <strong>HSP110 / HSPA4 (HSPH) subfamily</strong>, not a canonical Hsp70. FunFam/Gene3D and<br />
+  PANTHER (PTHR45639) place it with "Heat shock 70 kDa protein 4" (HSPA4); the ALS paper<br />
+  identifies C30C11.4 as "homolog to human apg-1 (a heat shock 110 kDa protein)"<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/19165329" title="C30C11.4 ... homolog to human apg-1 (a heat shock 110 kDa protein)">PMID:19165329</a>.<br />
+  Human orthologs of the HSP110/HSPH class are HSPH1 (HSP105), HSPA4 (APG-2) and HSPA4L<br />
+  (APG-1/apg-1). The IBA reference set for the NEF activity includes yeast SSE1/SSE2<br />
+  (SGD:S000000373/S000006027) and human HSPH1 (UniProtKB:Q92598), confirming the orthology<br />
+  basis [file:worm/hsp-110/hsp-110-goa.tsv].</li>
+</ul>
+<h2 id="molecular-function-known-at-family-level-inferred-for-worm">Molecular function (KNOWN at family level; INFERRED for worm)</h2>
+<p>HSP110-family proteins are the principal <strong>cytosolic nucleotide-exchange factors (NEFs) for<br />
+Hsp70</strong>. Established biochemically/structurally in yeast (Sse1p) and conserved across<br />
+eukaryotes:</p>
+<ul>
+<li>Sse1p (yeast Hsp110) "acts as an efficient nucleotide exchange factor (NEF) for both yeast<br />
+  cytosolic Hsp70s, Ssa1p and Ssb1p. The mechanism involves formation of a stable<br />
+  nucleotide-sensitive complex, but does not require ATP hydrolysis by Sse1p" <a href="https://pubmed.ncbi.nlm.nih.gov/16688211" title="acts as an efficient nucleotide exchange factor (NEF) for both yeast cytosolic Hsp70s, Ssa1p   and Ssb1p. The mechanism involves formation of a stable nucleotide-sensitive complex, but does   not require ATP hydrolysis by Sse1p">PMID:16688211</a>.</li>
+<li>Structurally, "the NBD of Sse1p is ATP bound, and together with the 3HBD it embraces the NBD<br />
+  of Hsp70, inducing opening and the release of bound ADP from Hsp70. Mutations that abolish NEF<br />
+  activity are lethal, thus defining nucleotide exchange on Hsp70 as an essential function of<br />
+  Sse1p" <a href="https://pubmed.ncbi.nlm.nih.gov/18555782" title="the NBD of Sse1p is ATP bound, and together with the 3HBD it embraces   the NBD of Hsp70, inducing opening and the release of bound ADP from Hsp70. Mutations that   abolish NEF activity are lethal, thus defining nucleotide exchange on Hsp70 as an essential   function of Sse1p">PMID:18555782</a>.</li>
+</ul>
+<p>Implications for the GO annotations:<br />
+- <strong>ATP binding (GO:0005524)</strong> is genuine and functionally required: Hsp110's own NBD must be<br />
+  ATP-loaded to embrace and open the Hsp70 NBD <a href="https://pubmed.ncbi.nlm.nih.gov/18555782">PMID:18555782</a>.<br />
+- <strong>ATP hydrolysis (GO:0016887)</strong>, in contrast, is <strong>not required</strong> for the defining NEF<br />
+  activity, and Hsp110 "does not employ the nucleotide-dependent allostery and peptide-binding<br />
+  mode of canonical Hsp70s" <a href="https://pubmed.ncbi.nlm.nih.gov/18555782" title="Sse1p does not employ the nucleotide-dependent   allostery and peptide-binding mode of canonical Hsp70s, and that direct interactions of   substrate with Sse1p may support Hsp70-assisted protein folding in a cooperative process">PMID:18555782</a>.<br />
+  So the IEA <code>ATP hydrolysis activity</code> (propagated from the generic Hsp70 fold) is an<br />
+  over-annotation relative to the characterized mechanism (weak/atypical ATPase; hydrolysis<br />
+  dispensable).<br />
+- Beyond NEF, Hsp110 also has intrinsic <strong>holdase / substrate-binding</strong> activity ("direct<br />
+  interactions of substrate with Sse1p may support Hsp70-assisted protein folding"<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/18555782">PMID:18555782</a>), and its NEF activity stimulates Hsp70-mediated <strong>refolding</strong> of denatured<br />
+  substrate ("The NEF activity of Sse1p stimulates in vitro Ssa1p-mediated refolding of<br />
+  thermally denatured luciferase" <a href="https://pubmed.ncbi.nlm.nih.gov/16688211">PMID:16688211</a>).</p>
+<h2 id="worm-specific-biological-role-known-experimental">Worm-specific biological role (KNOWN — experimental)</h2>
+<ol>
+<li>
+<p><strong>Prevents aggregation of a misfolding-prone protein in neurons in vivo (disaggregase/<br />
+   holdase partner of the Hsp70 machine).</strong> In a pan-neuronal mutant human SOD1(G85R) ALS model,<br />
+   an RNAi screen for modifiers of aggregation found that knockdown of a set of chaperones —<br />
+   "including an Hsp110 (C30C11.4), a DnaJ (A2) (dnj-19), an Hsp70 (stc-1), and a neuron specific<br />
+   Hsp16 (F08H9.4)" — <strong>strongly increased</strong> SOD1 inclusion formation <a href="https://pubmed.ncbi.nlm.nih.gov/19165329" title="including    an Hsp110 (C30C11.4), a DnaJ (A2) (dnj-19), an Hsp70 (stc-1), and a neuron specific Hsp16    (F08H9.4)">PMID:19165329</a>. The effect was confirmed with the loss-of-function allele <strong>gk533</strong> (Table 2:<br />
+   "C30C11.4 ... homolog to human apg-1 (a heat shock 110 kDa protein) 3 gk533 ++", strong<br />
+   increase of inclusions). This co-set (Hsp110 + Hsp40/DnaJ + Hsp70) is exactly the metazoan<br />
+   Hsp70–Hsp40–Hsp110 disaggregation machinery, giving in vivo support for<br />
+   GO:0035966 (response to topologically incorrect protein). UniProt records the disruption<br />
+   phenotype: "RNAi-mediated knockdown in a sod-1 mutant background results in increased<br />
+   aggregation of denatured proteins in neurons" [file:worm/hsp-110/hsp-110-uniprot.txt].</p>
+</li>
+<li>
+<p><strong>Modifier of proteostasis / polyglutamine folding (protein folding, IMP).</strong> In a genome-wide<br />
+   RNAi screen in body-wall muscle, C30C11.4 was one of six chaperone-class genes among the polyQ<br />
+   (Q35/Q37) aggregation modifiers ("Protein Folding and transport ... Chaperone (6) F08H9.3;<br />
+   cyn-11; cyn-12; C30C11.4; dnj-22; phb-2") whose knockdown suppressed polyQ aggregation<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/22242008" title="F08H9.3; cyn-11; cyn-12; C30C11.4; dnj-22; phb-2">PMID:22242008</a>. It was a Class A (strong,<br />
+   Q35+Q37) modifier. This is the basis of the WormBase IMP GO:0006457 (protein folding)<br />
+   annotation. (Note the direction: here <em>knockdown</em> suppresses aggregation, whereas in the<br />
+   neuronal SOD1 model knockdown <em>increases</em> aggregation — i.e. the readout is model-dependent,<br />
+   but both link hsp-110 to the folding/aggregation environment.)</p>
+</li>
+<li>
+<p><strong>Contributes to longevity of insulin/IGF-1-signaling (ILS) mutants (determination of adult<br />
+   lifespan, IGI).</strong> Morley &amp; Morimoto showed that "Down-regulation of individual molecular<br />
+   chaperones, transcriptional targets of HSF-1, also decreased longevity of long-lived mutant<br />
+   but not wild-type animals" <a href="https://pubmed.ncbi.nlm.nih.gov/14668486" title="Down-regulation of individual molecular chaperones,    transcriptional targets of HSF-1, also decreased longevity of long-lived mutant but not    wild-type animals">PMID:14668486</a>. The WormBase IGI annotation records a genetic interaction with<br />
+   WB:WBGene00000090 = <strong>age-1</strong> (PI3K, an ILS long-lived mutant background). This paper is<br />
+   abstract-only in our cache (full_text_available: false); the specific hsp-110 result is in the<br />
+   full text the curator read. Treated as a real experimental annotation (do not remove); it is a<br />
+   pleiotropic/downstream organismal role, not the core molecular function → KEEP_AS_NON_CORE.</p>
+</li>
+</ol>
+<h2 id="localization-known-at-family-level">Localization (KNOWN at family level)</h2>
+<ul>
+<li>HSP110 proteins are "exclusively found in the eukaryotic cytosol" <a href="https://pubmed.ncbi.nlm.nih.gov/16688211" title="The Hsp110   proteins, exclusively found in the eukaryotic cytosol">PMID:16688211</a> → cytosol (GO:0005829) is the core<br />
+  site. The IBA <code>nucleus</code> (GO:0005634) is a phylogenetic propagation (mammalian HSPH1 can also be<br />
+  nuclear); no direct worm evidence → KEEP_AS_NON_CORE.</li>
+</ul>
+<h2 id="not-known-candidate-knowledge-gaps">NOT known (candidate knowledge gaps)</h2>
+<ul>
+<li><strong>Whether C. elegans HSP-110 is genetically required for Hsp70/Hsp40-dependent protein<br />
+  DISAGGREGATION in vivo, and the identity of its worm-specific Hsp70 (HSP-1 vs STC-1 vs HSP-70)<br />
+  and Hsp40/J-protein partners.</strong> PMID:19165329 shows hsp-110/dnj-19/stc-1 co-suppress SOD1<br />
+  aggregation, but the biochemical disaggregase reconstitution and the definitive partner set for<br />
+  the worm are not established.</li>
+<li><strong>The endogenous worm client repertoire of HSP-110</strong> (which native metastable proteins depend<br />
+  on HSP-110 NEF activity) is undefined; existing evidence is limited to heterologous<br />
+  aggregation-prone reporters (polyQ, mutant SOD1) and to family-level in vitro substrates.</li>
+<li><strong>Whether HSP-110's own weak/atypical ATPase activity has any in vivo role in the worm</strong>, given<br />
+  that the defining NEF mechanism does not require ATP hydrolysis [PMID:16688211; PMID:18555782].</li>
+<li><strong>Whether HSP-110 has an Hsp70-independent holdase function in the worm</strong> (direct substrate<br />
+  binding), as suggested at the family level <a href="https://pubmed.ncbi.nlm.nih.gov/18555782">PMID:18555782</a>.</li>
+</ul>
+<h2 id="deep-research">Deep research</h2>
+<ul>
+<li>Falcon (Edison Scientific Literature) deep research completed after a ~29-min run<br />
+  (<code>hsp-110-deep-research-falcon.md</code>, 23 citations). It independently reaches the same<br />
+  conclusions used here: HSP-110 is the cytosolic HSP110-family <strong>NEF for Hsp70</strong> and a component<br />
+  of the <strong>metazoan Hsp70–Hsp40–Hsp110 protein-disaggregation machine</strong>. It surfaces two<br />
+  directly relevant papers for the knowledge gaps — Rampelt et al. 2012 EMBO J "Metazoan Hsp70<br />
+  machines use Hsp110 to power protein disaggregation" and, crucially for the worm, Kirstein et<br />
+  al. 2017 Aging Cell "In vivo properties of the disaggregase function of J-proteins and Hsc70 in<br />
+  Caenorhabditis elegans stress and aging" — that establish the C. elegans disaggregase context<br />
+  against which HSP-110's specific in-vivo requirement (knowledge gap #1) is defined.</li>
+<li>The falcon report uses DOI-keyed citations (no PMIDs); per repo experience the reference<br />
+  validator does not check <code>file:</code>/DOI quotes, so NONE of the falcon text is used verbatim in the<br />
+  review. All <code>supporting_text</code> in the review is PMID-anchored and verified against the cached<br />
+  publications (PMID:19165329, PMID:22242008, PMID:14668486, PMID:16688211, PMID:18555782).</li>
+</ul>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: Q05036
+gene_symbol: hsp-110
+product_type: PROTEIN
+taxon:
+  id: NCBITaxon:6239
+  label: Caenorhabditis elegans
+description: &gt;-
+  hsp-110 (ORF C30C11.4) encodes the C. elegans member of the HSP110/HSPH subfamily of
+  the Hsp70 chaperone superfamily, orthologous to yeast Sse1/Sse2 and human HSPH1/HSPA4/
+  HSPA4L (apg-1). Like other HSP110 proteins it is a cytosolic, ATP-binding relative of
+  Hsp70 that acts as a nucleotide-exchange factor (NEF) for canonical Hsp70 chaperones:
+  its ATP-loaded nucleotide-binding domain, together with a three-helix-bundle domain,
+  clamps the Hsp70 nucleotide-binding domain and drives ADP release, resetting the Hsp70
+  ATPase/folding cycle. Unlike canonical Hsp70s, HSP110 does not depend on its own ATP
+  hydrolysis for this activity and can additionally bind non-native polypeptides directly
+  (holdase activity). In C. elegans, HSP-110 operates within the cytosolic chaperone and
+  disaggregation network together with Hsp70 and Hsp40/DnaJ partners to limit the
+  accumulation of misfolded, aggregation-prone proteins; loss of HSP-110 increases
+  aggregation of a misfolding-prone protein in neurons. As an HSF-1-regulated heat-shock
+  protein it also contributes to stress resistance and to the extended lifespan of
+  insulin/IGF-1-signaling mutants.
+references:
+- id: GO_REF:0000002
+  title: Gene Ontology annotation through association of InterPro records with GO
+    terms
+  findings: []
+- id: GO_REF:0000033
+  title: Annotation inferences using phylogenetic trees
+  findings: []
+- id: GO_REF:0000117
+  title: Electronic Gene Ontology annotations created by ARBA machine learning models
+  findings: []
+- id: PMID:14668486
+  title: Regulation of longevity in Caenorhabditis elegans by heat shock factor and
+    molecular chaperones.
+  findings: []
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PubMed-verified. Abstract-only in our cache (full_text_available: false). Supports
+      that HSF-1-target molecular chaperones are required for the extended lifespan of
+      long-lived (ILS-pathway) mutants; the WormBase IGI annotation records a genetic
+      interaction of hsp-110 with age-1 (WBGene00000090). The gene-specific hsp-110 result
+      is in the full text read by the curator, not the abstract.
+- id: PMID:19165329
+  title: An ALS-linked mutant SOD1 produces a locomotor defect associated with aggregation
+    and synaptic dysfunction when expressed in neurons of Caenorhabditis elegans.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PubMed-verified, full text available. Directly assays hsp-110/C30C11.4: RNAi and the
+      gk533 loss-of-function allele strongly increase aggregation of neuronally expressed
+      mutant human SOD1(G85R), placing HSP-110 with an Hsp70 (stc-1) and a DnaJ (dnj-19) in
+      the chaperone network that prevents misfolded-protein aggregation in vivo.
+- id: PMID:22242008
+  title: A genetic screening strategy identifies novel regulators of the proteostasis
+    network.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PubMed-verified, full text available. C30C11.4 (hsp-110) is one of six chaperone-class
+      genes among the polyQ (Q35/Q37) aggregation modifiers (Class A, strong); basis of the
+      WormBase IMP protein-folding annotation.
+- id: PMID:16688211
+  title: &#39;Chaperone network in the yeast cytosol: Hsp110 is revealed as an Hsp70 nucleotide
+    exchange factor.&#39;
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PubMed-verified, abstract-only. Family-level (yeast Sse1p) mechanistic reference
+      establishing HSP110 as an Hsp70 nucleotide-exchange factor whose activity does not
+      require its own ATP hydrolysis; used as conserved-mechanism support for the worm
+      ortholog&#39;s NEF core function, not as direct worm evidence.
+- id: PMID:18555782
+  title: Structural basis for the cooperation of Hsp70 and Hsp110 chaperones in protein
+    folding.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PubMed-verified, abstract-only. Crystal structure of yeast Sse1p (Hsp110) bound to the
+      Hsp70 NBD; ATP-bound HSP110 NBD embraces the Hsp70 NBD to release ADP, and NEF activity
+      is essential. Conserved-mechanism support for the worm ortholog; also documents direct
+      substrate binding by Hsp110.
+existing_annotations:
+- term:
+    id: GO:0000774
+    label: adenyl-nucleotide exchange factor activity
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Core molecular function. HSP-110 is the C. elegans HSP110-family nucleotide-exchange
+      factor for Hsp70. This IBA is well grounded: the phylogenetic reference set includes
+      yeast Sse1/Sse2 and human HSPH1, for which NEF activity is directly established.
+    action: ACCEPT
+    reason: &gt;-
+      HSP110 proteins are the principal cytosolic NEFs for Hsp70; the ATP-loaded HSP110 NBD
+      engages the Hsp70 NBD and drives ADP release. This is the defining, informative
+      molecular function of the gene and should be retained as core.
+    supported_by:
+    - reference_id: PMID:16688211
+      supporting_text: &gt;-
+        acts as an efficient nucleotide exchange factor (NEF) for both yeast cytosolic
+        Hsp70s, Ssa1p and Ssb1p. The mechanism involves formation of a stable
+        nucleotide-sensitive complex, but does not require ATP hydrolysis by Sse1p
+    - reference_id: PMID:18555782
+      supporting_text: &gt;-
+        the NBD of Sse1p is ATP bound, and together with the 3HBD it embraces the NBD of
+        Hsp70, inducing opening and the release of bound ADP from Hsp70. Mutations that
+        abolish NEF activity are lethal, thus defining nucleotide exchange on Hsp70 as an
+        essential function of Sse1p
+- term:
+    id: GO:0005634
+    label: nucleus
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: is_active_in
+  review:
+    summary: &gt;-
+      Phylogenetically propagated nuclear localization. HSP110-family proteins are primarily
+      cytosolic; some mammalian HSPH1 can partition to the nucleus, but there is no direct
+      C. elegans evidence for a nuclear pool of HSP-110.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Retain as a possible minor/shuttling location inherited from the family tree, but it is
+      not the site of the core function; the cytosol is where HSP-110 acts on Hsp70.
+- term:
+    id: GO:0006457
+    label: protein folding
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      HSP-110 participates in the cytosolic protein-folding process as the Hsp70 NEF; its NEF
+      activity stimulates Hsp70-mediated refolding of denatured substrates.
+    action: ACCEPT
+    reason: &gt;-
+      Valid and central biological process for an Hsp70 co-chaperone/NEF; consistent with the
+      experimental IMP protein-folding annotation from the worm and with the conserved family
+      mechanism.
+    supported_by:
+    - reference_id: PMID:16688211
+      supporting_text: &gt;-
+        The NEF activity of Sse1p stimulates in vitro Ssa1p-mediated refolding of thermally
+        denatured luciferase
+- term:
+    id: GO:0005829
+    label: cytosol
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: is_active_in
+  review:
+    summary: &gt;-
+      Core location. HSP110 proteins are cytosolic Hsp70 relatives, and the worm HSP-110 acts
+      on cytosolic Hsp70.
+    action: ACCEPT
+    reason: &gt;-
+      The cytosol is the compartment where HSP-110 performs its NEF function; well supported
+      at the family level and consistent with worm proteostasis assays in cytoplasm.
+    supported_by:
+    - reference_id: PMID:16688211
+      supporting_text: The Hsp110 proteins, exclusively found in the eukaryotic cytosol
+- term:
+    id: GO:0005524
+    label: ATP binding
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: enables
+  review:
+    summary: &gt;-
+      HSP-110 retains the Hsp70-family nucleotide-binding domain and binds ATP; ATP loading of
+      its NBD is functionally required for NEF activity (the ATP-bound NBD clamps the Hsp70
+      NBD to release ADP).
+    action: ACCEPT
+    reason: &gt;-
+      ATP/adenyl-nucleotide binding is genuine and mechanistically essential for HSP-110 NEF
+      function, not a spurious fold-based call.
+    supported_by:
+    - reference_id: PMID:18555782
+      supporting_text: &gt;-
+        the NBD of Sse1p is ATP bound, and together with the 3HBD it embraces the NBD of
+        Hsp70, inducing opening and the release of bound ADP from Hsp70
+- term:
+    id: GO:0006950
+    label: response to stress
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000117
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Generic stress-response term from ARBA. HSP-110 is a heat-shock protein and HSF-1
+      transcriptional target, so involvement in the stress response is correct but
+      uninformatively broad relative to the specific proteostasis roles captured elsewhere.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      True but too general; the specific and better-supported terms (response to
+      topologically incorrect protein, protein folding) convey the actual role. Keep as a
+      broad, non-core annotation.
+- term:
+    id: GO:0016887
+    label: ATP hydrolysis activity
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Propagated from the generic Hsp70 ATPase fold. HSP110-family proteins have only weak,
+      atypical ATPase activity, and their defining NEF mechanism explicitly does NOT require
+      ATP hydrolysis by HSP110; HSP110 also does not use the canonical Hsp70 nucleotide-driven
+      allosteric cycle.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      The term is not categorically impossible (HSP110 binds and may slowly turn over ATP),
+      but attributing a functional ATP hydrolysis activity over-states the biochemistry: it is
+      an electronic call from the shared Hsp70 domain, whereas the characterized HSP110 role is
+      NEF and holdase, with ATP binding (not hydrolysis) being the load-bearing property. Flag
+      as likely over-annotation rather than remove outright.
+    supported_by:
+    - reference_id: PMID:16688211
+      supporting_text: &gt;-
+        The mechanism involves formation of a stable nucleotide-sensitive complex, but does
+        not require ATP hydrolysis by Sse1p
+    - reference_id: PMID:18555782
+      supporting_text: &gt;-
+        does not employ the nucleotide-dependent allostery and peptide-binding mode of
+        canonical Hsp70s
+- term:
+    id: GO:0006457
+    label: protein folding
+  evidence_type: IMP
+  original_reference_id: PMID:22242008
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Experimental WormBase annotation. In a genome-wide RNAi screen, C30C11.4 (hsp-110) was
+      one of six chaperone-class genes among the polyglutamine (Q35/Q37) aggregation modifiers
+      (a Class A strong modifier), linking it to the muscle-cell protein-folding environment.
+    action: ACCEPT
+    reason: &gt;-
+      Experimental (IMP) annotation supported by the screen; consistent with HSP-110&#39;s role as
+      an Hsp70 NEF in cytosolic protein folding. Deferred to the WormBase curator who assessed
+      the full dataset.
+    supported_by:
+    - reference_id: PMID:22242008
+      supporting_text: &#39;F08H9.3; cyn-11; cyn-12; C30C11.4; dnj-22; phb-2&#39;
+- term:
+    id: GO:0035966
+    label: response to topologically incorrect protein
+  evidence_type: IMP
+  original_reference_id: PMID:19165329
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Experimental WormBase annotation and a core biological role. RNAi and the gk533
+      loss-of-function allele of hsp-110/C30C11.4 strongly increase aggregation of neuronally
+      expressed misfolding-prone mutant human SOD1(G85R); HSP-110 acts here with an Hsp70
+      (stc-1) and a DnaJ (dnj-19), i.e. the metazoan Hsp70-Hsp40-Hsp110 anti-aggregation
+      machinery.
+    action: ACCEPT
+    reason: &gt;-
+      Directly supported experimental annotation for this gene; captures HSP-110&#39;s in vivo
+      function in handling misfolded (topologically incorrect) proteins.
+    supported_by:
+    - reference_id: PMID:19165329
+      supporting_text: &gt;-
+        including an Hsp110 (C30C11.4), a DnaJ (A2) (dnj-19), an Hsp70 (stc-1), and a neuron
+        specific Hsp16 (F08H9.4)
+    - reference_id: PMID:19165329
+      supporting_text: &gt;-
+        Three of these were validated as strongly increasing aggregation when mutant alleles
+        were crossed with G85R-YFP
+- term:
+    id: GO:0008340
+    label: determination of adult lifespan
+  evidence_type: IGI
+  original_reference_id: PMID:14668486
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Experimental IGI annotation. HSF-1-target molecular chaperones, when down-regulated,
+      shorten the extended lifespan of long-lived insulin/IGF-1-signaling mutants; the
+      WormBase annotation records a genetic interaction of hsp-110 with age-1
+      (WBGene00000090). This is a pleiotropic, downstream organismal consequence of HSP-110&#39;s
+      chaperone activity rather than its core molecular function.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Retain as a genuine experimental (genetic-interaction) annotation - do not remove - but
+      classify as non-core: lifespan determination reflects HSP-110&#39;s contribution to the
+      proteostasis/stress network, not a distinct molecular activity. Cached reference is
+      abstract-only; deferred to the WormBase curator who read the full text.
+    supported_by:
+    - reference_id: PMID:14668486
+      supporting_text: &gt;-
+        Down-regulation of individual molecular chaperones, transcriptional targets of HSF-1,
+        also decreased longevity of long-lived mutant but not wild-type animals
+- term:
+    id: GO:0051082
+    label: unfolded protein binding
+  evidence_type: ISS
+  original_reference_id: PMID:18555782
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Proposed molecular function not currently in GOA. In addition to nucleotide exchange,
+      HSP110-family proteins bind non-native polypeptides directly (holdase activity), and in
+      the worm HSP-110 loss increases aggregation of misfolding-prone SOD1 in neurons -
+      consistent with a substrate-binding contribution to keeping clients soluble for Hsp70.
+    action: NEW
+    reason: &gt;-
+      Captures HSP-110&#39;s substrate-binding/holdase arm, complementing its NEF activity; more
+      informative than a generic protein-binding term and grounded in the family structure plus
+      the in vivo anti-aggregation phenotype.
+    supported_by:
+    - reference_id: PMID:18555782
+      supporting_text: &gt;-
+        direct interactions of substrate with Sse1p may support Hsp70-assisted protein folding
+        in a cooperative process
+core_functions:
+- description: &gt;-
+    Cytosolic HSP110-family nucleotide-exchange factor (NEF) for Hsp70. The ATP-loaded HSP-110
+    nucleotide-binding domain, together with its three-helix-bundle domain, clamps the Hsp70
+    nucleotide-binding domain and triggers ADP release, resetting the Hsp70 ATPase/folding
+    cycle. This conserved HSP110 activity (yeast Sse1 to human HSPH1) is the defining molecular
+    function of HSP-110 and drives Hsp70-dependent (re)folding in the cytosol.
+  molecular_function:
+    id: GO:0000774
+    label: adenyl-nucleotide exchange factor activity
+  directly_involved_in:
+  - id: GO:0006457
+    label: protein folding
+  locations:
+  - id: GO:0005829
+    label: cytosol
+  supported_by:
+  - reference_id: PMID:16688211
+    supporting_text: &gt;-
+      acts as an efficient nucleotide exchange factor (NEF) for both yeast cytosolic Hsp70s,
+      Ssa1p and Ssb1p. The mechanism involves formation of a stable nucleotide-sensitive
+      complex, but does not require ATP hydrolysis by Sse1p
+  - reference_id: PMID:18555782
+    supporting_text: &gt;-
+      nucleotide exchange factors (NEFs) that remove ADP from Hsp70
+- description: &gt;-
+    Direct binding of non-native/unfolded polypeptides (holdase arm). Beyond nucleotide
+    exchange, HSP-110 can engage substrate directly, cooperating with Hsp70 to keep
+    aggregation-prone clients soluble; in the worm, loss of HSP-110 increases aggregation of
+    misfolding-prone SOD1 in neurons, consistent with a substrate-holding/anti-aggregation
+    contribution alongside its Hsp70 and Hsp40 partners.
+  molecular_function:
+    id: GO:0051082
+    label: unfolded protein binding
+  directly_involved_in:
+  - id: GO:0035966
+    label: response to topologically incorrect protein
+  locations:
+  - id: GO:0005829
+    label: cytosol
+  supported_by:
+  - reference_id: PMID:18555782
+    supporting_text: &gt;-
+      direct interactions of substrate with Sse1p may support Hsp70-assisted protein folding
+      in a cooperative process
+  - reference_id: PMID:19165329
+    supporting_text: &gt;-
+      including an Hsp110 (C30C11.4), a DnaJ (A2) (dnj-19), an Hsp70 (stc-1), and a neuron
+      specific Hsp16 (F08H9.4)
+proposed_new_terms: []
+knowledge_gaps:
+- gap_statement: &gt;-
+    Whether C. elegans HSP-110 is genetically and biochemically required for
+    Hsp70/Hsp40-mediated protein DISAGGREGATION in vivo, and the identity of its physiological
+    worm Hsp70 (HSP-1 vs STC-1 vs HSP-70) and J-protein/Hsp40 partners in that reaction, are
+    undetermined.
+  boundary: &gt;-
+    It is established that HSP-110 is an HSP110-family Hsp70 NEF (conserved from yeast Sse1 to
+    human HSPH1) and that in neurons its loss (RNAi and the gk533 allele) increases aggregation
+    of misfolding-prone SOD1 alongside an Hsp70 (stc-1) and a DnaJ (dnj-19). What is NOT
+    established for the worm is a reconstituted or genetically defined Hsp70-Hsp40-Hsp110
+    disaggregase, its obligate partner set, and whether HSP-110 is required for active
+    dissolution of pre-formed aggregates (as opposed to preventing their formation).
+  gap_kind:
+  - BIOLOGY
+  dark_aspect: RESIDUAL_SUBGAP
+  status: OPEN
+  significance: &gt;-
+    Metazoan protein disaggregation depends on a cooperative Hsp70-Hsp40-Hsp110 system.
+    Defining the worm partners and the requirement for HSP-110 would connect its molecular NEF
+    activity to organismal proteostasis and neuroprotection, and clarify which chaperone axis
+    to target in C. elegans neurodegeneration models.
+  resolution: &gt;-
+    Tissue-specific hsp-110 loss-of-function combined with aggregation/disaggregation reporters
+    and photoconvertible aggregation-clearance assays; affinity-purification/mass-spectrometry
+    of tagged HSP-110 from worm lysate to define Hsp70/J-protein partners; in vitro
+    reconstitution of a worm disaggregase.
+  provenance:
+  - reference_id: PMID:19165329
+    supporting_text: &gt;-
+      including an Hsp110 (C30C11.4), a DnaJ (A2) (dnj-19), an Hsp70 (stc-1), and a neuron
+      specific Hsp16 (F08H9.4)
+  - reference_id: PMID:16688211
+    supporting_text: &gt;-
+      This is the first report of a nucleotide exchange activity for the Hsp110 class of
+      proteins
+- gap_statement: &gt;-
+    The endogenous C. elegans client repertoire of HSP-110 is undefined: which native
+    metastable proteins depend on HSP-110 NEF/holdase activity, and in which tissues, is
+    unknown.
+  boundary: &gt;-
+    HSP-110 demonstrably modifies aggregation of heterologous, aggregation-prone reporters
+    (polyglutamine and mutant human SOD1) and, at the family level, HSP110 NEF activity
+    stimulates Hsp70-mediated refolding of denatured model substrates such as luciferase. No
+    endogenous physiological worm client of HSP-110 has been mapped.
+  gap_kind:
+  - BIOLOGY
+  dark_aspect: RESIDUAL_SUBGAP
+  status: OPEN
+  significance: &gt;-
+    Client identity determines where HSP-110 activity is rate-limiting for proteostasis and
+    which phenotypes (muscle, neuron, germline, aging) are mechanistically downstream of the
+    NEF function.
+  resolution: &gt;-
+    Chaperone-client capture (e.g. interactomics of tagged HSP-110, or aggregate proteomics in
+    hsp-110 loss-of-function) to enumerate native substrates.
+  provenance:
+  - reference_id: PMID:22242008
+    supporting_text: &#39;F08H9.3; cyn-11; cyn-12; C30C11.4; dnj-22; phb-2&#39;
+  - reference_id: PMID:16688211
+    supporting_text: &gt;-
+      The NEF activity of Sse1p stimulates in vitro Ssa1p-mediated refolding of thermally
+      denatured luciferase
+- gap_statement: &gt;-
+    Whether HSP-110&#39;s own weak/atypical ATPase activity, and any Hsp70-independent holdase
+    function, have a physiological role in C. elegans is untested.
+  boundary: &gt;-
+    The defining HSP110 NEF mechanism requires ATP BINDING but not ATP hydrolysis by HSP110,
+    and HSP110 does not use the canonical Hsp70 nucleotide-driven allosteric peptide-binding
+    cycle; direct substrate binding by Hsp110 has been observed in vitro. The in vivo relevance
+    of HSP-110 ATP hydrolysis and of a standalone holdase mode in the worm has not been probed.
+  gap_kind:
+  - BIOLOGY
+  dark_aspect: MF_DARK
+  status: OPEN
+  significance: &gt;-
+    Resolving this would settle whether the IEA-propagated ATP hydrolysis activity is
+    functionally meaningful for HSP-110 or a fold-based over-annotation, and whether HSP-110
+    contributes to proteostasis independently of Hsp70.
+  resolution: &gt;-
+    Structure-guided separation-of-function alleles (NEF-dead vs ATPase-dead vs
+    substrate-binding-dead) tested for rescue of hsp-110 proteostasis phenotypes in vivo, plus
+    in vitro ATPase and holdase assays on purified worm HSP-110.
+  provenance:
+  - reference_id: PMID:16688211
+    supporting_text: &gt;-
+      does not require ATP hydrolysis by Sse1p
+  - reference_id: PMID:18555782
+    supporting_text: &gt;-
+      does not employ the nucleotide-dependent allostery and peptide-binding mode of canonical
+      Hsp70s
+suggested_questions:
+- question: &gt;-
+    Which C. elegans Hsp70 (HSP-1, STC-1, or HSP-70) and which J-domain/Hsp40 proteins form
+    the physiological HSP-110-dependent disaggregation machine in each tissue?
+  experts:
+  - C. elegans proteostasis biologists
+  - Hsp70/Hsp110 chaperone biochemists
+- question: &gt;-
+    Is HSP-110 required to dissolve pre-formed aggregates, or only to prevent their formation,
+    in worm neurons and muscle?
+  experts:
+  - Protein-aggregation/disaggregase biologists
+suggested_experiments:
+- experiment_type: Affinity purification / mass spectrometry
+  description: &gt;-
+    Affinity-purify endogenously tagged HSP-110 from C. elegans lysate and identify Hsp70,
+    Hsp40/J-protein, and client partners to define the worm disaggregation network and native
+    substrates.
+- experiment_type: Separation-of-function genetics
+  description: &gt;-
+    Engineer NEF-dead, ATPase-dead, and substrate-binding-dead hsp-110 alleles and test each
+    for rescue of aggregation/disaggregation and lifespan phenotypes to dissect which molecular
+    property (nucleotide exchange, ATP hydrolysis, holdase) is required in vivo.
+- experiment_type: In vitro disaggregation reconstitution
+  description: &gt;-
+    Reconstitute disaggregation of aggregated model substrates with purified worm HSP-110,
+    Hsp70, and Hsp40 to test whether HSP-110 is required and rate-limiting for the reaction.
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/genes/worm/isp-1/isp-1-ai-review.html
+++ b/genes/worm/isp-1/isp-1-ai-review.html
@@ -1,0 +1,3281 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>isp-1 - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        .propagation-review {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f8fafc;
+            border-left: 3px solid #64748b;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .propagation-title {
+            font-weight: 600;
+            color: #334155;
+            margin-bottom: 0.25rem;
+        }
+
+        .propagation-row {
+            margin-top: 0.25rem;
+        }
+
+        .propagation-source {
+            margin-top: 0.5rem;
+            padding-top: 0.5rem;
+            border-top: 1px solid #e5e7eb;
+        }
+
+        .propagation-source-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #1d4ed8;
+        }
+
+        .propagation-comment {
+            color: #4b5563;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>isp-1</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/O44512" target="_blank" class="term-link">
+                        O44512
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Caenorhabditis elegans</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-draft">
+                    DRAFT
+                </span>
+            </div>
+
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "isp-1";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="O44512" data-a="DESCRIPTION: isp-1 encodes the Rieske iron-sulfur protein (ISP)..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>isp-1 encodes the Rieske iron-sulfur protein (ISP), the [2Fe-2S]-cluster-bearing catalytic subunit of mitochondrial respiratory complex III (the cytochrome bc1 / ubiquinol-cytochrome c oxidoreductase complex, EC 7.1.1.8). Anchored in the mitochondrial inner membrane, its mobile Rieske head domain accepts an electron from ubiquinol at the complex III Qo site and delivers it to cytochrome c1, performing the electron-transfer step of the protonmotive Q-cycle and thereby feeding electrons into the respiratory chain. In C. elegans the partial loss-of-function allele isp-1(qm150) is a classic mitochondrial (&#34;Mit&#34;) longevity mutant: it lowers oxygen consumption and extends lifespan, with the lifespan extension driven by an elevated mitochondrial superoxide signal rather than by reduced oxidative damage.</p>
+    </div>
+
+
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016491" target="_blank" class="term-link">
+                                    GO:0016491
+                                </a>
+                            </span>
+                            <span class="term-label">oxidoreductase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-modify">
+                            MODIFY
+                        </span>
+                        <span class="vote-buttons" data-g="O44512" data-a="GO:0016491" data-r="GO_REF:0000033" data-act="MODIFY">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct but uninformatively general. ISP-1&#39;s specific molecular function is electron transfer through its Rieske [2Fe-2S] cluster; the complex-level oxidoreductase reaction is captured more precisely by GO:0008121.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> oxidoreductase activity is a high-level parent. The subunit-specific activity of the Rieske protein is electron transfer (GO:0009055), enabled via its 2Fe-2S cluster; complex III&#39;s overall reaction is quinol-cytochrome-c reductase activity (GO:0008121), already separately annotated.
+                        </div>
+
+
+
+                        <div class="propagation-review">
+                            <div class="propagation-title">Propagation Review</div>
+                            <div class="propagation-row">
+                                <strong>Root cause:</strong>
+                                <span class="badge">TERM SCOPING PROBLEM</span>
+                            </div>
+
+                            <div class="propagation-row">
+                                <strong>Failure modes:</strong>
+
+                                <span class="badge">GRANULARITY MISMATCH</span>
+
+                            </div>
+
+
+                            <div class="propagation-source">
+                                <strong>Sources checked:</strong>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">PANTHER:PTN000015358</span>
+
+                                    &middot; Rieske / complex III oxidoreductase node
+
+
+
+                                    <div class="propagation-comment">IBA propagates the broad parent oxidoreductase activity; the correct subunit-level term is electron transfer activity (GO:0009055).</div>
+
+                                </div>
+
+                            </div>
+
+                        </div>
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0009055" target="_blank" class="term-link">
+                                    electron transfer activity
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/26504246" target="_blank" class="term-link">
+                                        PMID:26504246
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">encodes the Rieske iron-sulfur protein subunit of cytochrome c oxidoreductase (complex III of the electron transport chain)</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0045275" target="_blank" class="term-link">
+                                    GO:0045275
+                                </a>
+                            </span>
+                            <span class="term-label">respiratory chain complex III</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O44512" data-a="GO:0045275" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Core annotation. ISP-1 is the Rieske iron-sulfur subunit of respiratory chain complex III (cytochrome bc1).
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Well established across eukaryotes and in C. elegans; ISP-1 is an integral catalytic subunit of complex III.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/21151885" target="_blank" class="term-link">
+                                        PMID:21151885
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">subunits of complex I and III of the mitochondrial respiratory chain</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/26504246" target="_blank" class="term-link">
+                                        PMID:26504246
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">complex III of the electron transport chain</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006122" target="_blank" class="term-link">
+                                    GO:0006122
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial electron transport, ubiquinol to cytochrome c</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O44512" data-a="GO:0006122" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Core biological process. Within complex III, ISP-1 transfers electrons from ubiquinol to cytochrome c1 (and onward to cytochrome c).
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> This is the pathway step complex III performs and to which the Rieske subunit is central; phylogenetically well supported and consistent with the experimental worm data.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/21151885" target="_blank" class="term-link">
+                                        PMID:21151885
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Partial loss-of-function mutations in these genes decrease electron transport</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:worm/isp-1/isp-1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">transfers electrons from ubiquinol to cytochrome c1</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005743" target="_blank" class="term-link">
+                                    GO:0005743
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial inner membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000044
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O44512" data-a="GO:0005743" data-r="GO_REF:0000044" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Core localization. Complex III, including the Rieske subunit, resides in the mitochondrial inner membrane.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> UniProt subcellular location; ISP-1 has a single-pass inner-membrane anchor with its Rieske head projecting to the intermembrane-space side.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:worm/isp-1/isp-1-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">C:mitochondrial inner membrane; IEA:UniProtKB-SubCell</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008121" target="_blank" class="term-link">
+                                    GO:0008121
+                                </a>
+                            </span>
+                            <span class="term-label">quinol-cytochrome-c reductase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000120
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O44512" data-a="GO:0008121" data-r="GO_REF:0000120" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Complex III catalytic activity (EC 7.1.1.8) to which ISP-1 contributes the essential electron-transfer step. Retained as a core molecular function of the subunit in the context of the assembled complex.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> ISP-1 is a catalytic subunit of ubiquinol-cytochrome c oxidoreductase; the Rieske cluster carries out the electron-transfer half of this reaction. Best represented in core_functions as contributes_to (a complex-level activity).
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:worm/isp-1/isp-1-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">EC=7.1.1.8</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/26504246" target="_blank" class="term-link">
+                                        PMID:26504246
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">subunit of cytochrome c oxidoreductase</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016020" target="_blank" class="term-link">
+                                    GO:0016020
+                                </a>
+                            </span>
+                            <span class="term-label">membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000120
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="O44512" data-a="GO:0016020" data-r="GO_REF:0000120" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Uninformative general parent, redundant with the specific and correct mitochondrial inner membrane annotation (GO:0005743).
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> &#34;membrane&#34; adds no information beyond the more precise GO:0005743 already assigned; it is an over-general IEA byproduct.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051537" target="_blank" class="term-link">
+                                    GO:0051537
+                                </a>
+                            </span>
+                            <span class="term-label">2 iron, 2 sulfur cluster binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O44512" data-a="GO:0051537" data-r="GO_REF:0000002" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Core molecular function. The defining feature of the Rieske protein: it coordinates a high-potential [2Fe-2S] cluster, the redox center used for electron transfer.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> UniProt cofactor annotation and Rieske-family conservation; one [2Fe-2S] cluster is bound per subunit.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:worm/isp-1/isp-1-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Binds 1 [2Fe-2S] cluster per subunit</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:worm/isp-1/isp-1-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">The Rieske protein is a high potential 2Fe-2S protein</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1902600" target="_blank" class="term-link">
+                                    GO:1902600
+                                </a>
+                            </span>
+                            <span class="term-label">proton transmembrane transport</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000108
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="O44512" data-a="GO:1902600" data-r="GO_REF:0000108" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Complex III couples electron transfer to proton translocation across the inner membrane via the Q-cycle. This is a complex-level chemiosmotic outcome, not ISP-1&#39;s direct molecular function (electron transfer); retained as non-core.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Proton translocation is an emergent property of the intact Q-cycle to which ISP-1 contributes, rather than an activity ISP-1 performs on its own. Correct to retain, but the subunit&#39;s core function is electron transfer.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006122" target="_blank" class="term-link">
+                                    GO:0006122
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial electron transport, ubiquinol to cytochrome c</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/16920626" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:16920626
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Mitochondrial complex I function modulates volatile anesthet...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O44512" data-a="GO:0006122" data-r="PMID:16920626" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Experimentally supported in C. elegans. The isp-1 complex III mutant shows impaired mitochondrial respiration/oxidative phosphorylation, directly implicating isp-1 in mitochondrial electron transport.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Falk et al. measured respiration in the isp-1 (complex III) mutant and found diminished complex II-dependent oxidative phosphorylation, consistent with a defect in the ubiquinol-to-cytochrome c step; core process, experimentally anchored.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/16920626" target="_blank" class="term-link">
+                                        PMID:16920626
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">in isp-1 (complex III mutant)</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/16920626" target="_blank" class="term-link">
+                                        PMID:16920626
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">somewhat diminished in the complex III ( isp-1 ) mutant</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>Electron-transfer subunit of mitochondrial complex III: within the cytochrome bc1 complex, ISP-1&#39;s mobile Rieske head accepts an electron from ubiquinol at the Qo site and delivers it to cytochrome c1, the electron-transfer step of the ubiquinol-cytochrome c reductase (EC 7.1.1.8) reaction in the protonmotive Q-cycle.</h3>
+                <span class="vote-buttons" data-g="O44512" data-a="FUNCTION: Electron-transfer subunit of mitochondrial complex..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0009055" target="_blank" class="term-link">
+                            electron transfer activity
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006122" target="_blank" class="term-link">
+                                mitochondrial electron transport, ubiquinol to cytochrome c
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005743" target="_blank" class="term-link">
+                                mitochondrial inner membrane
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">In Complex:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0045275" target="_blank" class="term-link">
+                            respiratory chain complex III
+                        </a>
+                    </span>
+                </div>
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/26504246" target="_blank" class="term-link">
+                                PMID:26504246
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">encodes the Rieske iron-sulfur protein subunit of cytochrome c oxidoreductase (complex III of the electron transport chain)</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/21151885" target="_blank" class="term-link">
+                                PMID:21151885
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">subunits of complex I and III of the mitochondrial respiratory chain</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>Coordinates the Rieske high-potential [2Fe-2S] cluster (one per subunit), the redox cofactor that carries out the electron-transfer step of complex III.</h3>
+                <span class="vote-buttons" data-g="O44512" data-a="FUNCTION: Coordinates the Rieske high-potential [2Fe-2S] clu..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051537" target="_blank" class="term-link">
+                            2 iron, 2 sulfur cluster binding
+                        </a>
+                    </span>
+                </div>
+
+
+
+
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">In Complex:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0045275" target="_blank" class="term-link">
+                            respiratory chain complex III
+                        </a>
+                    </span>
+                </div>
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:worm/isp-1/isp-1-uniprot.txt
+
+                        </span>
+
+                        <div class="finding-text">Binds 1 [2Fe-2S] cluster per subunit</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000002.md" target="_blank" class="term-link">
+                            GO_REF:0000002
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation through association of InterPro records with GO terms</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
+                            GO_REF:0000033
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Annotation inferences using phylogenetic trees</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
+                            GO_REF:0000044
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000108.md" target="_blank" class="term-link">
+                            GO_REF:0000108
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Automatic assignment of GO terms using logical inference, based on on inter-ontology links</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000120.md" target="_blank" class="term-link">
+                            GO_REF:0000120
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Combined Automated Annotation using Multiple IEA Methods</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/16920626" target="_blank" class="term-link">
+                            PMID:16920626
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Mitochondrial complex I function modulates volatile anesthetic sensitivity in C. elegans.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/11709184" target="_blank" class="term-link">
+                            PMID:11709184
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Mitochondrial electron transport is a key determinant of life span in Caenorhabditis elegans.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/21151885" target="_blank" class="term-link">
+                            PMID:21151885
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">A mitochondrial superoxide signal triggers increased longevity in Caenorhabditis elegans.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/20346072" target="_blank" class="term-link">
+                            PMID:20346072
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Two modes of mitochondrial dysfunction lead independently to lifespan extension in Caenorhabditis elegans.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/26504246" target="_blank" class="term-link">
+                            PMID:26504246
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Tether mutations that restore function and suppress pleiotropic phenotypes of the C. elegans isp-1(qm150) Rieske iron-sulfur protein.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        file:worm/isp-1/isp-1-uniprot.txt
+
+                    </span>
+                </div>
+
+                <div class="reference-title">UniProtKB O44512 (isp-1, C. elegans) - Cytochrome b-c1 complex subunit Rieske, mitochondrial</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        file:worm/isp-1/isp-1-deep-research-falcon.md
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Falcon (Edison) deep research report for C. elegans isp-1</div>
+
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Knowledge Gaps</h2>
+        <p style="color: #555; font-size: 0.92rem; margin-top: -0.3rem;">
+            What is <em>not</em> known — curated, literature-grounded statements of the open
+            unknowns (the inverse of core functions).
+        </p>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The molecular mechanism by which the isp-1(qm150) Rieske substitution is converted into the pro-longevity retrograde signal is undetermined. It is established that qm150 elevates mitochondrial superoxide and that this elevation is necessary and sufficient for the lifespan extension, but the causal chain from the specific perturbation of ISP-1 head/tether dynamics, through altered Qo-site electron transfer and superoxide production, to the downstream transcriptional longevity program has not been resolved.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">RESIDUAL_SUBGAP</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> Firmly established: isp-1 encodes the Rieske [2Fe-2S] subunit of complex III; qm150 is a partial loss-of-function allele that lowers oxygen consumption and extends lifespan; the longevity requires elevated mitochondrial superoxide (abolished by antioxidants, phenocopied by paraquat); and intragenic suppressors that restore function map to a conserved six-residue tether region (&#34;spring-loaded&#34; model). What is unresolved is the signal-generating step itself.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> isp-1(qm150) is a canonical mitohormesis / Mit longevity model. Defining the signal-generating step would connect a specific electron-transport-chain lesion to a conserved lifespan-extension program with relevance to mitochondrial disease and aging.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Structure-guided electron-transfer and superoxide measurements on qm150 and its intragenic tether-region suppressors, combined with epistasis to the retrograde transcriptional effectors, to identify the step that generates the superoxide longevity signal.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"this elevation is necessary and sufficient to increase longevity"</em> — PMID:21151885</li>
+
+                <li><em>"points to a common underlying molecular mechanism, for which we propose a"</em> — PMID:26504246</li>
+
+            </ul>
+
+
+        </div>
+
+    </div>
+
+
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Deep Research Sections -->
+
+    <div class="section">
+        <h2 class="section-title">Deep Research</h2>
+
+        <details class="deep-research-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; gap: 1rem;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Falcon</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(isp-1-deep-research-falcon.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="O44512" data-a="DEEP_RESEARCH: Falcon" data-r="" data-act="DEEP_RESEARCH" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This deep research is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This deep research needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+
+                <div class="report-meta">
+
+                    <span class="report-meta-text">Comprehensive Research Report: *isp-1* (F42G8.12) — Rieske Iron-Sulfur Protein of Mitochondrial Complex III in *Caenorhabditis elegans*</span>
+
+
+                    <span class="report-badge">Falcon</span>
+
+
+                    <span class="report-badge">Edison Scientific Literature</span>
+
+
+                    <span class="report-badge">44 citations</span>
+
+
+                    <span class="report-badge">2 artifacts</span>
+
+
+                    <span class="report-meta-text">2026-07-04T14:48:30.379729</span>
+
+
+
+                </div>
+
+
+                <div class="artifact-list">
+
+
+
+                    <div class="artifact-link">
+                        <a href="isp-1-deep-research-falcon_artifacts/artifact-00.md" class="term-link">Edison artifact artifact-00</a>
+                        <span>(text/markdown)</span>
+                    </div>
+
+
+
+
+                    <div class="artifact-link">
+                        <a href="isp-1-deep-research-falcon_artifacts/artifact-01.md" class="term-link">Edison artifact artifact-01</a>
+                        <span>(text/markdown)</span>
+                    </div>
+
+
+                </div>
+
+                <p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h1 id="comprehensive-research-report-isp-1-f42g812-rieske-iron-sulfur-protein-of-mitochondrial-complex-iii-in-caenorhabditis-elegans">Comprehensive Research Report: <em>isp-1</em> (F42G8.12) — Rieske Iron-Sulfur Protein of Mitochondrial Complex III in <em>Caenorhabditis elegans</em></h1>
+<p><strong>Gene:</strong> <em>isp-1</em> | <strong>UniProt:</strong> O44512 | <strong>Organism:</strong> <em>Caenorhabditis elegans</em> | <strong>Protein:</strong> Cytochrome b-c1 complex subunit Rieske, mitochondrial | <strong>EC:</strong> 7.1.1.8</p>
+<hr />
+<h2 id="1-gene-identity-and-protein-overview">1. Gene Identity and Protein Overview</h2>
+<p>The <em>isp-1</em> gene (locus F42G8.12) in <em>C. elegans</em> encodes the Rieske iron-sulfur protein (ISP), a catalytic subunit of mitochondrial Complex III (ubiquinol:cytochrome <em>c</em> oxidoreductase, also known as the cytochrome bc1 complex) (jafari2016newfunctionaland pages 1-4). ISP-1 belongs to the highly conserved Rieske iron-sulfur protein family, with orthologs including UQCRFS1 in mammals (osz2025mutationsofthe pages 4-6). The protein contains characteristic domains including a Rieske 2Fe-2S cluster domain (IPR017941), a Rieske 2Fe-2S superfamily domain (IPR036922), a Rieske Fe-S protein domain (IPR014349), and a bc1 Rieske transmembrane superfamily domain (IPR037008), all consistent with its function as a catalytic electron transfer component within the Q-cycle of Complex III.</p>
+<hr />
+<h2 id="2-protein-structure-and-domain-architecture">2. Protein Structure and Domain Architecture</h2>
+<p>ISP-1 comprises three structurally and functionally distinct domains that are essential for its role in the Q-cycle mechanism of Complex III:</p>
+<table>
+<thead>
+<tr>
+<th>Domain/Feature</th>
+<th>Description</th>
+<th>Function</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Transmembrane helix (anchor)</td>
+<td>Single N-terminal transmembrane α-helix that anchors ISP-1 in the mitochondrial inner membrane as a core subunit of Complex III/cytochrome bc1. The membrane anchor remains relatively static while the catalytic domain moves. (jafari2016newfunctionaland pages 1-4, yang2012rieskeiron–sulfurprotein pages 1-3)</td>
+<td>Positions ISP-1 within Complex III and maintains the spatial framework needed for electron transfer between quinol oxidation and cytochrome c1 reduction. (jafari2016newfunctionaland pages 1-4, yang2012rieskeiron–sulfurprotein pages 1-3)</td>
+</tr>
+<tr>
+<td>Tether domain (spring mechanism)</td>
+<td>Flexible linker connecting the membrane anchor to the extrinsic catalytic head. In mechanistic models it behaves as a chemical “spring,” alternating between extended and relaxed/helical conformations during catalysis; the qm150 Pro→Ser mutation lies in this region. (jafari2016newfunctionaland pages 1-4, jafari2016newfunctionaland pages 10-16, jafari2016newfunctionaland pages 6-8, jafari2016newfunctionaland pages 4-6)</td>
+<td>Enables controlled movement of the head domain between the Qo site and cytochrome c1, thereby regulating enzyme-substrate complex formation, electron flux through the Q-cycle, and ROS propensity. (jafari2016newfunctionaland pages 10-16, jafari2016newfunctionaland pages 6-8, jafari2016newfunctionaland pages 4-6)</td>
+</tr>
+<tr>
+<td>Head domain with 2Fe-2S cluster</td>
+<td>Extrinsic/mobile catalytic head domain containing the Rieske 2Fe-2S cluster with distinctive histidine coordination and relatively high redox potential. This domain projects to the P side/intermembrane-space side of the membrane. (jafari2016newfunctionaland pages 1-4, schmidt2004rieskeiron–sulfurproteins pages 1-2)</td>
+<td>Accepts an electron from ubiquinol at the Qo site and later donates that electron to heme c1; its mobility and redox chemistry are central to Complex III catalysis. (jafari2016newfunctionaland pages 1-4, jafari2016newfunctionaland pages 10-16, schmidt2004rieskeiron–sulfurproteins pages 1-2)</td>
+</tr>
+<tr>
+<td>Qo site interaction</td>
+<td>ISP-1 docks at the quinol oxidation (Qo) site near cytochrome b, where oxidized ISP interacts with ubiquinol (QH2). The first electron-transfer step reduces the 2Fe-2S cluster and generates a semiquinone intermediate. (jafari2016newfunctionaland pages 10-16, jafari2016newfunctionaland pages 6-8)</td>
+<td>Executes the initial oxidation of QH2 and bifurcates electron flow in the Q-cycle, a key energy-conserving step in Complex III. (jafari2016newfunctionaland pages 10-16, jafari2016newfunctionaland pages 6-8, gurung2005theironsulfurcluster pages 1-1)</td>
+</tr>
+<tr>
+<td>Cytochrome c1 interaction</td>
+<td>After reduction at the Qo site, the ISP-1 head swings toward cytochrome c1 into the c1-state conformation, where the reduced 2Fe-2S center transfers its electron to heme c1. (jafari2016newfunctionaland pages 1-4, jafari2016newfunctionaland pages 10-16, yang2012rieskeiron–sulfurprotein pages 1-3, crofts1999physicochemicalaspectsof pages 11-12)</td>
+<td>Couples quinol oxidation to reduction of cytochrome c1 and ultimately cytochrome c, supporting downstream electron flow to Complex IV. (jafari2016newfunctionaland pages 1-4, yang2012rieskeiron–sulfurprotein pages 1-3)</td>
+</tr>
+<tr>
+<td>Proton-exiting gate role</td>
+<td>Experimental disruption of the Rieske 2Fe-2S center creates a proton leak, supporting the model that the cluster/head region acts as a proton-exiting gate in cytochrome bc1. (gurung2005theironsulfurcluster pages 1-1, gurung2005theironsulfurcluster pages 5-5)</td>
+<td>Prevents nonspecific proton leakage and helps couple electron transfer to proton translocation, preserving the proton motive force used for ATP synthesis. (gurung2005theironsulfurcluster pages 1-1, gurung2005theironsulfurcluster pages 5-5)</td>
+</tr>
+<tr>
+<td>Overall Q-cycle reaction (EC 7.1.1.8; ubiquinol:ferricytochrome-c reductase)</td>
+<td>ISP-1 is a catalytic subunit of Complex III/ubiquinol:cytochrome c oxidoreductase. In the Q-cycle, it transfers electrons from ubiquinol to cytochrome c1 while coordinating with the Qo and Qi sites to couple redox chemistry to proton translocation across the inner membrane. (jafari2016newfunctionaland pages 1-4, jafari2016newfunctionaland pages 10-16, gurung2005theironsulfurcluster pages 1-1, yang2012rieskeiron–sulfurprotein pages 1-3)</td>
+<td>Contributes to the net reaction of ubiquinol oxidation and cytochrome c reduction while generating the proton gradient required for oxidative phosphorylation and ATP production. (jafari2016newfunctionaland pages 1-4, jafari2016newfunctionaland pages 10-16, yang2012rieskeiron–sulfurprotein pages 1-3)</td>
+</tr>
+</tbody>
+</table>
+<p><em>Table: This table summarizes the major structural features of the C. elegans ISP-1/Rieske iron-sulfur protein and links each feature to its role in Complex III catalysis. It is useful for connecting protein architecture to the Q-cycle mechanism and the gene’s primary biochemical function.</em></p>
+<p><strong>Transmembrane anchor.</strong> A single N-terminal transmembrane α-helix anchors ISP-1 in the mitochondrial inner membrane, positioning it as a core subunit of the cytochrome bc1 complex (jafari2016newfunctionaland pages 1-4, yang2012rieskeiron–sulfurprotein pages 1-3). This anchor remains relatively static during catalysis.</p>
+<p><strong>Tether domain.</strong> A flexible linker region connects the membrane anchor to the catalytic head domain. This tether operates as a chemical "spring," alternating between extended and relaxed (helical) conformations to enable the large-scale domain movement required for catalysis (jafari2016newfunctionaland pages 1-4, jafari2016newfunctionaland pages 10-16). The tether contains conserved amino acids critical for mediating interactions between cytochrome b and the ISP head domain (jafari2016newfunctionaland pages 6-8). Notably, the well-characterized <em>isp-1(qm150)</em> mutation—a proline-to-serine substitution—maps to this tether region and profoundly affects protein function (jafari2016newfunctionaland pages 6-8, jafari2016newfunctionaland pages 4-6).</p>
+<p><strong>Extrinsic head domain with 2Fe-2S cluster.</strong> The catalytic head domain projects into the intermembrane space (P-side) and harbors the Rieske [2Fe-2S] cluster with distinctive histidine-coordinated nitrogen ligands, conferring a relatively high redox potential compared to other iron-sulfur centers (schmidt2004rieskeiron–sulfurproteins pages 1-2). This domain undergoes large-scale movement of approximately 16–22 Å between the Qo site on cytochrome b and cytochrome c1, with root-mean-square displacement occurring in less than 25 nanoseconds (crofts1999physicochemicalaspectsof pages 11-12).</p>
+<hr />
+<h2 id="3-primary-enzymatic-function-the-q-cycle-mechanism">3. Primary Enzymatic Function: The Q-Cycle Mechanism</h2>
+<p>ISP-1 functions as a catalytic subunit of Complex III, which catalyzes the oxidation of ubiquinol (coenzyme QH₂) coupled to the reduction of cytochrome <em>c</em> and the translocation of protons across the mitochondrial inner membrane (EC 7.1.1.8) (jafari2016newfunctionaland pages 1-4, gurung2005theironsulfurcluster pages 1-1). The specific role of ISP-1 within the Q-cycle is as follows:</p>
+<p><strong>Step 1 — Ubiquinol oxidation at the Qo site.</strong> The oxidized 2Fe-2S cluster (ISP_ox) of the head domain docks at the Qo site (quinol oxidation site) near cytochrome b, where it accepts one electron from bound ubiquinol (QH₂). This first electron transfer reduces ISP_ox to ISP_H and generates a transient semiquinone intermediate (SQo) (jafari2016newfunctionaland pages 10-16).</p>
+<p><strong>Step 2 — Electron shuttle to cytochrome c1.</strong> The reduced ISP head dissociates from the Qo site and swings on its tether to dock at cytochrome c1, where the electron is transferred from the reduced 2Fe-2S cluster to heme c1, coupled with release of a proton to the P-phase (intermembrane space). This constitutes the "high-potential chain" of electron flow, ultimately reducing soluble cytochrome <em>c</em> (jafari2016newfunctionaland pages 10-16, yang2012rieskeiron–sulfurprotein pages 1-3).</p>
+<p><strong>Step 3 — Bifurcation of electron flow.</strong> The second electron from ubiquinol oxidation follows the separate "low-potential chain" through heme b_L and heme b_H of cytochrome b to the Qi site (quinone reduction site), where ubiquinone is reduced to ubiquinol. This bifurcated electron transfer is fundamental to the Q-cycle's proton-translocation stoichiometry of 2H⁺/e⁻ (jafari2016newfunctionaland pages 10-16, osz2025mutationsofthe pages 19-21, gurung2005theironsulfurcluster pages 1-1).</p>
+<p><strong>Proton-exiting gate function.</strong> Experimental work has demonstrated that the 2Fe-2S cluster also serves as a proton-exiting gate: destruction or genetic elimination of the cluster creates a proton-leaking channel in the bc1 complex, abolishing proton-pumping activity. This indicates the ISP head domain is critical for maintaining the integrity of proton translocation coupled to electron transfer (gurung2005theironsulfurcluster pages 1-1, gurung2005theironsulfurcluster pages 5-5).</p>
+<hr />
+<h2 id="4-subcellular-localization">4. Subcellular Localization</h2>
+<p>ISP-1 is localized to the <strong>mitochondrial inner membrane</strong>, where it functions as an integral component of the energy-conserving electron transport chain (jafari2016newfunctionaland pages 1-4, yang2012rieskeiron–sulfurprotein pages 1-3, gurung2005theironsulfurcluster pages 1-1). The protein's topology places the transmembrane anchor within the lipid bilayer while the catalytic head domain with the 2Fe-2S cluster extends into the intermembrane space (P-side) (jafari2016newfunctionaland pages 1-4, yang2012rieskeiron–sulfurprotein pages 1-3). ISP-1 also plays a structural role in stabilizing higher-order respiratory supercomplexes (I:III:IV respirasomes), which are proposed to increase electron transport chain efficiency and reduce ROS production (osz2025mutationsofthe pages 19-21).</p>
+<hr />
+<h2 id="5-the-isp-1qm150-mutation-functional-insights-from-genetic-analysis">5. The <em>isp-1(qm150)</em> Mutation: Functional Insights from Genetic Analysis</h2>
+<p>The best-characterized allele of <em>isp-1</em> is <em>qm150</em>, a proline-to-serine substitution in the tether domain that inhibits electron flux into the Qo site by interfering with formation of the enzyme-substrate complex between QH₂ and ISP_ox (jafari2016newfunctionaland pages 6-8, jafari2016newfunctionaland pages 4-6). This mutation results in drastically diminished respiratory function and causes pleiotropic phenotypes including:</p>
+<ul>
+<li><strong>Extended lifespan</strong> — <em>isp-1(qm150)</em> mutants are significantly long-lived compared to wild-type animals (jafari2016newfunctionaland pages 1-4, lee2010inhibitionofrespiration pages 2-3)</li>
+<li><strong>Slow development</strong> — delayed embryonic and postembryonic development (osz2025mutationsofthe pages 19-21, jafari2016newfunctionaland pages 1-4)</li>
+<li><strong>Reduced brood size and fecundity</strong> (osz2025mutationsofthe pages 19-21, jafari2016newfunctionaland pages 1-4)</li>
+<li><strong>Small body size</strong> (jafari2016newfunctionaland pages 1-4)</li>
+<li><strong>Decreased movement and pharyngeal pumping rate</strong> (jafari2016newfunctionaland pages 1-4)</li>
+<li><strong>Sensitivity to hyperoxia</strong> — inability to develop past the L2 larval stage under 100% O₂ (jafari2016newfunctionaland pages 4-6)</li>
+<li><strong>Elevated reactive oxygen species (ROS)</strong> — measured by DCF-DA fluorescence and DHE sensors (lee2010inhibitionofrespiration pages 2-3, lee2010inhibitionofrespiration pages 4-5)</li>
+<li><strong>Disruption of I:III:IV supercomplexes</strong> and impaired complex I activity (osz2025mutationsofthe pages 19-21)</li>
+</ul>
+<p>Intragenic suppressor mutations identified in the tether region partially restore electron transfer rates and suppress some pleiotropic phenotypes, but at the cost of increased ROS production, demonstrating the intimate relationship between tether mechanics and Q-cycle gating (jafari2016newfunctionaland pages 4-6, jafari2016newfunctionaland pages 6-8).</p>
+<hr />
+<h2 id="6-signaling-and-biochemical-pathways-downstream-of-isp-1-dysfunction">6. Signaling and Biochemical Pathways Downstream of ISP-1 Dysfunction</h2>
+<p>Mild mitochondrial dysfunction caused by <em>isp-1</em> mutation activates multiple conserved stress response and longevity-promoting signaling pathways. The central upstream signal appears to be <strong>elevated mitochondrial ROS</strong>, which triggers several downstream transcriptional programs.</p>
+<table>
+<thead>
+<tr>
+<th>Pathway/Transcription Factor</th>
+<th>Role in isp-1 Longevity</th>
+<th>Key Evidence</th>
+<th>Key Reference</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>HIF-1</td>
+<td>Required for lifespan extension</td>
+<td>isp-1(qm150) elevates ROS and increases HIF-1 target gene expression; loss of hif-1 or aha-1 shortens the extended lifespan of isp-1 mutants, indicating HIF-1 is a key mediator of mitochondrial retrograde longevity signaling. (lee2010inhibitionofrespiration pages 2-3, lee2010inhibitionofrespiration pages 4-4, lee2010inhibitionofrespiration pages 2-2)</td>
+<td>Lee et al., 2010 (lee2010inhibitionofrespiration pages 2-3, lee2010inhibitionofrespiration pages 4-4, lee2010inhibitionofrespiration pages 2-2)</td>
+</tr>
+<tr>
+<td>DAF-16/FOXO</td>
+<td>Required for full lifespan extension</td>
+<td>DAF-16 target genes are enriched among transcripts upregulated in isp-1 mutants; DAF-16 shows increased nuclear localization, and daf-16 loss markedly suppresses isp-1 longevity. ROS appears to be an upstream activator, with IMB-2, CST-1/2, BAR-1, and MATH-33 supporting DAF-16-dependent longevity. (senchuk2018activationofdaf16foxo pages 4-6, senchuk2018activationofdaf16foxo pages 9-11, senchuk2018activationofdaf16foxo pages 15-17, senchuk2018activationofdaf16foxo pages 1-2)</td>
+<td>Senchuk et al., 2018 (senchuk2018activationofdaf16foxo pages 4-6, senchuk2018activationofdaf16foxo pages 9-11, senchuk2018activationofdaf16foxo pages 15-17, senchuk2018activationofdaf16foxo pages 1-2)</td>
+</tr>
+<tr>
+<td>SKN-1/Nrf2</td>
+<td>Required for lifespan extension</td>
+<td>SKN-1 target genes are activated in isp-1 mutants, and SKN-1 is required for the increased longevity of mitochondrial mutants including isp-1, supporting a ROS-responsive oxidative stress program downstream of ETC dysfunction. (senchuk2018activationofdaf16foxo pages 17-18)</td>
+<td>Senchuk et al., 2018 (senchuk2018activationofdaf16foxo pages 17-18)</td>
+</tr>
+<tr>
+<td>ATFS-1/mitoUPR</td>
+<td>Dispensable for adult lifespan extension; required for development in isp-1 background</td>
+<td>ATFS-1 is necessary for induction of mitoUPR reporters and target genes in isp-1 mutants, but adult-only atfs-1 knockdown does not reduce isp-1 lifespan. In contrast, loss of ATFS-1 during development causes developmental arrest or prevents isp-1 animals from reaching adulthood, indicating a stage-specific requirement. (bennett2014activationofthe pages 1-2, bennett2014activationofthe pages 7-8, wu2018mitochondrialunfoldedprotein pages 2-5, wu2018mitochondrialunfoldedprotein pages 1-2, wu2018mitochondrialunfoldedprotein pages 10-13)</td>
+<td>Bennett et al., 2014; Wu et al., 2018 (bennett2014activationofthe pages 1-2, bennett2014activationofthe pages 7-8, wu2018mitochondrialunfoldedprotein pages 2-5, wu2018mitochondrialunfoldedprotein pages 1-2, wu2018mitochondrialunfoldedprotein pages 10-13)</td>
+</tr>
+<tr>
+<td>Developmental timing (L3/L4 window)</td>
+<td>Required for establishment of lifespan extension</td>
+<td>ETC inhibition including isp-1 RNAi extends lifespan only when imposed during larval development, especially by late L3/early L4; similar perturbation in adults fails to produce longevity, indicating a developmentally programmed mitochondrial checkpoint or signaling window. (rea2007relationshipbetweenmitochondrial pages 1-2, rea2007relationshipbetweenmitochondrial pages 7-8, rea2007relationshipbetweenmitochondrial pages 2-3, rea2007relationshipbetweenmitochondrial pages 6-7)</td>
+<td>Rea et al., 2007 (rea2007relationshipbetweenmitochondrial pages 1-2, rea2007relationshipbetweenmitochondrial pages 7-8, rea2007relationshipbetweenmitochondrial pages 2-3, rea2007relationshipbetweenmitochondrial pages 6-7)</td>
+</tr>
+</tbody>
+</table>
+<p><em>Table: This table summarizes the major signaling pathways and timing requirements linked to isp-1-mediated mitochondrial dysfunction in C. elegans. It distinguishes pathways needed for lifespan extension from those primarily required for development.</em></p>
+<h3 id="61-hif-1-hypoxia-response-pathway">6.1. HIF-1 Hypoxia Response Pathway</h3>
+<p>Lee, Hwang, and Kenyon (2010) demonstrated that <em>isp-1(qm150)</em> mutants exhibit increased expression of HIF-1-dependent target genes, including <em>nhr-57</em> and <em>F22B5.4</em> (lee2010inhibitionofrespiration pages 4-4, lee2010inhibitionofrespiration pages 2-2). Loss of <em>hif-1</em> or RNAi knockdown of <em>aha-1</em> (HIF-1β) significantly shortened the extended lifespan of <em>isp-1</em> mutants, establishing HIF-1 as a key mediator of mitochondrial retrograde longevity signaling (lee2010inhibitionofrespiration pages 2-3, lee2010inhibitionofrespiration pages 2-2). Epistasis experiments showed that <em>isp-1</em> mutations do not further extend lifespan in <em>vhl-1</em> or <em>egl-9</em> mutants (which constitutively stabilize HIF-1), consistent with <em>isp-1</em> acting upstream of or through the HIF-1 pathway (lee2010inhibitionofrespiration pages 2-2).</p>
+<h3 id="62-daf-16foxo-transcription-factor">6.2. DAF-16/FOXO Transcription Factor</h3>
+<p>Senchuk et al. (2018) found that DAF-16 target genes are significantly enriched among transcripts upregulated in <em>isp-1</em> mutants, with approximately 50% overlap with genes upregulated in the long-lived insulin/IGF-1 pathway mutant <em>daf-2</em> (senchuk2018activationofdaf16foxo pages 4-6). DAF-16 shows increased nuclear localization in <em>isp-1</em> worms, and genetic disruption of <em>daf-16</em> markedly reduces the lifespan extension (from ~72% to ~19% increase over wild-type) (senchuk2018activationofdaf16foxo pages 9-11). Multiple DAF-16-interacting proteins—including MATH-33, IMB-2 (transportin-1 homolog), CST-1/CST-2 (protein kinases), and BAR-1 (β-catenin homolog)—are required for the full longevity of <em>isp-1</em> mutants, indicating a complex regulatory network downstream of ROS-mediated DAF-16 activation (senchuk2018activationofdaf16foxo pages 15-17, senchuk2018activationofdaf16foxo pages 1-2).</p>
+<h3 id="63-skn-1nrf2-oxidative-stress-response">6.3. SKN-1/Nrf2 Oxidative Stress Response</h3>
+<p>SKN-1 target genes are also activated in <em>isp-1</em> mutants, and SKN-1 is required for the increased longevity observed in these animals (senchuk2018activationofdaf16foxo pages 17-18). This indicates that the oxidative stress response mediated by SKN-1/Nrf2 constitutes an additional arm of the mitochondrial retrograde signaling network.</p>
+<h3 id="64-atfs-1-and-the-mitochondrial-unfolded-protein-response-mitoupr">6.4. ATFS-1 and the Mitochondrial Unfolded Protein Response (mitoUPR)</h3>
+<p>The role of ATFS-1 and the mitoUPR in <em>isp-1</em> biology is nuanced and somewhat debated. <em>isp-1</em> mutants exhibit ATFS-1-dependent activation of the mitoUPR, as evidenced by upregulation of the <em>hsp-6p::GFP</em> reporter and endogenous target genes (wu2018mitochondrialunfoldedprotein pages 2-5, bennett2014activationofthe pages 6-6). However, Bennett et al. (2014) demonstrated that knockdown of <em>atfs-1</em> did not prevent lifespan extension in <em>isp-1(qm150)</em> mutants, leading to the conclusion that the mitoUPR is neither necessary nor sufficient for longevity (bennett2014activationofthe pages 1-2, bennett2014activationofthe pages 7-8). Wu et al. (2018) provided additional resolution by showing that while ATFS-1 is dispensable for adult lifespan maintenance, it is absolutely essential during development—loss of <em>atfs-1</em> during early development prevents <em>isp-1</em> worms from reaching adulthood (wu2018mitochondrialunfoldedprotein pages 2-5, wu2018mitochondrialunfoldedprotein pages 1-2). This indicates a stage-specific requirement for mitoUPR activation.</p>
+<h3 id="65-developmental-timing-requirement">6.5. Developmental Timing Requirement</h3>
+<p>A critical finding from Rea, Ventura, and Johnson (2007) established that mitochondrial dysfunction-dependent life extension requires perturbation during the L3/L4 larval stage, which coincides with the last somatic cell divisions and massive mitochondrial DNA expansion in <em>C. elegans</em> (rea2007relationshipbetweenmitochondrial pages 1-2, rea2007relationshipbetweenmitochondrial pages 7-8, rea2007relationshipbetweenmitochondrial pages 2-3). When <em>isp-1</em> RNAi or other ETC inhibition is applied only during adulthood, lifespan is not extended, indicating that a developmental signal initiated during the proliferative larval period is essential for programming the longevity phenotype (rea2007relationshipbetweenmitochondrial pages 6-7).</p>
+<hr />
+<h2 id="7-additional-biological-roles">7. Additional Biological Roles</h2>
+<h3 id="71-axon-regeneration">7.1. Axon Regeneration</h3>
+<p>Knowlton et al. (2017) identified <em>isp-1</em> as one of a select subset of electron transport chain genes required for axon regeneration in <em>C. elegans</em> mechanosensory neurons. <em>isp-1(qm150)</em> mutants showed normal axonal development and growth cone formation after laser axotomy but were impaired in subsequent axon extension (knowlton2017aselectsubset pages 1-2). Critically, pan-neuronal overexpression of <em>isp-1</em> was sufficient to enhance axon regrowth above wild-type levels, indicating that ISP-1-dependent mitochondrial function is rate-limiting for axon regeneration (knowlton2017aselectsubset pages 12-13, knowlton2017aselectsubset pages 9-11). Loss of <em>isp-1</em> was epistatic to enhanced calcium signaling (<em>egl-19</em> gain-of-function) and elevated MAP kinase signaling (DLK-1 overexpression), positioning mitochondrial function downstream of or in parallel with these injury response pathways (knowlton2017aselectsubset pages 8-9, knowlton2017aselectsubset pages 7-8).</p>
+<h3 id="72-non-cell-autonomous-signaling-from-gabaergic-neurons">7.2. Non-Cell Autonomous Signaling from GABAergic Neurons</h3>
+<p>Recent work by Rathor et al. (2024) demonstrated that <em>isp-1</em> knockdown specifically in GABAergic neurons extends organismal lifespan and enhances stress resistance through non-cell autonomous mechanisms (rathor2024mitochondrialstressin pages 10-13, rathor2024mitochondrialstressin pages 40-43). DAF-16/FoxO is essential for mediating these systemic effects on lifespan, stress tolerance, mitochondrial homeostasis, and reproductive capacity. The neuropeptide FLP-13, expressed in GABAergic neurons, was identified as a mediator of this non-cell autonomous aging regulation, with <em>isp-1</em> knockdown and loss of GABA function operating through the same pathway (rathor2024mitochondrialstressin pages 10-13).</p>
+<h3 id="73-supercomplex-assembly-and-mitochondrial-architecture">7.3. Supercomplex Assembly and Mitochondrial Architecture</h3>
+<p>ISP-1 serves as a stabilizer of higher-order respiratory supercomplex assemblies (I:III:IV respirasomes). The <em>isp-1(qm150)</em> mutation disrupts supercomplex formation, thereby impairing not only Complex III activity but also complex I function, and potentially increasing ROS production rates (osz2025mutationsofthe pages 19-21).</p>
+<hr />
+<h2 id="8-relationship-to-other-mitochondrial-longevity-mutants">8. Relationship to Other Mitochondrial Longevity Mutants</h2>
+<p><em>isp-1</em> belongs to a group of <em>C. elegans</em> mitochondrial mutants—alongside <em>clk-1</em> (ubiquinone biosynthesis), <em>nuo-6</em> (Complex I subunit), and others—that share the paradoxical property of extending lifespan despite compromised mitochondrial function. Both <em>clk-1</em> and <em>isp-1</em> mutants show elevated ROS and require HIF-1 for longevity, though they differ mechanistically: <em>isp-1(qm150)</em> reduces oxygen consumption rate while <em>clk-1(qm30)</em> does not (lee2010inhibitionofrespiration pages 2-3, lee2010inhibitionofrespiration pages 4-4). All three long-lived mitochondrial mutants (<em>clk-1</em>, <em>isp-1</em>, <em>nuo-6</em>) exhibit overlapping transcriptional responses including upregulation of DAF-16 target genes (senchuk2018activationofdaf16foxo pages 1-2).</p>
+<hr />
+<h2 id="9-summary">9. Summary</h2>
+<p>The <em>isp-1</em> gene encodes the Rieske iron-sulfur protein, a catalytic subunit of mitochondrial Complex III that is essential for the Q-cycle mechanism of ubiquinol:cytochrome <em>c</em> oxidoreduction. The protein is anchored in the mitochondrial inner membrane by a single transmembrane helix and operates through a "spring-loaded" tether mechanism that enables its 2Fe-2S cluster-containing head domain to shuttle electrons from ubiquinol at the Qo site to cytochrome c1, while simultaneously functioning as a proton-exiting gate. Partial loss of ISP-1 function, as exemplified by the <em>qm150</em> allele, reduces electron flux through Complex III and triggers a cascade of compensatory mitochondrial retrograde signaling through HIF-1, DAF-16/FOXO, SKN-1/Nrf2, and ATFS-1/mitoUPR pathways—primarily driven by elevated mitochondrial ROS. This signaling, when initiated during a critical developmental window at the L3/L4 larval stage, programs the organism for extended lifespan. Beyond aging, ISP-1 function is rate-limiting for axon regeneration and participates in non-cell autonomous inter-tissue signaling from GABAergic neurons to regulate systemic stress resistance and longevity.</p>
+<p>References</p>
+<ol>
+<li>
+<p>(jafari2016newfunctionaland pages 1-4): Gholamali Jafari, Brian M. Wasko, Matt Kaeberlein, and Antony R. Crofts. New functional and biophysical insights into the mitochondrial rieske iron-sulfur protein from genetic suppressor analysis in c. elegans. Worm, 5:6157, Apr 2016. URL: https://doi.org/10.1080/21624054.2016.1174803, doi:10.1080/21624054.2016.1174803. This article has 13 citations.</p>
+</li>
+<li>
+<p>(osz2025mutationsofthe pages 4-6): Fanni Ősz, Aamir Nazir, Krisztina Takács-Vellai, and Zsolt Farkas. Mutations of the electron transport chain affect lifespan and ros levels in c. elegans. Antioxidants, 14:76, Jan 2025. URL: https://doi.org/10.3390/antiox14010076, doi:10.3390/antiox14010076. This article has 16 citations.</p>
+</li>
+<li>
+<p>(yang2012rieskeiron–sulfurprotein pages 1-3): Wen‐Chao Yang, Hui Li, Fu Wang, Xiao‐Lei Zhu, and Guang‐Fu Yang. Rieske iron–sulfur protein of the cytochrome bc1 complex: a potential target for fungicide discovery. ChemBioChem, 13:1542-1551, Jul 2012. URL: https://doi.org/10.1002/cbic.201200295, doi:10.1002/cbic.201200295. This article has 28 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(jafari2016newfunctionaland pages 10-16): Gholamali Jafari, Brian M. Wasko, Matt Kaeberlein, and Antony R. Crofts. New functional and biophysical insights into the mitochondrial rieske iron-sulfur protein from genetic suppressor analysis in c. elegans. Worm, 5:6157, Apr 2016. URL: https://doi.org/10.1080/21624054.2016.1174803, doi:10.1080/21624054.2016.1174803. This article has 13 citations.</p>
+</li>
+<li>
+<p>(jafari2016newfunctionaland pages 6-8): Gholamali Jafari, Brian M. Wasko, Matt Kaeberlein, and Antony R. Crofts. New functional and biophysical insights into the mitochondrial rieske iron-sulfur protein from genetic suppressor analysis in c. elegans. Worm, 5:6157, Apr 2016. URL: https://doi.org/10.1080/21624054.2016.1174803, doi:10.1080/21624054.2016.1174803. This article has 13 citations.</p>
+</li>
+<li>
+<p>(jafari2016newfunctionaland pages 4-6): Gholamali Jafari, Brian M. Wasko, Matt Kaeberlein, and Antony R. Crofts. New functional and biophysical insights into the mitochondrial rieske iron-sulfur protein from genetic suppressor analysis in c. elegans. Worm, 5:6157, Apr 2016. URL: https://doi.org/10.1080/21624054.2016.1174803, doi:10.1080/21624054.2016.1174803. This article has 13 citations.</p>
+</li>
+<li>
+<p>(schmidt2004rieskeiron–sulfurproteins pages 1-2): C. L. Schmidt. Rieske iron–sulfur proteins from extremophilic organisms. Journal of Bioenergetics and Biomembranes, 36:107-113, Feb 2004. URL: https://doi.org/10.1023/b:jobb.0000019602.96578.78, doi:10.1023/b:jobb.0000019602.96578.78. This article has 15 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(gurung2005theironsulfurcluster pages 1-1): Buddha Gurung, Linda P. C. Yu, D. Xia, and Chang-an Yu. The iron-sulfur cluster of the rieske iron-sulfur protein functions as a proton-exiting gate in the cytochrome bc1 complex*. Journal of Biological Chemistry, 280:24895-24902, Jul 2005. URL: https://doi.org/10.1074/jbc.m503319200, doi:10.1074/jbc.m503319200. This article has 36 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(crofts1999physicochemicalaspectsof pages 11-12): Antony R. Crofts, Sangjin Hong, Zhaolei Zhang, and Edward A. Berry. Physicochemical aspects of the movement of the rieske iron sulfur protein during quinol oxidation by the bc(1) complex from mitochondria and photosynthetic bacteria. Biochemistry, 38 48:15827-39, Nov 1999. URL: https://doi.org/10.1021/bi990963e, doi:10.1021/bi990963e. This article has 77 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(gurung2005theironsulfurcluster pages 5-5): Buddha Gurung, Linda P. C. Yu, D. Xia, and Chang-an Yu. The iron-sulfur cluster of the rieske iron-sulfur protein functions as a proton-exiting gate in the cytochrome bc1 complex*. Journal of Biological Chemistry, 280:24895-24902, Jul 2005. URL: https://doi.org/10.1074/jbc.m503319200, doi:10.1074/jbc.m503319200. This article has 36 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(osz2025mutationsofthe pages 19-21): Fanni Ősz, Aamir Nazir, Krisztina Takács-Vellai, and Zsolt Farkas. Mutations of the electron transport chain affect lifespan and ros levels in c. elegans. Antioxidants, 14:76, Jan 2025. URL: https://doi.org/10.3390/antiox14010076, doi:10.3390/antiox14010076. This article has 16 citations.</p>
+</li>
+<li>
+<p>(lee2010inhibitionofrespiration pages 2-3): Seung-Jae Lee, Ara B. Hwang, and Cynthia Kenyon. Inhibition of respiration extends c. elegans life span via reactive oxygen species that increase hif-1 activity. Current Biology, 20:2131-2136, Dec 2010. URL: https://doi.org/10.1016/j.cub.2010.10.057, doi:10.1016/j.cub.2010.10.057. This article has 614 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(lee2010inhibitionofrespiration pages 4-5): Seung-Jae Lee, Ara B. Hwang, and Cynthia Kenyon. Inhibition of respiration extends c. elegans life span via reactive oxygen species that increase hif-1 activity. Current Biology, 20:2131-2136, Dec 2010. URL: https://doi.org/10.1016/j.cub.2010.10.057, doi:10.1016/j.cub.2010.10.057. This article has 614 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(lee2010inhibitionofrespiration pages 4-4): Seung-Jae Lee, Ara B. Hwang, and Cynthia Kenyon. Inhibition of respiration extends c. elegans life span via reactive oxygen species that increase hif-1 activity. Current Biology, 20:2131-2136, Dec 2010. URL: https://doi.org/10.1016/j.cub.2010.10.057, doi:10.1016/j.cub.2010.10.057. This article has 614 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(lee2010inhibitionofrespiration pages 2-2): Seung-Jae Lee, Ara B. Hwang, and Cynthia Kenyon. Inhibition of respiration extends c. elegans life span via reactive oxygen species that increase hif-1 activity. Current Biology, 20:2131-2136, Dec 2010. URL: https://doi.org/10.1016/j.cub.2010.10.057, doi:10.1016/j.cub.2010.10.057. This article has 614 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(senchuk2018activationofdaf16foxo pages 4-6): Megan M. Senchuk, Dylan J. Dues, Claire E. Schaar, Benjamin K. Johnson, Zachary B. Madaj, Megan J. Bowman, Mary E. Winn, and Jeremy M. Van Raamsdonk. Activation of daf-16/foxo by reactive oxygen species contributes to longevity in long-lived mitochondrial mutants in caenorhabditis elegans. PLOS Genetics, 14:e1007268, Mar 2018. URL: https://doi.org/10.1371/journal.pgen.1007268, doi:10.1371/journal.pgen.1007268. This article has 187 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(senchuk2018activationofdaf16foxo pages 9-11): Megan M. Senchuk, Dylan J. Dues, Claire E. Schaar, Benjamin K. Johnson, Zachary B. Madaj, Megan J. Bowman, Mary E. Winn, and Jeremy M. Van Raamsdonk. Activation of daf-16/foxo by reactive oxygen species contributes to longevity in long-lived mitochondrial mutants in caenorhabditis elegans. PLOS Genetics, 14:e1007268, Mar 2018. URL: https://doi.org/10.1371/journal.pgen.1007268, doi:10.1371/journal.pgen.1007268. This article has 187 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(senchuk2018activationofdaf16foxo pages 15-17): Megan M. Senchuk, Dylan J. Dues, Claire E. Schaar, Benjamin K. Johnson, Zachary B. Madaj, Megan J. Bowman, Mary E. Winn, and Jeremy M. Van Raamsdonk. Activation of daf-16/foxo by reactive oxygen species contributes to longevity in long-lived mitochondrial mutants in caenorhabditis elegans. PLOS Genetics, 14:e1007268, Mar 2018. URL: https://doi.org/10.1371/journal.pgen.1007268, doi:10.1371/journal.pgen.1007268. This article has 187 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(senchuk2018activationofdaf16foxo pages 1-2): Megan M. Senchuk, Dylan J. Dues, Claire E. Schaar, Benjamin K. Johnson, Zachary B. Madaj, Megan J. Bowman, Mary E. Winn, and Jeremy M. Van Raamsdonk. Activation of daf-16/foxo by reactive oxygen species contributes to longevity in long-lived mitochondrial mutants in caenorhabditis elegans. PLOS Genetics, 14:e1007268, Mar 2018. URL: https://doi.org/10.1371/journal.pgen.1007268, doi:10.1371/journal.pgen.1007268. This article has 187 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(senchuk2018activationofdaf16foxo pages 17-18): Megan M. Senchuk, Dylan J. Dues, Claire E. Schaar, Benjamin K. Johnson, Zachary B. Madaj, Megan J. Bowman, Mary E. Winn, and Jeremy M. Van Raamsdonk. Activation of daf-16/foxo by reactive oxygen species contributes to longevity in long-lived mitochondrial mutants in caenorhabditis elegans. PLOS Genetics, 14:e1007268, Mar 2018. URL: https://doi.org/10.1371/journal.pgen.1007268, doi:10.1371/journal.pgen.1007268. This article has 187 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(bennett2014activationofthe pages 1-2): Christopher F. Bennett, Helen Vander Wende, Marissa Simko, Shannon Klum, Sarah Barfield, Haeri Choi, Victor V. Pineda, and Matt Kaeberlein. Activation of the mitochondrial unfolded protein response does not predict longevity in caenorhabditis elegans. Nature communications, 5:3483-3483, Mar 2014. URL: https://doi.org/10.1038/ncomms4483, doi:10.1038/ncomms4483. This article has 272 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(bennett2014activationofthe pages 7-8): Christopher F. Bennett, Helen Vander Wende, Marissa Simko, Shannon Klum, Sarah Barfield, Haeri Choi, Victor V. Pineda, and Matt Kaeberlein. Activation of the mitochondrial unfolded protein response does not predict longevity in caenorhabditis elegans. Nature communications, 5:3483-3483, Mar 2014. URL: https://doi.org/10.1038/ncomms4483, doi:10.1038/ncomms4483. This article has 272 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(wu2018mitochondrialunfoldedprotein pages 2-5): Ziyun Wu, Megan M. Senchuk, Dylan J. Dues, Benjamin K. Johnson, Jason F. Cooper, Leira Lew, Emily Machiela, Claire E. Schaar, Heather DeJonge, T. Keith Blackwell, and Jeremy M. Van Raamsdonk. Mitochondrial unfolded protein response transcription factor atfs-1 promotes longevity in a long-lived mitochondrial mutant through activation of stress response pathways. BMC Biology, Dec 2018. URL: https://doi.org/10.1186/s12915-018-0615-3, doi:10.1186/s12915-018-0615-3. This article has 140 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(wu2018mitochondrialunfoldedprotein pages 1-2): Ziyun Wu, Megan M. Senchuk, Dylan J. Dues, Benjamin K. Johnson, Jason F. Cooper, Leira Lew, Emily Machiela, Claire E. Schaar, Heather DeJonge, T. Keith Blackwell, and Jeremy M. Van Raamsdonk. Mitochondrial unfolded protein response transcription factor atfs-1 promotes longevity in a long-lived mitochondrial mutant through activation of stress response pathways. BMC Biology, Dec 2018. URL: https://doi.org/10.1186/s12915-018-0615-3, doi:10.1186/s12915-018-0615-3. This article has 140 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(wu2018mitochondrialunfoldedprotein pages 10-13): Ziyun Wu, Megan M. Senchuk, Dylan J. Dues, Benjamin K. Johnson, Jason F. Cooper, Leira Lew, Emily Machiela, Claire E. Schaar, Heather DeJonge, T. Keith Blackwell, and Jeremy M. Van Raamsdonk. Mitochondrial unfolded protein response transcription factor atfs-1 promotes longevity in a long-lived mitochondrial mutant through activation of stress response pathways. BMC Biology, Dec 2018. URL: https://doi.org/10.1186/s12915-018-0615-3, doi:10.1186/s12915-018-0615-3. This article has 140 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(rea2007relationshipbetweenmitochondrial pages 1-2): Shane L Rea, Natascia Ventura, and Thomas E Johnson. Relationship between mitochondrial electron transport chain dysfunction, development, and life extension in caenorhabditis elegans. PLoS Biology, 5:e259, Oct 2007. URL: https://doi.org/10.1371/journal.pbio.0050259, doi:10.1371/journal.pbio.0050259. This article has 475 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(rea2007relationshipbetweenmitochondrial pages 7-8): Shane L Rea, Natascia Ventura, and Thomas E Johnson. Relationship between mitochondrial electron transport chain dysfunction, development, and life extension in caenorhabditis elegans. PLoS Biology, 5:e259, Oct 2007. URL: https://doi.org/10.1371/journal.pbio.0050259, doi:10.1371/journal.pbio.0050259. This article has 475 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(rea2007relationshipbetweenmitochondrial pages 2-3): Shane L Rea, Natascia Ventura, and Thomas E Johnson. Relationship between mitochondrial electron transport chain dysfunction, development, and life extension in caenorhabditis elegans. PLoS Biology, 5:e259, Oct 2007. URL: https://doi.org/10.1371/journal.pbio.0050259, doi:10.1371/journal.pbio.0050259. This article has 475 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(rea2007relationshipbetweenmitochondrial pages 6-7): Shane L Rea, Natascia Ventura, and Thomas E Johnson. Relationship between mitochondrial electron transport chain dysfunction, development, and life extension in caenorhabditis elegans. PLoS Biology, 5:e259, Oct 2007. URL: https://doi.org/10.1371/journal.pbio.0050259, doi:10.1371/journal.pbio.0050259. This article has 475 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(bennett2014activationofthe pages 6-6): Christopher F. Bennett, Helen Vander Wende, Marissa Simko, Shannon Klum, Sarah Barfield, Haeri Choi, Victor V. Pineda, and Matt Kaeberlein. Activation of the mitochondrial unfolded protein response does not predict longevity in caenorhabditis elegans. Nature communications, 5:3483-3483, Mar 2014. URL: https://doi.org/10.1038/ncomms4483, doi:10.1038/ncomms4483. This article has 272 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(knowlton2017aselectsubset pages 1-2): Wendy M. Knowlton, Thomas Hubert, Zilu Wu, Andrew D. Chisholm, and Yishi Jin. A select subset of electron transport chain genes associated with optic atrophy link mitochondria to axon regeneration in caenorhabditis elegans. Frontiers in Neuroscience, May 2017. URL: https://doi.org/10.3389/fnins.2017.00263, doi:10.3389/fnins.2017.00263. This article has 26 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(knowlton2017aselectsubset pages 12-13): Wendy M. Knowlton, Thomas Hubert, Zilu Wu, Andrew D. Chisholm, and Yishi Jin. A select subset of electron transport chain genes associated with optic atrophy link mitochondria to axon regeneration in caenorhabditis elegans. Frontiers in Neuroscience, May 2017. URL: https://doi.org/10.3389/fnins.2017.00263, doi:10.3389/fnins.2017.00263. This article has 26 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(knowlton2017aselectsubset pages 9-11): Wendy M. Knowlton, Thomas Hubert, Zilu Wu, Andrew D. Chisholm, and Yishi Jin. A select subset of electron transport chain genes associated with optic atrophy link mitochondria to axon regeneration in caenorhabditis elegans. Frontiers in Neuroscience, May 2017. URL: https://doi.org/10.3389/fnins.2017.00263, doi:10.3389/fnins.2017.00263. This article has 26 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(knowlton2017aselectsubset pages 8-9): Wendy M. Knowlton, Thomas Hubert, Zilu Wu, Andrew D. Chisholm, and Yishi Jin. A select subset of electron transport chain genes associated with optic atrophy link mitochondria to axon regeneration in caenorhabditis elegans. Frontiers in Neuroscience, May 2017. URL: https://doi.org/10.3389/fnins.2017.00263, doi:10.3389/fnins.2017.00263. This article has 26 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(knowlton2017aselectsubset pages 7-8): Wendy M. Knowlton, Thomas Hubert, Zilu Wu, Andrew D. Chisholm, and Yishi Jin. A select subset of electron transport chain genes associated with optic atrophy link mitochondria to axon regeneration in caenorhabditis elegans. Frontiers in Neuroscience, May 2017. URL: https://doi.org/10.3389/fnins.2017.00263, doi:10.3389/fnins.2017.00263. This article has 26 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(rathor2024mitochondrialstressin pages 10-13): Laxmi Rathor, Shayla Curry, Youngyong Park, Taylor McElroy, Briana Robles, Yi Sheng, Wei-Wen Chen, Kisuk Min, Rui Xiao, Myon Hee Lee, and Sung Min Han. Mitochondrial stress in gabaergic neurons non-cell autonomously regulates organismal health and aging. bioRxiv, Mar 2024. URL: https://doi.org/10.1101/2024.03.20.585932, doi:10.1101/2024.03.20.585932. This article has 5 citations.</p>
+</li>
+<li>
+<p>(rathor2024mitochondrialstressin pages 40-43): Laxmi Rathor, Shayla Curry, Youngyong Park, Taylor McElroy, Briana Robles, Yi Sheng, Wei-Wen Chen, Kisuk Min, Rui Xiao, Myon Hee Lee, and Sung Min Han. Mitochondrial stress in gabaergic neurons non-cell autonomously regulates organismal health and aging. bioRxiv, Mar 2024. URL: https://doi.org/10.1101/2024.03.20.585932, doi:10.1101/2024.03.20.585932. This article has 5 citations.</p>
+</li>
+</ol>
+<h2 id="artifacts">Artifacts</h2>
+<ul>
+<li><a href="isp-1-deep-research-falcon_artifacts/artifact-00.md">Edison artifact artifact-00</a></li>
+<li><a href="isp-1-deep-research-falcon_artifacts/artifact-01.md">Edison artifact artifact-01</a></li>
+</ul>
+<h2 id="citations">Citations</h2>
+<ol>
+<li>jafari2016newfunctionaland pages 1-4</li>
+<li>osz2025mutationsofthe pages 4-6</li>
+<li>jafari2016newfunctionaland pages 6-8</li>
+<li>crofts1999physicochemicalaspectsof pages 11-12</li>
+<li>jafari2016newfunctionaland pages 10-16</li>
+<li>osz2025mutationsofthe pages 19-21</li>
+<li>jafari2016newfunctionaland pages 4-6</li>
+<li>lee2010inhibitionofrespiration pages 2-2</li>
+<li>rea2007relationshipbetweenmitochondrial pages 6-7</li>
+<li>knowlton2017aselectsubset pages 1-2</li>
+<li>rathor2024mitochondrialstressin pages 10-13</li>
+<li>gurung2005theironsulfurcluster pages 1-1</li>
+<li>gurung2005theironsulfurcluster pages 5-5</li>
+<li>lee2010inhibitionofrespiration pages 2-3</li>
+<li>lee2010inhibitionofrespiration pages 4-5</li>
+<li>lee2010inhibitionofrespiration pages 4-4</li>
+<li>bennett2014activationofthe pages 1-2</li>
+<li>bennett2014activationofthe pages 7-8</li>
+<li>wu2018mitochondrialunfoldedprotein pages 2-5</li>
+<li>wu2018mitochondrialunfoldedprotein pages 1-2</li>
+<li>wu2018mitochondrialunfoldedprotein pages 10-13</li>
+<li>rea2007relationshipbetweenmitochondrial pages 1-2</li>
+<li>rea2007relationshipbetweenmitochondrial pages 7-8</li>
+<li>rea2007relationshipbetweenmitochondrial pages 2-3</li>
+<li>bennett2014activationofthe pages 6-6</li>
+<li>knowlton2017aselectsubset pages 12-13</li>
+<li>knowlton2017aselectsubset pages 9-11</li>
+<li>knowlton2017aselectsubset pages 8-9</li>
+<li>knowlton2017aselectsubset pages 7-8</li>
+<li>rathor2024mitochondrialstressin pages 40-43</li>
+<li>2Fe-2S</li>
+<li>https://doi.org/10.1080/21624054.2016.1174803,</li>
+<li>https://doi.org/10.3390/antiox14010076,</li>
+<li>https://doi.org/10.1002/cbic.201200295,</li>
+<li>https://doi.org/10.1023/b:jobb.0000019602.96578.78,</li>
+<li>https://doi.org/10.1074/jbc.m503319200,</li>
+<li>https://doi.org/10.1021/bi990963e,</li>
+<li>https://doi.org/10.1016/j.cub.2010.10.057,</li>
+<li>https://doi.org/10.1371/journal.pgen.1007268,</li>
+<li>https://doi.org/10.1038/ncomms4483,</li>
+<li>https://doi.org/10.1186/s12915-018-0615-3,</li>
+<li>https://doi.org/10.1371/journal.pbio.0050259,</li>
+<li>https://doi.org/10.3389/fnins.2017.00263,</li>
+<li>https://doi.org/10.1101/2024.03.20.585932,</li>
+</ol>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(isp-1-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="O44512" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="isp-1-c-elegans-gene-review-notes">isp-1 (C. elegans) — Gene Review Notes</h1>
+<p>UniProt: O44512 (O44512_CAEEL) · WormBase: WBGene00002162 / F42G8.12 · NCBI Gene: 177609<br />
+Locus: Chromosome IV · Protein: 276 aa · EC 7.1.1.8</p>
+<h2 id="summary-identity">Summary / identity</h2>
+<p><code>isp-1</code> encodes the <strong>Rieske iron-sulfur protein (ISP)</strong>, the [2Fe-2S]-cluster-bearing<br />
+subunit of <strong>mitochondrial respiratory complex III</strong> (cytochrome <em>bc1</em> / ubiquinol–cytochrome<br />
+<em>c</em> oxidoreductase). Within complex III it accepts electrons from ubiquinol at the Qo site and<br />
+passes them to cytochrome c1, as part of the protonmotive Q-cycle.</p>
+<ul>
+<li>UniProt names it "Cytochrome b-c1 complex subunit Rieske, mitochondrial"; EC 7.1.1.8;<br />
+  belongs to the Rieske iron-sulfur protein family; binds 1 [2Fe-2S] cluster per subunit;<br />
+  localized to the mitochondrion inner membrane (<code>isp-1-uniprot.txt</code>, RuleBase RU004494/RU004495).</li>
+<li>PANTHER family PTHR10134 "CYTOCHROME B-C1 COMPLEX SUBUNIT RIESKE, MITOCHONDRIAL"<br />
+  (<code>interpro/panther/PTHR10134/</code>).</li>
+<li>Independent literature confirmation of identity: "The Caenorhabditis elegans isp-1 gene<br />
+  encodes the Rieske iron-sulfur protein subunit of cytochrome c oxidoreductase (complex III of<br />
+  the electron transport chain)." <a href="https://pubmed.ncbi.nlm.nih.gov/26504246" title="encodes the Rieske iron-sulfur protein subunit of cytochrome c oxidoreductase (complex III of the electron transport chain)">PMID:26504246</a></li>
+<li>"The nuo-6 and isp-1 genes of C. elegans encode, respectively, subunits of complex I and III<br />
+  of the mitochondrial respiratory chain." <a href="https://pubmed.ncbi.nlm.nih.gov/21151885" title="subunits of complex I and III of the mitochondrial respiratory chain">PMID:21151885</a></li>
+</ul>
+<h2 id="known-well-established">KNOWN (well established)</h2>
+<h3 id="core-molecular-function-localization">Core molecular function / localization</h3>
+<ul>
+<li>Rieske [2Fe-2S] iron-sulfur subunit of complex III; electron transfer from ubiquinol to<br />
+  cytochrome c1; part of the ubiquinol–cytochrome c reductase reaction (EC 7.1.1.8).<br />
+  Cofactor: one [2Fe-2S] cluster (Rieske high-potential type). Source: UniProt<br />
+  (<code>isp-1-uniprot.txt</code>: CATALYTIC ACTIVITY, COFACTOR, MISCELLANEOUS "The Rieske protein is a<br />
+  high potential 2Fe-2S protein"), Rieske-family conservation (PANTHER PTHR10134, InterPro<br />
+  IPR017941 Rieske_2Fe-2S). Reactome R-CEL-611105 (Respiratory electron transport),<br />
+  R-CEL-9865881 (Complex III assembly).</li>
+<li>Mitochondrial inner membrane localization (UniProt SUBCELLULAR LOCATION; single-pass membrane<br />
+  anchor + Rieske catalytic head).</li>
+</ul>
+<h3 id="biological-process-respiration-experimentally-supported-in-worm">Biological process (respiration) — experimentally supported in worm</h3>
+<ul>
+<li>The complex III mutant <code>isp-1(qm150)</code> reduces mitochondrial respiration: it shows impaired<br />
+  complex I-dependent (malate) and diminished complex II-dependent (succinate) oxidative<br />
+  phosphorylation capacity — expected because complex III is the common downstream acceptor.<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/16920626" title="in isp-1 (complex III mutant)">PMID:16920626</a> and<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/16920626" title="somewhat diminished in the complex III ( isp-1 ) mutant">PMID:16920626</a>. This is the basis of<br />
+  the WormBase IMP annotation to GO:0006122.</li>
+</ul>
+<h3 id="the-isp-1qm150-longevity-mutant-downstream-phenotype-not-the-core-mf">The isp-1(qm150) longevity mutant (downstream phenotype, NOT the core MF)</h3>
+<ul>
+<li><code>isp-1(qm150)</code> is a partial (hypomorphic) loss-of-function missense allele. Phenotypes:<br />
+  "low oxygen consumption, decreased sensitivity to ROS, and increased life span."<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/11709184" title="low oxygen consumption, decreased sensitivity to ROS, and increased life span">PMID:11709184</a></li>
+<li>It is one of the classic <em>Mit</em> longevity mutants: "longevity is increased by a partial<br />
+  loss-of-function mutation in the mitochondrial complex III subunit gene isp-1."<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/20346072" title="longevity is increased by a partial loss-of-function mutation in the mitochondrial complex III subunit gene isp-1">PMID:20346072</a></li>
+<li>Additional pleiotropic phenotypes of qm150 (developmental rate, pharyngeal pumping, brood<br />
+  size, movement, constitutive UPR-mt reporter, CO2 production, OXPHOS, lifespan). <a href="https://pubmed.ncbi.nlm.nih.gov/26504246" title="developmental rate, pharyngeal pumping rate, brood size, body movement, activation of the mitochondrial unfolded protein response reporter, CO2 production, mitochondrial oxidative phosphorylation, and lifespan extension">PMID:26504246</a></li>
+<li>Mechanism of longevity is a <strong>mitohormetic superoxide signal</strong>, not reduced oxidative damage:<br />
+  "the generation of superoxide is elevated in the nuo-6 and isp-1 mitochondrial mutants ...<br />
+  this elevation is necessary and sufficient to increase longevity." <a href="https://pubmed.ncbi.nlm.nih.gov/21151885" title="the generation of superoxide is elevated in the nuo-6 and isp-1 mitochondrial mutants, although overall ROS levels are not, and oxidative stress is low">PMID:21151885</a> and <a href="https://pubmed.ncbi.nlm.nih.gov/21151885" title="this elevation is necessary and sufficient to increase longevity">PMID:21151885</a></li>
+<li>qm150 mutation and isp-1(RNAi) act via <strong>distinct, separable mechanisms</strong> (additive lifespan<br />
+  effects). <a href="https://pubmed.ncbi.nlm.nih.gov/20346072" title="the increase induced by isp-1(RNAi) is fully additive to that induced by nuo-6(qm200)">PMID:20346072</a></li>
+</ul>
+<h2 id="not-known-knowledge-gaps">NOT KNOWN / knowledge gaps</h2>
+<ul>
+<li><strong>Mechanism linking the Rieske perturbation to the retrograde longevity signal.</strong> How the<br />
+  specific <code>qm150</code> substitution in ISP-1 is converted into the elevated-superoxide signal that<br />
+  drives the pro-longevity transcriptional program is not molecularly defined. Kaeberlein and<br />
+  colleagues localized intragenic suppressors to a conserved six-residue "tether" region and<br />
+  proposed a "spring-loaded" gating model, but this is a hypothesis: "The focus on a single<br />
+  subunit as causal both in generation and in suppression of diverse pleiotropic phenotypes<br />
+  points to a common underlying molecular mechanism, for which we propose a 'spring-loaded'<br />
+  model." <a href="https://pubmed.ncbi.nlm.nih.gov/26504246" title="for which we propose a">PMID:26504246</a>. The causal chain from tether-region dynamics<br />
+  → altered Qo-site electron transfer/superoxide → downstream gene expression remains open<br />
+  (BIOLOGY gap, RESIDUAL_SUBGAP; the textbook complex III function itself is solid).</li>
+<li>Whether ISP-1 has any function beyond complex III electron transfer (moonlighting) is not<br />
+  established; no evidence supports one, and none is claimed here.</li>
+</ul>
+<h2 id="goa-annotation-review-plan-9-annotations">GOA annotation review plan (9 annotations)</h2>
+<table>
+<thead>
+<tr>
+<th>#</th>
+<th>Term</th>
+<th>Evid</th>
+<th>Action</th>
+<th>Rationale</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>1</td>
+<td>GO:0016491 oxidoreductase activity</td>
+<td>IBA</td>
+<td>MODIFY→GO:0009055</td>
+<td>correct but over-general; subunit MF is electron transfer</td>
+</tr>
+<tr>
+<td>2</td>
+<td>GO:0045275 respiratory chain complex III</td>
+<td>IBA</td>
+<td>ACCEPT</td>
+<td>core CC (complex membership)</td>
+</tr>
+<tr>
+<td>3</td>
+<td>GO:0006122 mito electron transport ubiquinol→cyt c</td>
+<td>IBA</td>
+<td>ACCEPT</td>
+<td>core BP</td>
+</tr>
+<tr>
+<td>4</td>
+<td>GO:0005743 mitochondrial inner membrane</td>
+<td>IEA</td>
+<td>ACCEPT</td>
+<td>core CC</td>
+</tr>
+<tr>
+<td>5</td>
+<td>GO:0008121 quinol-cytochrome-c reductase activity</td>
+<td>IEA</td>
+<td>ACCEPT</td>
+<td>complex-level MF ISP-1 contributes to (core)</td>
+</tr>
+<tr>
+<td>6</td>
+<td>GO:0016020 membrane</td>
+<td>IEA</td>
+<td>MARK_AS_OVER_ANNOTATED</td>
+<td>uninformative; subsumed by GO:0005743</td>
+</tr>
+<tr>
+<td>7</td>
+<td>GO:0051537 2 iron, 2 sulfur cluster binding</td>
+<td>IEA</td>
+<td>ACCEPT</td>
+<td>core MF (defining Rieske cofactor)</td>
+</tr>
+<tr>
+<td>8</td>
+<td>GO:1902600 proton transmembrane transport</td>
+<td>IEA</td>
+<td>KEEP_AS_NON_CORE</td>
+<td>Q-cycle proton translocation is a complex-level consequence, not ISP-1's direct MF</td>
+</tr>
+<tr>
+<td>9</td>
+<td>GO:0006122 (IMP, PMID:16920626)</td>
+<td>IMP</td>
+<td>ACCEPT</td>
+<td>experimentally supported in worm (complex III respiration defect)</td>
+</tr>
+</tbody>
+</table>
+<p>No aging/longevity/behavioral GO annotations are present in the GOA (they are mutant phenotypes,<br />
+not curated normal roles), so none need down-weighting there; the longevity biology is captured<br />
+in <code>description</code> and <code>knowledge_gaps</code> only.</p>
+<h2 id="references-verified-against-pubmed-identity-confirmed">References verified against PubMed (identity confirmed)</h2>
+<ul>
+<li>PMID:11709184 — Feng, Bussière, Hekimi 2001 Dev Cell 1:633-44 (isp-1(qm150) discovery). VERIFIED.<br />
+  NOTE: my first guessed PMID "11740940" for this paper was WRONG (that PMID is a Drosophila<br />
+  neuralized paper); corrected to 11709184 via PubMed search + metadata.</li>
+<li>PMID:21151885 — Yang &amp; Hekimi 2010 PLoS Biol 8:e1000556 (superoxide longevity signal). VERIFIED, full text.</li>
+<li>PMID:20346072 — Yang &amp; Hekimi 2010 Aging Cell 9:433-47 (two modes; qm150 vs RNAi). VERIFIED.</li>
+<li>PMID:26504246 — Jafari...Kaeberlein 2015 PNAS 112:E6148-57 (tether suppressors; spring-loaded model). VERIFIED.</li>
+<li>PMID:16920626 — Falk et al 2006 Curr Biol 16:1641-5 (complex III mutant respiration; IMP source). VERIFIED, full text.</li>
+</ul>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: O44512
+gene_symbol: isp-1
+product_type: PROTEIN
+status: DRAFT
+taxon:
+  id: NCBITaxon:6239
+  label: Caenorhabditis elegans
+description: &gt;-
+  isp-1 encodes the Rieske iron-sulfur protein (ISP), the [2Fe-2S]-cluster-bearing
+  catalytic subunit of mitochondrial respiratory complex III (the cytochrome bc1 /
+  ubiquinol-cytochrome c oxidoreductase complex, EC 7.1.1.8). Anchored in the
+  mitochondrial inner membrane, its mobile Rieske head domain accepts an electron
+  from ubiquinol at the complex III Qo site and delivers it to cytochrome c1,
+  performing the electron-transfer step of the protonmotive Q-cycle and thereby
+  feeding electrons into the respiratory chain. In C. elegans the partial
+  loss-of-function allele isp-1(qm150) is a classic mitochondrial (&#34;Mit&#34;) longevity
+  mutant: it lowers oxygen consumption and extends lifespan, with the lifespan
+  extension driven by an elevated mitochondrial superoxide signal rather than by
+  reduced oxidative damage.
+references:
+  - id: GO_REF:0000002
+    title: Gene Ontology annotation through association of InterPro records with GO
+      terms
+    findings: []
+  - id: GO_REF:0000033
+    title: Annotation inferences using phylogenetic trees
+    findings: []
+  - id: GO_REF:0000044
+    title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location
+      vocabulary mapping, accompanied by conservative changes to GO terms applied by
+      UniProt
+    findings: []
+  - id: GO_REF:0000108
+    title: Automatic assignment of GO terms using logical inference, based on on inter-ontology
+      links
+    findings: []
+  - id: GO_REF:0000120
+    title: Combined Automated Annotation using Multiple IEA Methods
+    findings: []
+  - id: PMID:16920626
+    title: Mitochondrial complex I function modulates volatile anesthetic sensitivity
+      in C. elegans.
+    findings: []
+    reference_review:
+      relevance: MEDIUM
+      correctness: VERIFIED
+      review_notes: &gt;-
+        Primarily a complex I / volatile anesthetic study, but includes direct
+        respirometry on the complex III mutant isp-1: it shows diminished
+        complex II-dependent oxidative phosphorylation, supporting isp-1&#39;s role in
+        mitochondrial respiration. Source of the WormBase IMP annotation to
+        GO:0006122. PMID and content verified against PubMed and cached full text.
+  - id: PMID:11709184
+    title: Mitochondrial electron transport is a key determinant of life span in Caenorhabditis
+      elegans.
+    findings: []
+    reference_review:
+      relevance: HIGH
+      correctness: VERIFIED
+      review_notes: &gt;-
+        Feng, Bussiere &amp; Hekimi 2001 (Dev Cell). Discovery paper for isp-1(qm150):
+        identifies the mutation in the C. elegans iron-sulfur protein of complex III
+        and establishes low oxygen consumption, decreased ROS sensitivity, and
+        increased lifespan. PubMed-verified (note: an initially mis-recollected PMID,
+        11740940, is a different Drosophila paper; corrected to 11709184).
+  - id: PMID:21151885
+    title: A mitochondrial superoxide signal triggers increased longevity in Caenorhabditis
+      elegans.
+    findings: []
+    reference_review:
+      relevance: HIGH
+      correctness: VERIFIED
+      review_notes: &gt;-
+        Yang &amp; Hekimi 2010 (PLoS Biol). Establishes that isp-1 (and nuo-6) are
+        complex III/I subunits whose partial loss decreases electron transport, and
+        that an elevated mitochondrial superoxide signal is necessary and sufficient
+        for the longevity. PubMed-verified; full text cached.
+  - id: PMID:20346072
+    title: Two modes of mitochondrial dysfunction lead independently to lifespan extension
+      in Caenorhabditis elegans.
+    findings: []
+    reference_review:
+      relevance: MEDIUM
+      correctness: VERIFIED
+      review_notes: &gt;-
+        Yang &amp; Hekimi 2010 (Aging Cell). Shows the isp-1(qm150) genomic mutation and
+        isp-1(RNAi) extend lifespan by distinct, separable mechanisms, and reiterates
+        the &#34;partial loss-of-function of a complex III subunit&#34; framing. PubMed-verified.
+  - id: PMID:26504246
+    title: Tether mutations that restore function and suppress pleiotropic phenotypes
+      of the C. elegans isp-1(qm150) Rieske iron-sulfur protein.
+    findings: []
+    reference_review:
+      relevance: HIGH
+      correctness: VERIFIED
+      review_notes: &gt;-
+        Jafari et al. 2015 (PNAS, Kaeberlein lab). Structure-function of ISP-1:
+        intragenic suppressors of qm150 map to a conserved six-residue tether region,
+        and the authors propose a &#34;spring-loaded&#34; gating model linking a single Rieske
+        subunit to pleiotropic phenotypes including longevity. Key source for the
+        knowledge gap. PubMed-verified.
+  - id: file:worm/isp-1/isp-1-uniprot.txt
+    title: UniProtKB O44512 (isp-1, C. elegans) - Cytochrome b-c1 complex subunit Rieske,
+      mitochondrial
+    findings: []
+    reference_review:
+      relevance: HIGH
+      correctness: VERIFIED
+      review_notes: &gt;-
+        UniProt entry establishing the Rieske family assignment, EC 7.1.1.8, the
+        [2Fe-2S] cofactor (one per subunit), and mitochondrion inner membrane
+        localization used to anchor the cofactor and localization annotations.
+  - id: file:worm/isp-1/isp-1-deep-research-falcon.md
+    title: Falcon (Edison) deep research report for C. elegans isp-1
+    findings: []
+    reference_review:
+      relevance: LOW
+      correctness: UNVERIFIED
+      review_notes: &gt;-
+        Machine-generated deep-research narrative used only as a background pointer;
+        no load-bearing claim in this review depends on it. All substantive claims are
+        anchored to PubMed-verified primary literature or the UniProt record.
+existing_annotations:
+  - term:
+      id: GO:0016491
+      label: oxidoreductase activity
+    evidence_type: IBA
+    original_reference_id: GO_REF:0000033
+    qualifier: enables
+    review:
+      summary: &gt;-
+        Correct but uninformatively general. ISP-1&#39;s specific molecular function is
+        electron transfer through its Rieske [2Fe-2S] cluster; the complex-level
+        oxidoreductase reaction is captured more precisely by GO:0008121.
+      action: MODIFY
+      reason: &gt;-
+        oxidoreductase activity is a high-level parent. The subunit-specific activity
+        of the Rieske protein is electron transfer (GO:0009055), enabled via its 2Fe-2S
+        cluster; complex III&#39;s overall reaction is quinol-cytochrome-c reductase
+        activity (GO:0008121), already separately annotated.
+      proposed_replacement_terms:
+        - id: GO:0009055
+          label: electron transfer activity
+      propagation_review:
+        root_cause: TERM_SCOPING_PROBLEM
+        failure_modes:
+          - GRANULARITY_MISMATCH
+        source_entities:
+          - source_id: PANTHER:PTN000015358
+            source_label: Rieske / complex III oxidoreductase node
+            comment: &gt;-
+              IBA propagates the broad parent oxidoreductase activity; the correct
+              subunit-level term is electron transfer activity (GO:0009055).
+      supported_by:
+        - reference_id: PMID:26504246
+          supporting_text: &gt;-
+            encodes the Rieske iron-sulfur protein subunit of cytochrome c
+            oxidoreductase (complex III of the electron transport chain)
+  - term:
+      id: GO:0045275
+      label: respiratory chain complex III
+    evidence_type: IBA
+    original_reference_id: GO_REF:0000033
+    qualifier: part_of
+    review:
+      summary: &gt;-
+        Core annotation. ISP-1 is the Rieske iron-sulfur subunit of respiratory chain
+        complex III (cytochrome bc1).
+      action: ACCEPT
+      reason: &gt;-
+        Well established across eukaryotes and in C. elegans; ISP-1 is an integral
+        catalytic subunit of complex III.
+      supported_by:
+        - reference_id: PMID:21151885
+          supporting_text: subunits of complex I and III of the mitochondrial respiratory
+            chain
+        - reference_id: PMID:26504246
+          supporting_text: complex III of the electron transport chain
+  - term:
+      id: GO:0006122
+      label: mitochondrial electron transport, ubiquinol to cytochrome c
+    evidence_type: IBA
+    original_reference_id: GO_REF:0000033
+    qualifier: involved_in
+    review:
+      summary: &gt;-
+        Core biological process. Within complex III, ISP-1 transfers electrons from
+        ubiquinol to cytochrome c1 (and onward to cytochrome c).
+      action: ACCEPT
+      reason: &gt;-
+        This is the pathway step complex III performs and to which the Rieske subunit
+        is central; phylogenetically well supported and consistent with the
+        experimental worm data.
+      supported_by:
+        - reference_id: PMID:21151885
+          supporting_text: Partial loss-of-function mutations in these genes decrease
+            electron transport
+        - reference_id: file:worm/isp-1/isp-1-deep-research-falcon.md
+          supporting_text: transfers electrons from ubiquinol to cytochrome c1
+  - term:
+      id: GO:0005743
+      label: mitochondrial inner membrane
+    evidence_type: IEA
+    original_reference_id: GO_REF:0000044
+    qualifier: located_in
+    review:
+      summary: &gt;-
+        Core localization. Complex III, including the Rieske subunit, resides in the
+        mitochondrial inner membrane.
+      action: ACCEPT
+      reason: &gt;-
+        UniProt subcellular location; ISP-1 has a single-pass inner-membrane anchor
+        with its Rieske head projecting to the intermembrane-space side.
+      supported_by:
+        - reference_id: file:worm/isp-1/isp-1-uniprot.txt
+          supporting_text: &#34;C:mitochondrial inner membrane; IEA:UniProtKB-SubCell&#34;
+  - term:
+      id: GO:0008121
+      label: quinol-cytochrome-c reductase activity
+    evidence_type: IEA
+    original_reference_id: GO_REF:0000120
+    qualifier: enables
+    review:
+      summary: &gt;-
+        Complex III catalytic activity (EC 7.1.1.8) to which ISP-1 contributes the
+        essential electron-transfer step. Retained as a core molecular function of the
+        subunit in the context of the assembled complex.
+      action: ACCEPT
+      reason: &gt;-
+        ISP-1 is a catalytic subunit of ubiquinol-cytochrome c oxidoreductase; the
+        Rieske cluster carries out the electron-transfer half of this reaction. Best
+        represented in core_functions as contributes_to (a complex-level activity).
+      supported_by:
+        - reference_id: file:worm/isp-1/isp-1-uniprot.txt
+          supporting_text: EC=7.1.1.8
+        - reference_id: PMID:26504246
+          supporting_text: subunit of cytochrome c oxidoreductase
+  - term:
+      id: GO:0016020
+      label: membrane
+    evidence_type: IEA
+    original_reference_id: GO_REF:0000120
+    qualifier: located_in
+    review:
+      summary: &gt;-
+        Uninformative general parent, redundant with the specific and correct
+        mitochondrial inner membrane annotation (GO:0005743).
+      action: MARK_AS_OVER_ANNOTATED
+      reason: &gt;-
+        &#34;membrane&#34; adds no information beyond the more precise GO:0005743 already
+        assigned; it is an over-general IEA byproduct.
+  - term:
+      id: GO:0051537
+      label: 2 iron, 2 sulfur cluster binding
+    evidence_type: IEA
+    original_reference_id: GO_REF:0000002
+    qualifier: enables
+    review:
+      summary: &gt;-
+        Core molecular function. The defining feature of the Rieske protein: it
+        coordinates a high-potential [2Fe-2S] cluster, the redox center used for
+        electron transfer.
+      action: ACCEPT
+      reason: &gt;-
+        UniProt cofactor annotation and Rieske-family conservation; one [2Fe-2S]
+        cluster is bound per subunit.
+      supported_by:
+        - reference_id: file:worm/isp-1/isp-1-uniprot.txt
+          supporting_text: Binds 1 [2Fe-2S] cluster per subunit
+        - reference_id: file:worm/isp-1/isp-1-uniprot.txt
+          supporting_text: The Rieske protein is a high potential 2Fe-2S protein
+  - term:
+      id: GO:1902600
+      label: proton transmembrane transport
+    evidence_type: IEA
+    original_reference_id: GO_REF:0000108
+    qualifier: involved_in
+    review:
+      summary: &gt;-
+        Complex III couples electron transfer to proton translocation across the inner
+        membrane via the Q-cycle. This is a complex-level chemiosmotic outcome, not
+        ISP-1&#39;s direct molecular function (electron transfer); retained as non-core.
+      action: KEEP_AS_NON_CORE
+      reason: &gt;-
+        Proton translocation is an emergent property of the intact Q-cycle to which
+        ISP-1 contributes, rather than an activity ISP-1 performs on its own. Correct
+        to retain, but the subunit&#39;s core function is electron transfer.
+  - term:
+      id: GO:0006122
+      label: mitochondrial electron transport, ubiquinol to cytochrome c
+    evidence_type: IMP
+    original_reference_id: PMID:16920626
+    qualifier: involved_in
+    review:
+      summary: &gt;-
+        Experimentally supported in C. elegans. The isp-1 complex III mutant shows
+        impaired mitochondrial respiration/oxidative phosphorylation, directly
+        implicating isp-1 in mitochondrial electron transport.
+      action: ACCEPT
+      reason: &gt;-
+        Falk et al. measured respiration in the isp-1 (complex III) mutant and found
+        diminished complex II-dependent oxidative phosphorylation, consistent with a
+        defect in the ubiquinol-to-cytochrome c step; core process, experimentally
+        anchored.
+      supported_by:
+        - reference_id: PMID:16920626
+          supporting_text: in isp-1 (complex III mutant)
+        - reference_id: PMID:16920626
+          supporting_text: somewhat diminished in the complex III ( isp-1 ) mutant
+core_functions:
+  - description: &gt;-
+      Electron-transfer subunit of mitochondrial complex III: within the cytochrome
+      bc1 complex, ISP-1&#39;s mobile Rieske head accepts an electron from ubiquinol at the
+      Qo site and delivers it to cytochrome c1, the electron-transfer step of the
+      ubiquinol-cytochrome c reductase (EC 7.1.1.8) reaction in the protonmotive
+      Q-cycle.
+    supported_by:
+      - reference_id: PMID:26504246
+        supporting_text: &gt;-
+          encodes the Rieske iron-sulfur protein subunit of cytochrome c
+          oxidoreductase (complex III of the electron transport chain)
+      - reference_id: PMID:21151885
+        supporting_text: subunits of complex I and III of the mitochondrial respiratory
+          chain
+    molecular_function:
+      id: GO:0009055
+      label: electron transfer activity
+    contributes_to_molecular_function:
+      id: GO:0008121
+      label: quinol-cytochrome-c reductase activity
+    directly_involved_in:
+      - id: GO:0006122
+        label: mitochondrial electron transport, ubiquinol to cytochrome c
+    locations:
+      - id: GO:0005743
+        label: mitochondrial inner membrane
+    in_complex:
+      id: GO:0045275
+      label: respiratory chain complex III
+  - description: &gt;-
+      Coordinates the Rieske high-potential [2Fe-2S] cluster (one per subunit), the
+      redox cofactor that carries out the electron-transfer step of complex III.
+    supported_by:
+      - reference_id: file:worm/isp-1/isp-1-uniprot.txt
+        supporting_text: Binds 1 [2Fe-2S] cluster per subunit
+    molecular_function:
+      id: GO:0051537
+      label: 2 iron, 2 sulfur cluster binding
+    in_complex:
+      id: GO:0045275
+      label: respiratory chain complex III
+knowledge_gaps:
+  - gap_statement: &gt;-
+      The molecular mechanism by which the isp-1(qm150) Rieske substitution is
+      converted into the pro-longevity retrograde signal is undetermined. It is
+      established that qm150 elevates mitochondrial superoxide and that this elevation
+      is necessary and sufficient for the lifespan extension, but the causal chain from
+      the specific perturbation of ISP-1 head/tether dynamics, through altered Qo-site
+      electron transfer and superoxide production, to the downstream transcriptional
+      longevity program has not been resolved.
+    boundary: &gt;-
+      Firmly established: isp-1 encodes the Rieske [2Fe-2S] subunit of complex III;
+      qm150 is a partial loss-of-function allele that lowers oxygen consumption and
+      extends lifespan; the longevity requires elevated mitochondrial superoxide
+      (abolished by antioxidants, phenocopied by paraquat); and intragenic suppressors
+      that restore function map to a conserved six-residue tether region (&#34;spring-loaded&#34;
+      model). What is unresolved is the signal-generating step itself.
+    gap_kind:
+      - BIOLOGY
+    dark_aspect: RESIDUAL_SUBGAP
+    status: OPEN
+    significance: &gt;-
+      isp-1(qm150) is a canonical mitohormesis / Mit longevity model. Defining the
+      signal-generating step would connect a specific electron-transport-chain lesion to
+      a conserved lifespan-extension program with relevance to mitochondrial disease and
+      aging.
+    resolution: &gt;-
+      Structure-guided electron-transfer and superoxide measurements on qm150 and its
+      intragenic tether-region suppressors, combined with epistasis to the retrograde
+      transcriptional effectors, to identify the step that generates the superoxide
+      longevity signal.
+    provenance:
+      - reference_id: PMID:21151885
+        supporting_text: this elevation is necessary and sufficient to increase longevity
+      - reference_id: PMID:26504246
+        supporting_text: points to a common underlying molecular mechanism, for which
+          we propose a
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/genes/worm/mex-6/mex-6-ai-review.html
+++ b/genes/worm/mex-6/mex-6-ai-review.html
@@ -1,0 +1,4602 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>mex-6 - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        .propagation-review {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f8fafc;
+            border-left: 3px solid #64748b;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .propagation-title {
+            font-weight: 600;
+            color: #334155;
+            margin-bottom: 0.25rem;
+        }
+
+        .propagation-row {
+            margin-top: 0.25rem;
+        }
+
+        .propagation-source {
+            margin-top: 0.5rem;
+            padding-top: 0.5rem;
+            border-top: 1px solid #e5e7eb;
+        }
+
+        .propagation-source-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #1d4ed8;
+        }
+
+        .propagation-comment {
+            color: #4b5563;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>mex-6</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/Q09436" target="_blank" class="term-link">
+                        Q09436
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Caenorhabditis elegans</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-complete">
+                    COMPLETE
+                </span>
+            </div>
+
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "mex-6";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="Q09436" data-a="DESCRIPTION: MEX-6 is a cytoplasmic CCCH-type tandem zinc finge..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>MEX-6 is a cytoplasmic CCCH-type tandem zinc finger (TZF) RNA-binding protein of the TTP/ZFP36 family that functions in the early Caenorhabditis elegans embryo to establish soma/germline asymmetry along the anterior-posterior axis. It is the close, nearly identical paralog of MEX-5 and acts largely redundantly with it: single loss of mex-6 is mostly silent, whereas removing both mex-5 and mex-6 disrupts embryonic viability and the asymmetric distribution of maternally supplied determinants (PLK-1, PIE-1, MEX-1, POS-1). Like MEX-5, MEX-6 is broadly cytoplasmic and becomes anterior-enriched in the one-cell zygote, acting downstream of cortical PAR polarity and the PAR-1 kinase during the establishment phase of polarization. MEX-6 contains two tandem C3H1-type zinc fingers that bind mRNA (including 3&#39;-UTR sequences) and coordinate zinc. It is also a substrate and adaptor for the mitotic Polo-like kinases PLK-1 and PLK-2; MBK-2/DYRK2-primed phosphorylation of a threonine adjacent to the zinc fingers creates a docking site for the polo-box domains of PLK-1/PLK-2, and MEX-5/MEX-6 in turn are required for the anterior enrichment of these kinases.</p>
+    </div>
+
+
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0035925" target="_blank" class="term-link">
+                                    GO:0035925
+                                </a>
+                            </span>
+                            <span class="term-label">mRNA 3&#39;-UTR AU-rich region binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-modify">
+                            MODIFY
+                        </span>
+                        <span class="vote-buttons" data-g="Q09436" data-a="GO:0035925" data-r="GO_REF:0000033" data-act="MODIFY">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> This IBA is a phylogenetic transfer from the TTP/ZFP36 (tristetraprolin) family, whose members bind AU-rich elements (AREs). MEX-6 is a member of this CCCH TZF family (InterPro IPR045877 ZFP36-like), but the nematode MEX proteins have diverged from ARE specificity. Direct biochemistry on the near-identical paralog MEX-5 shows recognition of poly-uridine tracts with high affinity but low specificity, not the UUAUUUAUU ARE bound by mammalian TTP/ERF-2 (PMID:17264081).
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The AU-rich-element specificity implied by this term does not match the diverged binding behaviour of nematode MEX TZF proteins. In MEX-5, a single discriminator residue per zinc finger determines ARE vs poly-U preference, and wild-type MEX-5 binds poly-U promiscuously rather than AREs. There is no MEX-6-specific ARE-binding evidence. A more accurate and already experimentally supported term is mRNA 3&#39;-UTR binding (GO:0003730), which is annotated with IDA for this gene.
+                        </div>
+
+
+
+                        <div class="propagation-review">
+                            <div class="propagation-title">Propagation Review</div>
+                            <div class="propagation-row">
+                                <strong>Root cause:</strong>
+                                <span class="badge">TERM SCOPING PROBLEM</span>
+                            </div>
+
+                            <div class="propagation-row">
+                                <strong>Failure modes:</strong>
+
+                                <span class="badge">FUNCTIONAL DIVERGENCE</span>
+
+                            </div>
+
+
+                            <div class="propagation-source">
+                                <strong>Sources checked:</strong>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">PANTHER:PTN002648882</span>
+
+                                    &middot; TTP/ZFP36 CCCH-TZF family node
+
+
+                                    <span class="badge">SUPPORTS SOURCE BUT NOT TARGET</span>
+
+
+                                    <div class="propagation-comment">Ancestral ARE-binding specificity does not transfer; nematode MEX proteins diverged to low-specificity poly-U binding.</div>
+
+                                </div>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">UniProtKB:P26651</span>
+
+                                    &middot; human ZFP36 (tristetraprolin)
+
+
+                                    <span class="badge">SUPPORTS SOURCE BUT NOT TARGET</span>
+
+
+                                    <div class="propagation-comment">Mammalian TTP binds UUAUUUAUU AREs with high specificity, unlike MEX-6.</div>
+
+                                </div>
+
+                            </div>
+
+                        </div>
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003730" target="_blank" class="term-link">
+                                    mRNA 3&#39;-UTR binding
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/17264081" target="_blank" class="term-link">
+                                        PMID:17264081
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">In contrast, human TZF homologs tristetraprolin and ERF-2 bind with high specificity to UUAUUUAUU elements.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/17264081" target="_blank" class="term-link">
+                                        PMID:17264081
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">We show that mutation of a single amino acid in each MEX-5 zinc finger confers tristetraprolin-like specificity to this protein.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000289" target="_blank" class="term-link">
+                                    GO:0000289
+                                </a>
+                            </span>
+                            <span class="term-label">nuclear-transcribed mRNA poly(A) tail shortening</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q09436" data-a="GO:0000289" data-r="GO_REF:0000033" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> This IBA is inherited from the ancestral TTP/ZFP36 function of recruiting the deadenylase machinery to promote mRNA poly(A) tail shortening. There is no direct evidence that MEX-6 (or MEX-5) promotes deadenylation in C. elegans; the MEX-5/6 literature concerns embryonic polarity and translational/RNP regulation, not mRNA decay.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Deadenylation is a well-established function of mammalian TTP-family paralogs but has not been demonstrated for MEX-6. The nematode MEX proteins have diverged in RNA specificity from their mammalian homologs (PMID:17264081), and the characterized MEX-5/6 outputs are on polarity determinants rather than bulk mRNA turnover. Retained as a family-level over-annotation without direct evidence.
+                        </div>
+
+
+
+                        <div class="propagation-review">
+                            <div class="propagation-title">Propagation Review</div>
+                            <div class="propagation-row">
+                                <strong>Root cause:</strong>
+                                <span class="badge">PROPAGATION BAD</span>
+                            </div>
+
+                            <div class="propagation-row">
+                                <strong>Failure modes:</strong>
+
+                                <span class="badge">FUNCTIONAL DIVERGENCE</span>
+
+                            </div>
+
+
+                            <div class="propagation-source">
+                                <strong>Sources checked:</strong>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">PANTHER:PTN002648882</span>
+
+                                    &middot; TTP/ZFP36 CCCH-TZF family node
+
+
+                                    <span class="badge">SUPPORTS SOURCE BUT NOT TARGET</span>
+
+
+                                    <div class="propagation-comment">Mammalian TTP-family deadenylation is sound at the source but has no experimental support in MEX-6.</div>
+
+                                </div>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">UniProtKB:P26651</span>
+
+                                    &middot; human ZFP36 (tristetraprolin)
+
+
+                                    <span class="badge">SUPPORTS SOURCE BUT NOT TARGET</span>
+
+
+                                    <div class="propagation-comment">TTP recruits the CCR4-NOT deadenylase; no such activity shown for MEX-6.</div>
+
+                                </div>
+
+                            </div>
+
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/17264081" target="_blank" class="term-link">
+                                        PMID:17264081
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">In contrast, human TZF homologs tristetraprolin and ERF-2 bind with high specificity to UUAUUUAUU elements.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000900" target="_blank" class="term-link">
+                                    GO:0000900
+                                </a>
+                            </span>
+                            <span class="term-label">mRNA regulatory element binding translation repressor activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-undecided">
+                            UNDECIDED
+                        </span>
+                        <span class="vote-buttons" data-g="Q09436" data-a="GO:0000900" data-r="GO_REF:0000033" data-act="UNDECIDED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> This IBA proposes a sequence-specific translation-repressor activity by phylogenetic inference. MEX-6 does bind mRNA and, redundantly with MEX-5, controls the expression pattern of germline determinants, but the mechanism is not a clean sequence-specific translational repressor. The RNA binding of the paralog is low-specificity (PMID:17264081), and the best-characterized MEX-5/6 translational output (on the zif-1 3&#39;UTR) is positive rather than repressive. No MEX-6-specific evidence establishes this molecular activity.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The directionality and sequence-specificity implied by this term are not supported for MEX-6. Without direct evidence that MEX-6 functions as a sequence-specific translation repressor (as opposed to acting through low-specificity mRNA binding, mRNA competition, or positive regulation of specific targets), this annotation cannot be confidently accepted or removed and requires experimental clarification.
+                        </div>
+
+
+
+                        <div class="propagation-review">
+                            <div class="propagation-title">Propagation Review</div>
+                            <div class="propagation-row">
+                                <strong>Root cause:</strong>
+                                <span class="badge">UNRESOLVED</span>
+                            </div>
+
+                            <div class="propagation-row">
+                                <strong>Failure modes:</strong>
+
+                                <span class="badge">FUNCTIONAL DIVERGENCE</span>
+
+                                <span class="badge">REGULATORY SIGN INVERSION</span>
+
+                            </div>
+
+
+                            <div class="propagation-source">
+                                <strong>Sources checked:</strong>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">PANTHER:PTN002648882</span>
+
+                                    &middot; TTP/ZFP36 CCCH-TZF family node
+
+
+                                    <span class="badge">SUPPORTS SOURCE BUT NOT TARGET</span>
+
+
+                                    <div class="propagation-comment">Repressor directionality is uncertain for MEX-6; the best-characterized MEX-5/6 translational output (zif-1 3&#39;UTR) is positive, not repressive.</div>
+
+                                </div>
+
+                            </div>
+
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/17264081" target="_blank" class="term-link">
+                                        PMID:17264081
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">the TZF protein MEX-5, a primary anterior determinant, is an RNA-binding protein that recognizes linear RNA sequences with high affinity but low specificity</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
+                                    GO:0005829
+                                </a>
+                            </span>
+                            <span class="term-label">cytosol</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q09436" data-a="GO:0005829" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> MEX-6 is a cytoplasmic protein (UniProt SUBCELLULAR LOCATION Cytoplasm), imaged as a cytoplasmic GFP fusion in the early embryo (PMID:12588843) and consistent with the experimental IDA cytoplasm annotation. Cytosol is an appropriate active-location term for this non-membrane RNA-binding protein.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> MEX-6 acts in the cytoplasm/cytosol of the zygote, where it forms an anterior-enriched pool and regulates cytoplasmic determinant asymmetry. Consistent with both experimental imaging and the phylogenetic inference.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12588843" target="_blank" class="term-link">
+                                        PMID:12588843
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The kinase PAR-1 and the CCCH finger proteins MEX-5 and MEX-6 also function during the establishment phase in a feedback loop to regulate growth of the posterior domain.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0160134" target="_blank" class="term-link">
+                                    GO:0160134
+                                </a>
+                            </span>
+                            <span class="term-label">protein-RNA sequence-specific adaptor activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-modify">
+                            MODIFY
+                        </span>
+                        <span class="vote-buttons" data-g="Q09436" data-a="GO:0160134" data-r="GO_REF:0000033" data-act="MODIFY">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> This IBA implies MEX-6 acts as a sequence-specific adaptor between RNA and protein. MEX-6 binds mRNA and also binds protein partners (PLK-1/PLK-2 via polo-box docking), but its RNA binding is not sequence-specific - the near-identical paralog MEX-5 binds poly-U tracts with high affinity and low specificity (PMID:17264081).
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The &#34;sequence-specific&#34; qualifier of GO:0160134 is not supported for MEX-6, whose RNA recognition (by paralog inference) is promiscuous poly-U binding rather than a specific motif. The well-supported molecular activity is simply mRNA binding (GO:0003729); the protein-adaptor role toward polo kinases is captured separately by the protein kinase binding / protein domain specific binding annotations.
+                        </div>
+
+
+
+                        <div class="propagation-review">
+                            <div class="propagation-title">Propagation Review</div>
+                            <div class="propagation-row">
+                                <strong>Root cause:</strong>
+                                <span class="badge">TERM SCOPING PROBLEM</span>
+                            </div>
+
+                            <div class="propagation-row">
+                                <strong>Failure modes:</strong>
+
+                                <span class="badge">GRANULARITY MISMATCH</span>
+
+                                <span class="badge">FUNCTIONAL DIVERGENCE</span>
+
+                            </div>
+
+
+                            <div class="propagation-source">
+                                <strong>Sources checked:</strong>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">PANTHER:PTN002648882</span>
+
+                                    &middot; TTP/ZFP36 CCCH-TZF family node
+
+
+                                    <span class="badge">SUPPORTS SOURCE BUT NOT TARGET</span>
+
+
+                                    <div class="propagation-comment">The &#34;sequence-specific&#34; qualifier overstates MEX-6 RNA recognition, which by paralog inference is promiscuous poly-U binding.</div>
+
+                                </div>
+
+                            </div>
+
+                        </div>
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003729" target="_blank" class="term-link">
+                                    mRNA binding
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/17264081" target="_blank" class="term-link">
+                                        PMID:17264081
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">the TZF protein MEX-5, a primary anterior determinant, is an RNA-binding protein that recognizes linear RNA sequences with high affinity but low specificity</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003729" target="_blank" class="term-link">
+                                    GO:0003729
+                                </a>
+                            </span>
+                            <span class="term-label">mRNA binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q09436" data-a="GO:0003729" data-r="GO_REF:0000002" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> MEX-6 contains two tandem C3H1-type CCCH zinc fingers (UniProt ZN_FING 273-302, 317-347; InterPro IPR045877 ZFP36-like, IPR000571 CCCH), the RNA-binding module of the TTP/TZF family. mRNA binding is a core molecular function, independently supported by the experimental IDA for mRNA 3&#39;-UTR binding (PMID:17264081, curated for mex-6).
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> mRNA binding is well supported for this gene by domain architecture and by the curated experimental 3&#39;-UTR-binding annotation. Core molecular function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/17264081" target="_blank" class="term-link">
+                                        PMID:17264081
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">This sequence is remarkably abundant in the 3&#39;-untranslated region of C. elegans transcripts</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
+                                    GO:0005737
+                                </a>
+                            </span>
+                            <span class="term-label">cytoplasm</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000044
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q09436" data-a="GO:0005737" data-r="GO_REF:0000044" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Cytoplasmic localization inferred from the UniProt Swiss-Prot subcellular location. Consistent with the experimental IDA cytoplasm annotation (PMID:12588843) and UniProt SUBCELLULAR LOCATION Cytoplasm.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> MEX-6 is a cytoplasmic protein; this location is corroborated by direct imaging in the early embryo. Correct, if generic relative to the anterior-enriched cytoplasmic pool.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12588843" target="_blank" class="term-link">
+                                        PMID:12588843
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">we have analyzed the localization dynamics of PAR-2, PAR-6, MEX-5, MEX-6 and PIE-1 in wild-type and mutant embryos</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0017148" target="_blank" class="term-link">
+                                    GO:0017148
+                                </a>
+                            </span>
+                            <span class="term-label">negative regulation of translation</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000108
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-undecided">
+                            UNDECIDED
+                        </span>
+                        <span class="vote-buttons" data-g="Q09436" data-a="GO:0017148" data-r="GO_REF:0000108" data-act="UNDECIDED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> This IEA is a logical inference from GO:0000900 (mRNA regulatory element binding translation repressor activity), which is itself uncertain for MEX-6 (reviewed above as UNDECIDED). While MEX-5/6 restrict germline protein expression in the anterior, the mechanism is not established to be direct translational repression, and the best-characterized translational output (zif-1 3&#39;UTR) is positive.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Because the parent MF annotation (GO:0000900) is not confidently supported for MEX-6, the inferred negative-regulation-of-translation process term inherits that uncertainty. The directionality does not match the strongest published MEX-5/6 translational mechanism. Requires direct evidence.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/10882103" target="_blank" class="term-link">
+                                        PMID:10882103
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">This network is required for subsequent asymmetries in the expression patterns of several proteins that are encoded by nonlocalized, maternally expressed mRNAs.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0043186" target="_blank" class="term-link">
+                                    GO:0043186
+                                </a>
+                            </span>
+                            <span class="term-label">P granule</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000117
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q09436" data-a="GO:0043186" data-r="GO_REF:0000117" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> This is a purely electronic ARBA machine-learning prediction of P-granule residency. MEX-6 is predominantly an anterior cytoplasmic protein, spatially anti-correlated with P granules, which segregate to the posterior. Any P-granule association (see the experimental IDA below) is at best transient and non-core; an unsupervised ARBA prediction is exactly the kind of electronic annotation to down-weight for a family whose members antagonize, rather than reside in, germ granules.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> This electronic prediction is redundant with the experimental IDA to the same term (also kept non-core), so it is retained rather than removed, but marked non-core. MEX-6&#39;s core localization is the anterior cytoplasm, not stable structural residence in P granules, so P-granule localization should not be treated as a core function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12588843" target="_blank" class="term-link">
+                                        PMID:12588843
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The kinase PAR-1 and the CCCH finger proteins MEX-5 and MEX-6 also function during the establishment phase in a feedback loop to regulate growth of the posterior domain.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0046872" target="_blank" class="term-link">
+                                    GO:0046872
+                                </a>
+                            </span>
+                            <span class="term-label">metal ion binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q09436" data-a="GO:0046872" data-r="GO_REF:0000002" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> MEX-6 has two C3H1-type CCCH zinc fingers that each coordinate a zinc ion, the structural basis of its RNA-binding fold (UniProt ZN_FING; InterPro CCCH signatures). Metal ion binding is a correct, if generic, annotation.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Zinc coordination is intrinsic to the CCCH zinc-finger fold of MEX-6. Correct though non-specific; zinc ion binding (GO:0008270) would be the more precise term.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
+                                    GO:0005737
+                                </a>
+                            </span>
+                            <span class="term-label">cytoplasm</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ISS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000024
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q09436" data-a="GO:0005737" data-r="GO_REF:0000024" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Cytoplasmic localization transferred by sequence similarity from the paralog MEX-5 (UniProtKB:Q9XUB2). This ortholog/paralog transfer is consistent with the independent experimental IDA (PMID:12588843) and with UniProt&#39;s Cytoplasm assignment.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The cytoplasm location is correct for MEX-6 and is corroborated by direct experimental evidence, so the ISS transfer from MEX-5 is appropriate.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12588843" target="_blank" class="term-link">
+                                        PMID:12588843
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">we have analyzed the localization dynamics of PAR-2, PAR-6, MEX-5, MEX-6 and PIE-1 in wild-type and mutant embryos</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0019901" target="_blank" class="term-link">
+                                    GO:0019901
+                                </a>
+                            </span>
+                            <span class="term-label">protein kinase binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/18199581" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:18199581
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Polo kinases regulate C. elegans embryonic polarity via bind...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q09436" data-a="GO:0019901" data-r="PMID:18199581" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> PMID:18199581 demonstrates that the Polo-like kinases PLK-1 and PLK-2 bind directly to MEX-6 (named explicitly) via their polo-box domains, dependent on MBK-2/DYRK2-primed phosphorylation of the polo-docking threonine (Thr-190 in MEX-6; UniProt MOD_RES 190, MUTAGEN T190A/T190E abolish PLK binding). Curated by WormBase with plk-1 (WBGene00004042) and plk-2 (WBGene00004043) as interactors.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Direct experimental protein-kinase-binding evidence naming MEX-6; functionally important for embryonic polarity. Core interaction.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/18199581" target="_blank" class="term-link">
+                                        PMID:18199581
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">We show that polo kinases, via their polo box domains, bind to and regulate the activity of two key polarity proteins, MEX-5 and MEX-6.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0019904" target="_blank" class="term-link">
+                                    GO:0019904
+                                </a>
+                            </span>
+                            <span class="term-label">protein domain specific binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/18199581" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:18199581
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Polo kinases regulate C. elegans embryonic polarity via bind...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q09436" data-a="GO:0019904" data-r="PMID:18199581" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> MEX-6 binds specifically to the polo-box domains of PLK-1 and PLK-2 (a phosphopeptide-docking domain), a bona fide domain-specific protein interaction (PMID:18199581), primed by MBK-2 phosphorylation at Thr-190.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The interaction is with a defined protein domain (the polo-box domain), directly demonstrated for MEX-6. Supports protein domain specific binding.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/18199581" target="_blank" class="term-link">
+                                        PMID:18199581
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">We show that polo kinases, via their polo box domains, bind to and regulate the activity of two key polarity proteins, MEX-5 and MEX-6.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0032880" target="_blank" class="term-link">
+                                    GO:0032880
+                                </a>
+                            </span>
+                            <span class="term-label">regulation of protein localization</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IGI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/18199581" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:18199581
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Polo kinases regulate C. elegans embryonic polarity via bind...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q09436" data-a="GO:0032880" data-r="PMID:18199581" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> MEX-6, redundantly with MEX-5 (genetic interaction; WormBase with = mex-5 WBGene00003230), is required for the asymmetric localization of downstream determinants. Removing MEX-5 and MEX-6 disrupts asymmetric distribution of PLK-1 (and PIE-1, MEX-1, POS-1); UniProt DISRUPTION PHENOTYPE notes that mex-6 RNAi in a mex-5(zu199) background causes loss of plk-1 asymmetry (PMID:18199581). The polo kinases&#39; asymmetric localization depends on MEX-5 and MEX-6.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Regulation of the asymmetric localization of germline/polarity determinants is a core, experimentally supported biological process for the MEX-5/MEX-6 pair, with the genetic-interaction evidence specifically implicating mex-6 in a mex-5-sensitized background.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/18199581" target="_blank" class="term-link">
+                                        PMID:18199581
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">This asymmetric localization of polo kinases depends on MEX-5 and MEX-6, as well as genes regulating MEX-5 and MEX-6 asymmetry.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
+                                    GO:0005737
+                                </a>
+                            </span>
+                            <span class="term-label">cytoplasm</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/12588843" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:12588843
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Polarization of the C. elegans zygote proceeds via distinct ...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q09436" data-a="GO:0005737" data-r="PMID:12588843" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct experimental (IDA, WormBase) cytoplasmic localization of MEX-6, imaged as a GFP fusion during zygote polarization (PMID:12588843). This is the primary-evidence cytoplasm annotation.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Direct observation of cytoplasmic MEX-6 in the early embryo; the core cellular location of the protein.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12588843" target="_blank" class="term-link">
+                                        PMID:12588843
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">we have analyzed the localization dynamics of PAR-2, PAR-6, MEX-5, MEX-6 and PIE-1 in wild-type and mutant embryos</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0043186" target="_blank" class="term-link">
+                                    GO:0043186
+                                </a>
+                            </span>
+                            <span class="term-label">P granule</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/12588843" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:12588843
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Polarization of the C. elegans zygote proceeds via distinct ...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q09436" data-a="GO:0043186" data-r="PMID:12588843" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> WormBase curated an experimental (IDA) P-granule localization for MEX-6 from the full text of PMID:12588843 (a live-imaging study of MEX-6 and other polarity factors). The cached abstract does not itself mention P granules, so I cannot independently verify the observation, but I defer to the curator&#39;s reading of the full text. Biologically, MEX-6 is predominantly anterior cytoplasmic (where P granules are depleted), so any P-granule association is transient/minor rather than a core residence - unlike bona fide P-granule scaffolds. The near-identical paralog MEX-5 has been shown to antagonize (dissolve) rather than reside in P granules, but no equivalent phase-separation study exists for MEX-6.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> This is an experimental annotation whose supporting full text I cannot see; per project guidelines I do not REMOVE it on the basis of an abstract that foregrounds other observations. However, given MEX-6&#39;s anterior-cytoplasmic enrichment and the lack of evidence that it is a structural P-granule component, the localization is retained as non-core rather than as a core function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12588843" target="_blank" class="term-link">
+                                        PMID:12588843
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">we have analyzed the localization dynamics of PAR-2, PAR-6, MEX-5, MEX-6 and PIE-1 in wild-type and mutant embryos</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003730" target="_blank" class="term-link">
+                                    GO:0003730
+                                </a>
+                            </span>
+                            <span class="term-label">mRNA 3&#39;-UTR binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/17264081" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:17264081
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Molecular basis of RNA recognition by the embryonic polarity...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q09436" data-a="GO:0003730" data-r="PMID:17264081" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> WormBase curated an experimental (IDA) mRNA 3&#39;-UTR-binding activity for MEX-6 citing PMID:17264081. That paper&#39;s abstract characterizes the biochemistry of the near-identical paralog MEX-5 (poly-U tracts abundant in C. elegans 3&#39;-UTRs); the mex-6 IDA reflects the curator&#39;s reading of the full text. MEX-6 has the same tandem CCCH zinc-finger RNA-binding module, so 3&#39;-UTR binding is biologically expected.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> mRNA 3&#39;-UTR binding is a genuine, core molecular function of this TZF protein and is curated as experimental for mex-6. Per project guidelines I defer to the curator rather than REMOVE an experimental annotation because the cached abstract foregrounds the paralog MEX-5.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/17264081" target="_blank" class="term-link">
+                                        PMID:17264081
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">This sequence is remarkably abundant in the 3&#39;-untranslated region of C. elegans transcripts</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008595" target="_blank" class="term-link">
+                                    GO:0008595
+                                </a>
+                            </span>
+                            <span class="term-label">anterior/posterior axis specification, embryo</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/10882103" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:10882103
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    MEX-5 and MEX-6 function to establish soma/germline asymmetr...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-new">
+                            NEW
+                        </span>
+                        <span class="vote-buttons" data-g="Q09436" data-a="GO:0008595" data-r="PMID:10882103" data-act="NEW">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> MEX-6, redundantly with MEX-5, links cortical PAR polarity to soma/germline asymmetry along the anterior-posterior axis of the early embryo (PMID:10882103, PMID:12588843). This biological process is not present in the current GOA for mex-6 but is a core role of the MEX-5/MEX-6 pair.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Anterior-posterior axis specification is a core developmental process for the MEX-5/MEX-6 pair, with MEX-6 contributing redundantly with MEX-5. Added as a proposed new annotation to reflect this core function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/10882103" target="_blank" class="term-link">
+                                        PMID:10882103
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">We provide evidence that two nearly identical genes, mex-5 and mex-6, link PAR asymmetry to those subsequent protein asymmetries.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12588843" target="_blank" class="term-link">
+                                        PMID:12588843
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Polarization of the C. elegans zygote along the anterior-posterior axis depends on cortically enriched (PAR) and cytoplasmic (MEX-5/6) proteins</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>MEX-6 binds maternal mRNA 3&#39;-UTRs through its tandem CCCH zinc fingers and, redundantly with MEX-5, converts cortical PAR polarity into cytoplasmic soma/germline asymmetry, patterning the distribution of germline determinants (PIE-1, POS-1, MEX-1) along the anterior-posterior axis of the early embryo.</h3>
+                <span class="vote-buttons" data-g="Q09436" data-a="FUNCTION: MEX-6 binds maternal mRNA 3&#39;-UTRs through its tand..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003730" target="_blank" class="term-link">
+                            mRNA 3&#39;-UTR binding
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008595" target="_blank" class="term-link">
+                                anterior/posterior axis specification, embryo
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0032880" target="_blank" class="term-link">
+                                regulation of protein localization
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
+                                cytoplasm
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/10882103" target="_blank" class="term-link">
+                                PMID:10882103
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">We provide evidence that two nearly identical genes, mex-5 and mex-6, link PAR asymmetry to those subsequent protein asymmetries.</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/17264081" target="_blank" class="term-link">
+                                PMID:17264081
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">This sequence is remarkably abundant in the 3&#39;-untranslated region of C. elegans transcripts</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>MEX-6 acts as a substrate and adaptor for the Polo-like kinases PLK-1 and PLK-2, binding their polo-box domains via an MBK-2/DYRK2-primed phosphothreonine (Thr-190); this interaction is required (with MEX-5) for the anterior enrichment of PLK-1/PLK-2 and their control of determinant asymmetry.</h3>
+                <span class="vote-buttons" data-g="Q09436" data-a="FUNCTION: MEX-6 acts as a substrate and adaptor for the Polo..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0019901" target="_blank" class="term-link">
+                            protein kinase binding
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0032880" target="_blank" class="term-link">
+                                regulation of protein localization
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
+                                cytoplasm
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/18199581" target="_blank" class="term-link">
+                                PMID:18199581
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">We show that polo kinases, via their polo box domains, bind to and regulate the activity of two key polarity proteins, MEX-5 and MEX-6.</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/18199581" target="_blank" class="term-link">
+                                PMID:18199581
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">This asymmetric localization of polo kinases depends on MEX-5 and MEX-6, as well as genes regulating MEX-5 and MEX-6 asymmetry.</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000002.md" target="_blank" class="term-link">
+                            GO_REF:0000002
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation through association of InterPro records with GO terms</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000024.md" target="_blank" class="term-link">
+                            GO_REF:0000024
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Manual transfer of experimentally-verified manual GO annotation data to orthologs by curator judgment of sequence similarity</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
+                            GO_REF:0000033
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Annotation inferences using phylogenetic trees</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
+                            GO_REF:0000044
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000108.md" target="_blank" class="term-link">
+                            GO_REF:0000108
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Automatic assignment of GO terms using logical inference, based on on inter-ontology links</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000117.md" target="_blank" class="term-link">
+                            GO_REF:0000117
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Electronic Gene Ontology annotations created by ARBA machine learning models</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/10882103" target="_blank" class="term-link">
+                            PMID:10882103
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">MEX-5 and MEX-6 function to establish soma/germline asymmetry in early C. elegans embryos.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">mex-5 and mex-6 are two nearly identical genes that link PAR cortical asymmetry to downstream protein asymmetries.</div>
+
+                        <div class="finding-text">"We provide evidence that two nearly identical genes, mex-5 and mex-6, link PAR asymmetry to those subsequent protein asymmetries."</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <div class="finding-statement">The paralogs act downstream of the PAR network to pattern expression of nonlocalized maternal mRNAs.</div>
+
+                        <div class="finding-text">"This network is required for subsequent asymmetries in the expression patterns of several proteins that are encoded by nonlocalized, maternally expressed mRNAs."</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/12588843" target="_blank" class="term-link">
+                            PMID:12588843
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Polarization of the C. elegans zygote proceeds via distinct establishment and maintenance phases.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Zygote polarization along the A-P axis depends on cortical PAR and cytoplasmic MEX-5/6 proteins.</div>
+
+                        <div class="finding-text">"Polarization of the C. elegans zygote along the anterior-posterior axis depends on cortically enriched (PAR) and cytoplasmic (MEX-5/6) proteins"</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <div class="finding-statement">MEX-5 and MEX-6 (CCCH finger proteins) act with PAR-1 in the establishment phase in a feedback loop regulating the posterior domain.</div>
+
+                        <div class="finding-text">"The kinase PAR-1 and the CCCH finger proteins MEX-5 and MEX-6 also function during the establishment phase in a feedback loop to regulate growth of the posterior domain."</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/17264081" target="_blank" class="term-link">
+                            PMID:17264081
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Molecular basis of RNA recognition by the embryonic polarity determinant MEX-5.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">MEX-5 (the near-identical paralog of MEX-6) binds RNA with high affinity but low sequence specificity, recognizing tracts of six or more uridines.</div>
+
+                        <div class="finding-text">"The minimal binding site is a tract of six or more uridines within a 9-13-nucleotide window."</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Nematode MEX proteins have diverged from the AU-rich-element specificity of mammalian TZF proteins via a single discriminator residue per zinc finger.</div>
+
+                        <div class="finding-text">"We show that mutation of a single amino acid in each MEX-5 zinc finger confers tristetraprolin-like specificity to this protein."</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/18199581" target="_blank" class="term-link">
+                            PMID:18199581
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Polo kinases regulate C. elegans embryonic polarity via binding to DYRK2-primed MEX-5 and MEX-6.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Polo kinases (PLK-1, PLK-2) bind MEX-5 and MEX-6 via their polo-box domains and regulate their activity.</div>
+
+                        <div class="finding-text">"We show that polo kinases, via their polo box domains, bind to and regulate the activity of two key polarity proteins, MEX-5 and MEX-6."</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Asymmetric localization of the polo kinases depends on MEX-5 and MEX-6.</div>
+
+                        <div class="finding-text">"This asymmetric localization of polo kinases depends on MEX-5 and MEX-6, as well as genes regulating MEX-5 and MEX-6 asymmetry."</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <div class="finding-statement">MBK-2/DYRK2 primes the polo-docking threonine (T186 in MEX-5) for polo kinase-dependent phosphorylation during the oocyte-to-embryo transition.</div>
+
+                        <div class="finding-text">"We also show that MBK-2, a developmentally regulated DYRK2 kinase activated at meiosis II, primes T(186) for subsequent polo kinase-dependent phosphorylation."</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Questions for Experts</h2>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Does MEX-6 have any non-redundant function, target mRNA, tissue, or developmental timing distinct from MEX-5, or is it a purely redundant backup copy?</p>
+
+                    <p style="margin-top: 0.5rem;"><em>Suggested experts: Lin R, Priess JR</em></p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q09436" data-a="Q: Does MEX-6 have any non-redundant function, target..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Is the RNA-binding activity of MEX-6 required for its role in embryonic polarity, and does MEX-6 (like MEX-5) bind poly-U tracts with low sequence specificity?</p>
+
+                    <p style="margin-top: 0.5rem;"><em>Suggested experts: Ryder SP</em></p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q09436" data-a="Q: Is the RNA-binding activity of MEX-6 required for ..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Experiments</h2>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Perform iCLIP/CLIP-seq on endogenously tagged MEX-6 in early embryos to define its direct mRNA targets genome-wide and compare them to MEX-5 targets, testing whether MEX-6 has any private target repertoire.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: MEX-6 binds essentially the same poly-U-rich 3&#39;-UTR set as MEX-5, consistent with full functional redundancy.</em></p>
+
+
+                </div>
+                <span class="vote-buttons" data-g="Q09436" data-a="EXPERIMENT: Perform iCLIP/CLIP-seq on endogenously tagged MEX-..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Generate RNA-binding-deficient MEX-6 zinc-finger mutants at the endogenous locus in a mex-5 null background and assay embryonic viability and PLK-1/PIE-1 asymmetry, to test whether MEX-6 RNA binding is required for its polarity function.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: MEX-6 RNA binding is required for anterior enrichment and for establishing determinant asymmetry when MEX-5 is absent.</em></p>
+
+
+                </div>
+                <span class="vote-buttons" data-g="Q09436" data-a="EXPERIMENT: Generate RNA-binding-deficient MEX-6 zinc-finger m..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Live-image endogenously tagged MEX-6 together with a P-granule marker (e.g. PGL-1) to determine whether the curated P-granule signal reflects stable residence or transient association, and whether MEX-6 promotes anterior P-granule dissolution as reported for MEX-5.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: MEX-6 is anterior-enriched and only transiently overlaps P granules, mirroring the P-granule-antagonizing behaviour of MEX-5.</em></p>
+
+
+                </div>
+                <span class="vote-buttons" data-g="Q09436" data-a="EXPERIMENT: Live-image endogenously tagged MEX-6 together with..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Knowledge Gaps</h2>
+        <p style="color: #555; font-size: 0.92rem; margin-top: -0.3rem;">
+            What is <em>not</em> known — curated, literature-grounded statements of the open
+            unknowns (the inverse of core functions).
+        </p>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The non-redundant, MEX-6-specific contribution to embryonic polarity is undefined. It is unknown whether MEX-6 has any private target mRNA, tissue, developmental timing, or molecular activity distinct from its near-identical paralog MEX-5, or whether it is a functionally interchangeable backup copy.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">RESIDUAL_SUBGAP</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> It is firmly established that mex-5 and mex-6 are nearly identical genes that act together to link PAR asymmetry to downstream determinant asymmetries, and that the mex-6 contribution is exposed genetically only in a mex-5-sensitized background (mex-6 RNAi in mex-5(zu199) causes loss of PLK-1 asymmetry). MEX-5 is consistently the dominant, better-characterized paralog.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Distinguishing genuine redundancy from division of labor is central to understanding the robustness of the soma/germline decision and whether MEX-6 is a dispensable paralog or a buffer with its own regulatory inputs.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Endogenous single- and double-null comparisons with quantitative determinant readouts, plus paralog-specific CLIP-seq, to test for any MEX-6-only target or phenotype.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"We provide evidence that two nearly identical genes, mex-5 and mex-6, link PAR asymmetry to those subsequent protein asymmetries."</em> — PMID:10882103</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The direct mRNA targets of MEX-6 and its RNA-binding specificity have not been determined for MEX-6 itself. All biochemical RNA-recognition data (poly-U tract, high affinity, low specificity, discriminator residue) come from the paralog MEX-5.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">MF_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> MEX-6 has two tandem C3H1-type CCCH zinc fingers of the TTP/ZFP36 family and a curated experimental mRNA 3&#39;-UTR-binding activity, so it is an mRNA-binding protein; but no MEX-6-specific binding constants, motif, or target set are published, and even for MEX-5 the field notes that its binding cannot by itself specify target selection.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Without direct MEX-6 targets it is impossible to assign a specific molecular mechanism (repression, competition, stabilization) to the polarity phenotype, leaving MEX-6 mechanistically dark despite a well-defined developmental role.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> MEX-6-specific in vitro binding measurements and in vivo CLIP-seq to define the motif preference and target set directly.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"This sequence is remarkably abundant in the 3&#39;-untranslated region of C. elegans transcripts, demonstrating that MEX-5 alone cannot specify mRNA target selection."</em> — PMID:17264081</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> Whether MEX-6 RNA binding is required for its function in anterior-posterior polarity is untested for MEX-6. It is unknown whether zinc-finger/RNA-binding-dead MEX-6 can still form an anterior gradient, dock PLK-1/PLK-2, and support determinant asymmetry when MEX-5 is absent.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">RESIDUAL_SUBGAP</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> The polo-docking arm of MEX-6 function is well mapped (MBK-2-primed Thr-190, polo-box binding, requirement for PLK-1/PLK-2 asymmetry), and the RNA-binding-to-polarity link has been argued for MEX-5; but no separation-of-function RNA-binding mutant of MEX-6 has been assayed in vivo.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> This determines whether MEX-6&#39;s essential activity is RNA-binding, a protein-scaffold (polo-adaptor) role, or both, and therefore which molecular function should anchor its polarity annotation.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Endogenous RNA-binding-deficient MEX-6 zinc-finger mutants assayed in a mex-5 null background for gradient formation, PLK-1 docking, and determinant asymmetry.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"We show that polo kinases, via their polo box domains, bind to and regulate the activity of two key polarity proteins, MEX-5 and MEX-6."</em> — PMID:18199581</li>
+
+            </ul>
+
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Tags</h2>
+        <div class="aliases">
+
+            <span class="badge">caeel-p-granules</span>
+
+        </div>
+    </div>
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Deep Research Sections -->
+
+    <div class="section">
+        <h2 class="section-title">Deep Research</h2>
+
+        <details class="deep-research-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; gap: 1rem;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Falcon</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(mex-6-deep-research-falcon.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="Q09436" data-a="DEEP_RESEARCH: Falcon" data-r="" data-act="DEEP_RESEARCH" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This deep research is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This deep research needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+
+                <div class="report-meta">
+
+                    <span class="report-meta-text">Comprehensive Research Report: MEX-6 (Zinc Finger Protein mex-6) in *Caenorhabditis elegans*</span>
+
+
+                    <span class="report-badge">Falcon</span>
+
+
+                    <span class="report-badge">Edison Scientific Literature</span>
+
+
+                    <span class="report-badge">33 citations</span>
+
+
+                    <span class="report-badge">2 artifacts</span>
+
+
+                    <span class="report-meta-text">2026-07-04T18:38:04.328597</span>
+
+
+
+                </div>
+
+
+                <div class="artifact-list">
+
+
+
+                    <div class="artifact-link">
+                        <a href="mex-6-deep-research-falcon_artifacts/artifact-00.md" class="term-link">Edison artifact artifact-00</a>
+                        <span>(text/markdown)</span>
+                    </div>
+
+
+
+
+                    <div class="artifact-link">
+                        <a href="mex-6-deep-research-falcon_artifacts/artifact-01.md" class="term-link">Edison artifact artifact-01</a>
+                        <span>(text/markdown)</span>
+                    </div>
+
+
+                </div>
+
+                <p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h1 id="comprehensive-research-report-mex-6-zinc-finger-protein-mex-6-in-caenorhabditis-elegans">Comprehensive Research Report: MEX-6 (Zinc Finger Protein mex-6) in <em>Caenorhabditis elegans</em></h1>
+<p><strong>Gene:</strong> mex-6 (ORFName: AH6.5) | <strong>UniProt:</strong> Q09436 | <strong>Organism:</strong> <em>Caenorhabditis elegans</em></p>
+<h2 id="1-geneprotein-identity-and-domain-architecture">1. Gene/Protein Identity and Domain Architecture</h2>
+<p>MEX-6 (Muscle EXcess-6) is a maternally supplied, cytoplasmic CCCH-type tandem zinc finger (TZF) RNA-binding protein in <em>C. elegans</em>. It shares greater than 50% sequence identity with its paralog MEX-5 and contains two tandem CCCH zinc finger motifs belonging to the ZFP36/tristetraprolin-like superfamily (InterPro: IPR045877, IPR000571) (albarqi2023theroleof pages 8-9, tavella2020adisordertoordertransition pages 1-2). The tandem zinc finger domain is the primary RNA-binding module, and structural studies of the highly similar MEX-5 TZF domain (residues 268–341) reveal that each zinc finger coordinates a zinc ion through three cysteines and one histidine (CCCH motif), and adopts a fold similar to the vertebrate TIS11d/tristetraprolin family (tavella2020adisordertoordertransition pages 6-7, tavella2020adisordertoordertransition pages 1-2). A notable feature is that in the RNA-free state, the N-terminal zinc finger exists in a partially unstructured, molten-globule conformation and undergoes a disorder-to-order transition upon RNA binding, which is required for stable zinc coordination and high-affinity RNA recognition (tavella2020adisordertoordertransition pages 1-2, tavella2020adisordertoordertransition pages 12-13).</p>
+<table>
+<thead>
+<tr>
+<th>Protein name</th>
+<th>Gene name</th>
+<th>Organism</th>
+<th>UniProt ID</th>
+<th>Protein domains</th>
+<th>Molecular function</th>
+<th>Subcellular localization</th>
+<th>Biological processes</th>
+<th>Key interaction partners</th>
+<th>Phenotype of loss</th>
+<th>RNA-binding specificity</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Zinc finger protein MEX-6</td>
+<td>mex-6 (ORF AH6.5)</td>
+<td><em>Caenorhabditis elegans</em></td>
+<td>Q09436</td>
+<td>Tandem CCCH-type zinc finger / ZFP36-like RNA-binding domains; functionally treated as a MEX-5 paralog with related RNA-binding properties (albarqi2023theroleof pages 8-9, tavella2020adisordertoordertransition pages 5-6, tavella2020adisordertoordertransition pages 1-2)</td>
+<td>RNA-binding polarity mediator and translational regulator acting partially redundantly with MEX-5; promotes soma-specific translation of targets such as <em>zif-1</em> and contributes to degradation or exclusion of germline determinants from somatic blastomeres (rose2014polarityestablishmentasymmetric pages 26-29, rose2014polarityestablishmentasymmetric pages 24-26, wang2013germcellspecification. pages 4-6)</td>
+<td>Maternally supplied cytoplasmic protein; initially broadly distributed, then enriched in the anterior cytoplasm of the 1-cell embryo and inherited preferentially by anterior blastomeres; later also associated with posterior germline/P-granule-rich lineages in broader MEX-5/6 descriptions (rose2014polarityestablishmentasymmetric pages 24-26, nance2005parproteinsand pages 1-2, oldenbroek2013regulationofmaternal pages 6-7, albarqi2023theroleof pages 8-9)</td>
+<td>Asymmetric cell division, embryonic polarity, germline specification, anti-germ-plasm activity in somatic lineages, P granule segregation/disassembly, maternal mRNA turnover, and cell fate specification (wang2013germcellspecification. pages 4-6, wang2013germcellspecification. pages 3-4)</td>
+<td>MEX-5 (partially redundant paralog), PAR-1 (upstream kinase controlling gradient behavior), PLK-1/PLK-2 (physical association via polo-box domains), MEX-3, PIE-1, POS-1, MEX-1, ZIF-1 pathway components (rose2014polarityestablishmentasymmetric pages 26-29, griffin2011regulationofthe pages 10-11, wu2015couplingbetweencytoplasmic pages 5-6, rose2014polarityestablishmentasymmetric pages 24-26)</td>
+<td><em>mex-6</em> single mutants are largely viable with relatively mild effects, but loss or depletion of <em>mex-6</em> strongly enhances <em>mex-5</em> defects, causing more severe embryonic patterning and cell fate abnormalities; thus MEX-6 has a partially redundant backup role (albarqi2023theroleof pages 8-9)</td>
+<td>Direct specificity is best defined for the close paralog MEX-5: broad affinity for poly-U/uridine-rich 3'UTR sequences, including UAUU- and AU-rich motifs, with 6-8 uridines in an ~8-nt window; MEX-6 is inferred to have similar specificity because it is highly related and partially redundant (tavella2020adisordertoordertransition pages 5-6, tavella2020adisordertoordertransition pages 10-12, albarqi2023theroleof pages 8-9)</td>
+</tr>
+</tbody>
+</table>
+<p><em>Table: This table summarizes the core identity, function, localization, pathway role, and phenotype of the C. elegans RNA-binding protein MEX-6. It is useful as a compact reference for functional annotation grounded in primary and review evidence.</em></p>
+<h2 id="2-rna-binding-specificity-and-biochemical-function">2. RNA-Binding Specificity and Biochemical Function</h2>
+<p>MEX-6 functions as a broad-specificity RNA-binding protein. Although direct biochemical characterization has focused primarily on the closely related paralog MEX-5 (which has near-identical zinc finger sequences), the functional redundancy between the two proteins strongly supports conserved RNA-binding properties. MEX-5's TZF domain binds poly-U-rich RNA sequences with submicromolar affinity, recognizing uridine-rich motifs containing 6–8 uridines within an ~8-nucleotide window (tavella2020adisordertoordertransition pages 5-6, tavella2020adisordertoordertransition pages 10-12). Each zinc finger recognizes approximately a four-nucleotide motif, with a preference for UAUU and UUUU elements. The highest affinity sequences include AU-rich elements (AREs) such as those found in the 3′-UTR of TNF-α mRNA (Kd,app = 16 ± 1 nM for ARE13 oligonucleotide 5′-UUUUAUUUAUUUU-3′) (tavella2020adisordertoordertransition pages 6-7, tavella2020adisordertoordertransition pages 4-5). Importantly, MEX-5 (and by extension MEX-6) displays lower RNA-binding specificity than mammalian TTP/TIS11d, a feature attributed to its shorter helix and flexible glycine-rich loop between the first and second zinc-coordinating cysteines (tavella2020adisordertoordertransition pages 10-12). This broad specificity is functionally significant: MEX-5/6 act as general RNA-binding proteins that can compete with other RNA-binding proteins for access to mRNAs throughout the cytoplasm (tavella2020adisordertoordertransition pages 2-3).</p>
+<h2 id="3-primary-molecular-functions">3. Primary Molecular Functions</h2>
+<p>MEX-6 is not an enzyme in the classical sense; rather, it is a <strong>cytoplasmic RNA-binding polarity mediator</strong> that functions through several interconnected mechanisms:</p>
+<h3 id="31-translational-regulation">3.1. Translational Regulation</h3>
+<p>MEX-6 positively regulates translation of specific mRNAs in somatic blastomeres. Most notably, MEX-5/6 promote translation of the <em>zif-1</em> mRNA by binding its 3′-UTR and antagonizing translational repressors, thereby allowing ZIF-1 protein expression in somatic (AB) cells (rose2014polarityestablishmentasymmetric pages 26-29, rose2014polarityestablishmentasymmetric pages 24-26). ZIF-1 is a SOCS-box E3 ubiquitin ligase adaptor that targets CCCH zinc finger germline proteins (PIE-1, POS-1, MEX-1) for proteasomal degradation, thereby clearing germ plasm from somatic lineages (wang2013germcellspecification. pages 4-6, rose2014polarityestablishmentasymmetric pages 24-26).</p>
+<h3 id="32-competition-for-rna-and-p-granule-dissolution">3.2. Competition for RNA and P Granule Dissolution</h3>
+<p>MEX-5/6 dissolve P granule condensates (germ granules) in the anterior cytoplasm through competitive RNA binding. In vitro reconstitution studies demonstrated that MEX-5 dissolves preassembled PGL-3/RNA condensates by competing with PGL-3 for RNA binding. MEX-5 has approximately sevenfold higher RNA affinity than PGL-3 (Kd = 0.52 μM vs. 3.42 μM for poly-rU), and its zinc finger domain is essential for this activity—deletion of the zinc finger domain abolishes condensate disassembly (lewis2025amechanismfor pages 1-2, lewis2025amechanismfor pages 7-8, lewis2025amechanismfor pages 3-4, lewis2025amechanismfor pages 6-7). The mechanism involves MEX-5 sequestering RNA away from PGL-3, thereby shifting the phase boundary and reducing the free energy driving condensate formation (lewis2025amechanismfor pages 7-8, lewis2025amechanismfor pages 6-7).</p>
+<h3 id="33-regulation-of-protein-mobility-gradients">3.3. Regulation of Protein Mobility Gradients</h3>
+<p>MEX-5/6 act in a concentration-dependent manner to increase the diffusional mobility of germline determinants PIE-1, POS-1, and MEX-1 in the anterior cytoplasm. This creates opposing diffusion gradients: PIE-1 and POS-1 diffuse fast in the anterior (where MEX-5/6 is high) and slow in the posterior, leading to their posterior accumulation by a diffusion-retention mechanism (wu2015couplingbetweencytoplasmic pages 5-6, wu2015couplingbetweencytoplasmic pages 2-3, wu2015couplingbetweencytoplasmic pages 1-2). The proposed mechanism involves MEX-5/6 competing with these proteins for common target mRNAs, thereby releasing them from slow-diffusing RNA-bound complexes (wu2015couplingbetweencytoplasmic pages 5-6).</p>
+<h3 id="34-recruitment-of-mrna-decay-machinery">3.4. Recruitment of mRNA Decay Machinery</h3>
+<p>MEX-5/6 activity is temporally correlated with recruitment of LSM-1 (an Sm-like protein involved in mRNA decapping) and CCF-1 (a CCR4/NOT deadenylase complex component) to P bodies at the 4-cell stage. In embryos depleted of MEX-5/6, LSM-1 is not recruited to P bodies and maternal mRNAs remain stabilized, indicating that MEX-5/6 promote maternal mRNA turnover in somatic blastomeres (wang2013germcellspecification. pages 4-6).</p>
+<h2 id="4-subcellular-localization">4. Subcellular Localization</h2>
+<p>MEX-6 is a maternally supplied cytoplasmic protein whose distribution changes dynamically during early embryonic development. Initially uniformly distributed in the cytoplasm of the newly fertilized zygote, MEX-6 becomes asymmetrically enriched in the anterior cytoplasm by the end of the one-cell stage and is preferentially inherited by the AB (somatic) daughter cell upon the first division (rose2014polarityestablishmentasymmetric pages 24-26, nance2005parproteinsand pages 1-2). In subsequent divisions, MEX-5/6 are present at higher levels in anterior/somatic blastomeres (AB, EMS lineages) and are associated with P granules in posterior blastomeres and their descendants at later stages (albarqi2023theroleof pages 8-9, nance2005parproteinsand pages 1-2). MEX-6 also localizes to distal oocytes in the gonad (albarqi2023theroleof pages 8-9).</p>
+<h2 id="5-mechanism-of-gradient-formation-the-par-1pp2a-diffusion-retention-system">5. Mechanism of Gradient Formation: The PAR-1/PP2A Diffusion-Retention System</h2>
+<p>The anterior enrichment of MEX-5/6 is established through a spatially segregated kinase/phosphatase cycle rather than through directed transport, localized synthesis, or degradation. PAR-1 kinase, enriched at the posterior cortex and cytoplasm, directly phosphorylates MEX-5 at serine residues S404 and S458, shifting it from slow-diffusing RNA-bound complexes (~0.086 μm²/s) into fast-diffusing complexes (~5.15 μm²/s) (griffin2011regulationofthe pages 10-11, griffin2011regulationofthe pages 1-2, griffin2011regulationofthe pages 8-9). The uniformly distributed phosphatase PP2A dephosphorylates MEX-5, returning it to slow-diffusing, RNA-associated states (griffin2011regulationofthe pages 10-11, gubieda2020goingwiththe pages 12-13, wu2015couplingbetweencytoplasmic pages 2-3). The result is that phosphorylated MEX-5/6 rapidly diffuse away from the posterior while dephosphorylated MEX-5/6 accumulate anteriorly in slow-diffusing, RNA-bound complexes. Mathematical modeling demonstrates that this spatially segregated phosphorylation–dephosphorylation cycle is sufficient to generate the observed ~2.9-fold anterior–posterior concentration gradient without requiring protein synthesis or degradation (griffin2011regulationofthe pages 1-2, griffin2011regulationofthe pages 8-9).</p>
+<h2 id="6-signaling-pathway-and-protein-interactions">6. Signaling Pathway and Protein Interactions</h2>
+<p>MEX-6 operates within a hierarchical signaling pathway linking cortical PAR polarity to cytoplasmic cell fate determination:</p>
+<table>
+<thead>
+<tr>
+<th>Component</th>
+<th>Localization</th>
+<th>Relationship to MEX-5/6</th>
+<th>Function in pathway</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>PAR-1 kinase</td>
+<td>Posterior cortex/cytoplasm of the zygote and posterior blastomeres</td>
+<td>Upstream regulator; phosphorylates MEX-5/6, shifting them into faster-diffusing states in the posterior and thereby helping generate the anterior-high MEX-5/6 gradient (wang2013germcellspecification. pages 3-4, griffin2011regulationofthe pages 10-11, gubieda2020goingwiththe pages 12-13, griffin2011regulationofthe pages 1-2)</td>
+<td>Couples PAR polarity to cytoplasmic fate determinant segregation through a kinase/phosphatase diffusion-retention mechanism (griffin2011regulationofthe pages 10-11, griffin2011regulationofthe pages 1-2)</td>
+</tr>
+<tr>
+<td>PP2A phosphatase</td>
+<td>Broadly/uniformly distributed in the zygote cytoplasm</td>
+<td>Antagonizes PAR-1 by dephosphorylating MEX-5/6, promoting slow-diffusing RNA-bound states and anterior retention (griffin2011regulationofthe pages 10-11, gubieda2020goingwiththe pages 12-13, wu2015couplingbetweencytoplasmic pages 2-3)</td>
+<td>Maintains the phosphorylation cycle that stabilizes the MEX-5/6 concentration gradient without requiring localized synthesis or degradation (griffin2011regulationofthe pages 10-11, griffin2011regulationofthe pages 1-2)</td>
+</tr>
+<tr>
+<td>MEX-5/MEX-6</td>
+<td>Initially uniform; then enriched in anterior cytoplasm of the 1-cell embryo and inherited mainly by anterior blastomeres; later associated with posterior germline/P-granule-related compartments (albarqi2023theroleof pages 8-9, rose2014polarityestablishmentasymmetric pages 24-26, nance2005parproteinsand pages 1-2)</td>
+<td>Core polarity mediators; partially redundant CCCH zinc-finger RNA-binding proteins that bind U-rich 3'UTR sequences and regulate mRNA translation, RNA turnover, protein mobility gradients, and germ plasm asymmetry (wang2013germcellspecification. pages 4-6, rose2014polarityestablishmentasymmetric pages 24-26, tavella2020adisordertoordertransition pages 5-6, tavella2020adisordertoordertransition pages 10-12)</td>
+<td>Convert cortical polarity into asymmetric cell fate specification by promoting somatic anti-germ-plasm activity, translational activation of zif-1, recruitment of decay factors, and anterior dissolution/exclusion of germline determinants (wang2013germcellspecification. pages 4-6, rose2014polarityestablishmentasymmetric pages 24-26)</td>
+</tr>
+<tr>
+<td>PIE-1</td>
+<td>Posterior-enriched cytoplasm and germline blastomeres</td>
+<td>Downstream target opposed by MEX-5/6; MEX-5/6 increase PIE-1 mobility in the anterior and promote its post-division degradation in somatic cells through ZIF-1-dependent mechanisms (rose2014polarityestablishmentasymmetric pages 26-29, wu2015couplingbetweencytoplasmic pages 5-6, rose2014polarityestablishmentasymmetric pages 24-26, wu2015couplingbetweencytoplasmic pages 1-2)</td>
+<td>Germline determinant whose posterior enrichment and somatic clearance help distinguish germline from soma (wang2013germcellspecification. pages 4-6, rose2014polarityestablishmentasymmetric pages 24-26)</td>
+</tr>
+<tr>
+<td>POS-1</td>
+<td>Posterior cytoplasm and germline blastomeres</td>
+<td>Opposed by MEX-5/6; MEX-5/6 help restrict POS-1 to germline by promoting ZIF-1 expression in soma and by competing for shared RNA substrates that alter POS-1 mobility (wang2013germcellspecification. pages 4-6, wu2015couplingbetweencytoplasmic pages 5-6, rose2014polarityestablishmentasymmetric pages 24-26)</td>
+<td>CCCH zinc-finger cell fate determinant contributing to posterior/germline identity; must be excluded or degraded in somatic blastomeres (wang2013germcellspecification. pages 4-6, rose2014polarityestablishmentasymmetric pages 24-26)</td>
+</tr>
+<tr>
+<td>PLK-1</td>
+<td>Enriched in the anterior cytoplasm/cells</td>
+<td>Physical interactor recruited by MEX-5/6; association with polo-box domains helps generate anterior PLK-1 enrichment, and MEX-5-dependent PLK-1 activity promotes polarization of posterior determinants such as POS-1 and MEX-1 (rose2014polarityestablishmentasymmetric pages 26-29)</td>
+<td>Promotes somatic cell-cycle features and phosphorylation-dependent segregation dynamics downstream of the MEX-5/6 gradient (wang2013germcellspecification. pages 4-6, rose2014polarityestablishmentasymmetric pages 26-29)</td>
+</tr>
+<tr>
+<td>ZIF-1</td>
+<td>Expressed in somatic blastomeres where its translation is activated</td>
+<td>Key downstream effector positively regulated at the translational level by MEX-5/6 through the zif-1 3'UTR; executes degradation of CCCH zinc-finger germline proteins in soma (rose2014polarityestablishmentasymmetric pages 26-29, rose2014polarityestablishmentasymmetric pages 24-26)</td>
+<td>SOCS-box/E3 ubiquitin ligase substrate adaptor that clears PIE-1, POS-1, and related germ plasm proteins from somatic lineages (wang2013germcellspecification. pages 4-6, rose2014polarityestablishmentasymmetric pages 24-26)</td>
+</tr>
+<tr>
+<td>P granules / PGL-3 condensates</td>
+<td>Posterior cytoplasm and germline blastomeres</td>
+<td>Indirectly antagonized by MEX-5/6; MEX-5-driven RNA competition dissolves PGL-3/RNA condensates in the anterior, while low MEX-5/6 posteriorly permits granule stability and germ plasm retention (wang2013germcellspecification. pages 3-4, lewis2025amechanismfor pages 1-2, lewis2025amechanismfor pages 3-4, lewis2025amechanismfor pages 6-7)</td>
+<td>Membraneless germ plasm condensates whose posterior assembly/retention supports germ cell fate, whereas anterior disassembly prevents ectopic germline specification in soma (wang2013germcellspecification. pages 3-4, lewis2025amechanismfor pages 1-2)</td>
+</tr>
+</tbody>
+</table>
+<p><em>Table: This table summarizes the core components of the MEX-6/MEX-5 polarity and germline-specification pathway in the early C. elegans embryo. It highlights where each component localizes, how it relates to MEX-5/6, and the specific function it serves in asymmetric cell fate regulation.</em></p>
+<p>Key protein–protein interactions of MEX-6 include:</p>
+<ul>
+<li><strong>PLK-1/PLK-2 (Polo-like kinases):</strong> MEX-6 physically associates with PLK-1 and PLK-2 through their polo-box domains (PBD), as demonstrated by yeast two-hybrid assays. This interaction recruits PLK-1 to the anterior cytoplasm, where PLK-1 phosphorylates posterior determinants such as POS-1 and MEX-1 to promote their polarization (rose2014polarityestablishmentasymmetric pages 26-29).</li>
+<li><strong>MEX-3:</strong> MEX-6 interacts with MEX-3, another CCCH zinc finger RNA-binding protein, potentially stabilizing MEX-3 protein levels (rose2014polarityestablishmentasymmetric pages 26-29).</li>
+<li><strong>PIE-1, POS-1, MEX-1:</strong> MEX-5/6 do not appear to interact directly with these proteins but rather compete for shared RNA substrates, creating coupled mobility gradients that drive the posterior enrichment of these germline determinants (wu2015couplingbetweencytoplasmic pages 5-6, wu2015couplingbetweencytoplasmic pages 2-3).</li>
+</ul>
+<h2 id="7-functional-redundancy-with-mex-5">7. Functional Redundancy with MEX-5</h2>
+<p>MEX-6 and MEX-5 are partially redundant paralogs. Critically, <em>mex-6</em> null mutant animals produce viable eggs that develop normally, whereas <em>mex-5</em> null mutants produce lethal eggs with developmental defects (albarqi2023theroleof pages 8-9). However, when <em>mex-6</em> is depleted in a <em>mex-5</em> null background, embryonic defects are significantly more severe than in <em>mex-5</em> single mutants, demonstrating that MEX-6 contributes meaningfully to embryonic patterning but in a manner only visible when MEX-5 function is compromised (albarqi2023theroleof pages 8-9). Double loss of <em>mex-5</em> and <em>mex-6</em> (through combined mutation and RNAi) results in failure to segregate P granules and PIE-1, failure to recruit LSM-1 to P bodies, stabilization of maternal mRNAs, ectopic expression of germline factors in somatic cells, and severe cell fate transformation phenotypes (wang2013germcellspecification. pages 4-6, wang2013germcellspecification. pages 3-4).</p>
+<h2 id="8-biological-role-anti-germ-plasm-activity-and-germlinesoma-distinction">8. Biological Role: Anti-Germ-Plasm Activity and Germline–Soma Distinction</h2>
+<p>The overarching biological role of MEX-6 (together with MEX-5) is to serve as a cytoplasmic "anti-germ plasm" factor that ensures the distinction between germline and somatic cell fates during early embryogenesis (wang2013germcellspecification. pages 4-6). The germline–soma boundary in <em>C. elegans</em> depends not on the active specification of germline identity per se, but rather on the active degradation and exclusion of germ plasm components from somatic lineages—a function executed by MEX-5/6 (wang2013germcellspecification. pages 4-6). MEX-5/6 accomplish this through at least three complementary mechanisms: (i) promoting anterior P granule disassembly through competitive RNA binding (wang2013germcellspecification. pages 3-4, lewis2025amechanismfor pages 1-2), (ii) activating ZIF-1-dependent ubiquitin-mediated degradation of germline CCCH zinc finger proteins in somatic cells (wang2013germcellspecification. pages 4-6, rose2014polarityestablishmentasymmetric pages 24-26), and (iii) recruiting mRNA decay machinery (LSM-1, CCR4/NOT) to destabilize maternal mRNAs in somatic blastomeres (wang2013germcellspecification. pages 4-6). Mutual antagonism between MEX-5/6 and PAR-1 creates a regulatory feedback loop that maintains germ plasm asymmetry through successive P blastomere divisions (wang2013germcellspecification. pages 4-6, wang2013germcellspecification. pages 3-4).</p>
+<h2 id="9-summary">9. Summary</h2>
+<p>MEX-6 is a CCCH-type tandem zinc finger RNA-binding protein that functions as a central polarity mediator in the early <em>C. elegans</em> embryo. It is not an enzyme but rather a regulatory RNA-binding protein whose primary biochemical activity is the broad-specificity binding of poly-U-rich sequences in mRNA 3′-UTRs. Through this RNA-binding activity, MEX-6 executes multiple downstream functions: dissolving P granule condensates by competing for RNA, activating translation of the E3 ligase adaptor ZIF-1, generating opposing diffusion gradients of germline determinants, and recruiting mRNA decay factors. These activities collectively ensure the clearance of germ plasm from somatic lineages, thereby establishing the fundamental germline–soma distinction during <em>C. elegans</em> embryogenesis. MEX-6 acts partially redundantly with its paralog MEX-5; while <em>mex-6</em> single mutants are viable, MEX-6 is essential for robust embryonic patterning when MEX-5 function is compromised.</p>
+<p>References</p>
+<ol>
+<li>
+<p>(albarqi2023theroleof pages 8-9): Mennatallah M. Y. Albarqi and Sean P. Ryder. The role of rna-binding proteins in orchestrating germline development in caenorhabditis elegans. Frontiers in Cell and Developmental Biology, Jan 2023. URL: https://doi.org/10.3389/fcell.2022.1094295, doi:10.3389/fcell.2022.1094295. This article has 32 citations.</p>
+</li>
+<li>
+<p>(tavella2020adisordertoordertransition pages 1-2): Davide Tavella, Asli Ertekin, Hila Schaal, Sean P. Ryder, and Francesca Massi. A disorder-to-order transition mediates rna binding of the caenorhabditis elegans protein mex-5. Biophysical Journal, 118:2001-2014, Apr 2020. URL: https://doi.org/10.1016/j.bpj.2020.02.032, doi:10.1016/j.bpj.2020.02.032. This article has 10 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(tavella2020adisordertoordertransition pages 6-7): Davide Tavella, Asli Ertekin, Hila Schaal, Sean P. Ryder, and Francesca Massi. A disorder-to-order transition mediates rna binding of the caenorhabditis elegans protein mex-5. Biophysical Journal, 118:2001-2014, Apr 2020. URL: https://doi.org/10.1016/j.bpj.2020.02.032, doi:10.1016/j.bpj.2020.02.032. This article has 10 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(tavella2020adisordertoordertransition pages 12-13): Davide Tavella, Asli Ertekin, Hila Schaal, Sean P. Ryder, and Francesca Massi. A disorder-to-order transition mediates rna binding of the caenorhabditis elegans protein mex-5. Biophysical Journal, 118:2001-2014, Apr 2020. URL: https://doi.org/10.1016/j.bpj.2020.02.032, doi:10.1016/j.bpj.2020.02.032. This article has 10 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(tavella2020adisordertoordertransition pages 5-6): Davide Tavella, Asli Ertekin, Hila Schaal, Sean P. Ryder, and Francesca Massi. A disorder-to-order transition mediates rna binding of the caenorhabditis elegans protein mex-5. Biophysical Journal, 118:2001-2014, Apr 2020. URL: https://doi.org/10.1016/j.bpj.2020.02.032, doi:10.1016/j.bpj.2020.02.032. This article has 10 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(rose2014polarityestablishmentasymmetric pages 26-29): Lesilee Rose and Pierre Gonczy. Polarity establishment, asymmetric division and segregation of fate determinants in early c. elegans embryos. WormBook : the online review of C. elegans biology, pages 1-43, Dec 2014. URL: https://doi.org/10.1895/wormbook.1.30.2, doi:10.1895/wormbook.1.30.2. This article has 261 citations.</p>
+</li>
+<li>
+<p>(rose2014polarityestablishmentasymmetric pages 24-26): Lesilee Rose and Pierre Gonczy. Polarity establishment, asymmetric division and segregation of fate determinants in early c. elegans embryos. WormBook : the online review of C. elegans biology, pages 1-43, Dec 2014. URL: https://doi.org/10.1895/wormbook.1.30.2, doi:10.1895/wormbook.1.30.2. This article has 261 citations.</p>
+</li>
+<li>
+<p>(wang2013germcellspecification. pages 4-6): Jennifer T. Wang and Geraldine Seydoux. Germ cell specification. Advances in experimental medicine and biology, 757:17-39, Jun 2013. URL: https://doi.org/10.1007/978-1-4614-4015-4_2, doi:10.1007/978-1-4614-4015-4_2. This article has 97 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(nance2005parproteinsand pages 1-2): Jeremy Nance. Par proteins and the establishment of cell polarity during c. elegans development. BioEssays, 27:126-135, Feb 2005. URL: https://doi.org/10.1002/bies.20175, doi:10.1002/bies.20175. This article has 124 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(oldenbroek2013regulationofmaternal pages 6-7): Marieke Oldenbroek, S. Robertson, Tugba Guven-Ozkan, C. Spike, D. Greenstein, and Rueyling Lin. Regulation of maternal wnt mrna translation in c. elegans embryos. Development, 140:4614-4623, Nov 2013. URL: https://doi.org/10.1242/dev.096313, doi:10.1242/dev.096313. This article has 35 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(wang2013germcellspecification. pages 3-4): Jennifer T. Wang and Geraldine Seydoux. Germ cell specification. Advances in experimental medicine and biology, 757:17-39, Jun 2013. URL: https://doi.org/10.1007/978-1-4614-4015-4_2, doi:10.1007/978-1-4614-4015-4_2. This article has 97 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(griffin2011regulationofthe pages 10-11): Erik E. Griffin, David J. Odde, and Geraldine Seydoux. Regulation of the mex-5 gradient by a spatially segregated kinase/phosphatase cycle. Cell, 146:955-968, Sep 2011. URL: https://doi.org/10.1016/j.cell.2011.08.012, doi:10.1016/j.cell.2011.08.012. This article has 170 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(wu2015couplingbetweencytoplasmic pages 5-6): Youjun Wu, Huaiying Zhang, and Erik E. Griffin. Coupling between cytoplasmic concentration gradients through local control of protein mobility in the caenorhabditis elegans zygote. Molecular Biology of the Cell, 26:2963-2970, Sep 2015. URL: https://doi.org/10.1091/mbc.e15-05-0302, doi:10.1091/mbc.e15-05-0302. This article has 35 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(tavella2020adisordertoordertransition pages 10-12): Davide Tavella, Asli Ertekin, Hila Schaal, Sean P. Ryder, and Francesca Massi. A disorder-to-order transition mediates rna binding of the caenorhabditis elegans protein mex-5. Biophysical Journal, 118:2001-2014, Apr 2020. URL: https://doi.org/10.1016/j.bpj.2020.02.032, doi:10.1016/j.bpj.2020.02.032. This article has 10 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(tavella2020adisordertoordertransition pages 4-5): Davide Tavella, Asli Ertekin, Hila Schaal, Sean P. Ryder, and Francesca Massi. A disorder-to-order transition mediates rna binding of the caenorhabditis elegans protein mex-5. Biophysical Journal, 118:2001-2014, Apr 2020. URL: https://doi.org/10.1016/j.bpj.2020.02.032, doi:10.1016/j.bpj.2020.02.032. This article has 10 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(tavella2020adisordertoordertransition pages 2-3): Davide Tavella, Asli Ertekin, Hila Schaal, Sean P. Ryder, and Francesca Massi. A disorder-to-order transition mediates rna binding of the caenorhabditis elegans protein mex-5. Biophysical Journal, 118:2001-2014, Apr 2020. URL: https://doi.org/10.1016/j.bpj.2020.02.032, doi:10.1016/j.bpj.2020.02.032. This article has 10 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(lewis2025amechanismfor pages 1-2): Natasha S. Lewis, Silja Zedlitz, Hannes Ausserwöger, Patrick M. McCall, Lars Hubatsch, Marco Nousch, Martine Ruer-Gruß, Carsten Hoege, Frank Jülicher, Christian R. Eckmann, Tuomas P. J. Knowles, and Anthony A. Hyman. A mechanism for mex-5-driven disassembly of pgl-3/rna condensates in vitro. Proceedings of the National Academy of Sciences of the United States of America, May 2025. URL: https://doi.org/10.1073/pnas.2412218122, doi:10.1073/pnas.2412218122. This article has 5 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(lewis2025amechanismfor pages 7-8): Natasha S. Lewis, Silja Zedlitz, Hannes Ausserwöger, Patrick M. McCall, Lars Hubatsch, Marco Nousch, Martine Ruer-Gruß, Carsten Hoege, Frank Jülicher, Christian R. Eckmann, Tuomas P. J. Knowles, and Anthony A. Hyman. A mechanism for mex-5-driven disassembly of pgl-3/rna condensates in vitro. Proceedings of the National Academy of Sciences of the United States of America, May 2025. URL: https://doi.org/10.1073/pnas.2412218122, doi:10.1073/pnas.2412218122. This article has 5 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(lewis2025amechanismfor pages 3-4): Natasha S. Lewis, Silja Zedlitz, Hannes Ausserwöger, Patrick M. McCall, Lars Hubatsch, Marco Nousch, Martine Ruer-Gruß, Carsten Hoege, Frank Jülicher, Christian R. Eckmann, Tuomas P. J. Knowles, and Anthony A. Hyman. A mechanism for mex-5-driven disassembly of pgl-3/rna condensates in vitro. Proceedings of the National Academy of Sciences of the United States of America, May 2025. URL: https://doi.org/10.1073/pnas.2412218122, doi:10.1073/pnas.2412218122. This article has 5 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(lewis2025amechanismfor pages 6-7): Natasha S. Lewis, Silja Zedlitz, Hannes Ausserwöger, Patrick M. McCall, Lars Hubatsch, Marco Nousch, Martine Ruer-Gruß, Carsten Hoege, Frank Jülicher, Christian R. Eckmann, Tuomas P. J. Knowles, and Anthony A. Hyman. A mechanism for mex-5-driven disassembly of pgl-3/rna condensates in vitro. Proceedings of the National Academy of Sciences of the United States of America, May 2025. URL: https://doi.org/10.1073/pnas.2412218122, doi:10.1073/pnas.2412218122. This article has 5 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(wu2015couplingbetweencytoplasmic pages 2-3): Youjun Wu, Huaiying Zhang, and Erik E. Griffin. Coupling between cytoplasmic concentration gradients through local control of protein mobility in the caenorhabditis elegans zygote. Molecular Biology of the Cell, 26:2963-2970, Sep 2015. URL: https://doi.org/10.1091/mbc.e15-05-0302, doi:10.1091/mbc.e15-05-0302. This article has 35 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(wu2015couplingbetweencytoplasmic pages 1-2): Youjun Wu, Huaiying Zhang, and Erik E. Griffin. Coupling between cytoplasmic concentration gradients through local control of protein mobility in the caenorhabditis elegans zygote. Molecular Biology of the Cell, 26:2963-2970, Sep 2015. URL: https://doi.org/10.1091/mbc.e15-05-0302, doi:10.1091/mbc.e15-05-0302. This article has 35 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(griffin2011regulationofthe pages 1-2): Erik E. Griffin, David J. Odde, and Geraldine Seydoux. Regulation of the mex-5 gradient by a spatially segregated kinase/phosphatase cycle. Cell, 146:955-968, Sep 2011. URL: https://doi.org/10.1016/j.cell.2011.08.012, doi:10.1016/j.cell.2011.08.012. This article has 170 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(griffin2011regulationofthe pages 8-9): Erik E. Griffin, David J. Odde, and Geraldine Seydoux. Regulation of the mex-5 gradient by a spatially segregated kinase/phosphatase cycle. Cell, 146:955-968, Sep 2011. URL: https://doi.org/10.1016/j.cell.2011.08.012, doi:10.1016/j.cell.2011.08.012. This article has 170 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(gubieda2020goingwiththe pages 12-13): Alicia G. Gubieda, John R. Packer, Iolo Squires, Jack Martin, and Josana Rodriguez. Going with the flow: insights from caenorhabditis elegans zygote polarization. Philosophical Transactions of the Royal Society B, 375:20190555, Aug 2020. URL: https://doi.org/10.1098/rstb.2019.0555, doi:10.1098/rstb.2019.0555. This article has 35 citations.</p>
+</li>
+</ol>
+<h2 id="artifacts">Artifacts</h2>
+<ul>
+<li><a href="mex-6-deep-research-falcon_artifacts/artifact-00.md">Edison artifact artifact-00</a></li>
+<li><a href="mex-6-deep-research-falcon_artifacts/artifact-01.md">Edison artifact artifact-01</a></li>
+</ul>
+<h2 id="citations">Citations</h2>
+<ol>
+<li>albarqi2023theroleof pages 8-9</li>
+<li>tavella2020adisordertoordertransition pages 10-12</li>
+<li>tavella2020adisordertoordertransition pages 2-3</li>
+<li>wu2015couplingbetweencytoplasmic pages 5-6</li>
+<li>rose2014polarityestablishmentasymmetric pages 26-29</li>
+<li>tavella2020adisordertoordertransition pages 1-2</li>
+<li>tavella2020adisordertoordertransition pages 6-7</li>
+<li>tavella2020adisordertoordertransition pages 12-13</li>
+<li>tavella2020adisordertoordertransition pages 5-6</li>
+<li>rose2014polarityestablishmentasymmetric pages 24-26</li>
+<li>nance2005parproteinsand pages 1-2</li>
+<li>oldenbroek2013regulationofmaternal pages 6-7</li>
+<li>griffin2011regulationofthe pages 10-11</li>
+<li>tavella2020adisordertoordertransition pages 4-5</li>
+<li>lewis2025amechanismfor pages 1-2</li>
+<li>lewis2025amechanismfor pages 7-8</li>
+<li>lewis2025amechanismfor pages 3-4</li>
+<li>lewis2025amechanismfor pages 6-7</li>
+<li>wu2015couplingbetweencytoplasmic pages 2-3</li>
+<li>wu2015couplingbetweencytoplasmic pages 1-2</li>
+<li>griffin2011regulationofthe pages 1-2</li>
+<li>griffin2011regulationofthe pages 8-9</li>
+<li>gubieda2020goingwiththe pages 12-13</li>
+<li>https://doi.org/10.3389/fcell.2022.1094295,</li>
+<li>https://doi.org/10.1016/j.bpj.2020.02.032,</li>
+<li>https://doi.org/10.1895/wormbook.1.30.2,</li>
+<li>https://doi.org/10.1007/978-1-4614-4015-4_2,</li>
+<li>https://doi.org/10.1002/bies.20175,</li>
+<li>https://doi.org/10.1242/dev.096313,</li>
+<li>https://doi.org/10.1016/j.cell.2011.08.012,</li>
+<li>https://doi.org/10.1091/mbc.e15-05-0302,</li>
+<li>https://doi.org/10.1073/pnas.2412218122,</li>
+<li>https://doi.org/10.1098/rstb.2019.0555,</li>
+</ol>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(mex-6-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="Q09436" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="mex-6-c-elegans-research-notes">mex-6 (C. elegans) research notes</h1>
+<p>UniProt: Q09436 (MEX6_CAEEL) · WormBase: WBGene00003231 · ORF: AH6.5 · 467 aa<br />
+Gene: mex-6 ("Muscle EXcess 6"). Paralog: mex-5 (Q9XUB2, WBGene00003230).</p>
+<p>These are a working research journal for the AI GO-annotation review. Provenance is<br />
+recorded inline as <code>[PMID:xxxxx "verbatim quote"]</code>. <strong>All cached publications for this<br />
+gene are abstract-only</strong> (<code>full_text_available: false</code> in each <code>publications/PMID_*.md</code>),<br />
+so experimental IDA/IPI/IGI annotations are curated by WormBase from full text I cannot<br />
+see — I defer to the curator on those per project guidelines and use UNDECIDED only where<br />
+neither the abstract nor UniProt can corroborate.</p>
+<h2 id="overriding-caution-mex-5-is-the-dominant-paralog">Overriding caution: mex-5 is the dominant paralog</h2>
+<p>mex-5 and mex-6 are "two nearly identical genes" <a href="https://pubmed.ncbi.nlm.nih.gov/10882103" title="We provide evidence that two nearly identical genes, mex-5 and mex-6, link PAR asymmetry to those subsequent protein asymmetries">PMID:10882103</a>. Almost every mechanistic / biochemical study foregrounds <strong>mex-5</strong>:<br />
+- The RNA-recognition biochemistry (poly-U tract, low specificity, discriminator residue)<br />
+  was done on <strong>MEX-5</strong> <a href="https://pubmed.ncbi.nlm.nih.gov/17264081" title="the TZF protein MEX-5, a primary anterior   determinant, is an RNA-binding protein that recognizes linear RNA sequences with high   affinity but low specificity">PMID:17264081</a>. There is <strong>no equivalent mex-6-specific biochemistry</strong>.<br />
+- The P-granule/phase-separation mRNA-competition mechanism (PMID:27594427) was demonstrated<br />
+  for <strong>MEX-5</strong>, not mex-6.<br />
+Therefore, for mex-6 I treat shared-family/paralog properties as inference and flag them,<br />
+and I rely on the sources that name <strong>mex-6 explicitly</strong> for the strongest calls.</p>
+<h2 id="what-is-known-about-mex-6-specifically-mex-6-named-in-the-source">What is KNOWN about mex-6 specifically (mex-6 named in the source)</h2>
+<ol>
+<li>
+<p><strong>Redundant polarity/soma-germline function with mex-5.</strong> mex-5 and mex-6 together link<br />
+   PAR cortical asymmetry to downstream cytoplasmic protein asymmetries; loss of both (not<br />
+   either alone) produces the strong phenotype <a href="https://pubmed.ncbi.nlm.nih.gov/10882103" title="two nearly identical genes,    mex-5 and mex-6, link PAR asymmetry to those subsequent protein asymmetries">PMID:10882103</a>.<br />
+   UniProt summarizes: mex-6 "Functions with mex-5 to affect embryonic viability, establish<br />
+   soma germline asymmetry in embryos and establish plk-1, pie-1, mex-1, and pos-1 asymmetry<br />
+   in embryos ... Also affects formation of intestinal cells" (Q09436 CC FUNCTION, cites<br />
+   PubMed:10882103, PubMed:18199581).</p>
+</li>
+<li>
+<p><strong>MEX-6 is one of two cytoplasmic CCCH-finger proteins acting in the establishment phase<br />
+   of zygote polarity.</strong> <a href="https://pubmed.ncbi.nlm.nih.gov/12588843" title="The kinase PAR-1 and the CCCH finger proteins MEX-5    and MEX-6 also function during the establishment phase in a feedback loop to regulate    growth of the posterior domain">PMID:12588843</a>. MEX-6 localization dynamics were imaged by GFP fusion<br />
+   alongside MEX-5 <a href="https://pubmed.ncbi.nlm.nih.gov/12588843" title="we have analyzed the localization dynamics of PAR-2,    PAR-6, MEX-5, MEX-6 and PIE-1 in wild-type and mutant embryos">PMID:12588843</a>.</p>
+</li>
+<li>
+<p><strong>MEX-6 binds polo kinases PLK-1 and PLK-2 via their polo-box domains</strong> (direct, mex-6<br />
+   named). <a href="https://pubmed.ncbi.nlm.nih.gov/18199581" title="polo kinases, via their polo box domains, bind to and regulate    the activity of two key polarity proteins, MEX-5 and MEX-6">PMID:18199581</a>. This underpins the IPI<br />
+   annotations GO:0019901 (protein kinase binding) and GO:0019904 (protein domain specific<br />
+   binding), curated by WormBase with <code>with</code> = plk-1 (WBGene00004042) and plk-2<br />
+   (WBGene00004043). UniProt: mex-6 "Interacts (probably when phosphorylated on Thr-190)<br />
+   with plk-1 (via POLO box domain) and plk-2 (via POLO box domain)" (Q09436 CC SUBUNIT).</p>
+</li>
+<li>
+<p><strong>The polo docking is primed by MBK-2/DYRK2 phosphorylation of a Thr near the fingers.</strong><br />
+   In MEX-5 the primed residue is T186; the paralogous residue in MEX-6 is <strong>Thr-190</strong><br />
+   (UniProt MOD_RES 190 "Phosphothreonine", MUTAGEN T190A "Severe reduction in binding to<br />
+   plk-1 and plk-2"; MUTAGEN T190E phosphomimetic "severely abolishes interaction with plk-1<br />
+   and plk-2"), both citing PubMed:18199581. The paper's abstract describes the mechanism on<br />
+   MEX-5's T186 <a href="https://pubmed.ncbi.nlm.nih.gov/18199581" title="MBK-2, a developmentally regulated DYRK2 kinase activated at    meiosis II, primes T(186) for subsequent polo kinase-dependent phosphorylation">PMID:18199581</a>, with<br />
+   mex-6 assayed in the full text (UniProt MUTAGEN evidence is ECO:0000269|PubMed:18199581).</p>
+</li>
+<li>
+<p><strong>MEX-6 is required (redundantly with mex-5) for PLK-1 asymmetry.</strong> UniProt DISRUPTION<br />
+   PHENOTYPE: "RNAi-mediated knockdown in mex-5 zu199 mutant background causes a loss in<br />
+   plk-1 asymmetric distribution during the first embryonic cell divisions"<br />
+   (ECO:0000269|PubMed:18199581). This is the sensitized (mex-5 null) background that exposes<br />
+   the mex-6 contribution — the clearest statement of a mex-6 role beyond mex-5.<br />
+   Supports GO:0032880 (regulation of protein localization), curated IGI with <code>with</code> = mex-5.</p>
+</li>
+<li>
+<p><strong>Subcellular location: cytoplasm.</strong> UniProt SUBCELLULAR LOCATION "Cytoplasm"<br />
+   (ECO:0000250|UniProtKB:Q9XUB2, i.e. by similarity to mex-5). Also curated experimentally:<br />
+   GO:0005737 cytoplasm IDA from PMID:12588843.</p>
+</li>
+<li>
+<p><strong>PTM (by similarity):</strong> "Phosphorylation on Ser-457 by par-1 promotes localization of the<br />
+   protein to the anterior cytoplasm of the zygote" (Q09436 MOD_RES 457, ECO:0000250|<br />
+   UniProtKB:Q9XUB2) — inferred from mex-5, consistent with an anterior gradient like mex-5.</p>
+</li>
+</ol>
+<h2 id="domain-sequence-facts-mex-6-from-uniprot-q09436">Domain / sequence facts (mex-6, from UniProt Q09436)</h2>
+<ul>
+<li>Two C3H1-type (CCCH) tandem zinc fingers: 273–302 and 317–347 (PROSITE PS50103).</li>
+<li>InterPro: IPR045877 (ZFP36-like), IPR000571 + IPR036855 (CCCH znf). PANTHER PTHR12547<br />
+  (CCCH ZINC FINGER/TIS11-RELATED), subfamily PTHR12547:SF18 (PROTEIN TIS11).</li>
+<li>Pfam PF00642 (zf-CCCH ×2), SMART SM00356. =&gt; zinc binding intrinsic to the fold<br />
+  (supports GO:0046872 metal ion binding IEA from InterPro).</li>
+<li>Reactome cross-ref R-CEL-450513 "Tristetraprolin (TTP, ZFP36) binds and destabilizes mRNA"<br />
+  — i.e. the family reference pathway; this is the ancestral TTP-family framing behind the<br />
+  IBA deadenylation/AU-rich terms.</li>
+<li>Disordered/low-complexity N-term and central regions; not a DNA-binding protein: CCCH<br />
+  fingers are RNA-binding (the historical UniProt "DNA-binding" keyword annotation<br />
+  GO:0003677 has been dropped from the current GOA / QuickGO set for this gene).</li>
+</ul>
+<h2 id="mapping-to-existing-goa-annotations-17-in-the-stub-planned-action">Mapping to existing GOA annotations (17 in the stub) + planned action</h2>
+<p>MF (molecular function):<br />
+- GO:0035925 mRNA 3'-UTR AU-rich region binding (IBA) — <strong>MODIFY</strong>. Ancestral TTP/ZFP36<br />
+  (AU-rich) specificity; nematode MEX proteins diverged (discriminator residue) and MEX-5<br />
+  binds poly-U with low specificity, not AREs <a href="https://pubmed.ncbi.nlm.nih.gov/17264081" title="human TZF homologs   tristetraprolin and ERF-2 bind with high specificity to UUAUUUAUU elements ... mutation of   a single amino acid in each MEX-5 zinc finger confers tristetraprolin-like specificity">PMID:17264081</a>.<br />
+  Replace with the more accurate, already-curated GO:0003730 (mRNA 3'-UTR binding).<br />
+- GO:0000289 nuclear-transcribed mRNA poly(A) tail shortening (IBA) — <strong>MARK_AS_OVER_ANNOTATED</strong>.<br />
+  Ancestral TTP deadenylation function (Reactome R-CEL-450513); no direct mex-6 deadenylation<br />
+  evidence; MEX-5/6 literature is about polarity/translational control, not decay.<br />
+- GO:0000900 mRNA regulatory element binding translation repressor activity (IBA) — <strong>UNDECIDED</strong>.<br />
+  Mechanism of MEX-5/6 translational control is not a clean sequence-specific repressor;<br />
+  the best-supported translational output (zif-1 3'UTR) is <em>positive</em> (relieving POS-1<br />
+  repression). No direct mex-6 evidence. (Mirrors mex-5 review.)<br />
+- GO:0005829 cytosol (IBA) — <strong>ACCEPT</strong> (cytoplasmic; consistent with IDA cytoplasm).<br />
+- GO:0160134 protein-RNA sequence-specific adaptor activity (IBA) — <strong>MODIFY</strong> to GO:0003729<br />
+  mRNA binding. Binding is not sequence-specific (poly-U, low specificity in the paralog).<br />
+- GO:0003729 mRNA binding (IEA InterPro) — <strong>ACCEPT</strong> (core MF; CCCH TZF).<br />
+- GO:0046872 metal ion binding (IEA InterPro) — <strong>ACCEPT</strong> (zinc in CCCH fold).<br />
+- GO:0019901 protein kinase binding (IPI PMID:18199581) — <strong>ACCEPT</strong> (binds PLK-1/PLK-2).<br />
+- GO:0019904 protein domain specific binding (IPI PMID:18199581) — <strong>ACCEPT</strong> (polo-box).<br />
+- GO:0003730 mRNA 3'-UTR binding (IDA PMID:17264081) — <strong>ACCEPT</strong>, defer to curator. The<br />
+  cited paper's abstract characterizes MEX-5, but WormBase curated this as a mex-6 IDA from<br />
+  full text; mex-6 is a genuine mRNA/3'UTR-binding TZF protein. Core MF.</p>
+<p>CC (cellular component):<br />
+- GO:0005737 cytoplasm (IEA SubCell) — <strong>ACCEPT</strong>.<br />
+- GO:0005737 cytoplasm (ISS from mex-5 Q9XUB2) — <strong>ACCEPT</strong> (ortholog transfer; also IDA-backed).<br />
+- GO:0005737 cytoplasm (IDA PMID:12588843) — <strong>ACCEPT</strong> (experimental, core location).<br />
+- GO:0043186 P granule (IDA PMID:12588843) — <strong>KEEP_AS_NON_CORE</strong>. Experimental WormBase IDA;<br />
+  MEX-6 is predominantly <em>anterior</em> cytoplasmic (where P granules dissolve), so P-granule<br />
+  association is at best transient/minor and not the core localization. I do NOT REMOVE an<br />
+  experimental IDA whose full text I cannot read (unlike mex-5, mex-6 has no dedicated<br />
+  phase-separation paper establishing it <em>dissolves</em> rather than <em>resides in</em> P granules).<br />
+- GO:0043186 P granule (IEA ARBA, GO_REF:0000117) — <strong>MARK_AS_OVER_ANNOTATED</strong>. Pure<br />
+  machine-learning (ARBA) prediction of P-granule residency for an anterior-enriched TZF<br />
+  protein; redundant with the IDA and exactly the kind of electronic over-propagation to<br />
+  down-weight. Localization (if real) is already captured non-core by the IDA.</p>
+<p>BP (biological process):<br />
+- GO:0017148 negative regulation of translation (IEA, logical inference from GO:0000900) —<br />
+<strong>UNDECIDED</strong> (inherits the uncertainty of GO:0000900; directionality doesn't match the<br />
+  positive zif-1 output).<br />
+- GO:0032880 regulation of protein localization (IGI PMID:18199581, with mex-5) — <strong>ACCEPT</strong>.<br />
+  mex-6 (redundantly with mex-5) establishes plk-1/pie-1/mex-1/pos-1 asymmetry<br />
+  (UniProt CC FUNCTION; DISRUPTION PHENOTYPE for plk-1 asymmetry).</p>
+<h2 id="what-is-genuinely-not-known-about-mex-6-for-knowledge_gaps">What is genuinely NOT known about mex-6 (for knowledge_gaps)</h2>
+<ul>
+<li><strong>The non-redundant/unique contribution of mex-6 vs mex-5 is undefined.</strong> mex-6 single loss<br />
+  is largely silent; phenotypes require removing mex-5 too [PMID:10882103 nearly-identical,<br />
+  redundant]. Whether mex-6 has <em>any</em> private target, tissue, or timing distinct from mex-5<br />
+  is unknown. Boundary: we know the <em>pair</em> is required (UniProt DISRUPTION uses a mex-5(zu199)<br />
+  background to reveal mex-6).</li>
+<li><strong>Direct mex-6 mRNA targets are unknown.</strong> No CLIP/biochemistry on MEX-6 itself; RNA-binding<br />
+  properties are inferred from MEX-5 (poly-U, low specificity) <a href="https://pubmed.ncbi.nlm.nih.gov/17264081">PMID:17264081</a>.</li>
+<li><strong>Whether MEX-6 RNA binding is required for its polarity function is untested for mex-6.</strong><br />
+  The RNA-binding→gradient→polarity link is argued for MEX-5; no mex-6 RNA-binding-mutant<br />
+  in vivo test is published.</li>
+<li><strong>Whether MEX-6 residence in P granules is real or a gradient artefact</strong> (see IDA vs the<br />
+  anterior-enrichment biology).</li>
+</ul>
+<h2 id="falcon-deep-research">Falcon deep research</h2>
+<p>First attempt: <code>just deep-research-falcon worm mex-6 --fallback perplexity-lite</code> — the falcon<br />
+(Edison) provider <strong>timed out after 600s</strong>, and the perplexity-lite fallback returned <strong>HTTP 401<br />
+(insufficient_quota)</strong>, so no deep-research file was produced on the first pass. A second<br />
+falcon-only retry was launched; the wrapper again reported a 600s timeout, but the underlying<br />
+Edison client <strong>did complete just after the timeout and wrote a genuine report</strong><br />
+(<code>mex-6-deep-research-falcon.md</code>, Edison Scientific Literature, 33 citations, 636s duration,<br />
++ <code>_artifacts/</code>). That file is retained as a committed research artifact. Its citations use<br />
+falcon's internal <code>authorYYYY pages</code> format (not PMIDs), and the validator does not check<br />
+non-PMID quotes, so — per project guidance — <strong>I did NOT cite the falcon file in the review</strong>;<br />
+every <code>supporting_text</code> in the review is instead a verbatim substring of a cached PMID abstract,<br />
+grep-verified. The falcon report is consistent with (and corroborates) the review: it independently<br />
+describes mex-6 as the partially redundant paralog of mex-5, the CCCH-TZF poly-U RNA binding, the<br />
+PAR-1/PP2A diffusion gradient, PLK-1/2 polo-box association, and the zif-1/ZIF-1 anti-germ-plasm<br />
+axis. No content in the review was taken uncritically from it, and nothing was fabricated.<br />
+Annotations that could not be corroborated from cached primary sources remain UNDECIDED<br />
+(GO:0000900, GO:0017148).</p>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: Q09436
+gene_symbol: mex-6
+product_type: PROTEIN
+status: COMPLETE
+taxon:
+  id: NCBITaxon:6239
+  label: Caenorhabditis elegans
+description: &gt;-
+  MEX-6 is a cytoplasmic CCCH-type tandem zinc finger (TZF) RNA-binding protein of the
+  TTP/ZFP36 family that functions in the early Caenorhabditis elegans embryo to establish
+  soma/germline asymmetry along the anterior-posterior axis. It is the close, nearly
+  identical paralog of MEX-5 and acts largely redundantly with it: single loss of mex-6 is
+  mostly silent, whereas removing both mex-5 and mex-6 disrupts embryonic viability and the
+  asymmetric distribution of maternally supplied determinants (PLK-1, PIE-1, MEX-1, POS-1).
+  Like MEX-5, MEX-6 is broadly cytoplasmic and becomes anterior-enriched in the one-cell
+  zygote, acting downstream of cortical PAR polarity and the PAR-1 kinase during the
+  establishment phase of polarization. MEX-6 contains two tandem C3H1-type zinc fingers that
+  bind mRNA (including 3&#39;-UTR sequences) and coordinate zinc. It is also a substrate and
+  adaptor for the mitotic Polo-like kinases PLK-1 and PLK-2; MBK-2/DYRK2-primed
+  phosphorylation of a threonine adjacent to the zinc fingers creates a docking site for the
+  polo-box domains of PLK-1/PLK-2, and MEX-5/MEX-6 in turn are required for the anterior
+  enrichment of these kinases.
+references:
+- id: GO_REF:0000002
+  title: Gene Ontology annotation through association of InterPro records with GO terms
+  findings: []
+- id: GO_REF:0000024
+  title: Manual transfer of experimentally-verified manual GO annotation data to orthologs
+    by curator judgment of sequence similarity
+  findings: []
+- id: GO_REF:0000033
+  title: Annotation inferences using phylogenetic trees
+  findings: []
+- id: GO_REF:0000044
+  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location
+    vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt
+  findings: []
+- id: GO_REF:0000108
+  title: Automatic assignment of GO terms using logical inference, based on on inter-ontology
+    links
+  findings: []
+- id: GO_REF:0000117
+  title: Electronic Gene Ontology annotations created by ARBA machine learning models
+  findings: []
+- id: PMID:10882103
+  title: MEX-5 and MEX-6 function to establish soma/germline asymmetry in early C. elegans
+    embryos.
+  findings:
+  - statement: mex-5 and mex-6 are two nearly identical genes that link PAR cortical asymmetry
+      to downstream protein asymmetries.
+    supporting_text: We provide evidence that two nearly identical genes, mex-5 and mex-6,
+      link PAR asymmetry to those subsequent protein asymmetries.
+  - statement: The paralogs act downstream of the PAR network to pattern expression of
+      nonlocalized maternal mRNAs.
+    supporting_text: This network is required for subsequent asymmetries in the expression
+      patterns of several proteins that are encoded by nonlocalized, maternally expressed
+      mRNAs.
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: Founding paper that identifies and names mex-6 (with mex-5); PubMed-verified.
+      Abstract characterizes MEX-5 localization in detail but explicitly establishes the
+      redundant mex-5/mex-6 pair as the link between PAR asymmetry and downstream germline
+      protein asymmetries. Full text abstract-only in cache.
+- id: PMID:12588843
+  title: Polarization of the C. elegans zygote proceeds via distinct establishment and
+    maintenance phases.
+  findings:
+  - statement: Zygote polarization along the A-P axis depends on cortical PAR and cytoplasmic
+      MEX-5/6 proteins.
+    supporting_text: Polarization of the C. elegans zygote along the anterior-posterior axis
+      depends on cortically enriched (PAR) and cytoplasmic (MEX-5/6) proteins
+  - statement: MEX-5 and MEX-6 (CCCH finger proteins) act with PAR-1 in the establishment
+      phase in a feedback loop regulating the posterior domain.
+    supporting_text: The kinase PAR-1 and the CCCH finger proteins MEX-5 and MEX-6 also
+      function during the establishment phase in a feedback loop to regulate growth of
+      the posterior domain.
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: Live imaging of GFP-tagged MEX-6 (with MEX-5, PAR-2/6, PIE-1); places
+      MEX-6 in the establishment phase of zygote polarization. PubMed-verified; abstract-only
+      in cache. Source of the mex-6 IDA cytoplasm and (full-text) P granule annotations.
+- id: PMID:17264081
+  title: Molecular basis of RNA recognition by the embryonic polarity determinant MEX-5.
+  findings:
+  - statement: MEX-5 (the near-identical paralog of MEX-6) binds RNA with high affinity but
+      low sequence specificity, recognizing tracts of six or more uridines.
+    supporting_text: The minimal binding site is a tract of six or more uridines within a
+      9-13-nucleotide window.
+  - statement: Nematode MEX proteins have diverged from the AU-rich-element specificity of
+      mammalian TZF proteins via a single discriminator residue per zinc finger.
+    supporting_text: We show that mutation of a single amino acid in each MEX-5 zinc finger
+      confers tristetraprolin-like specificity to this protein.
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: Biochemistry characterizes MEX-5 specifically, not MEX-6. WormBase curated
+      the mex-6 mRNA 3&#39;-UTR binding IDA citing this paper from full text; MEX-6 is a
+      near-identical TZF paralog so the class RNA-binding behaviour is expected to transfer,
+      but no MEX-6-specific binding constants are published. Used here to justify MODIFY of
+      the AU-rich/sequence-specific IBA terms.
+- id: PMID:18199581
+  title: Polo kinases regulate C. elegans embryonic polarity via binding to DYRK2-primed
+    MEX-5 and MEX-6.
+  findings:
+  - statement: Polo kinases (PLK-1, PLK-2) bind MEX-5 and MEX-6 via their polo-box domains
+      and regulate their activity.
+    supporting_text: We show that polo kinases, via their polo box domains, bind to and
+      regulate the activity of two key polarity proteins, MEX-5 and MEX-6.
+  - statement: Asymmetric localization of the polo kinases depends on MEX-5 and MEX-6.
+    supporting_text: This asymmetric localization of polo kinases depends on MEX-5 and
+      MEX-6, as well as genes regulating MEX-5 and MEX-6 asymmetry.
+  - statement: MBK-2/DYRK2 primes the polo-docking threonine (T186 in MEX-5) for polo
+      kinase-dependent phosphorylation during the oocyte-to-embryo transition.
+    supporting_text: We also show that MBK-2, a developmentally regulated DYRK2 kinase
+      activated at meiosis II, primes T(186) for subsequent polo kinase-dependent
+      phosphorylation.
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: Names MEX-6 explicitly and is the source of the mex-6 IPI (PLK-1/PLK-2,
+      polo-box) and IGI (regulation of protein localization) annotations. In MEX-6 the
+      primed residue is Thr-190 (UniProt MOD_RES 190; MUTAGEN T190A/T190E abolish PLK
+      binding, ECO:0000269|PubMed:18199581). PubMed-verified; abstract-only in cache.
+existing_annotations:
+- term:
+    id: GO:0035925
+    label: mRNA 3&#39;-UTR AU-rich region binding
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: enables
+  review:
+    summary: This IBA is a phylogenetic transfer from the TTP/ZFP36 (tristetraprolin) family,
+      whose members bind AU-rich elements (AREs). MEX-6 is a member of this CCCH TZF family
+      (InterPro IPR045877 ZFP36-like), but the nematode MEX proteins have diverged from ARE
+      specificity. Direct biochemistry on the near-identical paralog MEX-5 shows recognition
+      of poly-uridine tracts with high affinity but low specificity, not the UUAUUUAUU ARE
+      bound by mammalian TTP/ERF-2 (PMID:17264081).
+    action: MODIFY
+    reason: The AU-rich-element specificity implied by this term does not match the diverged
+      binding behaviour of nematode MEX TZF proteins. In MEX-5, a single discriminator
+      residue per zinc finger determines ARE vs poly-U preference, and wild-type MEX-5 binds
+      poly-U promiscuously rather than AREs. There is no MEX-6-specific ARE-binding evidence.
+      A more accurate and already experimentally supported term is mRNA 3&#39;-UTR binding
+      (GO:0003730), which is annotated with IDA for this gene.
+    proposed_replacement_terms:
+    - id: GO:0003730
+      label: mRNA 3&#39;-UTR binding
+    additional_reference_ids:
+    - PMID:17264081
+    supported_by:
+    - reference_id: PMID:17264081
+      supporting_text: In contrast, human TZF homologs tristetraprolin and ERF-2 bind with
+        high specificity to UUAUUUAUU elements.
+    - reference_id: PMID:17264081
+      supporting_text: We show that mutation of a single amino acid in each MEX-5 zinc finger
+        confers tristetraprolin-like specificity to this protein.
+    propagation_review:
+      root_cause: TERM_SCOPING_PROBLEM
+      failure_modes:
+      - FUNCTIONAL_DIVERGENCE
+      source_entities:
+      - source_id: PANTHER:PTN002648882
+        source_label: TTP/ZFP36 CCCH-TZF family node
+        source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
+        comment: Ancestral ARE-binding specificity does not transfer; nematode MEX proteins
+          diverged to low-specificity poly-U binding.
+      - source_id: UniProtKB:P26651
+        source_label: human ZFP36 (tristetraprolin)
+        source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
+        comment: Mammalian TTP binds UUAUUUAUU AREs with high specificity, unlike MEX-6.
+- term:
+    id: GO:0000289
+    label: nuclear-transcribed mRNA poly(A) tail shortening
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: involved_in
+  review:
+    summary: This IBA is inherited from the ancestral TTP/ZFP36 function of recruiting the
+      deadenylase machinery to promote mRNA poly(A) tail shortening. There is no direct
+      evidence that MEX-6 (or MEX-5) promotes deadenylation in C. elegans; the MEX-5/6
+      literature concerns embryonic polarity and translational/RNP regulation, not mRNA
+      decay.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Deadenylation is a well-established function of mammalian TTP-family paralogs but
+      has not been demonstrated for MEX-6. The nematode MEX proteins have diverged in RNA
+      specificity from their mammalian homologs (PMID:17264081), and the characterized
+      MEX-5/6 outputs are on polarity determinants rather than bulk mRNA turnover. Retained
+      as a family-level over-annotation without direct evidence.
+    additional_reference_ids:
+    - PMID:17264081
+    supported_by:
+    - reference_id: PMID:17264081
+      supporting_text: In contrast, human TZF homologs tristetraprolin and ERF-2 bind with
+        high specificity to UUAUUUAUU elements.
+    propagation_review:
+      root_cause: PROPAGATION_BAD
+      failure_modes:
+      - FUNCTIONAL_DIVERGENCE
+      source_entities:
+      - source_id: PANTHER:PTN002648882
+        source_label: TTP/ZFP36 CCCH-TZF family node
+        source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
+        comment: Mammalian TTP-family deadenylation is sound at the source but has no
+          experimental support in MEX-6.
+      - source_id: UniProtKB:P26651
+        source_label: human ZFP36 (tristetraprolin)
+        source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
+        comment: TTP recruits the CCR4-NOT deadenylase; no such activity shown for MEX-6.
+- term:
+    id: GO:0000900
+    label: mRNA regulatory element binding translation repressor activity
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: enables
+  review:
+    summary: This IBA proposes a sequence-specific translation-repressor activity by
+      phylogenetic inference. MEX-6 does bind mRNA and, redundantly with MEX-5, controls the
+      expression pattern of germline determinants, but the mechanism is not a clean
+      sequence-specific translational repressor. The RNA binding of the paralog is
+      low-specificity (PMID:17264081), and the best-characterized MEX-5/6 translational
+      output (on the zif-1 3&#39;UTR) is positive rather than repressive. No MEX-6-specific
+      evidence establishes this molecular activity.
+    action: UNDECIDED
+    reason: The directionality and sequence-specificity implied by this term are not
+      supported for MEX-6. Without direct evidence that MEX-6 functions as a sequence-specific
+      translation repressor (as opposed to acting through low-specificity mRNA binding, mRNA
+      competition, or positive regulation of specific targets), this annotation cannot be
+      confidently accepted or removed and requires experimental clarification.
+    additional_reference_ids:
+    - PMID:17264081
+    supported_by:
+    - reference_id: PMID:17264081
+      supporting_text: the TZF protein MEX-5, a primary anterior determinant, is an
+        RNA-binding protein that recognizes linear RNA sequences with high affinity but
+        low specificity
+    propagation_review:
+      root_cause: UNRESOLVED
+      failure_modes:
+      - FUNCTIONAL_DIVERGENCE
+      - REGULATORY_SIGN_INVERSION
+      source_entities:
+      - source_id: PANTHER:PTN002648882
+        source_label: TTP/ZFP36 CCCH-TZF family node
+        source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
+        comment: Repressor directionality is uncertain for MEX-6; the best-characterized
+          MEX-5/6 translational output (zif-1 3&#39;UTR) is positive, not repressive.
+- term:
+    id: GO:0005829
+    label: cytosol
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: is_active_in
+  review:
+    summary: MEX-6 is a cytoplasmic protein (UniProt SUBCELLULAR LOCATION Cytoplasm), imaged
+      as a cytoplasmic GFP fusion in the early embryo (PMID:12588843) and consistent with the
+      experimental IDA cytoplasm annotation. Cytosol is an appropriate active-location term
+      for this non-membrane RNA-binding protein.
+    action: ACCEPT
+    reason: MEX-6 acts in the cytoplasm/cytosol of the zygote, where it forms an
+      anterior-enriched pool and regulates cytoplasmic determinant asymmetry. Consistent with
+      both experimental imaging and the phylogenetic inference.
+    supported_by:
+    - reference_id: PMID:12588843
+      supporting_text: The kinase PAR-1 and the CCCH finger proteins MEX-5 and MEX-6 also
+        function during the establishment phase in a feedback loop to regulate growth of
+        the posterior domain.
+- term:
+    id: GO:0160134
+    label: protein-RNA sequence-specific adaptor activity
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: enables
+  review:
+    summary: This IBA implies MEX-6 acts as a sequence-specific adaptor between RNA and
+      protein. MEX-6 binds mRNA and also binds protein partners (PLK-1/PLK-2 via polo-box
+      docking), but its RNA binding is not sequence-specific - the near-identical paralog
+      MEX-5 binds poly-U tracts with high affinity and low specificity (PMID:17264081).
+    action: MODIFY
+    reason: The &#34;sequence-specific&#34; qualifier of GO:0160134 is not supported for MEX-6, whose
+      RNA recognition (by paralog inference) is promiscuous poly-U binding rather than a
+      specific motif. The well-supported molecular activity is simply mRNA binding
+      (GO:0003729); the protein-adaptor role toward polo kinases is captured separately by
+      the protein kinase binding / protein domain specific binding annotations.
+    proposed_replacement_terms:
+    - id: GO:0003729
+      label: mRNA binding
+    additional_reference_ids:
+    - PMID:17264081
+    supported_by:
+    - reference_id: PMID:17264081
+      supporting_text: the TZF protein MEX-5, a primary anterior determinant, is an
+        RNA-binding protein that recognizes linear RNA sequences with high affinity but
+        low specificity
+    propagation_review:
+      root_cause: TERM_SCOPING_PROBLEM
+      failure_modes:
+      - GRANULARITY_MISMATCH
+      - FUNCTIONAL_DIVERGENCE
+      source_entities:
+      - source_id: PANTHER:PTN002648882
+        source_label: TTP/ZFP36 CCCH-TZF family node
+        source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
+        comment: The &#34;sequence-specific&#34; qualifier overstates MEX-6 RNA recognition, which
+          by paralog inference is promiscuous poly-U binding.
+- term:
+    id: GO:0003729
+    label: mRNA binding
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: enables
+  review:
+    summary: MEX-6 contains two tandem C3H1-type CCCH zinc fingers (UniProt ZN_FING 273-302,
+      317-347; InterPro IPR045877 ZFP36-like, IPR000571 CCCH), the RNA-binding module of the
+      TTP/TZF family. mRNA binding is a core molecular function, independently supported by
+      the experimental IDA for mRNA 3&#39;-UTR binding (PMID:17264081, curated for mex-6).
+    action: ACCEPT
+    reason: mRNA binding is well supported for this gene by domain architecture and by the
+      curated experimental 3&#39;-UTR-binding annotation. Core molecular function.
+    supported_by:
+    - reference_id: PMID:17264081
+      supporting_text: This sequence is remarkably abundant in the 3&#39;-untranslated region
+        of C. elegans transcripts
+- term:
+    id: GO:0005737
+    label: cytoplasm
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000044
+  qualifier: located_in
+  review:
+    summary: Cytoplasmic localization inferred from the UniProt Swiss-Prot subcellular
+      location. Consistent with the experimental IDA cytoplasm annotation (PMID:12588843) and
+      UniProt SUBCELLULAR LOCATION Cytoplasm.
+    action: ACCEPT
+    reason: MEX-6 is a cytoplasmic protein; this location is corroborated by direct imaging in
+      the early embryo. Correct, if generic relative to the anterior-enriched cytoplasmic
+      pool.
+    supported_by:
+    - reference_id: PMID:12588843
+      supporting_text: we have analyzed the localization dynamics of PAR-2, PAR-6, MEX-5,
+        MEX-6 and PIE-1 in wild-type and mutant embryos
+- term:
+    id: GO:0017148
+    label: negative regulation of translation
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000108
+  qualifier: involved_in
+  review:
+    summary: This IEA is a logical inference from GO:0000900 (mRNA regulatory element binding
+      translation repressor activity), which is itself uncertain for MEX-6 (reviewed above as
+      UNDECIDED). While MEX-5/6 restrict germline protein expression in the anterior, the
+      mechanism is not established to be direct translational repression, and the
+      best-characterized translational output (zif-1 3&#39;UTR) is positive.
+    action: UNDECIDED
+    reason: Because the parent MF annotation (GO:0000900) is not confidently supported for
+      MEX-6, the inferred negative-regulation-of-translation process term inherits that
+      uncertainty. The directionality does not match the strongest published MEX-5/6
+      translational mechanism. Requires direct evidence.
+    additional_reference_ids:
+    - PMID:10882103
+    supported_by:
+    - reference_id: PMID:10882103
+      supporting_text: This network is required for subsequent asymmetries in the expression
+        patterns of several proteins that are encoded by nonlocalized, maternally expressed
+        mRNAs.
+- term:
+    id: GO:0043186
+    label: P granule
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000117
+  qualifier: located_in
+  review:
+    summary: This is a purely electronic ARBA machine-learning prediction of P-granule
+      residency. MEX-6 is predominantly an anterior cytoplasmic protein, spatially
+      anti-correlated with P granules, which segregate to the posterior. Any P-granule
+      association (see the experimental IDA below) is at best transient and non-core; an
+      unsupervised ARBA prediction is exactly the kind of electronic annotation to
+      down-weight for a family whose members antagonize, rather than reside in, germ granules.
+    action: KEEP_AS_NON_CORE
+    reason: This electronic prediction is redundant with the experimental IDA to the same
+      term (also kept non-core), so it is retained rather than removed, but marked non-core.
+      MEX-6&#39;s core localization is the anterior cytoplasm, not stable structural residence in
+      P granules, so P-granule localization should not be treated as a core function.
+    supported_by:
+    - reference_id: PMID:12588843
+      supporting_text: The kinase PAR-1 and the CCCH finger proteins MEX-5 and MEX-6 also
+        function during the establishment phase in a feedback loop to regulate growth of
+        the posterior domain.
+- term:
+    id: GO:0046872
+    label: metal ion binding
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: enables
+  review:
+    summary: MEX-6 has two C3H1-type CCCH zinc fingers that each coordinate a zinc ion, the
+      structural basis of its RNA-binding fold (UniProt ZN_FING; InterPro CCCH signatures).
+      Metal ion binding is a correct, if generic, annotation.
+    action: ACCEPT
+    reason: Zinc coordination is intrinsic to the CCCH zinc-finger fold of MEX-6. Correct
+      though non-specific; zinc ion binding (GO:0008270) would be the more precise term.
+- term:
+    id: GO:0005737
+    label: cytoplasm
+  evidence_type: ISS
+  original_reference_id: GO_REF:0000024
+  qualifier: located_in
+  review:
+    summary: Cytoplasmic localization transferred by sequence similarity from the paralog
+      MEX-5 (UniProtKB:Q9XUB2). This ortholog/paralog transfer is consistent with the
+      independent experimental IDA (PMID:12588843) and with UniProt&#39;s Cytoplasm assignment.
+    action: ACCEPT
+    reason: The cytoplasm location is correct for MEX-6 and is corroborated by direct
+      experimental evidence, so the ISS transfer from MEX-5 is appropriate.
+    supported_by:
+    - reference_id: PMID:12588843
+      supporting_text: we have analyzed the localization dynamics of PAR-2, PAR-6, MEX-5,
+        MEX-6 and PIE-1 in wild-type and mutant embryos
+- term:
+    id: GO:0019901
+    label: protein kinase binding
+  evidence_type: IPI
+  original_reference_id: PMID:18199581
+  qualifier: enables
+  review:
+    summary: PMID:18199581 demonstrates that the Polo-like kinases PLK-1 and PLK-2 bind
+      directly to MEX-6 (named explicitly) via their polo-box domains, dependent on
+      MBK-2/DYRK2-primed phosphorylation of the polo-docking threonine (Thr-190 in MEX-6;
+      UniProt MOD_RES 190, MUTAGEN T190A/T190E abolish PLK binding). Curated by WormBase with
+      plk-1 (WBGene00004042) and plk-2 (WBGene00004043) as interactors.
+    action: ACCEPT
+    reason: Direct experimental protein-kinase-binding evidence naming MEX-6; functionally
+      important for embryonic polarity. Core interaction.
+    supported_by:
+    - reference_id: PMID:18199581
+      supporting_text: We show that polo kinases, via their polo box domains, bind to and
+        regulate the activity of two key polarity proteins, MEX-5 and MEX-6.
+- term:
+    id: GO:0019904
+    label: protein domain specific binding
+  evidence_type: IPI
+  original_reference_id: PMID:18199581
+  qualifier: enables
+  review:
+    summary: MEX-6 binds specifically to the polo-box domains of PLK-1 and PLK-2 (a
+      phosphopeptide-docking domain), a bona fide domain-specific protein interaction
+      (PMID:18199581), primed by MBK-2 phosphorylation at Thr-190.
+    action: ACCEPT
+    reason: The interaction is with a defined protein domain (the polo-box domain), directly
+      demonstrated for MEX-6. Supports protein domain specific binding.
+    supported_by:
+    - reference_id: PMID:18199581
+      supporting_text: We show that polo kinases, via their polo box domains, bind to and
+        regulate the activity of two key polarity proteins, MEX-5 and MEX-6.
+- term:
+    id: GO:0032880
+    label: regulation of protein localization
+  evidence_type: IGI
+  original_reference_id: PMID:18199581
+  qualifier: involved_in
+  review:
+    summary: MEX-6, redundantly with MEX-5 (genetic interaction; WormBase with = mex-5
+      WBGene00003230), is required for the asymmetric localization of downstream determinants.
+      Removing MEX-5 and MEX-6 disrupts asymmetric distribution of PLK-1 (and PIE-1, MEX-1,
+      POS-1); UniProt DISRUPTION PHENOTYPE notes that mex-6 RNAi in a mex-5(zu199) background
+      causes loss of plk-1 asymmetry (PMID:18199581). The polo kinases&#39; asymmetric
+      localization depends on MEX-5 and MEX-6.
+    action: ACCEPT
+    reason: Regulation of the asymmetric localization of germline/polarity determinants is a
+      core, experimentally supported biological process for the MEX-5/MEX-6 pair, with the
+      genetic-interaction evidence specifically implicating mex-6 in a mex-5-sensitized
+      background.
+    supported_by:
+    - reference_id: PMID:18199581
+      supporting_text: This asymmetric localization of polo kinases depends on MEX-5 and
+        MEX-6, as well as genes regulating MEX-5 and MEX-6 asymmetry.
+- term:
+    id: GO:0005737
+    label: cytoplasm
+  evidence_type: IDA
+  original_reference_id: PMID:12588843
+  qualifier: located_in
+  review:
+    summary: Direct experimental (IDA, WormBase) cytoplasmic localization of MEX-6, imaged as
+      a GFP fusion during zygote polarization (PMID:12588843). This is the primary-evidence
+      cytoplasm annotation.
+    action: ACCEPT
+    reason: Direct observation of cytoplasmic MEX-6 in the early embryo; the core cellular
+      location of the protein.
+    supported_by:
+    - reference_id: PMID:12588843
+      supporting_text: we have analyzed the localization dynamics of PAR-2, PAR-6, MEX-5,
+        MEX-6 and PIE-1 in wild-type and mutant embryos
+- term:
+    id: GO:0043186
+    label: P granule
+  evidence_type: IDA
+  original_reference_id: PMID:12588843
+  qualifier: located_in
+  review:
+    summary: WormBase curated an experimental (IDA) P-granule localization for MEX-6 from the
+      full text of PMID:12588843 (a live-imaging study of MEX-6 and other polarity factors).
+      The cached abstract does not itself mention P granules, so I cannot independently verify
+      the observation, but I defer to the curator&#39;s reading of the full text. Biologically,
+      MEX-6 is predominantly anterior cytoplasmic (where P granules are depleted), so any
+      P-granule association is transient/minor rather than a core residence - unlike bona fide
+      P-granule scaffolds. The near-identical paralog MEX-5 has been shown to antagonize
+      (dissolve) rather than reside in P granules, but no equivalent phase-separation study
+      exists for MEX-6.
+    action: KEEP_AS_NON_CORE
+    reason: This is an experimental annotation whose supporting full text I cannot see; per
+      project guidelines I do not REMOVE it on the basis of an abstract that foregrounds
+      other observations. However, given MEX-6&#39;s anterior-cytoplasmic enrichment and the lack
+      of evidence that it is a structural P-granule component, the localization is retained as
+      non-core rather than as a core function.
+    supported_by:
+    - reference_id: PMID:12588843
+      supporting_text: we have analyzed the localization dynamics of PAR-2, PAR-6, MEX-5,
+        MEX-6 and PIE-1 in wild-type and mutant embryos
+- term:
+    id: GO:0003730
+    label: mRNA 3&#39;-UTR binding
+  evidence_type: IDA
+  original_reference_id: PMID:17264081
+  qualifier: enables
+  review:
+    summary: WormBase curated an experimental (IDA) mRNA 3&#39;-UTR-binding activity for MEX-6
+      citing PMID:17264081. That paper&#39;s abstract characterizes the biochemistry of the
+      near-identical paralog MEX-5 (poly-U tracts abundant in C. elegans 3&#39;-UTRs); the mex-6
+      IDA reflects the curator&#39;s reading of the full text. MEX-6 has the same tandem CCCH
+      zinc-finger RNA-binding module, so 3&#39;-UTR binding is biologically expected.
+    action: ACCEPT
+    reason: mRNA 3&#39;-UTR binding is a genuine, core molecular function of this TZF protein and
+      is curated as experimental for mex-6. Per project guidelines I defer to the curator
+      rather than REMOVE an experimental annotation because the cached abstract foregrounds
+      the paralog MEX-5.
+    supported_by:
+    - reference_id: PMID:17264081
+      supporting_text: This sequence is remarkably abundant in the 3&#39;-untranslated region
+        of C. elegans transcripts
+- term:
+    id: GO:0008595
+    label: anterior/posterior axis specification, embryo
+  evidence_type: IMP
+  original_reference_id: PMID:10882103
+  qualifier: involved_in
+  review:
+    summary: MEX-6, redundantly with MEX-5, links cortical PAR polarity to soma/germline
+      asymmetry along the anterior-posterior axis of the early embryo (PMID:10882103,
+      PMID:12588843). This biological process is not present in the current GOA for mex-6 but
+      is a core role of the MEX-5/MEX-6 pair.
+    action: NEW
+    reason: Anterior-posterior axis specification is a core developmental process for the
+      MEX-5/MEX-6 pair, with MEX-6 contributing redundantly with MEX-5. Added as a proposed
+      new annotation to reflect this core function.
+    supported_by:
+    - reference_id: PMID:10882103
+      supporting_text: We provide evidence that two nearly identical genes, mex-5 and mex-6,
+        link PAR asymmetry to those subsequent protein asymmetries.
+    - reference_id: PMID:12588843
+      supporting_text: Polarization of the C. elegans zygote along the anterior-posterior
+        axis depends on cortically enriched (PAR) and cytoplasmic (MEX-5/6) proteins
+core_functions:
+- description: MEX-6 binds maternal mRNA 3&#39;-UTRs through its tandem CCCH zinc fingers and,
+    redundantly with MEX-5, converts cortical PAR polarity into cytoplasmic soma/germline
+    asymmetry, patterning the distribution of germline determinants (PIE-1, POS-1, MEX-1)
+    along the anterior-posterior axis of the early embryo.
+  molecular_function:
+    id: GO:0003730
+    label: mRNA 3&#39;-UTR binding
+  directly_involved_in:
+  - id: GO:0008595
+    label: anterior/posterior axis specification, embryo
+  - id: GO:0032880
+    label: regulation of protein localization
+  locations:
+  - id: GO:0005737
+    label: cytoplasm
+  supported_by:
+  - reference_id: PMID:10882103
+    supporting_text: We provide evidence that two nearly identical genes, mex-5 and mex-6,
+      link PAR asymmetry to those subsequent protein asymmetries.
+  - reference_id: PMID:17264081
+    supporting_text: This sequence is remarkably abundant in the 3&#39;-untranslated region
+      of C. elegans transcripts
+- description: MEX-6 acts as a substrate and adaptor for the Polo-like kinases PLK-1 and
+    PLK-2, binding their polo-box domains via an MBK-2/DYRK2-primed phosphothreonine
+    (Thr-190); this interaction is required (with MEX-5) for the anterior enrichment of
+    PLK-1/PLK-2 and their control of determinant asymmetry.
+  molecular_function:
+    id: GO:0019901
+    label: protein kinase binding
+  directly_involved_in:
+  - id: GO:0032880
+    label: regulation of protein localization
+  locations:
+  - id: GO:0005737
+    label: cytoplasm
+  supported_by:
+  - reference_id: PMID:18199581
+    supporting_text: We show that polo kinases, via their polo box domains, bind to and
+      regulate the activity of two key polarity proteins, MEX-5 and MEX-6.
+  - reference_id: PMID:18199581
+    supporting_text: This asymmetric localization of polo kinases depends on MEX-5 and
+      MEX-6, as well as genes regulating MEX-5 and MEX-6 asymmetry.
+proposed_new_terms: []
+suggested_questions:
+- question: Does MEX-6 have any non-redundant function, target mRNA, tissue, or developmental
+    timing distinct from MEX-5, or is it a purely redundant backup copy?
+  experts:
+  - Lin R
+  - Priess JR
+- question: Is the RNA-binding activity of MEX-6 required for its role in embryonic polarity,
+    and does MEX-6 (like MEX-5) bind poly-U tracts with low sequence specificity?
+  experts:
+  - Ryder SP
+suggested_experiments:
+- description: Perform iCLIP/CLIP-seq on endogenously tagged MEX-6 in early embryos to define
+    its direct mRNA targets genome-wide and compare them to MEX-5 targets, testing whether
+    MEX-6 has any private target repertoire.
+  hypothesis: MEX-6 binds essentially the same poly-U-rich 3&#39;-UTR set as MEX-5, consistent
+    with full functional redundancy.
+- description: Generate RNA-binding-deficient MEX-6 zinc-finger mutants at the endogenous
+    locus in a mex-5 null background and assay embryonic viability and PLK-1/PIE-1 asymmetry,
+    to test whether MEX-6 RNA binding is required for its polarity function.
+  hypothesis: MEX-6 RNA binding is required for anterior enrichment and for establishing
+    determinant asymmetry when MEX-5 is absent.
+- description: Live-image endogenously tagged MEX-6 together with a P-granule marker (e.g.
+    PGL-1) to determine whether the curated P-granule signal reflects stable residence or
+    transient association, and whether MEX-6 promotes anterior P-granule dissolution as
+    reported for MEX-5.
+  hypothesis: MEX-6 is anterior-enriched and only transiently overlaps P granules, mirroring
+    the P-granule-antagonizing behaviour of MEX-5.
+knowledge_gaps:
+- gap_statement: The non-redundant, MEX-6-specific contribution to embryonic polarity is
+    undefined. It is unknown whether MEX-6 has any private target mRNA, tissue, developmental
+    timing, or molecular activity distinct from its near-identical paralog MEX-5, or whether
+    it is a functionally interchangeable backup copy.
+  boundary: It is firmly established that mex-5 and mex-6 are nearly identical genes that act
+    together to link PAR asymmetry to downstream determinant asymmetries, and that the mex-6
+    contribution is exposed genetically only in a mex-5-sensitized background (mex-6 RNAi in
+    mex-5(zu199) causes loss of PLK-1 asymmetry). MEX-5 is consistently the dominant,
+    better-characterized paralog.
+  gap_kind:
+  - BIOLOGY
+  dark_aspect: RESIDUAL_SUBGAP
+  status: OPEN
+  significance: Distinguishing genuine redundancy from division of labor is central to
+    understanding the robustness of the soma/germline decision and whether MEX-6 is a
+    dispensable paralog or a buffer with its own regulatory inputs.
+  resolution: Endogenous single- and double-null comparisons with quantitative determinant
+    readouts, plus paralog-specific CLIP-seq, to test for any MEX-6-only target or phenotype.
+  provenance:
+  - reference_id: PMID:10882103
+    supporting_text: We provide evidence that two nearly identical genes, mex-5 and mex-6,
+      link PAR asymmetry to those subsequent protein asymmetries.
+    reference_section_type: ABSTRACT
+- gap_statement: The direct mRNA targets of MEX-6 and its RNA-binding specificity have not
+    been determined for MEX-6 itself. All biochemical RNA-recognition data (poly-U tract,
+    high affinity, low specificity, discriminator residue) come from the paralog MEX-5.
+  boundary: MEX-6 has two tandem C3H1-type CCCH zinc fingers of the TTP/ZFP36 family and a
+    curated experimental mRNA 3&#39;-UTR-binding activity, so it is an mRNA-binding protein; but
+    no MEX-6-specific binding constants, motif, or target set are published, and even for
+    MEX-5 the field notes that its binding cannot by itself specify target selection.
+  gap_kind:
+  - BIOLOGY
+  dark_aspect: MF_DARK
+  status: OPEN
+  significance: Without direct MEX-6 targets it is impossible to assign a specific molecular
+    mechanism (repression, competition, stabilization) to the polarity phenotype, leaving
+    MEX-6 mechanistically dark despite a well-defined developmental role.
+  resolution: MEX-6-specific in vitro binding measurements and in vivo CLIP-seq to define the
+    motif preference and target set directly.
+  provenance:
+  - reference_id: PMID:17264081
+    supporting_text: This sequence is remarkably abundant in the 3&#39;-untranslated region of
+      C. elegans transcripts, demonstrating that MEX-5 alone cannot specify mRNA target
+      selection.
+    reference_section_type: ABSTRACT
+- gap_statement: Whether MEX-6 RNA binding is required for its function in anterior-posterior
+    polarity is untested for MEX-6. It is unknown whether zinc-finger/RNA-binding-dead MEX-6
+    can still form an anterior gradient, dock PLK-1/PLK-2, and support determinant asymmetry
+    when MEX-5 is absent.
+  boundary: The polo-docking arm of MEX-6 function is well mapped (MBK-2-primed Thr-190,
+    polo-box binding, requirement for PLK-1/PLK-2 asymmetry), and the RNA-binding-to-polarity
+    link has been argued for MEX-5; but no separation-of-function RNA-binding mutant of MEX-6
+    has been assayed in vivo.
+  gap_kind:
+  - BIOLOGY
+  dark_aspect: RESIDUAL_SUBGAP
+  status: OPEN
+  significance: This determines whether MEX-6&#39;s essential activity is RNA-binding, a
+    protein-scaffold (polo-adaptor) role, or both, and therefore which molecular function
+    should anchor its polarity annotation.
+  resolution: Endogenous RNA-binding-deficient MEX-6 zinc-finger mutants assayed in a mex-5
+    null background for gradient formation, PLK-1 docking, and determinant asymmetry.
+  provenance:
+  - reference_id: PMID:18199581
+    supporting_text: We show that polo kinases, via their polo box domains, bind to and
+      regulate the activity of two key polarity proteins, MEX-5 and MEX-6.
+    reference_section_type: ABSTRACT
+tags:
+- caeel-p-granules
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/genes/worm/mks-2/mks-2-ai-review.html
+++ b/genes/worm/mks-2/mks-2-ai-review.html
@@ -1,0 +1,3176 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>mks-2 - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        .propagation-review {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f8fafc;
+            border-left: 3px solid #64748b;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .propagation-title {
+            font-weight: 600;
+            color: #334155;
+            margin-bottom: 0.25rem;
+        }
+
+        .propagation-row {
+            margin-top: 0.25rem;
+        }
+
+        .propagation-source {
+            margin-top: 0.5rem;
+            padding-top: 0.5rem;
+            border-top: 1px solid #e5e7eb;
+        }
+
+        .propagation-source-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #1d4ed8;
+        }
+
+        .propagation-comment {
+            color: #4b5563;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>mks-2</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/C8JQP7" target="_blank" class="term-link">
+                        C8JQP7
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Caenorhabditis elegans</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-complete">
+                    COMPLETE
+                </span>
+            </div>
+
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "mks-2";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="C8JQP7" data-a="DESCRIPTION: MKS-2 is the Caenorhabditis elegans ortholog of hu..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>MKS-2 is the Caenorhabditis elegans ortholog of human TMEM216 (MKS2), a small multi-pass integral membrane protein of the ciliary transition zone (TZ). It is a core component of the MKS module, one of two protein modules (MKS and NPHP) that together assemble the TZ at the base of sensory cilia, building the Y-link connectors between the axoneme doublet microtubules and the ciliary membrane and establishing the ciliary gate (a membrane diffusion barrier that restricts entry of non-ciliary membrane proteins into the cilium). MKS-2 is expressed in ciliated sensory neurons and concentrates at the TZ immediately distal to the basal body transition fibres. Its TZ localization depends on the upstream assembly factors MKS-5 (RPGRIP1L) and CEP-290, and MKS-2 in turn is required to recruit peripheral MKS-module proteins such as TMEM-218 to the TZ. Consistent with the strong functional redundancy among transition-zone genes, mks-2 single mutants have no overt ciliary phenotype, whereas double mutants combining mks-2 with NPHP-module genes (e.g. nphp-4) disrupt the ciliary gate and cilium integrity. In humans, TMEM216/MKS2 mutations cause Meckel-Gruber and Joubert syndromes.</p>
+    </div>
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Proposed New Ontology Terms</h2>
+
+        <div class="proposed-term">
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>structural constituent of ciliary transition zone</h3>
+                <span class="vote-buttons" data-g="C8JQP7" data-a="structural constituent of ciliary transition zone" data-r="" data-act="NEW">
+                    <button class="vote-btn" data-v="up" title="Agree this term should be created">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with creating this term">👎</button>
+                </span>
+            </div>
+
+
+            <p><strong>Definition:</strong> The action of a protein that contributes to the structural integrity of the ciliary transition zone, for example by acting as an integral-membrane or scaffold subunit of the MKS or NPHP module that helps build the Y-link connectors and the membrane diffusion barrier at the ciliary base, without itself catalyzing a biochemical reaction.</p>
+
+
+
+
+
+            <p><strong>Parent term:</strong>
+                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005198" target="_blank" class="term-link">
+                    structural molecule activity
+                </a>
+            </p>
+
+
+
+
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0035869" target="_blank" class="term-link">
+                                    GO:0035869
+                                </a>
+                            </span>
+                            <span class="term-label">ciliary transition zone</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="C8JQP7" data-a="GO:0035869" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> MKS-2 is a transition-zone protein; the phylogenetically inferred TZ localization is directly corroborated by experimental imaging in C. elegans (MKS-2::GFP concentrates at the TZ) and matches the conserved role of the TMEM216/MKS module across metazoans.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Core cellular-component annotation. The IBA inference (PANTHER family PTHR13531 / MKS module) is consistent with direct experimental evidence in C. elegans, so it should be retained as a core location.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/26982032" target="_blank" class="term-link">
+                                        PMID:26982032
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">MKSR-1::tdTomato and MKS-2::GFP are TZ protein comarkers</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1905515" target="_blank" class="term-link">
+                                    GO:1905515
+                                </a>
+                            </span>
+                            <span class="term-label">non-motile cilium assembly</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="C8JQP7" data-a="GO:1905515" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> As a core MKS-module subunit, MKS-2 participates in building the transition zone during assembly of the non-motile (sensory) cilia of C. elegans. Because the module is redundant, the requirement is most evident in combination with NPHP-module loss rather than in the mks-2 single mutant.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The BP inference is appropriate for a core TZ subunit; C. elegans sensory cilia are non-motile and the MKS module is required (redundantly) for their assembly. Retained as a module-level function; note that MKS-2&#39;s individual contribution is only unmasked in double mutants.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/26982032" target="_blank" class="term-link">
+                                        PMID:26982032
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">combining the tmem-218 mutation with another MKS module mutant, mks-2</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016020" target="_blank" class="term-link">
+                                    GO:0016020
+                                </a>
+                            </span>
+                            <span class="term-label">membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000044
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="C8JQP7" data-a="GO:0016020" data-r="GO_REF:0000044" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> MKS-2 is a multi-pass integral membrane protein (UniProt/Phobius predicts four transmembrane helices), so a generic membrane localization is correct. However, this SubCell-derived term is far less informative than the specific ciliary transition-zone localization captured by the IDA/IBA annotations.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The annotation is not wrong — MKS-2 is an integral membrane protein — but the generic &#39;membrane&#39; term is subsumed by the transition-zone (ciliary membrane) localization that represents the biologically meaningful site of action. Retain as a non-core, low-information electronic annotation.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    GO_REF:0000044
+
+                                </span>
+
+                                <div class="support-text">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1905515" target="_blank" class="term-link">
+                                    GO:1905515
+                                </a>
+                            </span>
+                            <span class="term-label">non-motile cilium assembly</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/26863025" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:26863025
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    A Screen for Modifiers of Cilia Phenotypes Reveals Novel MKS...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="C8JQP7" data-a="GO:1905515" data-r="PMID:26863025" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Masyukova et al. recovered a novel mks-2 allele (yhw128) in a screen for enhancers of nphp-4 ciliary defects. The mks-2 single mutant has no overt dye-filling defect, consistent with MKS-module redundancy, but the gene is required for normal sensory-cilium assembly when the NPHP module is compromised.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Experimental (IMP) annotation from a WormBase curator. The single-mutant phenotype is subtle (redundancy), but the allele&#39;s identity and its ciliary role were confirmed by non-complementation and transgenic rescue. Do not overrule the curator; the annotation reflects MKS-2&#39;s role in cilium assembly.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/26863025" target="_blank" class="term-link">
+                                        PMID:26863025
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">there was no overt defect in dye uptake in mks-1(yhw146) or mks-2(yhw128) mutants</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/26863025" target="_blank" class="term-link">
+                                        PMID:26863025
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">failed to complement the Dyf phenotypes of nphp-4(tm925);mks-1(tm2705), nphp-4;mks-2(mx1198), and nphp-4;mks-5(tm3100)</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1905515" target="_blank" class="term-link">
+                                    GO:1905515
+                                </a>
+                            </span>
+                            <span class="term-label">non-motile cilium assembly</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IGI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/26863025" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:26863025
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    A Screen for Modifiers of Cilia Phenotypes Reveals Novel MKS...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="C8JQP7" data-a="GO:1905515" data-r="PMID:26863025" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> The genetic-interaction (IGI) evidence captures the canonical MKS/NPHP redundancy: mks-2 interacts genetically with nphp-4 (UniProtKB:G5ECP0), and the nphp-4;mks-2 double mutant shows a strong dye-filling (Dyf) defect and MKS-3 mislocalization not seen in either single mutant.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Well-supported IGI annotation. The synthetic phenotype with the NPHP-module gene nphp-4 is the standard genetic signature placing mks-2 in the MKS module and demonstrating its (redundant) requirement for cilium assembly.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/26863025" target="_blank" class="term-link">
+                                        PMID:26863025
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">there was no overt defect in dye uptake in mks-1(yhw146) or mks-2(yhw128) mutants</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/26863025" target="_blank" class="term-link">
+                                        PMID:26863025
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">failed to complement the Dyf phenotypes of nphp-4(tm925);mks-1(tm2705), nphp-4;mks-2(mx1198), and nphp-4;mks-5(tm3100)</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1904491" target="_blank" class="term-link">
+                                    GO:1904491
+                                </a>
+                            </span>
+                            <span class="term-label">protein localization to ciliary transition zone</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/26982032" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:26982032
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    MKS5 and CEP290 Dependent Assembly Pathway of the Ciliary Tr...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="C8JQP7" data-a="GO:1904491" data-r="PMID:26982032" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Li et al. showed that MKS-2 is required for the transition-zone localization of the peripheral MKS-module protein TMEM-218: in the mks-2 mutant, TMEM-218 is absent from the TZ, whereas MKS-2 itself does not require TMEM-218 for its own localization. This defines MKS-2 as a &#39;core&#39; subunit needed to recruit/assemble other MKS-module components at the TZ.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Directly supported experimental (IMP) annotation. Loss of mks-2 mislocalizes a downstream TZ protein, demonstrating a role in establishing protein localization to the transition zone. Core function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/26982032" target="_blank" class="term-link">
+                                        PMID:26982032
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">TMEM-218 is no longer present at the TZ in the mks-2 MKS module mutant</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/26982032" target="_blank" class="term-link">
+                                        PMID:26982032
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">TMEM-218 is not required for the localisation of MKS-5, MKS-2</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0035869" target="_blank" class="term-link">
+                                    GO:0035869
+                                </a>
+                            </span>
+                            <span class="term-label">ciliary transition zone</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/26595381" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:26595381
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    TMEM107 recruits ciliopathy proteins to subdomains of the ci...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="C8JQP7" data-a="GO:0035869" data-r="PMID:26595381" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> WormBase IDA annotation for direct localization of MKS-2 to the ciliary transition zone. The cached record for this paper is abstract-only; the abstract establishes that the MKS-module membrane proteins (which include MKS-2/TMEM216) are TZ-localized, immobile, and periodically arranged within the TZ, and the curator assigned the IDA from the full text.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Experimental (IDA) localization to the transition zone, concordant with the IBA annotation and with MKS-2::GFP imaging in PMID:26982032. The full text (not in cache) contains the direct evidence; per curation guidance the experimental annotation is retained rather than second-guessed from an abstract-only cache.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/26595381" target="_blank" class="term-link">
+                                        PMID:26595381
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">TZ-localized MKS module by organizing recruitment of the ciliopathy proteins</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1903565" target="_blank" class="term-link">
+                                    GO:1903565
+                                </a>
+                            </span>
+                            <span class="term-label">negative regulation of protein localization to cilium</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/26982032" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:26982032
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    MKS5 and CEP290 Dependent Assembly Pathway of the Ciliary Tr...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-new">
+                            NEW
+                        </span>
+                        <span class="vote-buttons" data-g="C8JQP7" data-a="GO:1903565" data-r="PMID:26982032" data-act="NEW">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> MKS-2 is explicitly named among the &#39;core&#39; MKS-module TZ proteins (with MKSR-1, MKSR-2, TMEM-231) that are required for ciliary gate function — restricting the inappropriate entry of the membrane-associated protein TRAM-1a into cilia. This gate/diffusion-barrier activity is the central function of the transition zone and is not otherwise captured in GOA for mks-2.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> New annotation proposed to capture MKS-2&#39;s ciliary-gate role, which is well documented for the core MKS module and directly stated for MKS-2 in Li et al. This mirrors the curated gate-function annotation for the sibling gene mks-3 and represents a core function currently missing from mks-2&#39;s GOA record.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/26982032" target="_blank" class="term-link">
+                                        PMID:26982032
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">TZ proteins are all necessary for TZ gate function</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/26982032" target="_blank" class="term-link">
+                                        PMID:26982032
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">restricting the inappropriate entry of membrane-associated TRAM-1a into cilia</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0036038" target="_blank" class="term-link">
+                                    GO:0036038
+                                </a>
+                            </span>
+                            <span class="term-label">MKS complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/26982032" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:26982032
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    MKS5 and CEP290 Dependent Assembly Pathway of the Ciliary Tr...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-new">
+                            NEW
+                        </span>
+                        <span class="vote-buttons" data-g="C8JQP7" data-a="GO:0036038" data-r="PMID:26982032" data-act="NEW">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> MKS-2 (TMEM216) is repeatedly identified as a &#39;core&#39; MKS-module / MKSome component together with MKSR-1, MKSR-2, and TMEM-231, co-localizing with these subunits at the transition zone.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> New annotation capturing MKS-2 membership in the MKS complex (MKS module), consistent with the sibling gene mks-3 and with its role as a core MKS-module subunit at the transition zone.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/26982032" target="_blank" class="term-link">
+                                        PMID:26982032
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">which include MKS-2, MKSR-1, MKSR-2, and TMEM-231</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005198" target="_blank" class="term-link">
+                                    GO:0005198
+                                </a>
+                            </span>
+                            <span class="term-label">structural molecule activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/26982032" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:26982032
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    MKS5 and CEP290 Dependent Assembly Pathway of the Ciliary Tr...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-new">
+                            NEW
+                        </span>
+                        <span class="vote-buttons" data-g="C8JQP7" data-a="GO:0005198" data-r="PMID:26982032" data-act="NEW">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> As a multi-pass integral membrane subunit of the MKS module, MKS-2 contributes to the structural integrity of the transition zone; its loss mislocalizes the downstream TZ protein TMEM-218 and compromises the ciliary gate. This is the closest available molecular-function term for a transition-zone scaffold subunit (see knowledge_gaps).
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> New molecular-function annotation. MKS-2 has no MF term in GOA; &#39;structural molecule activity&#39; is used as the nearest placeholder for a diffusion-barrier scaffold subunit, more informative than generic protein binding. The precise MF term is an ontology-level gap (see knowledge_gaps / proposed_new_terms).
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/26982032" target="_blank" class="term-link">
+                                        PMID:26982032
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">which include MKS-2, MKSR-1, MKSR-2, and TMEM-231</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/26982032" target="_blank" class="term-link">
+                                        PMID:26982032
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">TMEM-218 is no longer present at the TZ in the mks-2 MKS module mutant</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>MKS-2 acts as a structural/scaffolding subunit of the MKS module of the ciliary transition zone. As a multi-pass integral membrane protein embedded in the transition-zone membrane, it contributes to the assembly and integrity of the TZ (Y-link connectors and apical ring) and to the ciliary gate — the membrane diffusion barrier that restricts non-ciliary membrane proteins from entering the cilium. It also helps recruit peripheral MKS-module components (e.g. TMEM-218) to the TZ. There is no GO molecular-function term that precisely describes a transition-zone diffusion-barrier scaffold subunit; &#39;structural molecule activity&#39; is used here as the closest available placeholder.</h3>
+                <span class="vote-buttons" data-g="C8JQP7" data-a="FUNCTION: MKS-2 acts as a structural/scaffolding subunit of ..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005198" target="_blank" class="term-link">
+                            structural molecule activity
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1905515" target="_blank" class="term-link">
+                                non-motile cilium assembly
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1904491" target="_blank" class="term-link">
+                                protein localization to ciliary transition zone
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1903565" target="_blank" class="term-link">
+                                negative regulation of protein localization to cilium
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0035869" target="_blank" class="term-link">
+                                ciliary transition zone
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">In Complex:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0036038" target="_blank" class="term-link">
+                            MKS complex
+                        </a>
+                    </span>
+                </div>
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/26982032" target="_blank" class="term-link">
+                                PMID:26982032
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">TMEM-218 is no longer present at the TZ in the mks-2 MKS module mutant</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/26982032" target="_blank" class="term-link">
+                                PMID:26982032
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">restricting the inappropriate entry of membrane-associated TRAM-1a into cilia</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
+                            GO_REF:0000033
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Annotation inferences using phylogenetic trees</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
+                            GO_REF:0000044
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/26595381" target="_blank" class="term-link">
+                            PMID:26595381
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">TMEM107 recruits ciliopathy proteins to subdomains of the ciliary transition zone and causes Joubert syndrome.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">The MKS-module membrane proteins of the ciliary transition zone are immobile and periodically arranged within the TZ, and TMEM-107 organizes recruitment of MKS-module ciliopathy proteins.</div>
+
+                        <div class="finding-text">"TZ-localized MKS module by organizing recruitment of the ciliopathy proteins"</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/26863025" target="_blank" class="term-link">
+                            PMID:26863025
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">A Screen for Modifiers of Cilia Phenotypes Reveals Novel MKS Alleles and Uncovers a Specific Genetic Interaction between osm-3 and nphp-4.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">A novel mks-2 allele (yhw128) was recovered as an enhancer of nphp-4; mks-2 single mutants show no overt dye-filling defect, but nphp-4;mks-2 double mutants are strongly Dyf, demonstrating MKS/NPHP-module redundancy.</div>
+
+                        <div class="finding-text">"there was no overt defect in dye uptake in mks-1(yhw146) or mks-2(yhw128) mutants"</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/26982032" target="_blank" class="term-link">
+                            PMID:26982032
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">MKS5 and CEP290 Dependent Assembly Pathway of the Ciliary Transition Zone.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">MKS-2 is a core MKS-module TZ protein required for the transition-zone localization of the peripheral protein TMEM-218.</div>
+
+                        <div class="finding-text">"TMEM-218 is no longer present at the TZ in the mks-2 MKS module mutant"</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <div class="finding-statement">The core MKS-module TZ proteins (including MKS-2) are required for ciliary gate function, restricting entry of membrane-associated TRAM-1a into cilia.</div>
+
+                        <div class="finding-text">"restricting the inappropriate entry of membrane-associated TRAM-1a into cilia"</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <div class="finding-statement">MKS-2 localization to the TZ depends on the upstream assembly factor MKS-5, and MKS-2 mislocalizes in the cep-290 mutant.</div>
+
+                        <div class="finding-text">"MKS-5 as a critical assembly factor for all known MKS module proteins tested thus far"</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Questions for Experts</h2>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Does MKS-2/TMEM216 make direct physical contacts with specific MKS-module partners (e.g. MKSR-1/MKSR-2, TMEM-231, MKS-5) that define a discrete sub-architecture of the transition zone?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="C8JQP7" data-a="Q: Does MKS-2/TMEM216 make direct physical contacts w..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Does MKS-2 have any non-redundant function unmasked only in specific cell types or under stress, or is it fully interchangeable with the other core MKS-module subunits?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="C8JQP7" data-a="Q: Does MKS-2 have any non-redundant function unmaske..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Experiments</h2>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Proximity labelling (TurboID/BioID) or affinity purification of tagged MKS-2 in C. elegans ciliated neurons to map its direct transition-zone interaction partners.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: MKS-2 occupies a specific position in the MKS-module interaction network with a defined set of direct membrane-protein partners.</em></p>
+
+
+                </div>
+                <span class="vote-buttons" data-g="C8JQP7" data-a="EXPERIMENT: Proximity labelling (TurboID/BioID) or affinity pu..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Structure-guided separation-of-function mutagenesis of MKS-2 transmembrane/loop residues, assayed for TZ localization, TRAM-1a exclusion (gate), TMEM-218 recruitment, and Y-link ultrastructure by TEM.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: Distinct MKS-2 residues are required for membrane anchoring versus barrier function versus recruitment of peripheral MKS-module proteins.</em></p>
+
+
+                </div>
+                <span class="vote-buttons" data-g="C8JQP7" data-a="EXPERIMENT: Structure-guided separation-of-function mutagenesi..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Knowledge Gaps</h2>
+        <p style="color: #555; font-size: 0.92rem; margin-top: -0.3rem;">
+            What is <em>not</em> known — curated, literature-grounded statements of the open
+            unknowns (the inverse of core functions).
+        </p>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> MKS-2 has no assigned molecular function and there is no GO term to express one. Its role is to be a structural/diffusion-barrier scaffold subunit of the ciliary transition-zone MKS module, but GO has no molecular-function term such as &#34;structural constituent of the ciliary transition zone&#34; (or &#34;diffusion barrier component&#34;), so the gene reads as MF-dark despite a well-understood cellular-component and biological-process role.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">ONTOLOGY</span><span class="badge">CURATION</span>
+                <span class="badge">MF_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> It is firmly established that MKS-2 = TMEM216/MKS2 is a small multi-pass membrane protein of the TZ, a core MKS-module component required (redundantly with the NPHP module) for cilium assembly, for the ciliary gate, and for recruiting other MKS-module proteins. What is missing is a molecular-function representation: the worm GOA record carries only cellular-component and biological-process terms and no molecular_function annotation.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> This is the canonical &#34;structural subunit&#34; ontology gap shared across the transition-zone/ciliopathy gene set (cf. the DYF-2/IFT-A gap): a mechanistically well-placed protein that cannot be given an informative MF term, contributing to apparent molecular-function darkness across MKS/NPHP-module genes.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Develop/adopt a molecular-function term for a structural constituent of the ciliary transition zone (analogous to &#34;structural constituent of ribosome&#34;), then annotate MKS-2 and the other core MKS/NPHP-module subunits to it.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"TMEM-218 is no longer present at the TZ in the mks-2 MKS module mutant"</em> — PMID:26982032</li>
+
+            </ul>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Proposed term (ontology gap):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><strong>structural constituent of ciliary transition zone</strong></li>
+
+            </ul>
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The specific, non-redundant molecular contribution of MKS-2/TMEM216 within the MKS module is undetermined: its direct binding partners in the worm transition zone are not mapped, and it is unknown whether MKS-2 provides a discrete sub-function (e.g. a particular membrane-anchoring or barrier contact) or is largely interchangeable with the other core MKS-module proteins.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">RESIDUAL_SUBGAP</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> Genetics and imaging establish that MKS-2 is a core MKS-module protein whose TZ localization depends on MKS-5 and CEP-290, that it is required to recruit TMEM-218, and that it contributes to the gate; single mks-2 mutants are phenotypically near-normal and defects emerge only in mks-2;nphp-4 double mutants. What is not resolved is MKS-2&#39;s molecular interface(s) and whether it has any function that the rest of the module cannot supply.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Distinguishing a genuine non-redundant role from full module redundancy is the load-bearing question for interpreting TMEM216/MKS2 ciliopathy alleles and for understanding how individual MKS-module subunits partition the barrier-building task.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Structural/proteomic mapping of MKS-2&#39;s direct TZ partners (e.g. affinity purification, proximity labelling, cryo-EM of the MKS module) combined with separation-of-function alleles assayed for gate, Y-link, and recruitment phenotypes.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"the reason for this is unclear"</em> — PMID:26982032</li>
+
+            </ul>
+
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Tags</h2>
+        <div class="aliases">
+
+            <span class="badge">caeel-ciliopathy</span>
+
+        </div>
+    </div>
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Deep Research Sections -->
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(mks-2-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="C8JQP7" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="mks-2-c-elegans-research-notes">mks-2 (C. elegans) research notes</h1>
+<p>UniProt: C8JQP7 (C8JQP7_CAEEL) · WormBase: WBGene00194710 / C30B5.9 · Human ortholog: <strong>TMEM216 (MKS2)</strong><br />
+Taxon: NCBITaxon:6239 (Caenorhabditis elegans)</p>
+<h2 id="summary-of-gene-product">Summary of gene product</h2>
+<ul>
+<li>Small (142 aa) integral membrane protein of the ciliary <strong>transition zone (TZ)</strong>.<br />
+  UniProt/Phobius predicts 4 transmembrane helices (12–35, 47–65, 77–99, 111–133);<br />
+  the mammalian TMEM216 literature usually describes 3–4 TM segments. Pfam<br />
+<code>PF09799</code> (Transmemb_17); InterPro <code>IPR019184</code> (Uncharacterised_TM-17);<br />
+  PANTHER <code>PTHR13531</code>. No catalytic domain; "Predicted" evidence level (PE 4).</li>
+<li>Ortholog of human <strong>TMEM216/MKS2</strong>, a Meckel-Gruber syndrome / Joubert syndrome<br />
+  (JBTS2) gene. In <em>C. elegans</em> it is a <strong>core component of the MKS module</strong> of the<br />
+  ciliary transition zone, which acts with the NPHP module to build the ciliary<br />
+  gate (membrane diffusion barrier) and the Y-link connectors between the axoneme<br />
+  doublet microtubules and the ciliary membrane.</li>
+</ul>
+<h2 id="known-well-supported">KNOWN (well supported)</h2>
+<h3 id="localization-ciliary-transition-zone">Localization: ciliary transition zone</h3>
+<ul>
+<li>MKS-2::GFP is concentrated at the TZ of amphid (head) and phasmid (tail) sensory<br />
+  cilia, immediately distal to the basal body/transition fibres, marked relative to<br />
+  XBX-1::tdTomato. [PMID:26982032 Fig 2/3/4 text: MKS-2::GFP is used as a TZ<br />
+  comarker throughout Li et al 2016]</li>
+<li><a href="https://pubmed.ncbi.nlm.nih.gov/26982032" title="MKSR-1::tdTomato and MKS-2::GFP are TZ protein comarkers (in wild-type) that mislocalise in the cep-290 mutant">PMID:26982032</a></li>
+<li>Lambacher et al 2016 (TMEM107 paper, abstract-only in cache): the MKS module<br />
+  membrane proteins (which include MKS-2/TMEM216) are immobile and show periodic<br />
+  localization within the TZ; TMEM-107 organizes recruitment of MKS-1, TMEM-231,<br />
+  JBTS-14. <a href="https://pubmed.ncbi.nlm.nih.gov/26595381" title="MKS module membrane proteins are immobile and super-resolution microscopy in worms and mammalian cells reveals periodic localizations within the TZ">PMID:26595381</a></li>
+<li>IDA annotation GO:0035869 (ciliary transition zone) is WormBase-assigned from<br />
+  PMID:26595381 (curator read full text; abstract-only in our cache).</li>
+</ul>
+<h3 id="core-mks-module-identity-and-gate-function">Core MKS-module identity and gate function</h3>
+<ul>
+<li>MKS-2 is explicitly one of the <strong>"core" MKS module proteins</strong> (with MKSR-1, MKSR-2,<br />
+  TMEM-231) that are all required for TZ <strong>gate function</strong> — restricting the<br />
+  inappropriate entry of the membrane-associated protein TRAM-1a into cilia.<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/26982032" title="these“core” TZ proteins are all necessary for TZ gate function—namely, restricting the inappropriate entry of membrane-associated TRAM-1a into cilia">PMID:26982032</a></li>
+<li>In the <em>cep-290</em> mutant, MKS-2 mislocalizes / "leaks" into the axoneme, i.e. its<br />
+  correct TZ confinement depends on the upstream assembly factors MKS-5 (RPGRIP1L)<br />
+  and CEP-290. <a href="https://pubmed.ncbi.nlm.nih.gov/26982032" title="MKS-2 “leaks'”into the axoneme">PMID:26982032</a></li>
+</ul>
+<h3 id="role-in-recruitingassembling-other-tz-proteins-protein-localization-to-tz">Role in recruiting/assembling other TZ proteins (protein localization to TZ)</h3>
+<ul>
+<li>MKS-2 is required for TZ localization of the peripheral MKS-module protein<br />
+  TMEM-218: in the <em>mks-2</em> mutant TMEM-218 is absent from the TZ.<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/26982032" title="TMEM-218 is no longer present at the TZ in the mks-2 MKS module mutant">PMID:26982032</a></li>
+<li>Reciprocally, MKS-2 does NOT require TMEM-218 for its own localization:<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/26982032" title="TMEM-218 is not required for the localisation of MKS-5, MKS-2 (“core” MKS module protein), or NPHP-4">PMID:26982032</a></li>
+<li>Supports GO:1904491 (protein localization to ciliary transition zone), IMP.</li>
+</ul>
+<h3 id="genetic-redundancy-cilium-assembly-module-logic">Genetic redundancy / cilium assembly (module logic)</h3>
+<ul>
+<li>Single <em>mks-2</em> null mutants have <strong>no overt dye-filling (Dyf) defect</strong> — cilia<br />
+  still assemble. The MKS module is highly redundant.<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/26863025" title="Similar to mks-1(tm2705) and mks-2(nx111) single mutants, there was no overt defect in dye uptake">PMID:26863025</a></li>
+<li>A novel EMS allele <em>mks-2(yhw128)</em> (start-codon G→A) was recovered as an<br />
+  enhancer of <em>nphp-4(tm925)</em>: <em>nphp-4;mks-2</em> double mutants are strongly Dyf and<br />
+  mislocalize MKS-3::GFP; non-complementation with <em>mks-2(mx1198)/(nx111)</em> confirms<br />
+  identity. <a href="https://pubmed.ncbi.nlm.nih.gov/26863025" title="failed to complement the Dyf phenotypes of nphp-4(tm925);mks-1(tm2705), nphp-4;mks-2(mx1198), and nphp-4;mks-5(tm3100)">PMID:26863025</a></li>
+<li>Supports GO:1905515 (non-motile cilium assembly) by IMP (mks-2 allele) and by<br />
+    IGI (genetic interaction with nphp-4 = UniProtKB:G5ECP0).</li>
+<li>Confirmed G5ECP0 = nphp-4 (genes/worm/nphp-4/nphp-4-ai-review.yaml <code>id: G5ECP0</code>).</li>
+<li>The redundancy logic is canonical: MKS-module single mutants are subtle; MKS+NPHP<br />
+  double mutants disrupt the barrier / Y-links. mks-2 behaves as an MKS-module gene<br />
+  (no synthetic Dyf with other MKS-module mutants such as tmem-218/mks-3;<br />
+  synthetic Dyf with NPHP-module nphp-4).<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/26982032" title="combining the tmem-218 mutation with another MKS module mutant, mks-2 [28], does not cause a dye-filling phenotype">PMID:26982032</a></li>
+</ul>
+<h3 id="assembly-hierarchy-upstream-factors">Assembly hierarchy (upstream factors)</h3>
+<ul>
+<li>MKS-5 (RPGRIP1L) is the master TZ assembly factor and CEP-290 acts between MKS-5<br />
+  and MKS-module proteins; both are required to localize MKS-2 to the TZ.<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/26982032" title="MKS-5 as a critical assembly factor for all known MKS module proteins tested thus far">PMID:26982032</a></li>
+</ul>
+<h2 id="not-known-knowledge-gaps">NOT known / knowledge gaps</h2>
+<ul>
+<li><strong>No precise molecular-function term / no assigned MF.</strong> GOA carries only CC and<br />
+  BP terms for mks-2; there is no GO molecular-function term for a "structural<br />
+  constituent / diffusion-barrier scaffold subunit of the ciliary transition zone."<br />
+  The gene reads as MF-dark despite a well-understood CC/BP role. (Analogous to the<br />
+  DYF-2 "structural constituent of IFT particle" ontology gap.) → ONTOLOGY gap.</li>
+<li><strong>The specific molecular contribution of MKS-2/TMEM216 within the MKS module is<br />
+  undetermined.</strong> Its direct binding partners in the worm TZ, and whether it<br />
+  contributes a discrete, non-redundant biochemical/structural sub-function (vs.<br />
+  being fully redundant with other core MKS proteins) are not resolved. Li et al<br />
+  note that <em>how</em> different core proteins mislocalize differs (MKS-2 "leaks" into<br />
+  the axoneme whereas TMEM-17 stays in the dendrite) but "the reason for this is<br />
+  unclear." <a href="https://pubmed.ncbi.nlm.nih.gov/26982032" title="the reason for this is unclear">PMID:26982032</a> → BIOLOGY / RESIDUAL_SUBGAP.</li>
+<li>No worm phenotype uniquely attributable to <em>mks-2</em> beyond the shared MKS-module<br />
+  redundancy; a non-redundant role, if any, is unknown.</li>
+</ul>
+<h2 id="existing-goa-annotations-7-review-plan">Existing GOA annotations (7) — review plan</h2>
+<table>
+<thead>
+<tr>
+<th>#</th>
+<th>Term</th>
+<th>Evidence</th>
+<th>Ref</th>
+<th>Plan</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>1</td>
+<td>GO:0035869 ciliary transition zone (is_active_in)</td>
+<td>IBA</td>
+<td>GO_REF:0000033</td>
+<td>ACCEPT (core CC)</td>
+</tr>
+<tr>
+<td>2</td>
+<td>GO:1905515 non-motile cilium assembly (involved_in)</td>
+<td>IBA</td>
+<td>GO_REF:0000033</td>
+<td>ACCEPT (module-level BP)</td>
+</tr>
+<tr>
+<td>3</td>
+<td>GO:0016020 membrane (located_in)</td>
+<td>IEA</td>
+<td>GO_REF:0000044</td>
+<td>KEEP_AS_NON_CORE (generic; subsumed by TZ membrane)</td>
+</tr>
+<tr>
+<td>4</td>
+<td>GO:1905515 non-motile cilium assembly (involved_in)</td>
+<td>IMP</td>
+<td>PMID:26863025</td>
+<td>ACCEPT (mks-2 allele; redundant single-mutant)</td>
+</tr>
+<tr>
+<td>5</td>
+<td>GO:1905515 non-motile cilium assembly (involved_in)</td>
+<td>IGI</td>
+<td>PMID:26863025 (with nphp-4)</td>
+<td>ACCEPT (synthetic Dyf)</td>
+</tr>
+<tr>
+<td>6</td>
+<td>GO:1904491 protein localization to ciliary transition zone (involved_in)</td>
+<td>IMP</td>
+<td>PMID:26982032</td>
+<td>ACCEPT (recruits TMEM-218)</td>
+</tr>
+<tr>
+<td>7</td>
+<td>GO:0035869 ciliary transition zone (located_in)</td>
+<td>IDA</td>
+<td>PMID:26595381</td>
+<td>ACCEPT (direct localization)</td>
+</tr>
+</tbody>
+</table>
+<p>Plus one NEW: GO:1903565 negative regulation of protein localization to cilium<br />
+(gate function; restricting TRAM-1a entry), IMP, PMID:26982032.</p>
+<h2 id="deep-research-provenance-note">Deep-research provenance note</h2>
+<p>Falcon (Edison) deep research was launched (<code>just deep-research-falcon worm mks-2
+--fallback perplexity-lite</code>) but did not return a file within ~24 min — the Edison<br />
+API was saturated by many concurrent gene jobs from parallel agents (429-class<br />
+slowdown; cf. falcon concurrency limits). No <code>*-deep-research-*.md</code> was produced.<br />
+Per project guidance, this review therefore rests on primary literature: the two<br />
+full-text papers PMID:26982032 (Li et al) and PMID:26863025 (Masyukova et al),<br />
+which both extensively assay mks-2, plus the abstract-only PMID:26595381<br />
+(Lambacher et al) whose WormBase IDA is deferred to the curator. Every<br />
+<code>supporting_text</code> is a verbatim substring of a cached publication; nothing was<br />
+fabricated. No annotation required UNDECIDED because all seven GOA annotations are<br />
+verifiable from the cached full-text papers.</p>
+<h2 id="references-used">References used</h2>
+<ul>
+<li>PMID:26982032 — Li et al 2016, PLoS Biol. MKS5/CEP290-dependent assembly of the<br />
+  TZ; full text cached; mks-2 heavily featured (core MKS module, gate, recruits<br />
+  TMEM-218). HIGH relevance, VERIFIED.</li>
+<li>PMID:26863025 — Masyukova et al 2016, PLoS Genet. Screen for nphp-4 modifiers;<br />
+  novel mks-2(yhw128) allele, synthetic Dyf with nphp-4. Full text cached. HIGH,<br />
+  VERIFIED. Source of the IMP + IGI cilium-assembly annotations.</li>
+<li>PMID:26595381 — Lambacher et al 2016, Nat Cell Biol. TMEM107 recruits ciliopathy<br />
+  proteins; MKS module membrane proteins immobile/periodic in TZ. Abstract-only in<br />
+  cache; WormBase IDA for mks-2 TZ localization drawn from full text. HIGH, VERIFIED<br />
+  (defer to curator for the IDA full-text evidence).</li>
+</ul>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: C8JQP7
+gene_symbol: mks-2
+product_type: PROTEIN
+status: COMPLETE
+taxon:
+  id: NCBITaxon:6239
+  label: Caenorhabditis elegans
+description: &gt;-
+  MKS-2 is the Caenorhabditis elegans ortholog of human TMEM216 (MKS2), a small
+  multi-pass integral membrane protein of the ciliary transition zone (TZ). It is
+  a core component of the MKS module, one of two protein modules (MKS and NPHP)
+  that together assemble the TZ at the base of sensory cilia, building the Y-link
+  connectors between the axoneme doublet microtubules and the ciliary membrane and
+  establishing the ciliary gate (a membrane diffusion barrier that restricts entry
+  of non-ciliary membrane proteins into the cilium). MKS-2 is expressed in ciliated
+  sensory neurons and concentrates at the TZ immediately distal to the basal body
+  transition fibres. Its TZ localization depends on the upstream assembly factors
+  MKS-5 (RPGRIP1L) and CEP-290, and MKS-2 in turn is required to recruit peripheral
+  MKS-module proteins such as TMEM-218 to the TZ. Consistent with the strong
+  functional redundancy among transition-zone genes, mks-2 single mutants have no
+  overt ciliary phenotype, whereas double mutants combining mks-2 with NPHP-module
+  genes (e.g. nphp-4) disrupt the ciliary gate and cilium integrity. In humans,
+  TMEM216/MKS2 mutations cause Meckel-Gruber and Joubert syndromes.
+existing_annotations:
+  - term:
+      id: GO:0035869
+      label: ciliary transition zone
+    evidence_type: IBA
+    original_reference_id: GO_REF:0000033
+    qualifier: is_active_in
+    review:
+      summary: &gt;-
+        MKS-2 is a transition-zone protein; the phylogenetically inferred TZ
+        localization is directly corroborated by experimental imaging in C. elegans
+        (MKS-2::GFP concentrates at the TZ) and matches the conserved role of the
+        TMEM216/MKS module across metazoans.
+      action: ACCEPT
+      reason: &gt;-
+        Core cellular-component annotation. The IBA inference (PANTHER family
+        PTHR13531 / MKS module) is consistent with direct experimental evidence in
+        C. elegans, so it should be retained as a core location.
+      supported_by:
+        - reference_id: PMID:26982032
+          supporting_text: &gt;-
+            MKSR-1::tdTomato and MKS-2::GFP are TZ protein comarkers
+  - term:
+      id: GO:1905515
+      label: non-motile cilium assembly
+    evidence_type: IBA
+    original_reference_id: GO_REF:0000033
+    qualifier: involved_in
+    review:
+      summary: &gt;-
+        As a core MKS-module subunit, MKS-2 participates in building the transition
+        zone during assembly of the non-motile (sensory) cilia of C. elegans.
+        Because the module is redundant, the requirement is most evident in
+        combination with NPHP-module loss rather than in the mks-2 single mutant.
+      action: ACCEPT
+      reason: &gt;-
+        The BP inference is appropriate for a core TZ subunit; C. elegans sensory
+        cilia are non-motile and the MKS module is required (redundantly) for their
+        assembly. Retained as a module-level function; note that MKS-2&#39;s individual
+        contribution is only unmasked in double mutants.
+      supported_by:
+        - reference_id: PMID:26982032
+          supporting_text: &gt;-
+            combining the tmem-218 mutation with another MKS module mutant, mks-2
+  - term:
+      id: GO:0016020
+      label: membrane
+    evidence_type: IEA
+    original_reference_id: GO_REF:0000044
+    qualifier: located_in
+    review:
+      summary: &gt;-
+        MKS-2 is a multi-pass integral membrane protein (UniProt/Phobius predicts
+        four transmembrane helices), so a generic membrane localization is correct.
+        However, this SubCell-derived term is far less informative than the specific
+        ciliary transition-zone localization captured by the IDA/IBA annotations.
+      action: KEEP_AS_NON_CORE
+      reason: &gt;-
+        The annotation is not wrong — MKS-2 is an integral membrane protein — but
+        the generic &#39;membrane&#39; term is subsumed by the transition-zone (ciliary
+        membrane) localization that represents the biologically meaningful site of
+        action. Retain as a non-core, low-information electronic annotation.
+      supported_by:
+        - reference_id: GO_REF:0000044
+          supporting_text: &gt;-
+            Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location
+  - term:
+      id: GO:1905515
+      label: non-motile cilium assembly
+    evidence_type: IMP
+    original_reference_id: PMID:26863025
+    qualifier: involved_in
+    review:
+      summary: &gt;-
+        Masyukova et al. recovered a novel mks-2 allele (yhw128) in a screen for
+        enhancers of nphp-4 ciliary defects. The mks-2 single mutant has no overt
+        dye-filling defect, consistent with MKS-module redundancy, but the gene is
+        required for normal sensory-cilium assembly when the NPHP module is
+        compromised.
+      action: ACCEPT
+      reason: &gt;-
+        Experimental (IMP) annotation from a WormBase curator. The single-mutant
+        phenotype is subtle (redundancy), but the allele&#39;s identity and its ciliary
+        role were confirmed by non-complementation and transgenic rescue. Do not
+        overrule the curator; the annotation reflects MKS-2&#39;s role in cilium
+        assembly.
+      supported_by:
+        - reference_id: PMID:26863025
+          supporting_text: &gt;-
+            there was no overt defect in dye uptake in mks-1(yhw146) or mks-2(yhw128) mutants
+        - reference_id: PMID:26863025
+          supporting_text: &gt;-
+            failed to complement the Dyf phenotypes of nphp-4(tm925);mks-1(tm2705), nphp-4;mks-2(mx1198), and nphp-4;mks-5(tm3100)
+  - term:
+      id: GO:1905515
+      label: non-motile cilium assembly
+    evidence_type: IGI
+    original_reference_id: PMID:26863025
+    qualifier: involved_in
+    review:
+      summary: &gt;-
+        The genetic-interaction (IGI) evidence captures the canonical MKS/NPHP
+        redundancy: mks-2 interacts genetically with nphp-4 (UniProtKB:G5ECP0), and
+        the nphp-4;mks-2 double mutant shows a strong dye-filling (Dyf) defect and
+        MKS-3 mislocalization not seen in either single mutant.
+      action: ACCEPT
+      reason: &gt;-
+        Well-supported IGI annotation. The synthetic phenotype with the NPHP-module
+        gene nphp-4 is the standard genetic signature placing mks-2 in the MKS
+        module and demonstrating its (redundant) requirement for cilium assembly.
+      supported_by:
+        - reference_id: PMID:26863025
+          supporting_text: &gt;-
+            there was no overt defect in dye uptake in mks-1(yhw146) or mks-2(yhw128) mutants
+        - reference_id: PMID:26863025
+          supporting_text: &gt;-
+            failed to complement the Dyf phenotypes of nphp-4(tm925);mks-1(tm2705), nphp-4;mks-2(mx1198), and nphp-4;mks-5(tm3100)
+  - term:
+      id: GO:1904491
+      label: protein localization to ciliary transition zone
+    evidence_type: IMP
+    original_reference_id: PMID:26982032
+    qualifier: involved_in
+    review:
+      summary: &gt;-
+        Li et al. showed that MKS-2 is required for the transition-zone localization
+        of the peripheral MKS-module protein TMEM-218: in the mks-2 mutant,
+        TMEM-218 is absent from the TZ, whereas MKS-2 itself does not require
+        TMEM-218 for its own localization. This defines MKS-2 as a &#39;core&#39; subunit
+        needed to recruit/assemble other MKS-module components at the TZ.
+      action: ACCEPT
+      reason: &gt;-
+        Directly supported experimental (IMP) annotation. Loss of mks-2 mislocalizes
+        a downstream TZ protein, demonstrating a role in establishing protein
+        localization to the transition zone. Core function.
+      supported_by:
+        - reference_id: PMID:26982032
+          supporting_text: &gt;-
+            TMEM-218 is no longer present at the TZ in the mks-2 MKS module mutant
+        - reference_id: PMID:26982032
+          supporting_text: &gt;-
+            TMEM-218 is not required for the localisation of MKS-5, MKS-2
+  - term:
+      id: GO:0035869
+      label: ciliary transition zone
+    evidence_type: IDA
+    original_reference_id: PMID:26595381
+    qualifier: located_in
+    review:
+      summary: &gt;-
+        WormBase IDA annotation for direct localization of MKS-2 to the ciliary
+        transition zone. The cached record for this paper is abstract-only; the
+        abstract establishes that the MKS-module membrane proteins (which include
+        MKS-2/TMEM216) are TZ-localized, immobile, and periodically arranged within
+        the TZ, and the curator assigned the IDA from the full text.
+      action: ACCEPT
+      reason: &gt;-
+        Experimental (IDA) localization to the transition zone, concordant with the
+        IBA annotation and with MKS-2::GFP imaging in PMID:26982032. The full text
+        (not in cache) contains the direct evidence; per curation guidance the
+        experimental annotation is retained rather than second-guessed from an
+        abstract-only cache.
+      supported_by:
+        - reference_id: PMID:26595381
+          supporting_text: &gt;-
+            TZ-localized MKS module by organizing recruitment of the ciliopathy proteins
+  - term:
+      id: GO:1903565
+      label: negative regulation of protein localization to cilium
+    evidence_type: IMP
+    original_reference_id: PMID:26982032
+    qualifier: involved_in
+    review:
+      summary: &gt;-
+        MKS-2 is explicitly named among the &#39;core&#39; MKS-module TZ proteins (with
+        MKSR-1, MKSR-2, TMEM-231) that are required for ciliary gate function —
+        restricting the inappropriate entry of the membrane-associated protein
+        TRAM-1a into cilia. This gate/diffusion-barrier activity is the central
+        function of the transition zone and is not otherwise captured in GOA for
+        mks-2.
+      action: NEW
+      reason: &gt;-
+        New annotation proposed to capture MKS-2&#39;s ciliary-gate role, which is well
+        documented for the core MKS module and directly stated for MKS-2 in Li et
+        al. This mirrors the curated gate-function annotation for the sibling gene
+        mks-3 and represents a core function currently missing from mks-2&#39;s GOA
+        record.
+      supported_by:
+        - reference_id: PMID:26982032
+          supporting_text: &gt;-
+            TZ proteins are all necessary for TZ gate function
+        - reference_id: PMID:26982032
+          supporting_text: &gt;-
+            restricting the inappropriate entry of membrane-associated TRAM-1a into cilia
+  - term:
+      id: GO:0036038
+      label: MKS complex
+    evidence_type: IDA
+    original_reference_id: PMID:26982032
+    qualifier: part_of
+    review:
+      summary: &gt;-
+        MKS-2 (TMEM216) is repeatedly identified as a &#39;core&#39; MKS-module / MKSome
+        component together with MKSR-1, MKSR-2, and TMEM-231, co-localizing with
+        these subunits at the transition zone.
+      action: NEW
+      reason: &gt;-
+        New annotation capturing MKS-2 membership in the MKS complex (MKS module),
+        consistent with the sibling gene mks-3 and with its role as a core
+        MKS-module subunit at the transition zone.
+      supported_by:
+        - reference_id: PMID:26982032
+          supporting_text: &gt;-
+            which include MKS-2, MKSR-1, MKSR-2, and TMEM-231
+  - term:
+      id: GO:0005198
+      label: structural molecule activity
+    evidence_type: IDA
+    original_reference_id: PMID:26982032
+    qualifier: enables
+    review:
+      summary: &gt;-
+        As a multi-pass integral membrane subunit of the MKS module, MKS-2
+        contributes to the structural integrity of the transition zone; its loss
+        mislocalizes the downstream TZ protein TMEM-218 and compromises the ciliary
+        gate. This is the closest available molecular-function term for a
+        transition-zone scaffold subunit (see knowledge_gaps).
+      action: NEW
+      reason: &gt;-
+        New molecular-function annotation. MKS-2 has no MF term in GOA; &#39;structural
+        molecule activity&#39; is used as the nearest placeholder for a diffusion-barrier
+        scaffold subunit, more informative than generic protein binding. The precise
+        MF term is an ontology-level gap (see knowledge_gaps / proposed_new_terms).
+      supported_by:
+        - reference_id: PMID:26982032
+          supporting_text: &gt;-
+            which include MKS-2, MKSR-1, MKSR-2, and TMEM-231
+        - reference_id: PMID:26982032
+          supporting_text: &gt;-
+            TMEM-218 is no longer present at the TZ in the mks-2 MKS module mutant
+references:
+  - id: GO_REF:0000033
+    title: Annotation inferences using phylogenetic trees
+    findings: []
+  - id: GO_REF:0000044
+    title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location
+      vocabulary mapping, accompanied by conservative changes to GO terms applied by
+      UniProt
+    findings: []
+  - id: PMID:26595381
+    title: TMEM107 recruits ciliopathy proteins to subdomains of the ciliary transition
+      zone and causes Joubert syndrome.
+    findings:
+      - statement: &gt;-
+          The MKS-module membrane proteins of the ciliary transition zone are
+          immobile and periodically arranged within the TZ, and TMEM-107 organizes
+          recruitment of MKS-module ciliopathy proteins.
+        supporting_text: &gt;-
+          TZ-localized MKS module by organizing recruitment of the ciliopathy proteins
+    reference_review:
+      relevance: HIGH
+      correctness: VERIFIED
+      review_notes: &gt;-
+        PubMed-verified (Lambacher et al 2016, Nat Cell Biol). Cached record is
+        abstract-only; the abstract supports the MKS module TZ localization and
+        barrier context. The WormBase IDA for MKS-2 TZ localization draws on the
+        full text; deferring to the curator for that experimental evidence.
+  - id: PMID:26863025
+    title: A Screen for Modifiers of Cilia Phenotypes Reveals Novel MKS Alleles and
+      Uncovers a Specific Genetic Interaction between osm-3 and nphp-4.
+    findings:
+      - statement: &gt;-
+          A novel mks-2 allele (yhw128) was recovered as an enhancer of nphp-4;
+          mks-2 single mutants show no overt dye-filling defect, but nphp-4;mks-2
+          double mutants are strongly Dyf, demonstrating MKS/NPHP-module redundancy.
+        supporting_text: &gt;-
+          there was no overt defect in dye uptake in mks-1(yhw146) or mks-2(yhw128) mutants
+    reference_review:
+      relevance: HIGH
+      correctness: VERIFIED
+      review_notes: &gt;-
+        PubMed-verified (Masyukova et al 2016, PLoS Genet); full text cached.
+        Source of the IMP and IGI non-motile-cilium-assembly annotations for mks-2;
+        allele identity confirmed by non-complementation and transgenic rescue.
+  - id: PMID:26982032
+    title: MKS5 and CEP290 Dependent Assembly Pathway of the Ciliary Transition Zone.
+    findings:
+      - statement: &gt;-
+          MKS-2 is a core MKS-module TZ protein required for the transition-zone
+          localization of the peripheral protein TMEM-218.
+        supporting_text: &gt;-
+          TMEM-218 is no longer present at the TZ in the mks-2 MKS module mutant
+      - statement: &gt;-
+          The core MKS-module TZ proteins (including MKS-2) are required for ciliary
+          gate function, restricting entry of membrane-associated TRAM-1a into cilia.
+        supporting_text: &gt;-
+          restricting the inappropriate entry of membrane-associated TRAM-1a into cilia
+      - statement: &gt;-
+          MKS-2 localization to the TZ depends on the upstream assembly factor
+          MKS-5, and MKS-2 mislocalizes in the cep-290 mutant.
+        supporting_text: &gt;-
+          MKS-5 as a critical assembly factor for all known MKS module proteins tested thus far
+    reference_review:
+      relevance: HIGH
+      correctness: VERIFIED
+      review_notes: &gt;-
+        PubMed-verified (Li et al 2016, PLoS Biol); full text cached and mks-2 is
+        extensively assayed as a core MKS-module comarker. Supports the protein
+        localization to TZ (IMP), the ciliary-gate NEW annotation, and the assembly
+        hierarchy.
+core_functions:
+  - description: &gt;-
+      MKS-2 acts as a structural/scaffolding subunit of the MKS module of the
+      ciliary transition zone. As a multi-pass integral membrane protein embedded in
+      the transition-zone membrane, it contributes to the assembly and integrity of
+      the TZ (Y-link connectors and apical ring) and to the ciliary gate — the
+      membrane diffusion barrier that restricts non-ciliary membrane proteins from
+      entering the cilium. It also helps recruit peripheral MKS-module components
+      (e.g. TMEM-218) to the TZ. There is no GO molecular-function term that
+      precisely describes a transition-zone diffusion-barrier scaffold subunit;
+      &#39;structural molecule activity&#39; is used here as the closest available placeholder.
+    molecular_function:
+      id: GO:0005198
+      label: structural molecule activity
+    in_complex:
+      id: GO:0036038
+      label: MKS complex
+    locations:
+      - id: GO:0035869
+        label: ciliary transition zone
+    directly_involved_in:
+      - id: GO:1905515
+        label: non-motile cilium assembly
+      - id: GO:1904491
+        label: protein localization to ciliary transition zone
+      - id: GO:1903565
+        label: negative regulation of protein localization to cilium
+    supported_by:
+      - reference_id: PMID:26982032
+        supporting_text: &gt;-
+          TMEM-218 is no longer present at the TZ in the mks-2 MKS module mutant
+      - reference_id: PMID:26982032
+        supporting_text: &gt;-
+          restricting the inappropriate entry of membrane-associated TRAM-1a into cilia
+knowledge_gaps:
+  - gap_statement: &gt;-
+      MKS-2 has no assigned molecular function and there is no GO term to express
+      one. Its role is to be a structural/diffusion-barrier scaffold subunit of the
+      ciliary transition-zone MKS module, but GO has no molecular-function term such
+      as &#34;structural constituent of the ciliary transition zone&#34; (or &#34;diffusion
+      barrier component&#34;), so the gene reads as MF-dark despite a well-understood
+      cellular-component and biological-process role.
+    boundary: &gt;-
+      It is firmly established that MKS-2 = TMEM216/MKS2 is a small multi-pass
+      membrane protein of the TZ, a core MKS-module component required (redundantly
+      with the NPHP module) for cilium assembly, for the ciliary gate, and for
+      recruiting other MKS-module proteins. What is missing is a molecular-function
+      representation: the worm GOA record carries only cellular-component and
+      biological-process terms and no molecular_function annotation.
+    gap_kind:
+      - ONTOLOGY
+      - CURATION
+    dark_aspect: MF_DARK
+    status: OPEN
+    significance: &gt;-
+      This is the canonical &#34;structural subunit&#34; ontology gap shared across the
+      transition-zone/ciliopathy gene set (cf. the DYF-2/IFT-A gap): a mechanistically
+      well-placed protein that cannot be given an informative MF term, contributing to
+      apparent molecular-function darkness across MKS/NPHP-module genes.
+    resolution: &gt;-
+      Develop/adopt a molecular-function term for a structural constituent of the
+      ciliary transition zone (analogous to &#34;structural constituent of ribosome&#34;),
+      then annotate MKS-2 and the other core MKS/NPHP-module subunits to it.
+    provenance:
+      - reference_id: PMID:26982032
+        supporting_text: &gt;-
+          TMEM-218 is no longer present at the TZ in the mks-2 MKS module mutant
+        reference_section_type: RESULTS
+    proposed_terms:
+      - proposed_name: structural constituent of ciliary transition zone
+        proposed_definition: &gt;-
+          The action of a protein that contributes to the structural integrity of the
+          ciliary transition zone, for example by acting as an integral-membrane or
+          scaffold subunit of the MKS or NPHP module that helps build the Y-link
+          connectors and the membrane diffusion barrier at the ciliary base, without
+          itself catalyzing a biochemical reaction.
+        proposed_parent:
+          id: GO:0005198
+          label: structural molecule activity
+  - gap_statement: &gt;-
+      The specific, non-redundant molecular contribution of MKS-2/TMEM216 within the
+      MKS module is undetermined: its direct binding partners in the worm transition
+      zone are not mapped, and it is unknown whether MKS-2 provides a discrete
+      sub-function (e.g. a particular membrane-anchoring or barrier contact) or is
+      largely interchangeable with the other core MKS-module proteins.
+    boundary: &gt;-
+      Genetics and imaging establish that MKS-2 is a core MKS-module protein whose TZ
+      localization depends on MKS-5 and CEP-290, that it is required to recruit
+      TMEM-218, and that it contributes to the gate; single mks-2 mutants are
+      phenotypically near-normal and defects emerge only in mks-2;nphp-4 double
+      mutants. What is not resolved is MKS-2&#39;s molecular interface(s) and whether it
+      has any function that the rest of the module cannot supply.
+    gap_kind:
+      - BIOLOGY
+    dark_aspect: RESIDUAL_SUBGAP
+    status: OPEN
+    significance: &gt;-
+      Distinguishing a genuine non-redundant role from full module redundancy is the
+      load-bearing question for interpreting TMEM216/MKS2 ciliopathy alleles and for
+      understanding how individual MKS-module subunits partition the barrier-building
+      task.
+    resolution: &gt;-
+      Structural/proteomic mapping of MKS-2&#39;s direct TZ partners (e.g. affinity
+      purification, proximity labelling, cryo-EM of the MKS module) combined with
+      separation-of-function alleles assayed for gate, Y-link, and recruitment
+      phenotypes.
+    provenance:
+      - reference_id: PMID:26982032
+        supporting_text: &gt;-
+          the reason for this is unclear
+        reference_section_type: RESULTS
+proposed_new_terms:
+  - proposed_name: structural constituent of ciliary transition zone
+    proposed_definition: &gt;-
+      The action of a protein that contributes to the structural integrity of the
+      ciliary transition zone, for example by acting as an integral-membrane or
+      scaffold subunit of the MKS or NPHP module that helps build the Y-link
+      connectors and the membrane diffusion barrier at the ciliary base, without
+      itself catalyzing a biochemical reaction.
+    proposed_parent:
+      id: GO:0005198
+      label: structural molecule activity
+suggested_questions:
+  - question: &gt;-
+      Does MKS-2/TMEM216 make direct physical contacts with specific MKS-module
+      partners (e.g. MKSR-1/MKSR-2, TMEM-231, MKS-5) that define a discrete
+      sub-architecture of the transition zone?
+    experts: []
+  - question: &gt;-
+      Does MKS-2 have any non-redundant function unmasked only in specific cell types
+      or under stress, or is it fully interchangeable with the other core MKS-module
+      subunits?
+    experts: []
+suggested_experiments:
+  - description: &gt;-
+      Proximity labelling (TurboID/BioID) or affinity purification of tagged MKS-2 in
+      C. elegans ciliated neurons to map its direct transition-zone interaction
+      partners.
+    hypothesis: &gt;-
+      MKS-2 occupies a specific position in the MKS-module interaction network with a
+      defined set of direct membrane-protein partners.
+  - description: &gt;-
+      Structure-guided separation-of-function mutagenesis of MKS-2 transmembrane/loop
+      residues, assayed for TZ localization, TRAM-1a exclusion (gate), TMEM-218
+      recruitment, and Y-link ultrastructure by TEM.
+    hypothesis: &gt;-
+      Distinct MKS-2 residues are required for membrane anchoring versus barrier
+      function versus recruitment of peripheral MKS-module proteins.
+tags:
+  - caeel-ciliopathy
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/genes/worm/nhr-47/nhr-47-ai-review.html
+++ b/genes/worm/nhr-47/nhr-47-ai-review.html
@@ -1,0 +1,3329 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>nhr-47 - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        .propagation-review {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f8fafc;
+            border-left: 3px solid #64748b;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .propagation-title {
+            font-weight: 600;
+            color: #334155;
+            margin-bottom: 0.25rem;
+        }
+
+        .propagation-row {
+            margin-top: 0.25rem;
+        }
+
+        .propagation-source {
+            margin-top: 0.5rem;
+            padding-top: 0.5rem;
+            border-top: 1px solid #e5e7eb;
+        }
+
+        .propagation-source-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #1d4ed8;
+        }
+
+        .propagation-comment {
+            color: #4b5563;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>nhr-47</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/Q17370" target="_blank" class="term-link">
+                        Q17370
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Caenorhabditis elegans</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-complete">
+                    COMPLETE
+                </span>
+            </div>
+
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "nhr-47";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="Q17370" data-a="DESCRIPTION: nhr-47 (C24G6.4) is one of the ~280 nuclear hormon..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>nhr-47 (C24G6.4) is one of the ~280 nuclear hormone receptors (NHRs) of Caenorhabditis elegans, the great majority of which arose by a nematode-specific expansion of an ancestral HNF4-like orphan receptor and are termed supplementary nuclear receptors (supnrs). The 579-residue protein has the canonical nuclear-receptor architecture: an N-terminal DNA-binding domain built from two C4-type (Cys4) zinc-finger motifs that coordinate zinc, and a C-terminal ligand-binding domain. On the basis of this diagnostic domain organization and phylogenetic placement, NHR-47 is a zinc-dependent, sequence-specific DNA-binding transcription factor of the nuclear-receptor superfamily that acts in the nucleus to regulate RNA polymerase II transcription. It is annotated as an orphan receptor: no endogenous ligand has been identified. NHR-47 is expressed in head and tail neurons, the ventral nerve cord, the spermatheca, the pharynx and the intestine, and it physically interacts with another nuclear receptor, NHR-17. The only reported loss-of-function phenotypes are in the germline: knockdown modulates susceptibility to environmental toxicants (polystyrene nanoparticles and 6-PPD-quinone), where NHR-47 acts as a positive mediator of reproductive and transgenerational toxicity and lies upstream of insulin, Ephrin and Wnt ligand-gene expression. nhr-47 transcription is also induced by exposure to the vertebrate steroid estradiol. Its endogenous physiological role, its ligand (if any), and its direct transcriptional targets remain undetermined.</p>
+    </div>
+
+
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005634" target="_blank" class="term-link">
+                                    GO:0005634
+                                </a>
+                            </span>
+                            <span class="term-label">nucleus</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q17370" data-a="GO:0005634" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> NHR-47 is a nuclear-receptor transcription factor and acts in the nucleus. Supported by the canonical NR DNA-binding domain and UniProt subcellular location.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Nuclear localization is expected for a functional nuclear-receptor transcription factor and is independently annotated from UniProt SubCell mapping. This is a core cellular-component assignment.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000978" target="_blank" class="term-link">
+                                    GO:0000978
+                                </a>
+                            </span>
+                            <span class="term-label">RNA polymerase II cis-regulatory region sequence-specific DNA binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q17370" data-a="GO:0000978" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Sequence-specific DNA binding at Pol II cis-regulatory regions is the diagnostic molecular function of the NR DNA-binding domain (two C4 zinc fingers) that NHR-47 possesses.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Consistent with the conserved NR DBD architecture and phylogenetic placement in the HNF4-like DNA-binding-domain class. A core molecular function.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004879" target="_blank" class="term-link">
+                                    GO:0004879
+                                </a>
+                            </span>
+                            <span class="term-label">nuclear receptor activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q17370" data-a="GO:0004879" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> NHR-47 is a member of the nuclear-receptor superfamily with a canonical DBD and ligand-binding domain; nuclear receptor activity (ligand-modulated sequence-specific DNA-binding TF activity) is its family-level molecular function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Well supported by domain architecture and family membership. Note that NHR-47 is an orphan receptor: no ligand is known, so the ligand-modulated aspect of this term is inferred, not demonstrated (see knowledge_gaps). Retained as a core MF.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006357" target="_blank" class="term-link">
+                                    GO:0006357
+                                </a>
+                            </span>
+                            <span class="term-label">regulation of transcription by RNA polymerase II</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q17370" data-a="GO:0006357" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> As a sequence-specific DNA-binding TF of the NR family, NHR-47 regulates Pol II transcription. This is the core biological process for the molecular function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Directly follows from the nuclear-receptor / DNA-binding-TF molecular function and nuclear localization. Core process.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030154" target="_blank" class="term-link">
+                                    GO:0030154
+                                </a>
+                            </span>
+                            <span class="term-label">cell differentiation</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q17370" data-a="GO:0030154" data-r="GO_REF:0000033" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> A generic biological process propagated across the nuclear-receptor family by phylogenetic inference. No nhr-47-specific evidence links it to a differentiation program.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> This is a broad pan-family IBA propagation. NHR-47 has no reported role in cell differentiation; its only experimental phenotypes are germline toxicant responses. Retain (family inference is not contradicted) but mark non-core rather than core.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000978" target="_blank" class="term-link">
+                                    GO:0000978
+                                </a>
+                            </span>
+                            <span class="term-label">RNA polymerase II cis-regulatory region sequence-specific DNA binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q17370" data-a="GO:0000978" data-r="GO_REF:0000002" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> InterPro2GO assignment (IPR049636, HNF4-like DBD) of the same sequence-specific Pol II DNA-binding function, in agreement with the IBA annotation above.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Independent InterPro domain-based support for the core sequence-specific DNA-binding molecular function. Consistent with the phylogenetic annotation.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003700" target="_blank" class="term-link">
+                                    GO:0003700
+                                </a>
+                            </span>
+                            <span class="term-label">DNA-binding transcription factor activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q17370" data-a="GO:0003700" data-r="GO_REF:0000002" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> General DNA-binding transcription factor activity assigned from the nuclear-receptor zinc-finger domain (IPR001628). NHR-47 is a bona fide DNA-binding TF.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct parent molecular function for a nuclear-receptor TF; supported by the C4 zinc-finger DBD. Core MF (the RNA Pol II-specific children above are the more precise forms).
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005634" target="_blank" class="term-link">
+                                    GO:0005634
+                                </a>
+                            </span>
+                            <span class="term-label">nucleus</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000044
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q17370" data-a="GO:0005634" data-r="GO_REF:0000044" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Nuclear localization from UniProt Swiss-Prot subcellular-location mapping (SL-0191), consistent with the IBA nucleus annotation.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Independent support for nuclear localization of this transcription factor. Core CC.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006355" target="_blank" class="term-link">
+                                    GO:0006355
+                                </a>
+                            </span>
+                            <span class="term-label">regulation of DNA-templated transcription</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q17370" data-a="GO:0006355" data-r="GO_REF:0000002" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> General (DNA-templated) transcription-regulation term from InterPro. This is the broad parent of the RNA Pol II-specific regulation term.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Not wrong, but less informative than the RNA polymerase II-specific regulation term (GO:0006357) already accepted as core. Retain as a non-core general annotation.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008270" target="_blank" class="term-link">
+                                    GO:0008270
+                                </a>
+                            </span>
+                            <span class="term-label">zinc ion binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q17370" data-a="GO:0008270" data-r="GO_REF:0000002" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> The two C4-type (Cys4) zinc-finger motifs of the NR DNA-binding domain coordinate zinc; zinc binding is a structural molecular function underpinning DNA binding.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Directly supported by the diagnostic C4 zinc-finger DBD (ZN_FING 11-31 and 47-71 in UniProt Q17370). Structural MF that enables the core DNA-binding function.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030522" target="_blank" class="term-link">
+                                    GO:0030522
+                                </a>
+                            </span>
+                            <span class="term-label">intracellular receptor signaling pathway</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000108
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q17370" data-a="GO:0030522" data-r="GO_REF:0000108" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Auto-inferred by inter-ontology logic from nuclear receptor activity (GO:0004879). For an orphan receptor with no known ligand, the signaling-pathway aspect is unproven.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> A logically-derived (GO_REF:0000108) consequence of the nuclear-receptor MF, not direct evidence. Because NHR-47 is an orphan receptor with no demonstrated ligand-activated signaling, retain as non-core rather than core.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0043565" target="_blank" class="term-link">
+                                    GO:0043565
+                                </a>
+                            </span>
+                            <span class="term-label">sequence-specific DNA binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q17370" data-a="GO:0043565" data-r="GO_REF:0000002" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Sequence-specific DNA binding assigned from the NR zinc-finger domain (IPR001628); the general parent of the Pol II cis-regulatory DNA-binding term.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Supported by the conserved C4 zinc-finger DBD. Core MF (parent of GO:0000978).
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/19123269" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:19123269
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Empirically controlled mapping of the Caenorhabditis elegans...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q17370" data-a="GO:0005515" data-r="PMID:19123269" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Experimental yeast two-hybrid interaction captured in the worm interactome; the partner is the nuclear receptor NHR-17 (UniProtKB:Q17589). &#34;Protein binding&#34; is an uninformative molecular-function term.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> A real, curated physical interaction (NHR-47&lt;-&gt;NHR-17), so it should not be removed. However GO:0005515 conveys no specific molecular function, and a single Y2H edge does not justify a more informative MF (e.g. nuclear receptor binding) as a core function. Retain as non-core.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/23791784" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:23791784
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Extensive rewiring and complex evolutionary dynamics in a C....
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q17370" data-a="GO:0005515" data-r="PMID:23791784" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Second experimental interaction annotation (C. elegans multiparameter TF network), again with NHR-17 (UniProtKB:Q17589). Uninformative &#34;protein binding&#34; term.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Corroborates the NHR-47&lt;-&gt;NHR-17 interaction from an independent dataset. Keep (real interaction) but non-core; GO:0005515 does not describe a specific molecular function.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>Sequence-specific DNA-binding transcription factor of the nuclear-receptor superfamily. NHR-47 carries the diagnostic nuclear-receptor DNA-binding domain formed by two C4-type (Cys4) zinc-finger motifs that coordinate zinc, together with a C-terminal ligand-binding domain. Acting in the nucleus, it binds RNA polymerase II cis-regulatory regions in a sequence-specific manner to regulate transcription. It is an orphan receptor (no ligand identified), belonging to the HNF4-derived supplementary nuclear receptor class of C. elegans.</h3>
+                <span class="vote-buttons" data-g="Q17370" data-a="FUNCTION: Sequence-specific DNA-binding transcription factor..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004879" target="_blank" class="term-link">
+                            nuclear receptor activity
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006357" target="_blank" class="term-link">
+                                regulation of transcription by RNA polymerase II
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005634" target="_blank" class="term-link">
+                                nucleus
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/15983867" target="_blank" class="term-link">
+                                PMID:15983867
+                            </a>
+
+                        </span>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>Zinc-dependent, sequence-specific DNA binding. The two C4 zinc fingers of the NR DNA-binding domain coordinate zinc and mediate recognition of specific DNA response elements, providing the biochemical basis for NHR-47 transcription-factor activity.</h3>
+                <span class="vote-buttons" data-g="Q17370" data-a="FUNCTION: Zinc-dependent, sequence-specific DNA binding. The..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0043565" target="_blank" class="term-link">
+                            sequence-specific DNA binding
+                        </a>
+                    </span>
+                </div>
+
+
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005634" target="_blank" class="term-link">
+                                nucleus
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/15983867" target="_blank" class="term-link">
+                                PMID:15983867
+                            </a>
+
+                        </span>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000002.md" target="_blank" class="term-link">
+                            GO_REF:0000002
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation through association of InterPro records with GO terms</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
+                            GO_REF:0000033
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Annotation inferences using phylogenetic trees</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
+                            GO_REF:0000044
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000108.md" target="_blank" class="term-link">
+                            GO_REF:0000108
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Automatic assignment of GO terms using logical inference, based on on inter-ontology links</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/19123269" target="_blank" class="term-link">
+                            PMID:19123269
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Empirically controlled mapping of the Caenorhabditis elegans protein-protein interactome network.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/23791784" target="_blank" class="term-link">
+                            PMID:23791784
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Extensive rewiring and complex evolutionary dynamics in a C. elegans multiparameter transcription factor network.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/15983867" target="_blank" class="term-link">
+                            PMID:15983867
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Explosive lineage-specific expansion of the orphan nuclear receptor HNF4 in nematodes.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/38922100" target="_blank" class="term-link">
+                            PMID:38922100
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Transgenerational Response of Germline Nuclear Hormone Receptor Genes to Nanoplastics at Predicted Environmental Doses in Caenorhabditis elegans.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/40482507" target="_blank" class="term-link">
+                            PMID:40482507
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">6-PPD quinone induces response of nuclear hormone receptors in the germline associated with formation of reproductive toxicity in Caenorhabditis elegans.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/21676746" target="_blank" class="term-link">
+                            PMID:21676746
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Changes in Nuclear Receptor and Vitellogenin Gene Expression in Response to Steroids and Heavy Metal in Caenorhabditis elegans.</div>
+
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Questions for Experts</h2>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Is NHR-47 a ligand-regulated receptor, and if so what endogenous metabolite or lipid binds its ligand-binding domain, or is it a constitutive/orphan transcriptional regulator?</p>
+
+                    <p style="margin-top: 0.5rem;"><em>Suggested experts: Nuclear-receptor biochemists, C. elegans NHR-family biologists</em></p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q17370" data-a="Q: Is NHR-47 a ligand-regulated receptor, and if so w..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> What are the direct genomic binding sites and target genes of NHR-47, and does it act as a transcriptional activator or repressor?</p>
+
+                    <p style="margin-top: 0.5rem;"><em>Suggested experts: Transcription / gene-regulatory-network biologists</em></p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q17370" data-a="Q: What are the direct genomic binding sites and targ..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> What is the endogenous (non-toxicant) physiological role of nhr-47, given its expression in neurons, the ventral nerve cord, spermatheca, pharynx and intestine and its germline role in toxicant responses?</p>
+
+                    <p style="margin-top: 0.5rem;"><em>Suggested experts: C. elegans developmental / germline biologists</em></p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q17370" data-a="Q: What is the endogenous (non-toxicant) physiologica..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Experiments</h2>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Determine the direct NHR-47 regulon by ChIP-seq or CUT&amp;RUN with an endogenously tagged NHR-47, combined with RNA-seq of a null mutant, to identify direct target genes and the DNA response element and to establish activator vs repressor behavior.</p>
+
+
+
+                    <p style="margin-top: 0.5rem;">Type: Genome-wide binding assay</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q17370" data-a="EXPERIMENT: Determine the direct NHR-47 regulon by ChIP-seq or..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Express and purify the NHR-47 ligand-binding domain and screen for bound endogenous lipids/metabolites (e.g. by lipidomics of co-purified ligands or reporter-based ligand-sensing assays) to test whether NHR-47 is ligand-regulated or a true orphan.</p>
+
+
+
+                    <p style="margin-top: 0.5rem;">Type: Ligand identification</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q17370" data-a="EXPERIMENT: Express and purify the NHR-47 ligand-binding domai..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Generate and characterize a null allele (CRISPR) across development, metabolism, reproduction, stress and innate-immune assays to define the baseline endogenous function, and test genetic interaction with the interacting receptor nhr-17.</p>
+
+
+
+                    <p style="margin-top: 0.5rem;">Type: Loss-of-function phenotyping</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q17370" data-a="EXPERIMENT: Generate and characterize a null allele (CRISPR) a..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Knowledge Gaps</h2>
+        <p style="color: #555; font-size: 0.92rem; margin-top: -0.3rem;">
+            What is <em>not</em> known — curated, literature-grounded statements of the open
+            unknowns (the inverse of core functions).
+        </p>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> Whether NHR-47 binds an endogenous small-molecule ligand — and, if so, its chemical identity — is unknown. It is classified as an orphan receptor, and as a member of the HNF4-derived supplementary nuclear receptors it may have lost or substantially altered ligand-dependent regulation.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">MF_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> NHR-47 has a canonical nuclear-receptor ligand-binding domain (UniProt NR LBD, residues 164-553), but UniProt annotates it as an orphan nuclear receptor and no ligand has been reported. nhr-47 transcription is induced by estradiol exposure, but transcriptional induction is not evidence that estradiol (or any specific molecule) is a direct NHR-47 ligand.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Knowing whether NHR-47 is ligand-regulated (and by what) would determine whether it is a sensor of a metabolite/hormone or a constitutive/orphan transcriptional regulator, and would shape any pharmacological or genetic strategy to control its activity.</p>
+
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"This origin has specific implications for the role of ligand binding in the function and evolution of the nematode supplementary nuclear receptors."</em> — PMID:15983867</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The direct transcriptional targets and the DNA response element bound by NHR-47 in vivo are undetermined, and it is unknown whether NHR-47 acts as an activator or a repressor. No ChIP, reporter, or motif data define its regulon; the downstream genes that change on nhr-47 knockdown in toxicant assays (e.g. ins-3, daf-28, efn-3) are whole-organism readouts, not demonstrated direct targets.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span><span class="badge">CURATION</span>
+                <span class="badge">MF_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> NHR-47 is a sequence-specific DNA-binding transcription factor and participates in the C. elegans transcription-factor interaction network, and knockdown alters downstream secreted-ligand gene expression, but no bona fide direct target has been established.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Identifying direct targets and the response element would convert NHR-47 from a predicted TF into a defined regulator and reveal the pathway(s) it controls.</p>
+
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"expressions of ins-3, daf-28, and ins-39 encoding insulin ligands, efn-3 encoding Ephrin ligand, and lin-44 encoding Wnt ligand, as well as expressions of their receptor genes (daf-2, vab-1, and/or mig-1), were dysregulated by the RNAi of daf-12, nhr-14, nhr-47, and nhr-12"</em> — PMID:38922100</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The endogenous physiological role and definitive loss-of-function phenotype of nhr-47 are unresolved. Its only reported phenotypes are germline RNAi effects that modulate susceptibility to environmental toxicants (polystyrene nanoparticles and 6-PPD-quinone); no baseline developmental, metabolic, or immune phenotype, and no characterized null mutant, has been reported.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">BP_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> nhr-47 is expressed in neurons, ventral nerve cord, spermatheca, pharynx and intestine, and germline knockdown modulates transgenerational/reproductive toxicant responses, but a stand-alone required function under normal conditions has not been defined.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> A defined loss-of-function phenotype would anchor NHR-47&#39;s biological process annotation, which is currently only family-propagated (IBA) or inferred from a toxicant-stress context.</p>
+
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"RNAi of daf-12, nhr-14, and nhr-47 caused resistance, whereas RNAi of nhr-12 conferred susceptibility to transgenerational PS-NP toxicity"</em> — PMID:38922100</li>
+
+                <li><em>"6-PPDQ reproductive toxicity was suppressed by nhr-47, nhr-14, daf-12, and nhr-249 RNAi and accelerated by nhr-12, nhr-145, and nhr-171 RNAi"</em> — PMID:40482507</li>
+
+            </ul>
+
+
+        </div>
+
+    </div>
+
+
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Deep Research Sections -->
+
+    <div class="section">
+        <h2 class="section-title">Deep Research</h2>
+
+        <details class="deep-research-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; gap: 1rem;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Falcon</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(nhr-47-deep-research-falcon.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="Q17370" data-a="DEEP_RESEARCH: Falcon" data-r="" data-act="DEEP_RESEARCH" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This deep research is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This deep research needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+
+                <div class="report-meta">
+
+                    <span class="report-meta-text">Comprehensive Research Report: NHR-47 (C24G6.4) in *Caenorhabditis elegans*</span>
+
+
+                    <span class="report-badge">Falcon</span>
+
+
+                    <span class="report-badge">Edison Scientific Literature</span>
+
+
+                    <span class="report-badge">22 citations</span>
+
+
+                    <span class="report-badge">1 artifacts</span>
+
+
+                    <span class="report-meta-text">2026-07-04T17:24:09.725428</span>
+
+
+
+                </div>
+
+
+                <div class="artifact-list">
+
+
+
+                    <div class="artifact-link">
+                        <a href="nhr-47-deep-research-falcon_artifacts/artifact-00.md" class="term-link">Edison artifact artifact-00</a>
+                        <span>(text/markdown)</span>
+                    </div>
+
+
+                </div>
+
+                <p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h1 id="comprehensive-research-report-nhr-47-c24g64-in-caenorhabditis-elegans">Comprehensive Research Report: NHR-47 (C24G6.4) in <em>Caenorhabditis elegans</em></h1>
+<h2 id="gene-identity-and-nomenclature">Gene Identity and Nomenclature</h2>
+<p>NHR-47 (UniProt: Q17370) is a nuclear hormone receptor encoded by the gene <em>nhr-47</em> (systematic/ORF name C24G6.4) on chromosome II of <em>Caenorhabditis elegans</em>. The gene carries an older synonym, <em>csr-1</em>, which must not be confused with the well-characterized CSR-1 Argonaute protein involved in small RNA pathways—a completely distinct gene product. NHR-47 contains an HNF4-like DNA-binding domain (IPR049636) and a nuclear hormone receptor ligand-binding domain (IPR000536), consistent with its classification as a member of the nuclear hormone receptor superfamily (Nuclear_hrmn_rcpt, IPR001723; Nuclear_hormone_rcpt_NR2, IPR050274).</p>
+<p>The following table summarizes verified properties and available experimental data for NHR-47:</p>
+<table>
+<thead>
+<tr>
+<th>Category</th>
+<th>NHR-47 summary</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Gene / protein identifiers</td>
+<td><strong>Gene name:</strong> nhr-47; <strong>Systematic name / ORF:</strong> C24G6.4; <strong>UniProt accession:</strong> Q17370; <strong>Reported synonym:</strong> csr-1 <em>(must not be confused with the unrelated CSR-1 Argonaute gene)</em> (novillo2005changesinnuclear pages 3-4)</td>
+</tr>
+<tr>
+<td>Organism</td>
+<td><em>Caenorhabditis elegans</em> (novillo2005changesinnuclear pages 3-4)</td>
+</tr>
+<tr>
+<td>Protein family</td>
+<td>Nuclear hormone receptor (NHR); HNF4-like <strong>supplementary NHR</strong> within the nematode-expanded receptor family (taubert2011nuclearhormonereceptors pages 2-4, taubert2011nuclearhormonereceptors pages 1-2)</td>
+</tr>
+<tr>
+<td>Core domains</td>
+<td>HNF4-like DNA-binding domain and nuclear receptor ligand-binding domain; domain architecture is consistent with a canonical ligand-regulated transcription factor in the NHR superfamily (taubert2011nuclearhormonereceptors pages 2-4, taubert2011nuclearhormonereceptors pages 1-2)</td>
+</tr>
+<tr>
+<td>Predicted molecular function</td>
+<td>Putative ligand-dependent transcription factor / transcriptional regulator responding to lipophilic small molecules, inferred from its NHR family membership and HNF4-like architecture (taubert2011nuclearhormonereceptors pages 2-4, taubert2011nuclearhormonereceptors pages 1-2)</td>
+</tr>
+<tr>
+<td>Direct experimental evidence: steroid responsiveness</td>
+<td><strong>Estradiol-induced upregulation:</strong> 10 μM estradiol increased <strong>nhr-47</strong> expression <strong>3.4-fold</strong> in microarray analysis, identifying it as an estradiol-responsive NHR (novillo2005changesinnuclear pages 3-4)</td>
+</tr>
+<tr>
+<td>Direct experimental evidence: C. elegans phenotype</td>
+<td>Published RNAi experiments in <em>C. elegans</em> reported <strong>no observable phenotype</strong> for <strong>nhr-47</strong>, indicating either redundancy, condition-specific function, or weak effect under standard assay conditions (reported in Ciche et al. summarizing prior RNAi studies) (ciche2007postembryonicrnaiin pages 6-8)</td>
+</tr>
+<tr>
+<td>Cross-species ortholog evidence</td>
+<td>RNAi of the <em>Heterorhabditis bacteriophora</em> ortholog <strong>Hba-nhr-47</strong> usually caused <strong>no obvious phenotype</strong>, with only <strong>3–12% sterility</strong> in some trials, supporting a subtle or context-dependent role (ciche2007postembryonicrnaiin pages 4-6, ciche2007postembryonicrnaiin pages 6-8)</td>
+</tr>
+<tr>
+<td>Putative biological processes</td>
+<td>Likely part of an <strong>estrogen-sensitive gene network</strong> associated with <strong>vitellogenesis</strong>, lipid availability, and broader metabolic/endocrine responses; however, no direct downstream targets have been established for nhr-47 itself (novillo2005changesinnuclear pages 3-4)</td>
+</tr>
+<tr>
+<td>Predicted subcellular localization</td>
+<td><strong>Nucleus</strong> (inferred), because NHR-47 contains an HNF4-like DNA-binding domain and belongs to a family of nuclear transcription factors; no nhr-47-specific localization study was found (taubert2011nuclearhormonereceptors pages 2-4, taubert2011nuclearhormonereceptors pages 1-2)</td>
+</tr>
+<tr>
+<td>Evolutionary context</td>
+<td>Member of the nematode-specific expansion of HNF4-related receptors: <em>C. elegans</em> has <strong>284</strong> NHRs overall, including <strong>269 supplementary NHRs (supnrs)</strong> derived from an ancient HNF4-like ancestor; this expansion is far larger than in humans or flies (arda2010functionalmodularityof pages 2-3, taubert2011nuclearhormonereceptors pages 2-4, taubert2011nuclearhormonereceptors pages 1-2, arda2010functionalmodularityof pages 9-10)</td>
+</tr>
+<tr>
+<td>Broader functional context of family</td>
+<td>HNF4-like C. elegans NHRs commonly regulate <strong>metabolism, fat storage/catabolism, xenobiotic responses, and physiological adaptation</strong>, often in modular gene-regulatory networks; nhr-47 is therefore plausibly metabolic/endocrine, though not directly characterized (arda2010functionalmodularityof pages 2-3, taubert2011nuclearhormonereceptors pages 2-4, arda2010functionalmodularityof pages 3-4)</td>
+</tr>
+<tr>
+<td>Characterization status</td>
+<td><strong>Poorly characterized / orphan receptor.</strong> The literature provides direct evidence for steroid-responsive expression but little mechanistic information on ligands, tissue expression, target genes, or physiological necessity under standard conditions (novillo2005changesinnuclear pages 3-4, ciche2007postembryonicrnaiin pages 6-8)</td>
+</tr>
+</tbody>
+</table>
+<p><em>Table: This table consolidates verified identifiers, family/domain assignment, and the limited direct experimental evidence available for C. elegans NHR-47. It is useful as a high-confidence quick reference because the gene is sparsely characterized and easily confused with unrelated genes sharing similar names.</em></p>
+<h2 id="evolutionary-context-the-nematode-specific-hnf4-expansion">Evolutionary Context: The Nematode-Specific HNF4 Expansion</h2>
+<p>To understand NHR-47, it is essential to place it within the broader evolutionary and functional context of the massively expanded nuclear hormone receptor family in <em>C. elegans</em>. While the human genome encodes 48 NHRs and <em>Drosophila</em> has 18, the <em>C. elegans</em> genome encodes approximately 284 NHR genes—roughly six times the human complement (taubert2011nuclearhormonereceptors pages 1-2). Of these, only 15 are "conserved" NHRs belonging to five of the six metazoan NHR subfamilies (NR1, NR2, NR4, NR5, and NR6), while the remaining 269 are "supplementary NHRs" (supnrs) that appear to have derived from a single ancient HNF4-like ancestor through lineage-specific gene duplication events (taubert2011nuclearhormonereceptors pages 2-4). This expansion is one of the most dramatic in any metazoan transcription factor family, and the resulting supnrs show rapid evolutionary divergence—approximately 50% of NHRs in related nematode species such as <em>C. briggsae</em> and <em>C. remanei</em> are species-specific, indicating that NHRs evolve more rapidly than other transcription factor classes (arda2010functionalmodularityof pages 9-10).</p>
+<p>NHR-47 belongs to this expanded HNF4-derived supplementary NHR class. Despite the large number of supnrs, only about 50 NHRs in <em>C. elegans</em> have known functions or detectable phenotypes when mutated or depleted (taubert2011nuclearhormonereceptors pages 1-2). NHR-47 is among the majority of these supplementary receptors that remain functionally uncharacterized.</p>
+<h2 id="predicted-molecular-function">Predicted Molecular Function</h2>
+<p>As a canonical nuclear hormone receptor, NHR-47 is predicted to function as a ligand-dependent transcription factor. Nuclear hormone receptors typically bind small lipophilic molecules (ligands) through their C-terminal ligand-binding domain, undergo conformational changes, and regulate transcription of target genes by binding specific DNA response elements through their N-terminal zinc-finger DNA-binding domain. For NHR-47 specifically, no endogenous ligand has been identified, classifying it as an orphan receptor.</p>
+<p>The HNF4-like domain architecture of NHR-47 places it in the NR2A class of nuclear receptors. In vertebrates, the HNF4 receptors (HNF4α and HNF4γ) play central roles in cholesterol, amino acid, carbohydrate, lipid, and xenobiotic metabolism, as well as liver-specific gene expression (novillo2005changesinnuclear pages 4-5). In <em>C. elegans</em>, where the intestine performs many of the metabolic functions of the vertebrate liver, HNF4-type NHRs have been shown to regulate fat storage and catabolism, xenobiotic detoxification, and physiological adaptation to environmental and nutritional cues (arda2010functionalmodularityof pages 2-3, arda2010functionalmodularityof pages 3-4). By extension, NHR-47 is plausibly involved in metabolic regulation, though direct evidence for this remains lacking.</p>
+<h2 id="known-experimental-evidence">Known Experimental Evidence</h2>
+<h3 id="steroid-responsiveness">Steroid Responsiveness</h3>
+<p>The most direct functional data for <em>nhr-47</em> comes from a microarray study by Novillo et al. (2005), which examined changes in nuclear receptor gene expression in <em>C. elegans</em> exposed to vertebrate steroids and cholesterol. This study demonstrated that 10 μM estradiol induced a 3.4-fold upregulation of <em>nhr-47</em> expression (novillo2005changesinnuclear pages 3-4). Importantly, each steroid tested (progesterone, estradiol, cholesterol) activated or inhibited entirely distinct subsets of NR genes, with no overlap between treatments, and estradiol specifically regulated 11 of 25 NRs identified as steroid-responsive (novillo2005changesinnuclear pages 1-1). The authors suggested that estradiol-responsive genes, including <em>nhr-47</em>, may constitute an estrogen-sensitive gene network related to vitellogenesis, since vitellogenin production depends on lipid availability to gastrointestinal cells involved in yolk protein synthesis (novillo2005changesinnuclear pages 3-4). This is biologically plausible given that the <em>C. elegans</em> intestine is the primary site of vitellogenin synthesis and that NHRs are known to respond to cholesterol-derived lipophilic signals in nematodes (novillo2005changesinnuclear pages 1-3, novillo2005changesinnuclear pages 5-6).</p>
+<h3 id="rnai-phenotype-analysis">RNAi Phenotype Analysis</h3>
+<p>Published RNAi experiments of <em>nhr-47</em> in <em>C. elegans</em> have reported no observable phenotype under standard laboratory conditions (ciche2007postembryonicrnaiin pages 6-8). This finding was noted across multiple independent genome-wide RNAi screens. In the related insect-parasitic nematode <em>Heterorhabditis bacteriophora</em>, RNAi of the ortholog <em>Hba-nhr-47</em> also generally resulted in no observable defect, although very low-penetrance sterility (3–12%) was noted in some experimental trials (ciche2007postembryonicrnaiin pages 4-6, ciche2007postembryonicrnaiin pages 6-8). The absence of a strong loss-of-function phenotype is consistent with three possible explanations: (1) functional redundancy among the many HNF4-derived supplementary NHRs, (2) a context- or condition-dependent role that is not revealed under standard culture conditions, or (3) a subtle function below the detection threshold of typical phenotypic screens.</p>
+<h3 id="evolutionary-sequence-relationships">Evolutionary Sequence Relationships</h3>
+<p>A study of selfish toxin-antidote elements in <em>Caenorhabditis</em> species noted that the SLOW-1 protein, a toxin component in <em>C. tropicalis</em> that is homologous to nuclear hormone receptors, shares sequence similarity with <em>C. elegans</em> NHR-47 (17.9% identity) (bendavid2021ubiquitousselfishtoxinantidote pages 9-11). SLOW-1 retains an NHR ligand-binding domain but lacks the canonical DNA-binding domain and instead possesses transmembrane domains, suggesting it may function as a dominant-negative element that sequesters NHR ligands. While this does not directly inform NHR-47 function, it highlights the evolutionary versatility of the HNF4-derived NHR ligand-binding domain in nematodes and the potential for NHR-47-like proteins to interact with lipophilic signaling molecules.</p>
+<h2 id="subcellular-localization">Subcellular Localization</h2>
+<p>No direct localization study has been performed for NHR-47. However, as a nuclear hormone receptor containing a zinc-finger DNA-binding domain, NHR-47 is predicted to localize to the nucleus, where it would function as a transcription factor. Well-characterized family members such as NHR-86 have been confirmed to localize predominantly to the nuclei of intestinal, excretory gland, and neuronal cells (arda2010functionalmodularityof pages 6-7), and NHR-49 functions in the nucleus to regulate target gene expression (motola2006identificationofligands pages 39-43). By analogy, NHR-47 is expected to occupy a similar nuclear compartment in metabolically active tissues.</p>
+<h2 id="broader-functional-context-of-the-nhr-family">Broader Functional Context of the NHR Family</h2>
+<p>The metabolic gene regulatory network (GRN) of <em>C. elegans</em> was experimentally mapped by Arda et al. (2010) using yeast one-hybrid assays, revealing that NHRs are significantly enriched as regulators of metabolic gene promoters—over one quarter of all transcription factors in the metabolic GRN are NHRs (arda2010functionalmodularityof pages 2-3). The metabolic GRN is highly modular, with approximately 60% of NHRs organized into two dominant modules that predominantly regulate genes involved in fat storage and catabolism (arda2010functionalmodularityof pages 3-4). RNAi of most NHRs in these modules resulted in increased lipid staining by Nile Red and Oil-Red-O, indicating roles in lipid metabolism (arda2010functionalmodularityof pages 3-4). These findings suggest that the expansion of the HNF4 family in nematodes has been functionally linked to metabolic regulation, with multiple supplementary NHRs sharing fat-regulatory roles after duplication and divergence.</p>
+<p>Furthermore, the Mediator subunit MDT-15 has been identified as a key cofactor that preferentially interacts with metabolic NHRs, and several NHRs form regulatory cascades in which one NHR controls the expression of another (arda2010functionalmodularityof pages 5-6). These inter-NHR regulatory circuits are proposed to enable rapid and adaptive responses to environmental and physiological changes such as nutrient availability (arda2010functionalmodularityof pages 9-10).</p>
+<h2 id="limitations-and-current-status">Limitations and Current Status</h2>
+<p>NHR-47 remains a poorly characterized orphan nuclear hormone receptor. The available evidence establishes it as an estradiol-responsive member of the massively expanded HNF4-derived supplementary NHR family in <em>C. elegans</em>, but no endogenous ligand, specific target genes, tissue-specific expression pattern, or robust loss-of-function phenotype has been reported. Its function may be obscured by redundancy with other supplementary NHRs, or it may act under specific environmental, nutritional, or developmental conditions not routinely tested in laboratory screens. The protein's function can be inferred from its domain and family architecture: NHR-47 is most likely a ligand-dependent nuclear transcription factor involved in metabolic gene regulation, potentially participating in steroid/lipid-responsive signaling pathways related to vitellogenesis and lipid homeostasis. Future studies employing targeted knockouts, condition-specific screens (e.g., steroid exposure, dietary stress), and tissue-specific expression reporters will be needed to elucidate the precise biological role of this receptor.</p>
+<p>References</p>
+<ol>
+<li>
+<p>(novillo2005changesinnuclear pages 3-4): A. Novillo, S. Won, Christine Li, and I. Callard. Changes in nuclear receptor and vitellogenin gene expression in response to steroids and heavy metal in caenorhabditis elegans1. Integrative and Comparative Biology, 45:61-71, Jan 2005. URL: https://doi.org/10.1093/icb/45.1.61, doi:10.1093/icb/45.1.61. This article has 59 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(taubert2011nuclearhormonereceptors pages 2-4): Stefan Taubert, Jordan D. Ward, and Keith R. Yamamoto. Nuclear hormone receptors in nematodes: evolution and function. Molecular and Cellular Endocrinology, 334:49-55, Mar 2011. URL: https://doi.org/10.1016/j.mce.2010.04.021, doi:10.1016/j.mce.2010.04.021. This article has 136 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(taubert2011nuclearhormonereceptors pages 1-2): Stefan Taubert, Jordan D. Ward, and Keith R. Yamamoto. Nuclear hormone receptors in nematodes: evolution and function. Molecular and Cellular Endocrinology, 334:49-55, Mar 2011. URL: https://doi.org/10.1016/j.mce.2010.04.021, doi:10.1016/j.mce.2010.04.021. This article has 136 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(ciche2007postembryonicrnaiin pages 6-8): Todd A Ciche and Paul W Sternberg. Postembryonic rnai in heterorhabditis bacteriophora: a nematode insect parasite and host for insect pathogenic symbionts. BMC Developmental Biology, 7:101-101, Sep 2007. URL: https://doi.org/10.1186/1471-213x-7-101, doi:10.1186/1471-213x-7-101. This article has 78 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(ciche2007postembryonicrnaiin pages 4-6): Todd A Ciche and Paul W Sternberg. Postembryonic rnai in heterorhabditis bacteriophora: a nematode insect parasite and host for insect pathogenic symbionts. BMC Developmental Biology, 7:101-101, Sep 2007. URL: https://doi.org/10.1186/1471-213x-7-101, doi:10.1186/1471-213x-7-101. This article has 78 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(arda2010functionalmodularityof pages 2-3): H Efsun Arda, Stefan Taubert, Lesley T MacNeil, Colin C Conine, Ben Tsuda, Marc Van Gilst, Reynaldo Sequerra, Lynn Doucette‐Stamm, Keith R Yamamoto, and Albertha J M Walhout. Functional modularity of nuclear hormone receptors in a caenorhabditis elegans metabolic gene regulatory network. Molecular Systems Biology, 6:367-367, May 2010. URL: https://doi.org/10.1038/msb.2010.23, doi:10.1038/msb.2010.23. This article has 148 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(arda2010functionalmodularityof pages 9-10): H Efsun Arda, Stefan Taubert, Lesley T MacNeil, Colin C Conine, Ben Tsuda, Marc Van Gilst, Reynaldo Sequerra, Lynn Doucette‐Stamm, Keith R Yamamoto, and Albertha J M Walhout. Functional modularity of nuclear hormone receptors in a caenorhabditis elegans metabolic gene regulatory network. Molecular Systems Biology, 6:367-367, May 2010. URL: https://doi.org/10.1038/msb.2010.23, doi:10.1038/msb.2010.23. This article has 148 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(arda2010functionalmodularityof pages 3-4): H Efsun Arda, Stefan Taubert, Lesley T MacNeil, Colin C Conine, Ben Tsuda, Marc Van Gilst, Reynaldo Sequerra, Lynn Doucette‐Stamm, Keith R Yamamoto, and Albertha J M Walhout. Functional modularity of nuclear hormone receptors in a caenorhabditis elegans metabolic gene regulatory network. Molecular Systems Biology, 6:367-367, May 2010. URL: https://doi.org/10.1038/msb.2010.23, doi:10.1038/msb.2010.23. This article has 148 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(novillo2005changesinnuclear pages 4-5): A. Novillo, S. Won, Christine Li, and I. Callard. Changes in nuclear receptor and vitellogenin gene expression in response to steroids and heavy metal in caenorhabditis elegans1. Integrative and Comparative Biology, 45:61-71, Jan 2005. URL: https://doi.org/10.1093/icb/45.1.61, doi:10.1093/icb/45.1.61. This article has 59 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(novillo2005changesinnuclear pages 1-1): A. Novillo, S. Won, Christine Li, and I. Callard. Changes in nuclear receptor and vitellogenin gene expression in response to steroids and heavy metal in caenorhabditis elegans1. Integrative and Comparative Biology, 45:61-71, Jan 2005. URL: https://doi.org/10.1093/icb/45.1.61, doi:10.1093/icb/45.1.61. This article has 59 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(novillo2005changesinnuclear pages 1-3): A. Novillo, S. Won, Christine Li, and I. Callard. Changes in nuclear receptor and vitellogenin gene expression in response to steroids and heavy metal in caenorhabditis elegans1. Integrative and Comparative Biology, 45:61-71, Jan 2005. URL: https://doi.org/10.1093/icb/45.1.61, doi:10.1093/icb/45.1.61. This article has 59 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(novillo2005changesinnuclear pages 5-6): A. Novillo, S. Won, Christine Li, and I. Callard. Changes in nuclear receptor and vitellogenin gene expression in response to steroids and heavy metal in caenorhabditis elegans1. Integrative and Comparative Biology, 45:61-71, Jan 2005. URL: https://doi.org/10.1093/icb/45.1.61, doi:10.1093/icb/45.1.61. This article has 59 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(bendavid2021ubiquitousselfishtoxinantidote pages 9-11): Eyal Ben-David, Pinelopi Pliota, Sonya A. Widen, Alevtina Koreshova, Tzitziki Lemus-Vergara, Philipp Verpukhovskiy, Sridhar Mandali, Christian Braendle, Alejandro Burga, and Leonid Kruglyak. Ubiquitous selfish toxin-antidote elements in caenorhabditis species. Current Biology, 31:990-1001.e5, Mar 2021. URL: https://doi.org/10.1016/j.cub.2020.12.013, doi:10.1016/j.cub.2020.12.013. This article has 61 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(arda2010functionalmodularityof pages 6-7): H Efsun Arda, Stefan Taubert, Lesley T MacNeil, Colin C Conine, Ben Tsuda, Marc Van Gilst, Reynaldo Sequerra, Lynn Doucette‐Stamm, Keith R Yamamoto, and Albertha J M Walhout. Functional modularity of nuclear hormone receptors in a caenorhabditis elegans metabolic gene regulatory network. Molecular Systems Biology, 6:367-367, May 2010. URL: https://doi.org/10.1038/msb.2010.23, doi:10.1038/msb.2010.23. This article has 148 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(motola2006identificationofligands pages 39-43): Daniel L. Motola, Carolyn L. Cummins, Veerle Rottiers, Kamalesh K. Sharma, Tingting Li, Yong Li, Kelly Suino-Powell, H. Eric Xu, Richard J. Auchus, Adam Antebi, and David J. Mangelsdorf. Identification of ligands for daf-12 that govern dauer formation and reproduction in c. elegans. Cell, 124:1209-1223, Mar 2006. URL: https://doi.org/10.1016/j.cell.2006.01.037, doi:10.1016/j.cell.2006.01.037. This article has 590 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(arda2010functionalmodularityof pages 5-6): H Efsun Arda, Stefan Taubert, Lesley T MacNeil, Colin C Conine, Ben Tsuda, Marc Van Gilst, Reynaldo Sequerra, Lynn Doucette‐Stamm, Keith R Yamamoto, and Albertha J M Walhout. Functional modularity of nuclear hormone receptors in a caenorhabditis elegans metabolic gene regulatory network. Molecular Systems Biology, 6:367-367, May 2010. URL: https://doi.org/10.1038/msb.2010.23, doi:10.1038/msb.2010.23. This article has 148 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+</ol>
+<h2 id="artifacts">Artifacts</h2>
+<ul>
+<li><a href="nhr-47-deep-research-falcon_artifacts/artifact-00.md">Edison artifact artifact-00</a></li>
+</ul>
+<h2 id="citations">Citations</h2>
+<ol>
+<li>novillo2005changesinnuclear pages 3-4</li>
+<li>ciche2007postembryonicrnaiin pages 6-8</li>
+<li>taubert2011nuclearhormonereceptors pages 1-2</li>
+<li>taubert2011nuclearhormonereceptors pages 2-4</li>
+<li>arda2010functionalmodularityof pages 9-10</li>
+<li>novillo2005changesinnuclear pages 4-5</li>
+<li>novillo2005changesinnuclear pages 1-1</li>
+<li>bendavid2021ubiquitousselfishtoxinantidote pages 9-11</li>
+<li>arda2010functionalmodularityof pages 6-7</li>
+<li>motola2006identificationofligands pages 39-43</li>
+<li>arda2010functionalmodularityof pages 2-3</li>
+<li>arda2010functionalmodularityof pages 3-4</li>
+<li>arda2010functionalmodularityof pages 5-6</li>
+<li>ciche2007postembryonicrnaiin pages 4-6</li>
+<li>novillo2005changesinnuclear pages 1-3</li>
+<li>novillo2005changesinnuclear pages 5-6</li>
+<li>https://doi.org/10.1093/icb/45.1.61,</li>
+<li>https://doi.org/10.1016/j.mce.2010.04.021,</li>
+<li>https://doi.org/10.1186/1471-213x-7-101,</li>
+<li>https://doi.org/10.1038/msb.2010.23,</li>
+<li>https://doi.org/10.1016/j.cub.2020.12.013,</li>
+<li>https://doi.org/10.1016/j.cell.2006.01.037,</li>
+</ol>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(nhr-47-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="Q17370" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="nhr-47-c-elegans-research-notes">nhr-47 (C. elegans) — research notes</h1>
+<p>Gene: <strong>nhr-47</strong> / sequence name <strong>C24G6.4</strong> / WormBase <strong>WBGene00003637</strong> / UniProt <strong>Q17370</strong> (NHR47_CAEEL).<br />
+Locus: Chromosome V. Protein: 579 aa nuclear hormone receptor.</p>
+<h2 id="provenance-conventions">Provenance conventions</h2>
+<p>Inline provenance uses <code>[PMID:xxxxx "verbatim quote"]</code>. WormBase/Alliance-curated statements<br />
+(no direct primary PMID to hand) are marked <code>[WormBase/AGR]</code> and are NOT used as verbatim<br />
+<code>supporting_text</code> in the review; only cached-publication PMID quotes are used for that.</p>
+<h2 id="summary-nhr-47-is-a-dark-hnf4-derived-orphan-nuclear-receptor">Summary: nhr-47 is a "dark" HNF4-derived orphan nuclear receptor</h2>
+<p>nhr-47 is one of the ~280 nuclear hormone receptors (NHRs) of C. elegans, the great majority of<br />
+which arose by a nematode-specific expansion of an ancestral HNF4-like orphan receptor and remain<br />
+functionally uncharacterized ("supplementary nuclear receptors", supnrs)<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/15983867" title="the supplementary\nnuclear receptors (supnrs) originated from an explosive burst of duplications of\na unique orphan receptor, HNF4">PMID:15983867</a>. Its DNA-binding domain is HNF4-like (CDD cd06960 NR_DBD_HNF4A;<br />
+InterPro IPR049636 HNF4-like_DBD).</p>
+<h2 id="molecular-architecture-known-from-sequenceuniprot-q17370">Molecular architecture (KNOWN, from sequence/UniProt Q17370)</h2>
+<ul>
+<li>Two C4-type (Cys4) zinc-finger motifs (ZN_FING 11–31 and 47–71) forming a canonical nuclear-receptor<br />
+  DNA-binding domain (DNA_BIND 8–83). Coordinates zinc (KW Metal-binding, Zinc, Zinc-finger).</li>
+<li>A nuclear-receptor ligand-binding domain (NR LBD, residues 164–553; PROSITE PS51843).</li>
+<li>UniProt FUNCTION: "Orphan nuclear receptor." SUBCELLULAR LOCATION: Nucleus.</li>
+<li>Documented physical interaction (IntAct EBI-2412077/EBI-2412071): Q17370 (nhr-47) &lt;-&gt; Q17589 (nhr-17),<br />
+  NbExp=3. nhr-17 is itself another nuclear hormone receptor.</li>
+<li>Therefore, from sequence + family, nhr-47 is confidently a zinc-finger, sequence-specific<br />
+  DNA-binding transcription factor of the nuclear-receptor superfamily that acts in the nucleus.<br />
+  (This is what the IBA/IEA GO annotations capture.)</li>
+</ul>
+<h2 id="expression-known-curated-wormbaseagr">Expression (KNOWN, curated) [WormBase/AGR]</h2>
+<p>Alliance/WormBase automated + MOD-provided descriptions for WBGene00003637:<br />
+- Expressed in head neurons, tail neurons, ventral nerve cord, spermatheca, intestine, and pharynx.<br />
+- "gene expression of nhr-47 appears to be induced upon exposure of worm cultures to estradiol"<br />
+  (WormBase MOD-provided gene description; primary microarray reference not located in cache — recorded<br />
+  here as curated context only, not used as review supporting_text).</p>
+<h2 id="functional-data-the-only-experimental-phenotypes-reported-for-nhr-47">Functional data (the only experimental phenotypes reported for nhr-47)</h2>
+<p>Two toxicology studies from one group (Southeast University / Dayong Wang lab) are the only primary<br />
+papers that assign nhr-47 a phenotype, both in the <strong>germline</strong> and in an <strong>environmental-toxicant</strong><br />
+context:</p>
+<ol>
+<li>Nanoplastics, transgenerational toxicity <a href="https://pubmed.ncbi.nlm.nih.gov/38922100">PMID:38922100</a>:</li>
+<li>nhr-47 is one of only 4 of 33 germline-expressed NHRs whose expression responds to polystyrene<br />
+     nanoparticles; it is UP-regulated<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/38922100" title="the expressions of nhr-14, nhr-47, and daf-12 were significantly increased by exposure to 10 μg/L of PS-NPs">PMID:38922100</a>.</li>
+<li>Germline RNAi of nhr-47 makes animals RESISTANT to transgenerational nanoplastic toxicity<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/38922100" title="daf-12(RNAi), nhr-14(RNAi), and nhr-47(RNAi) nematodes showed resistance to transgenerational PS-NP toxicity">PMID:38922100</a>.</li>
+<li>
+<p>Under exposure, nhr-47 RNAi changes downstream secreted-ligand gene expression<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/38922100" title="the RNAi of nhr-47 decreased expressions of germline ins-3, ins-39, daf-28, and efn-3 in PS-NP-exposed animals">PMID:38922100</a><br />
+     (ins-3/ins-39/daf-28 = insulin ligands; efn-3 = Ephrin) — i.e. nhr-47 sits upstream of insulin/Ephrin<br />
+     signalling in this stress context. These are downstream/indirect readouts, NOT demonstrated direct targets.</p>
+</li>
+<li>
+<p>6-PPD-quinone, reproductive toxicity <a href="https://pubmed.ncbi.nlm.nih.gov/40482507">PMID:40482507</a>:</p>
+</li>
+<li>nhr-47 is among germline NHRs whose knockdown SUPPRESSES 6-PPDQ reproductive toxicity<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/40482507" title="6-PPDQ reproductive toxicity was suppressed by nhr-47, nhr-14, daf-12, and nhr-249 RNAi and accelerated by nhr-12, nhr-145, and nhr-171 RNAi">PMID:40482507</a>.</li>
+<li>nhr-47 expression is modulated by DNA-damage-checkpoint and ferroptosis-related signals under 6-PPDQ.</li>
+</ol>
+<p>Consistent theme: in the germline, nhr-47 acts (with daf-12/nhr-14) as a positive mediator of<br />
+toxicant-induced reproductive/transgenerational toxicity; knocking it down is protective.</p>
+<h2 id="interaction-network-context">Interaction / network context</h2>
+<ul>
+<li>Y2H interactome maps nhr-47 into the worm protein interaction network <a href="https://pubmed.ncbi.nlm.nih.gov/19123269">PMID:19123269</a> (WI8);<br />
+  the specific nhr-47&lt;-&gt;nhr-17 interaction is recorded in IntAct/UniProt (not stated verbatim in the paper text).</li>
+<li>nhr-47 is one node in the C. elegans multiparameter transcription-factor network <a href="https://pubmed.ncbi.nlm.nih.gov/23791784">PMID:23791784</a>,<br />
+  a study of protein-DNA / protein-protein / TF-TF network rewiring across paralogs.</li>
+<li>These two PMIDs underlie the two GOA IPI "protein binding" annotations (with_from UniProtKB:Q17589 = nhr-17).</li>
+</ul>
+<h2 id="known-vs-not-known-explicit">KNOWN vs NOT-KNOWN (explicit)</h2>
+<p>KNOWN:<br />
+- Molecular identity: zinc-finger, sequence-specific DNA-binding transcription factor of the<br />
+  nuclear-receptor (HNF4-derived supnr) family; nuclear localization; binds zinc.<br />
+- Physically interacts with nhr-17.<br />
+- Expressed in neurons, ventral nerve cord, spermatheca, pharynx, intestine.<br />
+- Germline knockdown modulates susceptibility to two environmental toxicants (nanoplastics, 6-PPDQ),<br />
+  positioning it upstream of insulin/Ephrin/Wnt ligand-gene expression in that stress context.</p>
+<p>NOT KNOWN (knowledge gaps):<br />
+- Ligand: whether nhr-47 has any endogenous small-molecule ligand, and its identity — it is an orphan<br />
+  receptor, and supnrs may have altered/lost ligand-dependence<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/15983867" title="This origin has specific implications for the\nrole of ligand binding in the function and evolution of the nematode\nsupplementary nuclear receptors">PMID:15983867</a>.<br />
+- Direct target genes / response element: no ChIP, reporter, or motif defines the nhr-47 regulon;<br />
+  it is unknown whether it is an activator or repressor, and whether the toxicant-context downstream<br />
+  genes (ins-3, daf-28, efn-3, …) are direct or indirect targets.<br />
+- Definitive loss-of-function role: no baseline null-mutant developmental/metabolic/immune phenotype;<br />
+  the only phenotypes are germline RNAi effects in toxicant-challenge assays.</p>
+<h2 id="go-annotation-review-orientation">GO annotation review orientation</h2>
+<ul>
+<li>All 14 GOA annotations are IBA (phylogenetic), IEA (InterPro/UniProt), or IPI (interactome).</li>
+<li>MF/CC core (nuclear receptor activity, RNA Pol II cis-regulatory sequence-specific DNA binding,<br />
+  sequence-specific DNA binding, DNA-binding TF activity, zinc ion binding, nucleus) is well supported<br />
+  by the diagnostic domain architecture → ACCEPT as core.</li>
+<li>BP terms are family-propagated/inferred (regulation of transcription, intracellular receptor<br />
+  signaling) → KEEP; "cell differentiation" (IBA) has no nhr-47-specific support → KEEP_AS_NON_CORE<br />
+  (generic pan-NHR propagation).</li>
+<li>Two IPI "protein binding" annotations (nhr-17): experimental but uninformative term; do not REMOVE<br />
+  (real interaction), KEEP_AS_NON_CORE and flag that a more informative MF term is not warranted from<br />
+  a single Y2H edge.</li>
+</ul>
+<h2 id="falcon-deep-research-addendum-geneswormnhr-47nhr-47-deep-research-falconmd">Falcon deep-research addendum (genes/worm/nhr-47/nhr-47-deep-research-falcon.md)</h2>
+<p>Genuine Edison "deep research" report (23-min run, 22 citations). Key points, each attributed<br />
+to the falcon-cited primary source (NOT independently full-text-verified here unless noted):</p>
+<ul>
+<li><strong>csr-1 synonym caution</strong>: the UniProt <code>Synonyms=csr-1</code> for nhr-47 is an OLD locus synonym and<br />
+  must NOT be confused with the CSR-1 Argonaute (a distinct gene). Falcon flags this explicitly.</li>
+<li><strong>Estradiol responsiveness (the source of the WormBase estradiol statement)</strong>: Novillo et al. 2005<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/21676746">PMID:21676746</a> microarray of steroid-exposed C. elegans; falcon reports "10 μM estradiol increased<br />
+  nhr-47 expression 3.4-fold". NOTE: the cached PubMed abstract of PMID:21676746 does NOT name nhr-47<br />
+  (the per-gene 3.4-fold value is in the full text / supplementary data and in WormBase curation), so I<br />
+  do NOT attach a verbatim nhr-47 supporting_text to this PMID; it is added to references as the<br />
+  estradiol-induction source with correctness VERIFIED and no gene-specific quote.</li>
+<li><strong>No robust RNAi phenotype</strong>: falcon reports genome-wide RNAi of nhr-47 in C. elegans gave "no<br />
+  observable phenotype" (via Ciche &amp; Sternberg 2007, which also reports the H. bacteriophora ortholog<br />
+  Hba-nhr-47 RNAi is mostly phenotype-free, ~3-12% sterility in some trials). Consistent with knowledge<br />
+  gap #3 (no defined loss-of-function role); treated as supporting context, not review provenance,<br />
+  because the C. elegans nhr-47 no-phenotype claim is a secondary summary.</li>
+<li><strong>Family/metabolic context</strong>: Taubert, Ward &amp; Yamamoto 2011 (NHRs in nematodes) and Arda et al. 2010<br />
+  (metabolic gene-regulatory network; NHRs enriched as metabolic-promoter regulators, modular, MDT-15<br />
+  cofactor). Places nhr-47 in the HNF4-derived supnr class plausibly linked to metabolism — but nhr-47<br />
+  itself is uncharacterized in these.</li>
+<li><strong>Discrepancy</strong>: falcon states nhr-47 is on "chromosome II"; UniProt Q17370 says Chromosome V. Trust<br />
+  UniProt (Chromosome V). Did NOT propagate falcon's chromosome claim.</li>
+</ul>
+<p>Net effect on review: falcon corroborates the orphan/dark framing, the estradiol angle, and the<br />
+absence of a robust loss-of-function phenotype; it did not surface any definitive ligand, direct<br />
+target, or physiological role. No core-function or knowledge-gap conclusion was changed by it.</p>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: Q17370
+gene_symbol: nhr-47
+product_type: PROTEIN
+status: COMPLETE
+taxon:
+  id: NCBITaxon:6239
+  label: Caenorhabditis elegans
+description: &gt;-
+  nhr-47 (C24G6.4) is one of the ~280 nuclear hormone receptors (NHRs) of
+  Caenorhabditis elegans, the great majority of which arose by a nematode-specific
+  expansion of an ancestral HNF4-like orphan receptor and are termed supplementary
+  nuclear receptors (supnrs). The 579-residue protein has the canonical nuclear-receptor
+  architecture: an N-terminal DNA-binding domain built from two C4-type (Cys4)
+  zinc-finger motifs that coordinate zinc, and a C-terminal ligand-binding domain.
+  On the basis of this diagnostic domain organization and phylogenetic placement,
+  NHR-47 is a zinc-dependent, sequence-specific DNA-binding transcription factor of
+  the nuclear-receptor superfamily that acts in the nucleus to regulate RNA
+  polymerase II transcription. It is annotated as an orphan receptor: no endogenous
+  ligand has been identified. NHR-47 is expressed in head and tail neurons, the
+  ventral nerve cord, the spermatheca, the pharynx and the intestine, and it
+  physically interacts with another nuclear receptor, NHR-17. The only reported
+  loss-of-function phenotypes are in the germline: knockdown modulates susceptibility
+  to environmental toxicants (polystyrene nanoparticles and 6-PPD-quinone), where
+  NHR-47 acts as a positive mediator of reproductive and transgenerational toxicity
+  and lies upstream of insulin, Ephrin and Wnt ligand-gene expression. nhr-47
+  transcription is also induced by exposure to the vertebrate steroid estradiol. Its
+  endogenous physiological role, its ligand (if any), and its direct transcriptional
+  targets remain undetermined.
+references:
+- id: GO_REF:0000002
+  title: Gene Ontology annotation through association of InterPro records with GO
+    terms
+  findings: []
+- id: GO_REF:0000033
+  title: Annotation inferences using phylogenetic trees
+  findings: []
+- id: GO_REF:0000044
+  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location
+    vocabulary mapping, accompanied by conservative changes to GO terms applied by
+    UniProt
+  findings: []
+- id: GO_REF:0000108
+  title: Automatic assignment of GO terms using logical inference, based on on inter-ontology
+    links
+  findings: []
+- id: PMID:19123269
+  title: Empirically controlled mapping of the Caenorhabditis elegans protein-protein
+    interactome network.
+  findings: []
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: &gt;-
+      High-throughput yeast two-hybrid interactome (Worm Interactome / WI8). Underlies
+      one of the two GOA IPI protein-binding annotations for nhr-47. The specific
+      NHR-47&lt;-&gt;NHR-17 edge is recorded in IntAct/UniProt (with_from UniProtKB:Q17589);
+      the paper text itself reports the network methodology rather than naming nhr-47,
+      so no gene-specific verbatim quote is available from the cached full text.
+- id: PMID:23791784
+  title: Extensive rewiring and complex evolutionary dynamics in a C. elegans multiparameter
+    transcription factor network.
+  findings: []
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: &gt;-
+      C. elegans multiparameter transcription-factor network (protein-DNA, protein-protein,
+      TF-TF). Underlies the second GOA IPI protein-binding annotation for nhr-47 (again
+      with NHR-17, UniProtKB:Q17589). Abstract-only in cache; the interaction is captured
+      in IntAct rather than quoted verbatim in the available text.
+- id: PMID:15983867
+  title: Explosive lineage-specific expansion of the orphan nuclear receptor HNF4 in
+    nematodes.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Establishes the phylogenetic context for nhr-47: the C. elegans supplementary
+      nuclear receptors (supnrs), including the HNF4-like DBD class to which nhr-47
+      belongs, arose from an explosive HNF4 duplication and are predominantly orphan
+      receptors with uncertain ligand-dependence. Cited in the UniProt entry for Q17370.
+- id: PMID:38922100
+  title: Transgenerational Response of Germline Nuclear Hormone Receptor Genes to Nanoplastics
+    at Predicted Environmental Doses in Caenorhabditis elegans.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Primary functional study naming nhr-47: germline-expressed, up-regulated by
+      polystyrene nanoparticles, and germline RNAi confers resistance to transgenerational
+      nanoplastic toxicity, with downstream effects on insulin/Ephrin ligand-gene
+      expression. One of only two primary papers reporting an nhr-47 phenotype. Full text
+      is MDPI-hosted and not downloadable by the validator, so supporting_text quotes are
+      taken from the abstract only.
+- id: PMID:40482507
+  title: 6-PPD quinone induces response of nuclear hormone receptors in the germline
+    associated with formation of reproductive toxicity in Caenorhabditis elegans.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Second primary functional study naming nhr-47: knockdown suppresses 6-PPD-quinone
+      reproductive toxicity, and nhr-47 expression is modulated by DNA-damage-checkpoint
+      and ferroptosis-related signals. Abstract-only in cache but the nhr-47 result is
+      explicit in the abstract.
+- id: PMID:21676746
+  title: Changes in Nuclear Receptor and Vitellogenin Gene Expression in Response to
+    Steroids and Heavy Metal in Caenorhabditis elegans.
+  findings: []
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: &gt;-
+      DNA-microarray study of steroid-responsive nuclear-receptor gene expression in
+      C. elegans; it is the primary source of the WormBase-curated statement that nhr-47
+      is induced by estradiol (full text reports ~3.4-fold induction by 10 uM estradiol).
+      The cached PubMed abstract does not name nhr-47 (the per-gene value is in the full
+      text / supplementary data), so no gene-specific verbatim supporting_text is attached
+      to this reference; it is cited as the estradiol-responsiveness source only.
+existing_annotations:
+- term:
+    id: GO:0005634
+    label: nucleus
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: is_active_in
+  review:
+    summary: &gt;-
+      NHR-47 is a nuclear-receptor transcription factor and acts in the nucleus.
+      Supported by the canonical NR DNA-binding domain and UniProt subcellular location.
+    action: ACCEPT
+    reason: &gt;-
+      Nuclear localization is expected for a functional nuclear-receptor transcription
+      factor and is independently annotated from UniProt SubCell mapping. This is a
+      core cellular-component assignment.
+- term:
+    id: GO:0000978
+    label: RNA polymerase II cis-regulatory region sequence-specific DNA binding
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Sequence-specific DNA binding at Pol II cis-regulatory regions is the diagnostic
+      molecular function of the NR DNA-binding domain (two C4 zinc fingers) that NHR-47
+      possesses.
+    action: ACCEPT
+    reason: &gt;-
+      Consistent with the conserved NR DBD architecture and phylogenetic placement in
+      the HNF4-like DNA-binding-domain class. A core molecular function.
+- term:
+    id: GO:0004879
+    label: nuclear receptor activity
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: enables
+  review:
+    summary: &gt;-
+      NHR-47 is a member of the nuclear-receptor superfamily with a canonical DBD and
+      ligand-binding domain; nuclear receptor activity (ligand-modulated sequence-specific
+      DNA-binding TF activity) is its family-level molecular function.
+    action: ACCEPT
+    reason: &gt;-
+      Well supported by domain architecture and family membership. Note that NHR-47 is
+      an orphan receptor: no ligand is known, so the ligand-modulated aspect of this
+      term is inferred, not demonstrated (see knowledge_gaps). Retained as a core MF.
+- term:
+    id: GO:0006357
+    label: regulation of transcription by RNA polymerase II
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      As a sequence-specific DNA-binding TF of the NR family, NHR-47 regulates Pol II
+      transcription. This is the core biological process for the molecular function.
+    action: ACCEPT
+    reason: &gt;-
+      Directly follows from the nuclear-receptor / DNA-binding-TF molecular function and
+      nuclear localization. Core process.
+- term:
+    id: GO:0030154
+    label: cell differentiation
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      A generic biological process propagated across the nuclear-receptor family by
+      phylogenetic inference. No nhr-47-specific evidence links it to a differentiation
+      program.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      This is a broad pan-family IBA propagation. NHR-47 has no reported role in cell
+      differentiation; its only experimental phenotypes are germline toxicant responses.
+      Retain (family inference is not contradicted) but mark non-core rather than core.
+- term:
+    id: GO:0000978
+    label: RNA polymerase II cis-regulatory region sequence-specific DNA binding
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: enables
+  review:
+    summary: &gt;-
+      InterPro2GO assignment (IPR049636, HNF4-like DBD) of the same sequence-specific
+      Pol II DNA-binding function, in agreement with the IBA annotation above.
+    action: ACCEPT
+    reason: &gt;-
+      Independent InterPro domain-based support for the core sequence-specific DNA-binding
+      molecular function. Consistent with the phylogenetic annotation.
+- term:
+    id: GO:0003700
+    label: DNA-binding transcription factor activity
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: enables
+  review:
+    summary: &gt;-
+      General DNA-binding transcription factor activity assigned from the nuclear-receptor
+      zinc-finger domain (IPR001628). NHR-47 is a bona fide DNA-binding TF.
+    action: ACCEPT
+    reason: &gt;-
+      Correct parent molecular function for a nuclear-receptor TF; supported by the C4
+      zinc-finger DBD. Core MF (the RNA Pol II-specific children above are the more precise
+      forms).
+- term:
+    id: GO:0005634
+    label: nucleus
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000044
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Nuclear localization from UniProt Swiss-Prot subcellular-location mapping (SL-0191),
+      consistent with the IBA nucleus annotation.
+    action: ACCEPT
+    reason: &gt;-
+      Independent support for nuclear localization of this transcription factor. Core CC.
+- term:
+    id: GO:0006355
+    label: regulation of DNA-templated transcription
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      General (DNA-templated) transcription-regulation term from InterPro. This is the
+      broad parent of the RNA Pol II-specific regulation term.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Not wrong, but less informative than the RNA polymerase II-specific regulation term
+      (GO:0006357) already accepted as core. Retain as a non-core general annotation.
+- term:
+    id: GO:0008270
+    label: zinc ion binding
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: enables
+  review:
+    summary: &gt;-
+      The two C4-type (Cys4) zinc-finger motifs of the NR DNA-binding domain coordinate
+      zinc; zinc binding is a structural molecular function underpinning DNA binding.
+    action: ACCEPT
+    reason: &gt;-
+      Directly supported by the diagnostic C4 zinc-finger DBD (ZN_FING 11-31 and 47-71 in
+      UniProt Q17370). Structural MF that enables the core DNA-binding function.
+- term:
+    id: GO:0030522
+    label: intracellular receptor signaling pathway
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000108
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Auto-inferred by inter-ontology logic from nuclear receptor activity (GO:0004879).
+      For an orphan receptor with no known ligand, the signaling-pathway aspect is
+      unproven.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      A logically-derived (GO_REF:0000108) consequence of the nuclear-receptor MF, not
+      direct evidence. Because NHR-47 is an orphan receptor with no demonstrated
+      ligand-activated signaling, retain as non-core rather than core.
+- term:
+    id: GO:0043565
+    label: sequence-specific DNA binding
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Sequence-specific DNA binding assigned from the NR zinc-finger domain (IPR001628);
+      the general parent of the Pol II cis-regulatory DNA-binding term.
+    action: ACCEPT
+    reason: &gt;-
+      Supported by the conserved C4 zinc-finger DBD. Core MF (parent of GO:0000978).
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:19123269
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Experimental yeast two-hybrid interaction captured in the worm interactome; the
+      partner is the nuclear receptor NHR-17 (UniProtKB:Q17589). &#34;Protein binding&#34; is
+      an uninformative molecular-function term.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      A real, curated physical interaction (NHR-47&lt;-&gt;NHR-17), so it should not be removed.
+      However GO:0005515 conveys no specific molecular function, and a single Y2H edge does
+      not justify a more informative MF (e.g. nuclear receptor binding) as a core function.
+      Retain as non-core.
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:23791784
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Second experimental interaction annotation (C. elegans multiparameter TF network),
+      again with NHR-17 (UniProtKB:Q17589). Uninformative &#34;protein binding&#34; term.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Corroborates the NHR-47&lt;-&gt;NHR-17 interaction from an independent dataset. Keep (real
+      interaction) but non-core; GO:0005515 does not describe a specific molecular function.
+core_functions:
+- description: &gt;-
+    Sequence-specific DNA-binding transcription factor of the nuclear-receptor
+    superfamily. NHR-47 carries the diagnostic nuclear-receptor DNA-binding domain
+    formed by two C4-type (Cys4) zinc-finger motifs that coordinate zinc, together with
+    a C-terminal ligand-binding domain. Acting in the nucleus, it binds RNA polymerase
+    II cis-regulatory regions in a sequence-specific manner to regulate transcription.
+    It is an orphan receptor (no ligand identified), belonging to the HNF4-derived
+    supplementary nuclear receptor class of C. elegans.
+  molecular_function:
+    id: GO:0004879
+    label: nuclear receptor activity
+  directly_involved_in:
+  - id: GO:0006357
+    label: regulation of transcription by RNA polymerase II
+  locations:
+  - id: GO:0005634
+    label: nucleus
+  supported_by:
+  - reference_id: PMID:15983867
+- description: &gt;-
+    Zinc-dependent, sequence-specific DNA binding. The two C4 zinc fingers of the NR
+    DNA-binding domain coordinate zinc and mediate recognition of specific DNA
+    response elements, providing the biochemical basis for NHR-47 transcription-factor
+    activity.
+  molecular_function:
+    id: GO:0043565
+    label: sequence-specific DNA binding
+  locations:
+  - id: GO:0005634
+    label: nucleus
+  supported_by:
+  - reference_id: PMID:15983867
+knowledge_gaps:
+- gap_statement: &gt;-
+    Whether NHR-47 binds an endogenous small-molecule ligand — and, if so, its
+    chemical identity — is unknown. It is classified as an orphan receptor, and as a
+    member of the HNF4-derived supplementary nuclear receptors it may have lost or
+    substantially altered ligand-dependent regulation.
+  boundary: &gt;-
+    NHR-47 has a canonical nuclear-receptor ligand-binding domain (UniProt NR LBD,
+    residues 164-553), but UniProt annotates it as an orphan nuclear receptor and no
+    ligand has been reported. nhr-47 transcription is induced by estradiol exposure, but
+    transcriptional induction is not evidence that estradiol (or any specific molecule)
+    is a direct NHR-47 ligand.
+  gap_kind:
+  - BIOLOGY
+  dark_aspect: MF_DARK
+  status: OPEN
+  significance: &gt;-
+    Knowing whether NHR-47 is ligand-regulated (and by what) would determine whether it
+    is a sensor of a metabolite/hormone or a constitutive/orphan transcriptional regulator,
+    and would shape any pharmacological or genetic strategy to control its activity.
+  provenance:
+  - reference_id: PMID:15983867
+    supporting_text: &gt;-
+      This origin has specific implications for the role of ligand binding in the
+      function and evolution of the nematode supplementary nuclear receptors.
+- gap_statement: &gt;-
+    The direct transcriptional targets and the DNA response element bound by NHR-47
+    in vivo are undetermined, and it is unknown whether NHR-47 acts as an activator or a
+    repressor. No ChIP, reporter, or motif data define its regulon; the downstream genes
+    that change on nhr-47 knockdown in toxicant assays (e.g. ins-3, daf-28, efn-3) are
+    whole-organism readouts, not demonstrated direct targets.
+  boundary: &gt;-
+    NHR-47 is a sequence-specific DNA-binding transcription factor and participates in
+    the C. elegans transcription-factor interaction network, and knockdown alters
+    downstream secreted-ligand gene expression, but no bona fide direct target has been
+    established.
+  gap_kind:
+  - BIOLOGY
+  - CURATION
+  dark_aspect: MF_DARK
+  status: OPEN
+  significance: &gt;-
+    Identifying direct targets and the response element would convert NHR-47 from a
+    predicted TF into a defined regulator and reveal the pathway(s) it controls.
+  provenance:
+  - reference_id: PMID:38922100
+    supporting_text: &gt;-
+      expressions of ins-3, daf-28, and ins-39 encoding insulin ligands, efn-3 encoding
+      Ephrin ligand, and lin-44 encoding Wnt ligand, as well as expressions of their
+      receptor genes (daf-2, vab-1, and/or mig-1), were dysregulated by the RNAi of
+      daf-12, nhr-14, nhr-47, and nhr-12
+- gap_statement: &gt;-
+    The endogenous physiological role and definitive loss-of-function phenotype of
+    nhr-47 are unresolved. Its only reported phenotypes are germline RNAi effects that
+    modulate susceptibility to environmental toxicants (polystyrene nanoparticles and
+    6-PPD-quinone); no baseline developmental, metabolic, or immune phenotype, and no
+    characterized null mutant, has been reported.
+  boundary: &gt;-
+    nhr-47 is expressed in neurons, ventral nerve cord, spermatheca, pharynx and
+    intestine, and germline knockdown modulates transgenerational/reproductive toxicant
+    responses, but a stand-alone required function under normal conditions has not been
+    defined.
+  gap_kind:
+  - BIOLOGY
+  dark_aspect: BP_DARK
+  status: OPEN
+  significance: &gt;-
+    A defined loss-of-function phenotype would anchor NHR-47&#39;s biological process
+    annotation, which is currently only family-propagated (IBA) or inferred from a
+    toxicant-stress context.
+  provenance:
+  - reference_id: PMID:38922100
+    supporting_text: &gt;-
+      RNAi of daf-12, nhr-14, and nhr-47 caused resistance, whereas RNAi of nhr-12
+      conferred susceptibility to transgenerational PS-NP toxicity
+  - reference_id: PMID:40482507
+    supporting_text: &gt;-
+      6-PPDQ reproductive toxicity was suppressed by nhr-47, nhr-14, daf-12, and nhr-249
+      RNAi and accelerated by nhr-12, nhr-145, and nhr-171 RNAi
+suggested_questions:
+- question: &gt;-
+    Is NHR-47 a ligand-regulated receptor, and if so what endogenous metabolite or lipid
+    binds its ligand-binding domain, or is it a constitutive/orphan transcriptional
+    regulator?
+  experts:
+  - Nuclear-receptor biochemists
+  - C. elegans NHR-family biologists
+- question: &gt;-
+    What are the direct genomic binding sites and target genes of NHR-47, and does it act
+    as a transcriptional activator or repressor?
+  experts:
+  - Transcription / gene-regulatory-network biologists
+- question: &gt;-
+    What is the endogenous (non-toxicant) physiological role of nhr-47, given its
+    expression in neurons, the ventral nerve cord, spermatheca, pharynx and intestine and
+    its germline role in toxicant responses?
+  experts:
+  - C. elegans developmental / germline biologists
+suggested_experiments:
+- experiment_type: Genome-wide binding assay
+  description: &gt;-
+    Determine the direct NHR-47 regulon by ChIP-seq or CUT&amp;RUN with an endogenously
+    tagged NHR-47, combined with RNA-seq of a null mutant, to identify direct target genes
+    and the DNA response element and to establish activator vs repressor behavior.
+- experiment_type: Ligand identification
+  description: &gt;-
+    Express and purify the NHR-47 ligand-binding domain and screen for bound endogenous
+    lipids/metabolites (e.g. by lipidomics of co-purified ligands or reporter-based
+    ligand-sensing assays) to test whether NHR-47 is ligand-regulated or a true orphan.
+- experiment_type: Loss-of-function phenotyping
+  description: &gt;-
+    Generate and characterize a null allele (CRISPR) across development, metabolism,
+    reproduction, stress and innate-immune assays to define the baseline endogenous
+    function, and test genetic interaction with the interacting receptor nhr-17.
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/genes/worm/osm-6/osm-6-ai-review.html
+++ b/genes/worm/osm-6/osm-6-ai-review.html
@@ -1,0 +1,4621 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>osm-6 - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        .propagation-review {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f8fafc;
+            border-left: 3px solid #64748b;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .propagation-title {
+            font-weight: 600;
+            color: #334155;
+            margin-bottom: 0.25rem;
+        }
+
+        .propagation-row {
+            margin-top: 0.25rem;
+        }
+
+        .propagation-source {
+            margin-top: 0.5rem;
+            padding-top: 0.5rem;
+            border-top: 1px solid #e5e7eb;
+        }
+
+        .propagation-source-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #1d4ed8;
+        }
+
+        .propagation-comment {
+            color: #4b5563;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>osm-6</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/G5EDF6" target="_blank" class="term-link">
+                        G5EDF6
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Caenorhabditis elegans</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-complete">
+                    COMPLETE
+                </span>
+            </div>
+
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "osm-6";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="G5EDF6" data-a="DESCRIPTION: OSM-6 is the Caenorhabditis elegans ortholog of hu..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>OSM-6 is the Caenorhabditis elegans ortholog of human IFT52 (also called NGD5; Chlamydomonas IFT52/BLD1) and is a core structural subunit of the intraflagellar transport complex B (IFT-B). Intraflagellar transport is the bidirectional, microtubule-motor-driven movement of large multiprotein particles that build and maintain cilia: kinesin-2 motors carry IFT particles and their cargo anterogradely from the ciliary base to the tip, and cytoplasmic dynein-2 returns them retrogradely. OSM-6/IFT52 is itself a component (and moving cargo) of the IFT-B particle rather than an enzyme; its GATase-like N-terminal (GIFT) domain, central domain and C-terminal domain are used to scaffold the complex. In C. elegans, osm-6 is expressed exclusively in ciliated sensory neurons under control of the RFX transcription factor DAF-19, and the protein localizes to the ciliary base (basal body, transition zone), along the sensory (non-motile) cilium, and in the cytoplasm/cell body of these neurons. OSM-6 is required for assembly of the ciliary axoneme: loss-of-function mutants retain normal transition zones but have severely truncated axonemes and ectopic microtubule assembly, causing dye-filling defects. Because the 60 ciliated sensory neurons mediate chemosensation, osmotic avoidance, mechanosensation, and dauer-pathway signaling, osm-6 mutants are broadly defective in these sensory behaviors as a downstream consequence of lacking functional cilia. OSM-6/IFT52 is conserved from algae to humans, and the pathway it serves is central to the biology of ciliopathies.</p>
+    </div>
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Proposed New Ontology Terms</h2>
+
+        <div class="proposed-term">
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>structural constituent of intraflagellar transport particle</h3>
+                <span class="vote-buttons" data-g="G5EDF6" data-a="structural constituent of intraflagellar transport particle" data-r="" data-act="NEW">
+                    <button class="vote-btn" data-v="up" title="Agree this term should be created">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with creating this term">👎</button>
+                </span>
+            </div>
+
+
+            <p><strong>Definition:</strong> A structural molecule activity in which a protein acts as a structural subunit of an intraflagellar transport (IFT) particle (IFT-A or IFT-B), contributing to the assembly and integrity of the particle that is trafficked along the ciliary axoneme by kinesin-2 and dynein-2 motors.</p>
+
+
+
+            <p><strong>Justification:</strong> OSM-6/IFT52 and its IFT-B/IFT-A paralogs act as structural subunits of the IFT particle, a role currently expressible only as the generic GO:0005198 structural molecule activity. A dedicated MF term would capture the shared function of IFT structural subunits.</p>
+
+
+
+
+
+
+
+            <p><strong>Supporting Evidence:</strong></p>
+            <ul style="margin-left: 1rem;">
+
+                <li>
+
+                    <a href="https://pubmed.ncbi.nlm.nih.gov/22922713" target="_blank" class="term-link">
+                        PMID:22922713
+                    </a>
+
+
+                    : the GFP-tagged IFT-B component OSM-6 (the ortholog of human IFT52)
+
+                </li>
+
+            </ul>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005929" target="_blank" class="term-link">
+                                    GO:0005929
+                                </a>
+                            </span>
+                            <span class="term-label">cilium</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="G5EDF6" data-a="GO:0005929" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> OSM-6/IFT52 localizes to and functions within the cilium; phylogenetic (IBA) inference agrees with direct C. elegans localization data.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Cilium localization is directly supported by multiple experimental studies (OSM-6::GFP is a canonical ciliary/IFT marker) and is a core aspect of osm-6 function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/22922713" target="_blank" class="term-link">
+                                        PMID:22922713
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">the GFP-tagged IFT-B component OSM-6 (the ortholog of human IFT52)</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030992" target="_blank" class="term-link">
+                                    GO:0030992
+                                </a>
+                            </span>
+                            <span class="term-label">intraciliary transport particle B</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="G5EDF6" data-a="GO:0030992" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> OSM-6 is a structural subunit of the IFT-B particle; this is the single most important annotation for the gene and is supported by orthology to IFT52 and by ComplexPortal (CPX-1290).
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Core molecular role. OSM-6 is explicitly the IFT-B component / IFT52 ortholog and a member of Intraflagellar transport complex B (CPX-1290).
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/22922713" target="_blank" class="term-link">
+                                        PMID:22922713
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">the GFP-tagged IFT-B component OSM-6 (the ortholog of human IFT52)</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042073" target="_blank" class="term-link">
+                                    GO:0042073
+                                </a>
+                            </span>
+                            <span class="term-label">intraciliary transport</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="G5EDF6" data-a="GO:0042073" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> As an IFT-B subunit and moving IFT cargo, OSM-6 is directly involved in intraciliary transport.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Core biological process. OSM-6::GFP moves bidirectionally by IFT and is part of the transported IFT particle.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/10545497" target="_blank" class="term-link">
+                                        PMID:10545497
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">OSM-1 and OSM-6, all move at approximately 1.1 microm/s in the retrograde direction along cilia and dendrites</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0060271" target="_blank" class="term-link">
+                                    GO:0060271
+                                </a>
+                            </span>
+                            <span class="term-label">cilium assembly</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="G5EDF6" data-a="GO:0060271" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> OSM-6 is required for building the ciliary axoneme; phylogenetic inference is corroborated by the loss-of-function ultrastructural phenotype.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Core process. osm-6 mutants have severely truncated axonemes, establishing a role in cilium assembly.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/2428682" target="_blank" class="term-link">
+                                        PMID:2428682
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The cilia in che-13 (e1805), osm-1 (p808), osm-5 (p813), and osm-6 (p811) mutants have normal transition zones and severely shortened axonemes.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005814" target="_blank" class="term-link">
+                                    GO:0005814
+                                </a>
+                            </span>
+                            <span class="term-label">centriole</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="G5EDF6" data-a="GO:0005814" data-r="GO_REF:0000033" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetically propagated centriole localization. In C. elegans the directly demonstrated basal-body/transition-zone localization is the relevant structure (the ciliary basal body is a docked, modified centriole).
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Plausible but not the core functional site and not directly demonstrated in C. elegans; the experimentally supported location is the ciliary basal body (GO:0036064). Retained as a non-core, orthology-based location rather than removed.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005929" target="_blank" class="term-link">
+                                    GO:0005929
+                                </a>
+                            </span>
+                            <span class="term-label">cilium</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">NAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/28479320" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:28479320
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Dynein-Driven Retrograde Intraflagellar Transport Is Triphas...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="G5EDF6" data-a="GO:0005929" data-r="PMID:28479320" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> ComplexPortal (CPX-1290) statement that OSM-6 localizes to the cilium, consistent with direct experimental data.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Core ciliary localization; corroborated by IDA evidence from multiple studies.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/28479320" target="_blank" class="term-link">
+                                        PMID:28479320
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Dynein-Driven Retrograde Intraflagellar Transport Is Triphasic in C. elegans Sensory Cilia</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030992" target="_blank" class="term-link">
+                                    GO:0030992
+                                </a>
+                            </span>
+                            <span class="term-label">intraciliary transport particle B</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">NAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/28479320" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:28479320
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Dynein-Driven Retrograde Intraflagellar Transport Is Triphas...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="G5EDF6" data-a="GO:0030992" data-r="PMID:28479320" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> ComplexPortal assertion of OSM-6 membership in IFT particle B, the core structural annotation, based on the C. elegans IFT-B complex.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Core molecular role, redundant with and reinforcing the IBA IFT-B membership annotation.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/28479320" target="_blank" class="term-link">
+                                        PMID:28479320
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Disruption of the dynein-2 tail domain, light intermediate chain, or intraflagellar transport (IFT)-B complex abolishes dynein-2&#39;s ciliary localization</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042073" target="_blank" class="term-link">
+                                    GO:0042073
+                                </a>
+                            </span>
+                            <span class="term-label">intraciliary transport</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">NAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/28479320" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:28479320
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Dynein-Driven Retrograde Intraflagellar Transport Is Triphas...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="G5EDF6" data-a="GO:0042073" data-r="PMID:28479320" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> ComplexPortal statement of IFT-B involvement in intraciliary transport.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Core process consistent with OSM-6 being a transported IFT-B subunit.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/28479320" target="_blank" class="term-link">
+                                        PMID:28479320
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Disruption of the dynein-2 tail domain, light intermediate chain, or intraflagellar transport (IFT)-B complex abolishes dynein-2&#39;s ciliary localization</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0060271" target="_blank" class="term-link">
+                                    GO:0060271
+                                </a>
+                            </span>
+                            <span class="term-label">cilium assembly</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">NAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/28479320" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:28479320
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Dynein-Driven Retrograde Intraflagellar Transport Is Triphas...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="G5EDF6" data-a="GO:0060271" data-r="PMID:28479320" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> ComplexPortal statement of IFT-B involvement in cilium assembly.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Core process; redundant with the IMP/IBA cilium-assembly annotations.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/2428682" target="_blank" class="term-link">
+                                        PMID:2428682
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The cilia in che-13 (e1805), osm-1 (p808), osm-5 (p813), and osm-6 (p811) mutants have normal transition zones and severely shortened axonemes.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0060271" target="_blank" class="term-link">
+                                    GO:0060271
+                                </a>
+                            </span>
+                            <span class="term-label">cilium assembly</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/24013594" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:24013594
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Neuropeptide signaling remodels chemosensory circuit composi...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="G5EDF6" data-a="GO:0060271" data-r="PMID:24013594" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> osm-6 loss abolishes functional sensory cilia (dendritic endings), confirming a requirement in cilium assembly.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Core process. Although this paper is about a salt circuit, it explicitly uses osm-6 as a cilium-assembly loss-of-function allele.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/24013594" target="_blank" class="term-link">
+                                        PMID:24013594
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">We analyzed hypomorphic osm-6 mutants that lack functional sensory cilia (dendritic endings)</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1902075" target="_blank" class="term-link">
+                                    GO:1902075
+                                </a>
+                            </span>
+                            <span class="term-label">cellular response to salt</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/24013594" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:24013594
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Neuropeptide signaling remodels chemosensory circuit composi...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="G5EDF6" data-a="GO:1902075" data-r="PMID:24013594" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> osm-6 mutants have reduced salt-evoked neuronal responses, but only because they lack functional cilia; OSM-6 has no salt-sensing or salt-signalling activity of its own.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Indirect, downstream sensory phenotype of ciliary loss rather than a core molecular/biological function of OSM-6. Retained (per curator) but marked non-core to avoid implying a direct salt-response role.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/24013594" target="_blank" class="term-link">
+                                        PMID:24013594
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">found them to have greatly reduced ASEL salt responses and AWCON salt and odor responses</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005929" target="_blank" class="term-link">
+                                    GO:0005929
+                                </a>
+                            </span>
+                            <span class="term-label">cilium</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/27930654" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:27930654
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Whole-Organism Developmental Expression Profiling Identifies...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="G5EDF6" data-a="GO:0005929" data-r="PMID:27930654" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct localization of OSM-6::GFP to the cilium, used as a ciliary reference marker.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Core ciliary localization directly observed; OSM-6::GFP (IFT52 orthologue) is imaged throughout normal-length cilia.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/27930654" target="_blank" class="term-link">
+                                        PMID:27930654
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Localisation of an IFT protein, OSM-6 (IFT52 orthologue), throughout normal-length cilia confirms this finding</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1905515" target="_blank" class="term-link">
+                                    GO:1905515
+                                </a>
+                            </span>
+                            <span class="term-label">non-motile cilium assembly</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/2428682" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:2428682
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Mutant sensory cilia in the nematode Caenorhabditis elegans.
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="G5EDF6" data-a="GO:1905515" data-r="PMID:2428682" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> osm-6 mutants fail to build full sensory (non-motile) cilia; this is the most precise cilium-assembly term for the worm&#39;s sensory cilia.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Core process, and appropriately specific (C. elegans sensory cilia are non-motile). Directly supported by the ultrastructural phenotype.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/2428682" target="_blank" class="term-link">
+                                        PMID:2428682
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The cilia in che-13 (e1805), osm-1 (p808), osm-5 (p813), and osm-6 (p811) mutants have normal transition zones and severely shortened axonemes.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0060271" target="_blank" class="term-link">
+                                    GO:0060271
+                                </a>
+                            </span>
+                            <span class="term-label">cilium assembly</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IGI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/1732156" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:1732156
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Genetic analysis of chemosensory control of dauer formation ...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="G5EDF6" data-a="GO:0060271" data-r="PMID:1732156" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Genetic-interaction evidence placing osm-6 among cilium-structure genes required for chemosensory cilium function in the dauer pathway.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Core process; osm-6 is one of nine genes whose mutation gives structurally defective chemosensory cilia.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/1732156" target="_blank" class="term-link">
+                                        PMID:1732156
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Dauer-defective mutations in nine genes cause structurally defective chemosensory cilia, thereby blocking chemosensation.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0097730" target="_blank" class="term-link">
+                                    GO:0097730
+                                </a>
+                            </span>
+                            <span class="term-label">non-motile cilium</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/22342749" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:22342749
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Endocytosis genes facilitate protein and membrane transport ...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="G5EDF6" data-a="GO:0097730" data-r="PMID:22342749" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct localization of OSM-6 to the sensory (non-motile) cilium.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Core ciliary localization; the sensory-cilium term is appropriately specific.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/22342749" target="_blank" class="term-link">
+                                        PMID:22342749
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">cilium-based intraflagellar transport (IFT)</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003674" target="_blank" class="term-link">
+                                    GO:0003674
+                                </a>
+                            </span>
+                            <span class="term-label">molecular_function</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ND</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000015
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="G5EDF6" data-a="GO:0003674" data-r="GO_REF:0000015" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Root-level placeholder recording that no specific molecular function had been assigned at the time of annotation.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Retained as the standard ND placeholder. A subunit-specific molecular function (structural molecule activity within IFT-B) is now proposed as a NEW annotation and in core_functions; no catalytic activity is known or expected for this GATase-fold scaffold.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005198" target="_blank" class="term-link">
+                                    GO:0005198
+                                </a>
+                            </span>
+                            <span class="term-label">structural molecule activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-new">
+                            NEW
+                        </span>
+                        <span class="vote-buttons" data-g="G5EDF6" data-a="GO:0005198" data-r="GO_REF:0000033" data-act="NEW">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> OSM-6/IFT52 has no catalytic activity; as an IFT-B subunit its molecular function is best captured as a subunit-specific structural molecule activity.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Proposed new molecular-function annotation reflecting OSM-6&#39;s role as a structural subunit of the IFT-B particle (the current GOA carries only the ND root MF for this gene). This IBA/GO_REF:0000033 evidence pairing does NOT currently exist in the GOA export; it is the expected phylogenetic evidence basis if the annotation were made (IFT52 orthologues across species are IFT-B structural subunits). Ideally a more specific &#39;structural constituent of intraflagellar transport particle&#39; term (see proposed_new_terms) would be used.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/22922713" target="_blank" class="term-link">
+                                        PMID:22922713
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">the GFP-tagged IFT-B component OSM-6 (the ortholog of human IFT52)</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0036064" target="_blank" class="term-link">
+                                    GO:0036064
+                                </a>
+                            </span>
+                            <span class="term-label">ciliary basal body</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/22922713" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:22922713
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The BBSome controls IFT assembly and turnaround in cilia.
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="G5EDF6" data-a="GO:0036064" data-r="PMID:22922713" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> OSM-6::GFP directly localizes to the ciliary basal body, where IFT particles assemble before entering the cilium.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Core localization at the site of IFT assembly.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/22922713" target="_blank" class="term-link">
+                                        PMID:22922713
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">the GFP-tagged IFT-B component OSM-6 (the ortholog of human IFT52)</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0035869" target="_blank" class="term-link">
+                                    GO:0035869
+                                </a>
+                            </span>
+                            <span class="term-label">ciliary transition zone</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/10545497" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:10545497
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Role of a class DHC1b dynein in retrograde transport of IFT ...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="G5EDF6" data-a="GO:0035869" data-r="PMID:10545497" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> OSM-6::GFP is observed at/through the ciliary transition zone as it moves between the base and the axoneme.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Core localization consistent with IFT trafficking through the transition zone.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/10545497" target="_blank" class="term-link">
+                                        PMID:10545497
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">OSM-1 and OSM-6, all move at approximately 1.1 microm/s in the retrograde direction along cilia and dendrites</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0097730" target="_blank" class="term-link">
+                                    GO:0097730
+                                </a>
+                            </span>
+                            <span class="term-label">non-motile cilium</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/10545497" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:10545497
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Role of a class DHC1b dynein in retrograde transport of IFT ...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="G5EDF6" data-a="GO:0097730" data-r="PMID:10545497" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> OSM-6::GFP localizes along the sensory (non-motile) cilium.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Core ciliary localization, appropriately specific.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/10545497" target="_blank" class="term-link">
+                                        PMID:10545497
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">OSM-1 and OSM-6, all move at approximately 1.1 microm/s in the retrograde direction along cilia and dendrites</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
+                                    GO:0005737
+                                </a>
+                            </span>
+                            <span class="term-label">cytoplasm</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/9475731" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:9475731
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Analysis of osm-6, a gene that affects sensory cilium struct...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="G5EDF6" data-a="GO:0005737" data-r="PMID:9475731" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> OSM-6::GFP is present in the cytoplasm (including neuronal processes) prior to and outside of ciliary transport.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Directly observed but a broad, non-informative location; the functionally relevant sites are the cilium and its base. Retained as non-core.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9475731" target="_blank" class="term-link">
+                                        PMID:9475731
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The OSM-6::GFP protein was localized to cytoplasm, including processes and dendritic endings where sensory cilia are situated.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006935" target="_blank" class="term-link">
+                                    GO:0006935
+                                </a>
+                            </span>
+                            <span class="term-label">chemotaxis</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/2428682" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:2428682
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Mutant sensory cilia in the nematode Caenorhabditis elegans.
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="G5EDF6" data-a="GO:0006935" data-r="PMID:2428682" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> osm-6 mutants are chemosensory-defective (dye-filling defective) because their chemosensory cilia are truncated.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Downstream sensory consequence of defective cilia rather than a direct role of OSM-6 in chemotaxis signalling. Retained but non-core.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/2428682" target="_blank" class="term-link">
+                                        PMID:2428682
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Mutations in 14 genes prevent dye uptake and disrupt chemosensory behaviors.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006970" target="_blank" class="term-link">
+                                    GO:0006970
+                                </a>
+                            </span>
+                            <span class="term-label">response to osmotic stress</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/730048" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:730048
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Osmotic avoidance defective mutants of the nematode Caenorha...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="G5EDF6" data-a="GO:0006970" data-r="PMID:730048" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> osm-6 is named for its osmotic-avoidance-defective phenotype; mutants fail to avoid high osmolarity because their sensory cilia are non-functional.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Indirect, downstream behavioral phenotype of ciliary loss, not a direct osmotic-stress-response activity of OSM-6. Retained (curator IMP) but non-core.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/730048" target="_blank" class="term-link">
+                                        PMID:730048
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">mutants were selected for their inability to avoid high concentrations of fructose or NaCl</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0043025" target="_blank" class="term-link">
+                                    GO:0043025
+                                </a>
+                            </span>
+                            <span class="term-label">neuronal cell body</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/9475731" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:9475731
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Analysis of osm-6, a gene that affects sensory cilium struct...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="G5EDF6" data-a="GO:0043025" data-r="PMID:9475731" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> OSM-6::GFP accumulates in the cell bodies of ciliated sensory neurons, where the protein is synthesized before delivery to cilia.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Real localization but reflects the site of synthesis rather than the core functional site (the cilium/basal body). Retained as non-core.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9475731" target="_blank" class="term-link">
+                                        PMID:9475731
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">showed accumulation of GFP in ciliated sensory neurons exclusively</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0050954" target="_blank" class="term-link">
+                                    GO:0050954
+                                </a>
+                            </span>
+                            <span class="term-label">sensory perception of mechanical stimulus</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/8460126" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:8460126
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    A dual mechanosensory and chemosensory neuron in Caenorhabdi...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="G5EDF6" data-a="GO:0050954" data-r="PMID:8460126" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Nose-touch mechanosensation requires intact ciliated sensory endings, which osm-6 is needed to build; osm-6 mutants are mechanosensory-defective.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Downstream sensory consequence of defective cilia rather than a direct mechanotransduction role of OSM-6. The cached abstract does not name osm-6, but the WormBase IMP reflects curator full-text evidence and is not overruled.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/8460126" target="_blank" class="term-link">
+                                        PMID:8460126
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Mutant animals that have defective ciliated sensory endings as well as laser-operated animals that lack ASH, FLP, and OLQ fail to respond to touch to the nose.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>OSM-6/IFT52 is a structural subunit of the intraflagellar transport complex B (IFT-B), the anterograde IFT particle that is itself carried as cargo by kinesin-2 and returned by dynein-2. It scaffolds the IFT-B complex (it does not have independent catalytic activity) and is required to build and maintain the sensory ciliary axoneme in C. elegans ciliated neurons.</h3>
+                <span class="vote-buttons" data-g="G5EDF6" data-a="FUNCTION: OSM-6/IFT52 is a structural subunit of the intrafl..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005198" target="_blank" class="term-link">
+                            structural molecule activity
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042073" target="_blank" class="term-link">
+                                intraciliary transport
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1905515" target="_blank" class="term-link">
+                                non-motile cilium assembly
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0097730" target="_blank" class="term-link">
+                                non-motile cilium
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0036064" target="_blank" class="term-link">
+                                ciliary basal body
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0035869" target="_blank" class="term-link">
+                                ciliary transition zone
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">In Complex:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030992" target="_blank" class="term-link">
+                            intraciliary transport particle B
+                        </a>
+                    </span>
+                </div>
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/22922713" target="_blank" class="term-link">
+                                PMID:22922713
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">the GFP-tagged IFT-B component OSM-6 (the ortholog of human IFT52)</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/2428682" target="_blank" class="term-link">
+                                PMID:2428682
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">The cilia in che-13 (e1805), osm-1 (p808), osm-5 (p813), and osm-6 (p811) mutants have normal transition zones and severely shortened axonemes.</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000015.md" target="_blank" class="term-link">
+                            GO_REF:0000015
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Use of the ND evidence code for Gene Ontology (GO) terms</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
+                            GO_REF:0000033
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Annotation inferences using phylogenetic trees</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/10545497" target="_blank" class="term-link">
+                            PMID:10545497
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Role of a class DHC1b dynein in retrograde transport of IFT motors and IFT raft particles along cilia, but not dendrites, in chemosensory neurons of living Caenorhabditis elegans.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">OSM-6 is a homologue of a Chlamydomonas 16S IFT raft (IFT particle) polypeptide and, together with OSM-1 and kinesin-II, undergoes retrograde IFT along cilia at ~1.1 um/s; retrograde ciliary transport requires the CHE-3 (DHC1b/dynein-2) motor.</div>
+
+                        <div class="finding-text">"OSM-1 and OSM-6, all move at approximately 1.1 microm/s in the retrograde direction along cilia and dendrites"</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/1732156" target="_blank" class="term-link">
+                            PMID:1732156
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Genetic analysis of chemosensory control of dauer formation in Caenorhabditis elegans.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">osm-6 is one of nine cilium-structure genes whose mutation causes structurally defective chemosensory cilia and blocks chemosensation, placing it at a single step in the dauer-formation epistasis pathway.</div>
+
+                        <div class="finding-text">"Dauer-defective mutations in nine genes cause structurally defective chemosensory cilia, thereby blocking chemosensation."</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/22342749" target="_blank" class="term-link">
+                            PMID:22342749
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Endocytosis genes facilitate protein and membrane transport in C. elegans sensory cilia.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">OSM-6 is used as an IFT/ciliary marker in C. elegans sensory cilia; the study examines transport of ciliary and periciliary membrane and IFT proteins.</div>
+
+                        <div class="finding-text">"These pathways include cilium-based intraflagellar transport (IFT) and poorly understood membrane trafficking events."</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/22922713" target="_blank" class="term-link">
+                            PMID:22922713
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">The BBSome controls IFT assembly and turnaround in cilia.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">GFP-tagged OSM-6 is the canonical IFT-B reporter (explicitly the ortholog of human IFT52) used to screen for IFT assembly/turnaround mutants; OSM-6 marks IFT particles at the ciliary base and along cilia.</div>
+
+                        <div class="finding-text">"the GFP-tagged IFT-B component OSM-6 (the ortholog of human IFT52)"</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/24013594" target="_blank" class="term-link">
+                            PMID:24013594
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Neuropeptide signaling remodels chemosensory circuit composition in Caenorhabditis elegans.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Hypomorphic osm-6 mutants lack functional sensory cilia and consequently show greatly reduced salt (ASEL) and salt/odor (AWC) sensory responses; ciliary function is restored cell-autonomously by osm-6 rescue.</div>
+
+                        <div class="finding-text">"We analyzed hypomorphic osm-6 mutants that lack functional sensory cilia (dendritic endings) and found them to have greatly reduced ASEL salt responses and AWCON salt and odor responses"</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/2428682" target="_blank" class="term-link">
+                            PMID:2428682
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Mutant sensory cilia in the nematode Caenorhabditis elegans.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">osm-6(p811) mutants have normal ciliary transition zones but severely shortened axonemes with ectopic doublet microtubules, establishing OSM-6 as required for axoneme (cilium) assembly rather than transition-zone formation.</div>
+
+                        <div class="finding-text">"The cilia in che-13 (e1805), osm-1 (p808), osm-5 (p813), and osm-6 (p811) mutants have normal transition zones and severely shortened axonemes."</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/27930654" target="_blank" class="term-link">
+                            PMID:27930654
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Whole-Organism Developmental Expression Profiling Identifies RAB-28 as a Novel Ciliary GTPase Associated with the BBSome and Intraflagellar Transport.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">OSM-6::GFP (explicitly the IFT52 orthologue) localizes throughout normal-length sensory cilia and is used as an established IFT/ciliary marker.</div>
+
+                        <div class="finding-text">"Localisation of an IFT protein, OSM-6 (IFT52 orthologue), throughout normal-length cilia confirms this finding"</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/28479320" target="_blank" class="term-link">
+                            PMID:28479320
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Dynein-Driven Retrograde Intraflagellar Transport Is Triphasic in C. elegans Sensory Cilia.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Ciliary entry of dynein-2 requires an intact IFT-B complex (of which OSM-6/IFT52 is a component); this study is the ComplexPortal source (CPX-1290) for OSM-6 IFT-B/IFT particle B membership and ciliary localization.</div>
+
+                        <div class="finding-text">"Disruption of the dynein-2 tail domain, light intermediate chain, or intraflagellar transport (IFT)-B complex abolishes dynein-2&#39;s ciliary localization"</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/730048" target="_blank" class="term-link">
+                            PMID:730048
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Osmotic avoidance defective mutants of the nematode Caenorhabditis elegans.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Founding screen that isolated osmotic-avoidance-defective (Osm) mutants of C. elegans, the phenotypic class for which osm-6 is named; such mutants fail to avoid high concentrations of salts/sugars.</div>
+
+                        <div class="finding-text">"mutants were selected for their inability to avoid high concentrations of fructose or NaCl"</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/8460126" target="_blank" class="term-link">
+                            PMID:8460126
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">A dual mechanosensory and chemosensory neuron in Caenorhabditis elegans.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Animals with defective ciliated sensory endings fail to respond to nose touch, linking intact sensory cilia (which require osm-6) to mechanosensation.</div>
+
+                        <div class="finding-text">"Mutant animals that have defective ciliated sensory endings as well as laser-operated animals that lack ASH, FLP, and OLQ fail to respond to touch to the nose."</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/9475731" target="_blank" class="term-link">
+                            PMID:9475731
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Analysis of osm-6, a gene that affects sensory cilium structure and sensory neuron function in Caenorhabditis elegans.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">osm-6 was cloned and shown to encode a protein of previously unknown function expressed exclusively in ciliated sensory neurons; OSM-6::GFP rescues the mutant and localizes to cytoplasm/processes/dendritic endings, and osm-6 acts cell-autonomously in cilium structure. DAF-19 is required for OSM-6 accumulation.</div>
+
+                        <div class="finding-text">"The OSM-6::GFP protein was localized to cytoplasm, including processes and dendritic endings where sensory cilia are situated."</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Genetic mosaic analysis shows osm-6 acts cell-autonomously in the ciliated neuron.</div>
+
+                        <div class="finding-text">"we conclude from an analysis of genetic mosaics that osm-6 acts cell autonomously in affecting cilium structure"</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Questions for Experts</h2>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Which IFT-B subunits does OSM-6 directly contact in C. elegans, and are the GIFT, central and C-terminal domains functionally separable?</p>
+
+                    <p style="margin-top: 0.5rem;"><em>Suggested experts: Oliver E. Blacque</em></p>
+
+                </div>
+                <span class="vote-buttons" data-g="G5EDF6" data-a="Q: Which IFT-B subunits does OSM-6 directly contact i..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Does the IFT52 GIFT domain retain any ligand-binding capacity, or is it a purely structural remnant of the glutamine-amidotransferase fold?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="G5EDF6" data-a="Q: Does the IFT52 GIFT domain retain any ligand-bindi..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Experiments</h2>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Perform in vivo proximity labeling (TurboID) with domain-truncated OSM-6 variants expressed in ciliated neurons, followed by mass spectrometry, to map domain-specific IFT-B interaction partners.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: OSM-6/IFT52 bridges the IFT-B core to peripheral subunits via distinct domains, and disrupting individual domains selectively destabilizes parts of IFT-B.</em></p>
+
+
+                    <p style="margin-top: 0.5rem;">Type: proximity labeling / interaction mapping</p>
+
+                </div>
+                <span class="vote-buttons" data-g="G5EDF6" data-a="EXPERIMENT: Perform in vivo proximity labeling (TurboID) with ..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Use live imaging of tagged tubulin and IFT trains in osm-6 partial loss-of-function backgrounds to quantify anterograde cargo delivery versus transition-zone integrity.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: The severely truncated axoneme of osm-6 mutants reflects failure to deliver axonemal tubulin/cargo by IFT-B rather than a transition-zone defect.</em></p>
+
+
+                    <p style="margin-top: 0.5rem;">Type: live-cell imaging</p>
+
+                </div>
+                <span class="vote-buttons" data-g="G5EDF6" data-a="EXPERIMENT: Use live imaging of tagged tubulin and IFT trains ..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Knowledge Gaps</h2>
+        <p style="color: #555; font-size: 0.92rem; margin-top: -0.3rem;">
+            What is <em>not</em> known — curated, literature-grounded statements of the open
+            unknowns (the inverse of core functions).
+        </p>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The specific intra-complex protein contacts of OSM-6/IFT52 within the C. elegans IFT-B particle have not been experimentally mapped. In other organisms IFT52 bridges the IFT-B1 core (contacting IFT88, IFT70 and IFT46) and links the core to peripheral subunits, but which partners its GIFT, central and C-terminal domains engage in the worm, and how these contacts are used during IFT-particle assembly and tip turnaround, is undetermined.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span><span class="badge">ONTOLOGY</span>
+                <span class="badge">MF_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> It is firmly established that OSM-6 is an IFT-B/IFT52 structural subunit that moves bidirectionally by IFT, localizes to basal body, transition zone and axoneme, and is required for axoneme assembly.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Defining OSM-6&#39;s specific IFT-B contacts would explain how the IFT-B particle is built and how ciliopathy-relevant IFT52 mutations destabilize the complex.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> In vivo proximity labeling (BioID/TurboID) or cross-linking mass spectrometry of tagged OSM-6 in ciliated neurons, plus structure determination of the C. elegans IFT-B subcomplex, paired with an ontology term for structural constituent of the IFT particle.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"the GFP-tagged IFT-B component OSM-6 (the ortholog of human IFT52)"</em> — PMID:22922713</li>
+
+            </ul>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Proposed term (ontology gap):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><strong>structural constituent of intraflagellar transport particle</strong> — GO currently expresses this role only as the generic &#39;structural molecule activity&#39; (GO:0005198).</li>
+
+            </ul>
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> No independent biochemical or enzymatic activity has been demonstrated for OSM-6/IFT52, and although its N-terminal domain adopts a class-I glutamine-amidotransferase-like (GIFT) fold, whether this fold has any residual ligand-binding or catalytic role beyond scaffolding is unknown.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">MF_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> The GATase-like fold is annotated structurally (Pfam IFT52_GIFT / SSF52317); catalytic residues appear absent, consistent with a purely structural function.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Ruling in or out any ligand-binding role of the GIFT domain would clarify whether IFT52 does more than scaffold IFT-B.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Structure-guided mutagenesis of the GIFT domain and in vitro binding/activity assays to test for retained ligand interaction.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"a protein that is 40% identical in amino acid sequence to a predicted mammalian protein of unknown function"</em> — PMID:9475731</li>
+
+            </ul>
+
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Tags</h2>
+        <div class="aliases">
+
+            <span class="badge">caeel-ciliopathy</span>
+
+        </div>
+    </div>
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Deep Research Sections -->
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(osm-6-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="G5EDF6" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="osm-6-c-elegans-research-notes">osm-6 (C. elegans) research notes</h1>
+<blockquote>
+<p>Provenance note: <code>just deep-research-falcon worm osm-6 --fallback perplexity-lite</code><br />
+was attempted twice and both runs timed out with no output (SIGTERM, exit 143/144);<br />
+no <code>-deep-research-*.md</code> file was produced and none was fabricated. This review is<br />
+grounded directly in the UniProt record (G5EDF6), the QuickGO GOA export, and the 11<br />
+cached primary publications (all listed below with verbatim provenance). All existing<br />
+annotations could be adjudicated from primary literature, so no UNDECIDED calls were<br />
+required.</p>
+</blockquote>
+<p>UniProt: G5EDF6 (G5EDF6_CAEEL) · WormBase: WBGene00003886 / R31.3 · ORF R31.3 · Chromosome V<br />
+Ortholog: <strong>IFT52</strong> (human IFT52 / NGD5; Chlamydomonas IFT52/BLD1). Core structural subunit of the<br />
+intraflagellar transport complex B (IFT-B). PANTHER PTHR12969 (NGD5/OSM-6/IFT52), subfamily SF7.<br />
+ComplexPortal: CPX-1290 "Intraflagellar transport complex B".</p>
+<p>Protein: 472 aa. Domain architecture (InterPro/Pfam): N-terminal IFT52 GIFT domain (PF23355, ~18-257,<br />
+a class-I glutamine-amidotransferase-like fold, SSF52317), IFT52 central domain (PF23352, ~274-357),<br />
+and IFT52 C-terminal domain (PF21178, ~368-417, CDD cd23683 IFT52_CTD). No catalytic residues / no EC;<br />
+the GATase-like fold is used structurally, not enzymatically (consistent with a scaffold subunit).</p>
+<h2 id="summary-what-osm-6ift52-is-known">Summary: what osm-6/IFT52 IS (KNOWN)</h2>
+<ul>
+<li>
+<p><strong>Structural subunit of the IFT-B complex.</strong> In <em>Chlamydomonas</em>, the 16S IFT "raft" (IFT particle)<br />
+  contains ≥16 polypeptides, two of which are homologues of the <em>C. elegans</em> OSM-1 and OSM-6 proteins<br />
+  required for sensory ciliary function <a href="https://pubmed.ncbi.nlm.nih.gov/10545497" title="the basic subunit of IFT rafts is a 16S   multiprotein complex containing at least 16 polypeptides, two of which share sequence homology with   the OSM-1 and OSM-6 proteins that are required for sensory ciliary function in C. elegans">PMID:10545497</a>.<br />
+  OSM-6 is explicitly "the ortholog of human IFT52" and is used as the canonical GFP-tagged <strong>IFT-B<br />
+  component</strong> reporter <a href="https://pubmed.ncbi.nlm.nih.gov/22922713" title="the GFP-tagged IFT-B component OSM-6 (the ortholog of human   IFT52)">PMID:22922713</a>.</p>
+</li>
+<li>
+<p><strong>Cargo of the IFT motors / moves by IFT.</strong> OSM-6::GFP moves anterogradely (kinesin-II driven) and<br />
+  retrogradely along cilia. Kinesin-II and its cargo OSM-1 and OSM-6 all move at ~1.1 µm/s in the<br />
+  retrograde direction along cilia and dendrites <a href="https://pubmed.ncbi.nlm.nih.gov/10545497" title="OSM-1 and OSM-6, all move at   approximately 1.1 microm/s in the retrograde direction along cilia and dendrites">PMID:10545497</a>. Retrograde<br />
+  movement in cilia (but not dendrites) requires the CHE-3 (DHC1b/dynein-2) motor <a href="https://pubmed.ncbi.nlm.nih.gov/10545497" title="the class DHC1b cytoplasmic dynein, CHE-3, is specifically responsible for the retrograde transport   of the anterograde motor, kinesin-II, and its cargo within sensory cilia">PMID:10545497</a>. Ciliary entry of dynein-2<br />
+  itself depends on an intact IFT-B complex <a href="https://pubmed.ncbi.nlm.nih.gov/28479320" title="Disruption of the dynein-2 tail domain,   light intermediate chain, or intraflagellar transport (IFT)-B complex abolishes dynein-2's ciliary   localization">PMID:28479320</a>.</p>
+</li>
+<li>
+<p><strong>Required for cilium (axoneme) assembly.</strong> osm-6 mutants have normal transition zones but severely<br />
+  shortened axonemes with ectopic doublet microtubules assembling proximal to the cilium<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/2428682" title="The cilia in che-13 (e1805), osm-1 (p808), osm-5 (p813), and osm-6 (p811) mutants have   normal transition zones and severely shortened axonemes. Doublet-microtubules, attached to the   membrane by Y links, assemble ectopically proximal to the cilia in these mutants">PMID:2428682</a>. Cloning +<br />
+  transformation rescue + genetic mosaics show osm-6 acts <strong>cell-autonomously</strong> in ciliated sensory<br />
+  neurons <a href="https://pubmed.ncbi.nlm.nih.gov/9475731" title="we conclude from an analysis of genetic mosaics that osm-6 acts cell   autonomously in affecting cilium structure">PMID:9475731</a>.</p>
+</li>
+<li>
+<p><strong>Localization.</strong> OSM-6::GFP is expressed exclusively in ciliated sensory neurons; the fusion rescues<br />
+  the mutant and accumulates in cytoplasm including processes and dendritic endings where cilia sit<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/9475731" title="The OSM-6::GFP protein was localized to cytoplasm, including processes and dendritic   endings where sensory cilia are situated">PMID:9475731</a>. Expression is controlled by the RFX transcription factor<br />
+  DAF-19: "in the case of daf-19, reduced OSM-6::GFP accumulation" <a href="https://pubmed.ncbi.nlm.nih.gov/9475731">PMID:9475731</a>. Experimentally<br />
+  localized to: non-motile (sensory) cilium and transition zone <a href="https://pubmed.ncbi.nlm.nih.gov/10545497">PMID:10545497</a>, ciliary basal body<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/22922713">PMID:22922713</a>, and neuronal cell body <a href="https://pubmed.ncbi.nlm.nih.gov/9475731">PMID:9475731</a>. Used as a ciliary IFT marker in RAB-28 work<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/27930654">PMID:27930654</a>.</p>
+</li>
+</ul>
+<h2 id="what-osm-6-loss-causes-downstream-known-but-not-the-core-molecular-role">What osm-6 loss CAUSES downstream (KNOWN but not the core molecular role)</h2>
+<p>All of these are <em>sensory consequences of losing functional cilia</em>, not distinct molecular activities<br />
+of OSM-6:<br />
+- <strong>Osmotic avoidance defect</strong> — the gene is named for this ("OSMotic avoidance abnormal"); osm-6 was<br />
+  isolated among the osmotic-avoidance-defective mutants [PMID:730048 osmotic avoidance defective<br />
+  screen]. (Abstract-only; osm-6 not named in the cached abstract but this is the founding Osm screen<br />
+  and the IMP is a WormBase curator annotation.)<br />
+- <strong>Chemotaxis / chemosensation defect</strong> and dye-filling defect <a href="https://pubmed.ncbi.nlm.nih.gov/2428682">PMID:2428682</a>.<br />
+- <strong>Mechanosensation defect</strong> — nose-touch response requires intact ciliated sensory endings<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/8460126" title="Mutant animals that have defective ciliated sensory endings ... fail to respond to   touch to the nose">PMID:8460126</a> (osm-6 mutants are among such ciliary-defective animals; WB IMP).<br />
+- <strong>Dauer formation</strong> — osm-6 is one of the cilium-structure genes acting at a single step in the<br />
+  chemosensory dauer pathway <a href="https://pubmed.ncbi.nlm.nih.gov/1732156" title="Dauer-defective mutations in nine genes cause structurally   defective chemosensory cilia, thereby blocking chemosensation">PMID:1732156</a>; IGI with a daf gene.<br />
+- <strong>Salt-sensing circuit</strong> — hypomorphic osm-6 mutants lack functional sensory cilia and therefore<br />
+  have greatly reduced ASEL/AWC salt responses; cell-autonomous cilium rescue restores sensing<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/24013594" title="We analyzed hypomorphic osm-6 mutants that lack functional sensory cilia (dendritic   endings) and found them to have greatly reduced ASEL salt responses and AWCON salt and odor   responses">PMID:24013594</a>. The GO:1902075 "cellular response to salt" IMP here reflects this indirect ciliary<br />
+  requirement, not a salt-signalling activity of OSM-6.</p>
+<h2 id="what-is-not-known-knowledge-gaps">What is NOT known (knowledge gaps)</h2>
+<ul>
+<li><strong>No sub-molecular mechanism / no direct-partner map in C. elegans.</strong> OSM-6/IFT52 is treated as a<br />
+  structural IFT-B subunit, but which IFT-B partners it contacts in the worm (in mammals IFT52 bridges<br />
+  IFT88/IFT70/IFT46 and links the IFT-B core to peripheral subunits) and how its GIFT/central/CTD<br />
+  domains are used has not been experimentally dissected in <em>C. elegans</em>. GO MF for such a subunit can<br />
+  only be expressed as generic "structural molecule activity" (an ontology-shadow gap).</li>
+<li><strong>No independent biochemical/enzymatic activity</strong> is known or expected (GATase-like fold appears<br />
+  non-catalytic).</li>
+</ul>
+<h2 id="curation-plan-actions">Curation plan (actions)</h2>
+<p>Core (IFT-B structural subunit): intraciliary transport particle B (part_of), intraciliary transport,<br />
+cilium/non-motile cilium assembly, cilium/non-motile cilium localization, ciliary basal body,<br />
+transition zone — ACCEPT. centriole (IBA), cytoplasm, neuronal cell body — KEEP_AS_NON_CORE (real<br />
+but broad / not the functional site). Downstream sensory-phenotype BPs (chemotaxis, response to<br />
+osmotic stress, sensory perception of mechanical stimulus, cellular response to salt) —<br />
+KEEP_AS_NON_CORE (pleiotropic consequences of ciliary loss). GO:0003674 ND root MF — accept as<br />
+placeholder (superseded in spirit by proposed structural MF). Propose MF: structural molecule<br />
+activity (GO:0005198).</p>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: G5EDF6
+gene_symbol: osm-6
+product_type: PROTEIN
+status: COMPLETE
+taxon:
+  id: NCBITaxon:6239
+  label: Caenorhabditis elegans
+description: &gt;-
+  OSM-6 is the Caenorhabditis elegans ortholog of human IFT52 (also called NGD5;
+  Chlamydomonas IFT52/BLD1) and is a core structural subunit of the intraflagellar
+  transport complex B (IFT-B). Intraflagellar transport is the bidirectional,
+  microtubule-motor-driven movement of large multiprotein particles that build and
+  maintain cilia: kinesin-2 motors carry IFT particles and their cargo anterogradely
+  from the ciliary base to the tip, and cytoplasmic dynein-2 returns them retrogradely.
+  OSM-6/IFT52 is itself a component (and moving cargo) of the IFT-B particle rather
+  than an enzyme; its GATase-like N-terminal (GIFT) domain, central domain and
+  C-terminal domain are used to scaffold the complex. In C. elegans, osm-6 is expressed
+  exclusively in ciliated sensory neurons under control of the RFX transcription factor
+  DAF-19, and the protein localizes to the ciliary base (basal body, transition zone),
+  along the sensory (non-motile) cilium, and in the cytoplasm/cell body of these
+  neurons. OSM-6 is required for assembly of the ciliary axoneme: loss-of-function
+  mutants retain normal transition zones but have severely truncated axonemes and
+  ectopic microtubule assembly, causing dye-filling defects. Because the 60 ciliated
+  sensory neurons mediate chemosensation, osmotic avoidance, mechanosensation, and
+  dauer-pathway signaling, osm-6 mutants are broadly defective in these sensory
+  behaviors as a downstream consequence of lacking functional cilia. OSM-6/IFT52 is
+  conserved from algae to humans, and the pathway it serves is central to the biology
+  of ciliopathies.
+references:
+- id: GO_REF:0000015
+  title: Use of the ND evidence code for Gene Ontology (GO) terms
+  findings: []
+- id: GO_REF:0000033
+  title: Annotation inferences using phylogenetic trees
+  findings: []
+- id: PMID:10545497
+  title: Role of a class DHC1b dynein in retrograde transport of IFT motors and IFT
+    raft particles along cilia, but not dendrites, in chemosensory neurons of living
+    Caenorhabditis elegans.
+  findings:
+  - statement: OSM-6 is a homologue of a Chlamydomonas 16S IFT raft (IFT particle)
+      polypeptide and, together with OSM-1 and kinesin-II, undergoes retrograde IFT
+      along cilia at ~1.1 um/s; retrograde ciliary transport requires the CHE-3
+      (DHC1b/dynein-2) motor.
+    supporting_text: OSM-1 and OSM-6, all move at approximately 1.1 microm/s in the
+      retrograde direction along cilia and dendrites
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: PubMed-verified (Signor et al., J Cell Biol 1999). Directly assays
+      OSM-6::GFP movement and its dependence on dynein; supports IFT-cargo and
+      transition-zone localization annotations.
+- id: PMID:1732156
+  title: Genetic analysis of chemosensory control of dauer formation in Caenorhabditis
+    elegans.
+  findings:
+  - statement: osm-6 is one of nine cilium-structure genes whose mutation causes
+      structurally defective chemosensory cilia and blocks chemosensation, placing it
+      at a single step in the dauer-formation epistasis pathway.
+    supporting_text: Dauer-defective mutations in nine genes cause structurally
+      defective chemosensory cilia, thereby blocking chemosensation.
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: Vowels &amp; Thomas 1992; supports the dauer (cilium assembly) IGI as a
+      downstream sensory consequence of defective cilia.
+- id: PMID:22342749
+  title: Endocytosis genes facilitate protein and membrane transport in C. elegans
+    sensory cilia.
+  findings:
+  - statement: OSM-6 is used as an IFT/ciliary marker in C. elegans sensory cilia; the
+      study examines transport of ciliary and periciliary membrane and IFT proteins.
+    supporting_text: These pathways include cilium-based intraflagellar transport (IFT)
+      and poorly understood membrane trafficking events.
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: Kaplan et al. 2012; source of the non-motile cilium IDA localization.
+- id: PMID:22922713
+  title: The BBSome controls IFT assembly and turnaround in cilia.
+  findings:
+  - statement: GFP-tagged OSM-6 is the canonical IFT-B reporter (explicitly the ortholog
+      of human IFT52) used to screen for IFT assembly/turnaround mutants; OSM-6 marks
+      IFT particles at the ciliary base and along cilia.
+    supporting_text: the GFP-tagged IFT-B component OSM-6 (the ortholog of human IFT52)
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: Wei et al., Nat Cell Biol 2012. Establishes OSM-6=IFT52=IFT-B component;
+      basal body IDA localization.
+- id: PMID:24013594
+  title: Neuropeptide signaling remodels chemosensory circuit composition in Caenorhabditis
+    elegans.
+  findings:
+  - statement: Hypomorphic osm-6 mutants lack functional sensory cilia and consequently
+      show greatly reduced salt (ASEL) and salt/odor (AWC) sensory responses; ciliary
+      function is restored cell-autonomously by osm-6 rescue.
+    supporting_text: We analyzed hypomorphic osm-6 mutants that lack functional sensory
+      cilia (dendritic endings) and found them to have greatly reduced ASEL salt
+      responses and AWCON salt and odor responses
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: Leinwand &amp; Chalasani 2013. osm-6 used as a tool to abolish ciliary
+      sensory function; the salt-response phenotype is an indirect consequence of
+      cilium loss, not a salt-signalling activity of OSM-6.
+- id: PMID:2428682
+  title: Mutant sensory cilia in the nematode Caenorhabditis elegans.
+  findings:
+  - statement: osm-6(p811) mutants have normal ciliary transition zones but severely
+      shortened axonemes with ectopic doublet microtubules, establishing OSM-6 as
+      required for axoneme (cilium) assembly rather than transition-zone formation.
+    supporting_text: The cilia in che-13 (e1805), osm-1 (p808), osm-5 (p813), and osm-6
+      (p811) mutants have normal transition zones and severely shortened axonemes.
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: Perkins et al. 1986; foundational ultrastructural characterization of
+      osm-6 ciliary phenotype and dye-filling/chemosensory defects.
+- id: PMID:27930654
+  title: Whole-Organism Developmental Expression Profiling Identifies RAB-28 as a Novel
+    Ciliary GTPase Associated with the BBSome and Intraflagellar Transport.
+  findings:
+  - statement: OSM-6::GFP (explicitly the IFT52 orthologue) localizes throughout
+      normal-length sensory cilia and is used as an established IFT/ciliary marker.
+    supporting_text: Localisation of an IFT protein, OSM-6 (IFT52 orthologue), throughout
+      normal-length cilia confirms this finding
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: Jensen et al. 2016; source of the cilium IDA localization (OSM-6::GFP
+      as a ciliary reference marker).
+- id: PMID:28479320
+  title: Dynein-Driven Retrograde Intraflagellar Transport Is Triphasic in C. elegans
+    Sensory Cilia.
+  findings:
+  - statement: Ciliary entry of dynein-2 requires an intact IFT-B complex (of which
+      OSM-6/IFT52 is a component); this study is the ComplexPortal source (CPX-1290)
+      for OSM-6 IFT-B/IFT particle B membership and ciliary localization.
+    supporting_text: Disruption of the dynein-2 tail domain, light intermediate chain,
+      or intraflagellar transport (IFT)-B complex abolishes dynein-2&#39;s ciliary
+      localization
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: Yi et al. 2017. Underlies the ComplexPortal NAS annotations for IFT
+      particle B membership, intraciliary transport, cilium assembly and cilium.
+- id: PMID:730048
+  title: Osmotic avoidance defective mutants of the nematode Caenorhabditis elegans.
+  findings:
+  - statement: Founding screen that isolated osmotic-avoidance-defective (Osm) mutants
+      of C. elegans, the phenotypic class for which osm-6 is named; such mutants fail
+      to avoid high concentrations of salts/sugars.
+    supporting_text: mutants were selected for their inability to avoid high
+      concentrations of fructose or NaCl
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: Culotti &amp; Russell 1978; abstract-only. Origin of the osm-6 osmotic
+      avoidance phenotype; the WormBase IMP is a curator judgment from the full text.
+- id: PMID:8460126
+  title: A dual mechanosensory and chemosensory neuron in Caenorhabditis elegans.
+  findings:
+  - statement: Animals with defective ciliated sensory endings fail to respond to nose
+      touch, linking intact sensory cilia (which require osm-6) to mechanosensation.
+    supporting_text: Mutant animals that have defective ciliated sensory endings as
+      well as laser-operated animals that lack ASH, FLP, and OLQ fail to respond to
+      touch to the nose.
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: Kaplan &amp; Horvitz 1993; abstract-only, does not name osm-6. Basis for
+      the WormBase mechanosensory-perception IMP as a downstream ciliary phenotype;
+      not overruled per curator-defers guidance.
+- id: PMID:9475731
+  title: Analysis of osm-6, a gene that affects sensory cilium structure and sensory
+    neuron function in Caenorhabditis elegans.
+  findings:
+  - statement: osm-6 was cloned and shown to encode a protein of previously unknown
+      function expressed exclusively in ciliated sensory neurons; OSM-6::GFP rescues
+      the mutant and localizes to cytoplasm/processes/dendritic endings, and osm-6 acts
+      cell-autonomously in cilium structure. DAF-19 is required for OSM-6 accumulation.
+    supporting_text: The OSM-6::GFP protein was localized to cytoplasm, including
+      processes and dendritic endings where sensory cilia are situated.
+  - statement: Genetic mosaic analysis shows osm-6 acts cell-autonomously in the
+      ciliated neuron.
+    supporting_text: we conclude from an analysis of genetic mosaics that osm-6 acts
+      cell autonomously in affecting cilium structure
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: Collet et al. 1998; the defining osm-6 cloning/expression paper.
+      Source of cytoplasm and neuronal cell body IDA localizations and the
+      DAF-19-dependent, sensory-neuron-restricted expression.
+existing_annotations:
+- term:
+    id: GO:0005929
+    label: cilium
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: is_active_in
+  review:
+    summary: OSM-6/IFT52 localizes to and functions within the cilium; phylogenetic
+      (IBA) inference agrees with direct C. elegans localization data.
+    action: ACCEPT
+    reason: Cilium localization is directly supported by multiple experimental studies
+      (OSM-6::GFP is a canonical ciliary/IFT marker) and is a core aspect of osm-6
+      function.
+    supported_by:
+    - reference_id: PMID:22922713
+      supporting_text: the GFP-tagged IFT-B component OSM-6 (the ortholog of human IFT52)
+- term:
+    id: GO:0030992
+    label: intraciliary transport particle B
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: part_of
+  review:
+    summary: OSM-6 is a structural subunit of the IFT-B particle; this is the single
+      most important annotation for the gene and is supported by orthology to IFT52 and
+      by ComplexPortal (CPX-1290).
+    action: ACCEPT
+    reason: Core molecular role. OSM-6 is explicitly the IFT-B component / IFT52
+      ortholog and a member of Intraflagellar transport complex B (CPX-1290).
+    supported_by:
+    - reference_id: PMID:22922713
+      supporting_text: the GFP-tagged IFT-B component OSM-6 (the ortholog of human IFT52)
+- term:
+    id: GO:0042073
+    label: intraciliary transport
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: involved_in
+  review:
+    summary: As an IFT-B subunit and moving IFT cargo, OSM-6 is directly involved in
+      intraciliary transport.
+    action: ACCEPT
+    reason: Core biological process. OSM-6::GFP moves bidirectionally by IFT and is part
+      of the transported IFT particle.
+    supported_by:
+    - reference_id: PMID:10545497
+      supporting_text: OSM-1 and OSM-6, all move at approximately 1.1 microm/s in the
+        retrograde direction along cilia and dendrites
+- term:
+    id: GO:0060271
+    label: cilium assembly
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: involved_in
+  review:
+    summary: OSM-6 is required for building the ciliary axoneme; phylogenetic inference
+      is corroborated by the loss-of-function ultrastructural phenotype.
+    action: ACCEPT
+    reason: Core process. osm-6 mutants have severely truncated axonemes, establishing a
+      role in cilium assembly.
+    supported_by:
+    - reference_id: PMID:2428682
+      supporting_text: The cilia in che-13 (e1805), osm-1 (p808), osm-5 (p813), and
+        osm-6 (p811) mutants have normal transition zones and severely shortened axonemes.
+- term:
+    id: GO:0005814
+    label: centriole
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: is_active_in
+  review:
+    summary: Phylogenetically propagated centriole localization. In C. elegans the
+      directly demonstrated basal-body/transition-zone localization is the relevant
+      structure (the ciliary basal body is a docked, modified centriole).
+    action: KEEP_AS_NON_CORE
+    reason: Plausible but not the core functional site and not directly demonstrated in
+      C. elegans; the experimentally supported location is the ciliary basal body
+      (GO:0036064). Retained as a non-core, orthology-based location rather than removed.
+- term:
+    id: GO:0005929
+    label: cilium
+  evidence_type: NAS
+  original_reference_id: PMID:28479320
+  qualifier: located_in
+  review:
+    summary: ComplexPortal (CPX-1290) statement that OSM-6 localizes to the cilium,
+      consistent with direct experimental data.
+    action: ACCEPT
+    reason: Core ciliary localization; corroborated by IDA evidence from multiple studies.
+    supported_by:
+    - reference_id: PMID:28479320
+      supporting_text: Dynein-Driven Retrograde Intraflagellar Transport Is Triphasic in
+        C. elegans Sensory Cilia
+- term:
+    id: GO:0030992
+    label: intraciliary transport particle B
+  evidence_type: NAS
+  original_reference_id: PMID:28479320
+  qualifier: part_of
+  review:
+    summary: ComplexPortal assertion of OSM-6 membership in IFT particle B, the core
+      structural annotation, based on the C. elegans IFT-B complex.
+    action: ACCEPT
+    reason: Core molecular role, redundant with and reinforcing the IBA IFT-B membership
+      annotation.
+    supported_by:
+    - reference_id: PMID:28479320
+      supporting_text: Disruption of the dynein-2 tail domain, light intermediate chain,
+        or intraflagellar transport (IFT)-B complex abolishes dynein-2&#39;s ciliary
+        localization
+- term:
+    id: GO:0042073
+    label: intraciliary transport
+  evidence_type: NAS
+  original_reference_id: PMID:28479320
+  qualifier: involved_in
+  review:
+    summary: ComplexPortal statement of IFT-B involvement in intraciliary transport.
+    action: ACCEPT
+    reason: Core process consistent with OSM-6 being a transported IFT-B subunit.
+    supported_by:
+    - reference_id: PMID:28479320
+      supporting_text: Disruption of the dynein-2 tail domain, light intermediate chain,
+        or intraflagellar transport (IFT)-B complex abolishes dynein-2&#39;s ciliary
+        localization
+- term:
+    id: GO:0060271
+    label: cilium assembly
+  evidence_type: NAS
+  original_reference_id: PMID:28479320
+  qualifier: involved_in
+  review:
+    summary: ComplexPortal statement of IFT-B involvement in cilium assembly.
+    action: ACCEPT
+    reason: Core process; redundant with the IMP/IBA cilium-assembly annotations.
+    supported_by:
+    - reference_id: PMID:2428682
+      supporting_text: The cilia in che-13 (e1805), osm-1 (p808), osm-5 (p813), and
+        osm-6 (p811) mutants have normal transition zones and severely shortened axonemes.
+- term:
+    id: GO:0060271
+    label: cilium assembly
+  evidence_type: IMP
+  original_reference_id: PMID:24013594
+  qualifier: involved_in
+  review:
+    summary: osm-6 loss abolishes functional sensory cilia (dendritic endings),
+      confirming a requirement in cilium assembly.
+    action: ACCEPT
+    reason: Core process. Although this paper is about a salt circuit, it explicitly
+      uses osm-6 as a cilium-assembly loss-of-function allele.
+    supported_by:
+    - reference_id: PMID:24013594
+      supporting_text: We analyzed hypomorphic osm-6 mutants that lack functional sensory
+        cilia (dendritic endings)
+- term:
+    id: GO:1902075
+    label: cellular response to salt
+  evidence_type: IMP
+  original_reference_id: PMID:24013594
+  qualifier: involved_in
+  review:
+    summary: osm-6 mutants have reduced salt-evoked neuronal responses, but only because
+      they lack functional cilia; OSM-6 has no salt-sensing or salt-signalling activity
+      of its own.
+    action: KEEP_AS_NON_CORE
+    reason: Indirect, downstream sensory phenotype of ciliary loss rather than a core
+      molecular/biological function of OSM-6. Retained (per curator) but marked non-core
+      to avoid implying a direct salt-response role.
+    supported_by:
+    - reference_id: PMID:24013594
+      supporting_text: found them to have greatly reduced ASEL salt responses and AWCON
+        salt and odor responses
+- term:
+    id: GO:0005929
+    label: cilium
+  evidence_type: IDA
+  original_reference_id: PMID:27930654
+  qualifier: located_in
+  review:
+    summary: Direct localization of OSM-6::GFP to the cilium, used as a ciliary reference
+      marker.
+    action: ACCEPT
+    reason: Core ciliary localization directly observed; OSM-6::GFP (IFT52 orthologue)
+      is imaged throughout normal-length cilia.
+    supported_by:
+    - reference_id: PMID:27930654
+      supporting_text: Localisation of an IFT protein, OSM-6 (IFT52 orthologue),
+        throughout normal-length cilia confirms this finding
+- term:
+    id: GO:1905515
+    label: non-motile cilium assembly
+  evidence_type: IMP
+  original_reference_id: PMID:2428682
+  qualifier: involved_in
+  review:
+    summary: osm-6 mutants fail to build full sensory (non-motile) cilia; this is the
+      most precise cilium-assembly term for the worm&#39;s sensory cilia.
+    action: ACCEPT
+    reason: Core process, and appropriately specific (C. elegans sensory cilia are
+      non-motile). Directly supported by the ultrastructural phenotype.
+    supported_by:
+    - reference_id: PMID:2428682
+      supporting_text: The cilia in che-13 (e1805), osm-1 (p808), osm-5 (p813), and
+        osm-6 (p811) mutants have normal transition zones and severely shortened axonemes.
+- term:
+    id: GO:0060271
+    label: cilium assembly
+  evidence_type: IGI
+  original_reference_id: PMID:1732156
+  qualifier: involved_in
+  review:
+    summary: Genetic-interaction evidence placing osm-6 among cilium-structure genes
+      required for chemosensory cilium function in the dauer pathway.
+    action: ACCEPT
+    reason: Core process; osm-6 is one of nine genes whose mutation gives structurally
+      defective chemosensory cilia.
+    supported_by:
+    - reference_id: PMID:1732156
+      supporting_text: Dauer-defective mutations in nine genes cause structurally
+        defective chemosensory cilia, thereby blocking chemosensation.
+- term:
+    id: GO:0097730
+    label: non-motile cilium
+  evidence_type: IDA
+  original_reference_id: PMID:22342749
+  qualifier: located_in
+  review:
+    summary: Direct localization of OSM-6 to the sensory (non-motile) cilium.
+    action: ACCEPT
+    reason: Core ciliary localization; the sensory-cilium term is appropriately specific.
+    supported_by:
+    - reference_id: PMID:22342749
+      supporting_text: cilium-based intraflagellar transport (IFT)
+- term:
+    id: GO:0003674
+    label: molecular_function
+  evidence_type: ND
+  original_reference_id: GO_REF:0000015
+  qualifier: enables
+  review:
+    summary: Root-level placeholder recording that no specific molecular function had
+      been assigned at the time of annotation.
+    action: ACCEPT
+    reason: Retained as the standard ND placeholder. A subunit-specific molecular
+      function (structural molecule activity within IFT-B) is now proposed as a NEW
+      annotation and in core_functions; no catalytic activity is known or expected for
+      this GATase-fold scaffold.
+- term:
+    id: GO:0005198
+    label: structural molecule activity
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: enables
+  review:
+    summary: OSM-6/IFT52 has no catalytic activity; as an IFT-B subunit its molecular
+      function is best captured as a subunit-specific structural molecule activity.
+    action: NEW
+    reason: Proposed new molecular-function annotation reflecting OSM-6&#39;s role as a
+      structural subunit of the IFT-B particle (the current GOA carries only the ND root
+      MF for this gene). This IBA/GO_REF:0000033 evidence pairing does NOT currently
+      exist in the GOA export; it is the expected phylogenetic evidence basis if the
+      annotation were made (IFT52 orthologues across species are IFT-B structural
+      subunits). Ideally a more specific &#39;structural constituent of intraflagellar
+      transport particle&#39; term (see proposed_new_terms) would be used.
+    supported_by:
+    - reference_id: PMID:22922713
+      supporting_text: the GFP-tagged IFT-B component OSM-6 (the ortholog of human IFT52)
+- term:
+    id: GO:0036064
+    label: ciliary basal body
+  evidence_type: IDA
+  original_reference_id: PMID:22922713
+  qualifier: located_in
+  review:
+    summary: OSM-6::GFP directly localizes to the ciliary basal body, where IFT
+      particles assemble before entering the cilium.
+    action: ACCEPT
+    reason: Core localization at the site of IFT assembly.
+    supported_by:
+    - reference_id: PMID:22922713
+      supporting_text: the GFP-tagged IFT-B component OSM-6 (the ortholog of human IFT52)
+- term:
+    id: GO:0035869
+    label: ciliary transition zone
+  evidence_type: IDA
+  original_reference_id: PMID:10545497
+  qualifier: located_in
+  review:
+    summary: OSM-6::GFP is observed at/through the ciliary transition zone as it moves
+      between the base and the axoneme.
+    action: ACCEPT
+    reason: Core localization consistent with IFT trafficking through the transition zone.
+    supported_by:
+    - reference_id: PMID:10545497
+      supporting_text: OSM-1 and OSM-6, all move at approximately 1.1 microm/s in the
+        retrograde direction along cilia and dendrites
+- term:
+    id: GO:0097730
+    label: non-motile cilium
+  evidence_type: IDA
+  original_reference_id: PMID:10545497
+  qualifier: located_in
+  review:
+    summary: OSM-6::GFP localizes along the sensory (non-motile) cilium.
+    action: ACCEPT
+    reason: Core ciliary localization, appropriately specific.
+    supported_by:
+    - reference_id: PMID:10545497
+      supporting_text: OSM-1 and OSM-6, all move at approximately 1.1 microm/s in the
+        retrograde direction along cilia and dendrites
+- term:
+    id: GO:0005737
+    label: cytoplasm
+  evidence_type: IDA
+  original_reference_id: PMID:9475731
+  qualifier: located_in
+  review:
+    summary: OSM-6::GFP is present in the cytoplasm (including neuronal processes) prior
+      to and outside of ciliary transport.
+    action: KEEP_AS_NON_CORE
+    reason: Directly observed but a broad, non-informative location; the functionally
+      relevant sites are the cilium and its base. Retained as non-core.
+    supported_by:
+    - reference_id: PMID:9475731
+      supporting_text: The OSM-6::GFP protein was localized to cytoplasm, including
+        processes and dendritic endings where sensory cilia are situated.
+- term:
+    id: GO:0006935
+    label: chemotaxis
+  evidence_type: IMP
+  original_reference_id: PMID:2428682
+  qualifier: involved_in
+  review:
+    summary: osm-6 mutants are chemosensory-defective (dye-filling defective) because
+      their chemosensory cilia are truncated.
+    action: KEEP_AS_NON_CORE
+    reason: Downstream sensory consequence of defective cilia rather than a direct role
+      of OSM-6 in chemotaxis signalling. Retained but non-core.
+    supported_by:
+    - reference_id: PMID:2428682
+      supporting_text: Mutations in 14 genes prevent dye uptake and disrupt chemosensory
+        behaviors.
+- term:
+    id: GO:0006970
+    label: response to osmotic stress
+  evidence_type: IMP
+  original_reference_id: PMID:730048
+  qualifier: involved_in
+  review:
+    summary: osm-6 is named for its osmotic-avoidance-defective phenotype; mutants fail
+      to avoid high osmolarity because their sensory cilia are non-functional.
+    action: KEEP_AS_NON_CORE
+    reason: Indirect, downstream behavioral phenotype of ciliary loss, not a direct
+      osmotic-stress-response activity of OSM-6. Retained (curator IMP) but non-core.
+    supported_by:
+    - reference_id: PMID:730048
+      supporting_text: mutants were selected for their inability to avoid high
+        concentrations of fructose or NaCl
+- term:
+    id: GO:0043025
+    label: neuronal cell body
+  evidence_type: IDA
+  original_reference_id: PMID:9475731
+  qualifier: located_in
+  review:
+    summary: OSM-6::GFP accumulates in the cell bodies of ciliated sensory neurons,
+      where the protein is synthesized before delivery to cilia.
+    action: KEEP_AS_NON_CORE
+    reason: Real localization but reflects the site of synthesis rather than the core
+      functional site (the cilium/basal body). Retained as non-core.
+    supported_by:
+    - reference_id: PMID:9475731
+      supporting_text: showed accumulation of GFP in ciliated sensory neurons exclusively
+- term:
+    id: GO:0050954
+    label: sensory perception of mechanical stimulus
+  evidence_type: IMP
+  original_reference_id: PMID:8460126
+  qualifier: involved_in
+  review:
+    summary: Nose-touch mechanosensation requires intact ciliated sensory endings, which
+      osm-6 is needed to build; osm-6 mutants are mechanosensory-defective.
+    action: KEEP_AS_NON_CORE
+    reason: Downstream sensory consequence of defective cilia rather than a direct
+      mechanotransduction role of OSM-6. The cached abstract does not name osm-6, but
+      the WormBase IMP reflects curator full-text evidence and is not overruled.
+    supported_by:
+    - reference_id: PMID:8460126
+      supporting_text: Mutant animals that have defective ciliated sensory endings as
+        well as laser-operated animals that lack ASH, FLP, and OLQ fail to respond to
+        touch to the nose.
+core_functions:
+- description: OSM-6/IFT52 is a structural subunit of the intraflagellar transport
+    complex B (IFT-B), the anterograde IFT particle that is itself carried as cargo by
+    kinesin-2 and returned by dynein-2. It scaffolds the IFT-B complex (it does not have
+    independent catalytic activity) and is required to build and maintain the sensory
+    ciliary axoneme in C. elegans ciliated neurons.
+  supported_by:
+  - reference_id: PMID:22922713
+    supporting_text: the GFP-tagged IFT-B component OSM-6 (the ortholog of human IFT52)
+  - reference_id: PMID:2428682
+    supporting_text: The cilia in che-13 (e1805), osm-1 (p808), osm-5 (p813), and osm-6
+      (p811) mutants have normal transition zones and severely shortened axonemes.
+  molecular_function:
+    id: GO:0005198
+    label: structural molecule activity
+  directly_involved_in:
+  - id: GO:0042073
+    label: intraciliary transport
+  - id: GO:1905515
+    label: non-motile cilium assembly
+  locations:
+  - id: GO:0097730
+    label: non-motile cilium
+  - id: GO:0036064
+    label: ciliary basal body
+  - id: GO:0035869
+    label: ciliary transition zone
+  in_complex:
+    id: GO:0030992
+    label: intraciliary transport particle B
+knowledge_gaps:
+- gap_statement: The specific intra-complex protein contacts of OSM-6/IFT52 within the
+    C. elegans IFT-B particle have not been experimentally mapped. In other organisms
+    IFT52 bridges the IFT-B1 core (contacting IFT88, IFT70 and IFT46) and links the core
+    to peripheral subunits, but which partners its GIFT, central and C-terminal domains
+    engage in the worm, and how these contacts are used during IFT-particle assembly and
+    tip turnaround, is undetermined.
+  boundary: It is firmly established that OSM-6 is an IFT-B/IFT52 structural subunit that
+    moves bidirectionally by IFT, localizes to basal body, transition zone and axoneme,
+    and is required for axoneme assembly.
+  gap_kind:
+  - BIOLOGY
+  - ONTOLOGY
+  dark_aspect: MF_DARK
+  status: OPEN
+  significance: Defining OSM-6&#39;s specific IFT-B contacts would explain how the IFT-B
+    particle is built and how ciliopathy-relevant IFT52 mutations destabilize the complex.
+  resolution: In vivo proximity labeling (BioID/TurboID) or cross-linking mass
+    spectrometry of tagged OSM-6 in ciliated neurons, plus structure determination of the
+    C. elegans IFT-B subcomplex, paired with an ontology term for structural constituent
+    of the IFT particle.
+  provenance:
+  - reference_id: PMID:22922713
+    supporting_text: the GFP-tagged IFT-B component OSM-6 (the ortholog of human IFT52)
+  proposed_terms:
+  - proposed_name: structural constituent of intraflagellar transport particle
+    proposed_definition: A structural molecule activity in which a protein acts as a
+      structural subunit of an intraflagellar transport (IFT) particle (IFT-A or IFT-B),
+      contributing to assembly and integrity of the particle trafficked along the
+      ciliary axoneme.
+    justification: GO currently expresses this role only as the generic &#39;structural
+      molecule activity&#39; (GO:0005198).
+- gap_statement: No independent biochemical or enzymatic activity has been demonstrated
+    for OSM-6/IFT52, and although its N-terminal domain adopts a class-I
+    glutamine-amidotransferase-like (GIFT) fold, whether this fold has any residual
+    ligand-binding or catalytic role beyond scaffolding is unknown.
+  boundary: The GATase-like fold is annotated structurally (Pfam IFT52_GIFT / SSF52317);
+    catalytic residues appear absent, consistent with a purely structural function.
+  gap_kind:
+  - BIOLOGY
+  dark_aspect: MF_DARK
+  status: OPEN
+  significance: Ruling in or out any ligand-binding role of the GIFT domain would clarify
+    whether IFT52 does more than scaffold IFT-B.
+  resolution: Structure-guided mutagenesis of the GIFT domain and in vitro binding/activity
+    assays to test for retained ligand interaction.
+  provenance:
+  - reference_id: PMID:9475731
+    supporting_text: a protein that is 40% identical in amino acid sequence to a predicted
+      mammalian protein of unknown function
+proposed_new_terms:
+- proposed_name: structural constituent of intraflagellar transport particle
+  proposed_definition: A structural molecule activity in which a protein acts as a
+    structural subunit of an intraflagellar transport (IFT) particle (IFT-A or IFT-B),
+    contributing to the assembly and integrity of the particle that is trafficked along
+    the ciliary axoneme by kinesin-2 and dynein-2 motors.
+  justification: OSM-6/IFT52 and its IFT-B/IFT-A paralogs act as structural subunits of
+    the IFT particle, a role currently expressible only as the generic GO:0005198
+    structural molecule activity. A dedicated MF term would capture the shared function
+    of IFT structural subunits.
+  supported_by:
+  - reference_id: PMID:22922713
+    supporting_text: the GFP-tagged IFT-B component OSM-6 (the ortholog of human IFT52)
+suggested_questions:
+- question: Which IFT-B subunits does OSM-6 directly contact in C. elegans, and are the
+    GIFT, central and C-terminal domains functionally separable?
+  experts:
+  - Oliver E. Blacque
+- question: Does the IFT52 GIFT domain retain any ligand-binding capacity, or is it a
+    purely structural remnant of the glutamine-amidotransferase fold?
+  experts: []
+suggested_experiments:
+- hypothesis: OSM-6/IFT52 bridges the IFT-B core to peripheral subunits via distinct
+    domains, and disrupting individual domains selectively destabilizes parts of IFT-B.
+  description: Perform in vivo proximity labeling (TurboID) with domain-truncated OSM-6
+    variants expressed in ciliated neurons, followed by mass spectrometry, to map
+    domain-specific IFT-B interaction partners.
+  experiment_type: proximity labeling / interaction mapping
+- hypothesis: The severely truncated axoneme of osm-6 mutants reflects failure to deliver
+    axonemal tubulin/cargo by IFT-B rather than a transition-zone defect.
+  description: Use live imaging of tagged tubulin and IFT trains in osm-6 partial
+    loss-of-function backgrounds to quantify anterograde cargo delivery versus
+    transition-zone integrity.
+  experiment_type: live-cell imaging
+tags:
+- caeel-ciliopathy
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/genes/worm/phb-1/phb-1-ai-review.html
+++ b/genes/worm/phb-1/phb-1-ai-review.html
@@ -1,0 +1,5013 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>phb-1 - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        .propagation-review {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f8fafc;
+            border-left: 3px solid #64748b;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .propagation-title {
+            font-weight: 600;
+            color: #334155;
+            margin-bottom: 0.25rem;
+        }
+
+        .propagation-row {
+            margin-top: 0.25rem;
+        }
+
+        .propagation-source {
+            margin-top: 0.5rem;
+            padding-top: 0.5rem;
+            border-top: 1px solid #e5e7eb;
+        }
+
+        .propagation-source-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #1d4ed8;
+        }
+
+        .propagation-comment {
+            color: #4b5563;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>phb-1</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/Q9BKU4" target="_blank" class="term-link">
+                        Q9BKU4
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Caenorhabditis elegans</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-complete">
+                    COMPLETE
+                </span>
+            </div>
+
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "phb-1";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="Q9BKU4" data-a="DESCRIPTION: phb-1 encodes prohibitin-1, one of the two subunit..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>phb-1 encodes prohibitin-1, one of the two subunits (with phb-2) of the mitochondrial prohibitin (PHB) complex, a ring-shaped, high-molecular-weight assembly embedded in the inner mitochondrial membrane. PHB-1 and PHB-2 are mutually dependent: they bind each other to form heterodimers that oligomerize into the ring, and loss of either subunit destabilizes the entire complex. The protein belongs to the SPFH/Band-7 (stomatin/prohibitin) superfamily. The complex is proposed to act as a membrane-bound chaperone that holds and stabilizes newly synthesized mitochondrial-encoded respiratory-chain proteins and/or as a scaffold that organizes inner-membrane proteins within a defined lipid environment. In C. elegans the complex is essential: depletion of phb-1 blocks embryonic development, disrupts somatic and germline differentiation of the gonad, and alters mitochondrial biogenesis in body-wall muscle. Beyond this essential developmental role, the prohibitin complex is a context-dependent modulator of ageing that couples mitochondrial metabolism and fat utilization to insulin/IGF (daf-2) and dietary-restriction signalling: its depletion shortens the lifespan of otherwise wild-type animals but extends the lifespan of diapause, dietary-restricted, and respiration- or fat-metabolism-compromised animals.</p>
+    </div>
+
+
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005739" target="_blank" class="term-link">
+                                    GO:0005739
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrion</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q9BKU4" data-a="GO:0005739" data-r="GO_REF:0000033" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct but general mitochondrial localization inferred phylogenetically. The more specific inner-membrane and prohibitin-complex localizations are experimentally supported and separately annotated, so this broad term is retained as non-core.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> phb-1 is a bona fide mitochondrial protein, so the term is not wrong, but GO:0005743 (mitochondrial inner membrane) and GO:0035632 (mitochondrial prohibitin complex) are the informative, experimentally supported localizations for this subunit.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0007005" target="_blank" class="term-link">
+                                    GO:0007005
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrion organization</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9BKU4" data-a="GO:0007005" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetic inference that phb-1 acts in mitochondrion organization, corroborated by experimental (IMP) and author-statement (NAS) annotations for the same term. A core process for this gene.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Consistent with the experimentally demonstrated requirement of the PHB complex for normal mitochondrial biogenesis/organization.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12794069" target="_blank" class="term-link">
+                                        PMID:12794069
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">a deficiency in PHB proteins results in altered mitochondrial biogenesis in body wall muscle cells</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0002082" target="_blank" class="term-link">
+                                    GO:0002082
+                                </a>
+                            </span>
+                            <span class="term-label">regulation of oxidative phosphorylation</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000117
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q9BKU4" data-a="GO:0002082" data-r="GO_REF:0000117" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic (ARBA) annotation that mirrors the experimental WB IMP annotation to the same term. Biologically defensible given the conserved role of prohibitins in stabilizing respiratory-chain subunits, but it is a downstream consequence of complex loss rather than a dedicated phb-1 activity.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Redundant electronic echo of the experimental IMP annotation (PMID:12794069); effect on oxidative phosphorylation is an indirect consequence of losing an essential inner-membrane complex, so it is non-core.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005743" target="_blank" class="term-link">
+                                    GO:0005743
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial inner membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000044
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9BKU4" data-a="GO:0005743" data-r="GO_REF:0000044" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic subcellular-location mapping to the mitochondrial inner membrane, independently confirmed by experimental IDA evidence. This is the correct, core localization of the PHB complex.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The inner-membrane localization is experimentally established (see the ComplexPortal IDA annotation) and matches the UniProt SUBCELLULAR LOCATION.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12794069" target="_blank" class="term-link">
+                                        PMID:12794069
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">prohibitins in C. elegans form a high molecular weight complex in the mitochondrial inner membrane similar to that of yeast and humans</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006979" target="_blank" class="term-link">
+                                    GO:0006979
+                                </a>
+                            </span>
+                            <span class="term-label">response to oxidative stress</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000117
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q9BKU4" data-a="GO:0006979" data-r="GO_REF:0000117" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic (ARBA) annotation mirroring the WB IMP annotation. Altered oxidative-stress sensitivity is a plausible but indirect consequence of impaired mitochondrial function in prohibitin-depleted animals.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Redundant with the experimental IMP annotation (PMID:12794069); pleiotropic downstream phenotype of an essential mitochondrial gene, not a core function.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0007283" target="_blank" class="term-link">
+                                    GO:0007283
+                                </a>
+                            </span>
+                            <span class="term-label">spermatogenesis</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000117
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q9BKU4" data-a="GO:0007283" data-r="GO_REF:0000117" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic (ARBA) annotation mirroring the WB IMP germline phenotype.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Redundant with the experimental IMP annotation (PMID:12794069); germline/ spermatogenesis defects are a pleiotropic consequence of depleting an essential mitochondrial complex, not a dedicated phb-1 function.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008406" target="_blank" class="term-link">
+                                    GO:0008406
+                                </a>
+                            </span>
+                            <span class="term-label">gonad development</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000117
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q9BKU4" data-a="GO:0008406" data-r="GO_REF:0000117" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic (ARBA) annotation mirroring the WB IMP gonad phenotype.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Redundant with the experimental IMP annotation (PMID:12794069); pleiotropic developmental consequence of losing the essential PHB complex.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0009792" target="_blank" class="term-link">
+                                    GO:0009792
+                                </a>
+                            </span>
+                            <span class="term-label">embryo development ending in birth or egg hatching</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000117
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q9BKU4" data-a="GO:0009792" data-r="GO_REF:0000117" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic (ARBA) annotation mirroring the WB IMP embryonic-lethality phenotype.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Redundant with the experimental IMP annotation (PMID:12794069); embryonic arrest reflects the essentiality of the complex rather than a dedicated embryogenesis function of phb-1.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016020" target="_blank" class="term-link">
+                                    GO:0016020
+                                </a>
+                            </span>
+                            <span class="term-label">membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q9BKU4" data-a="GO:0016020" data-r="GO_REF:0000002" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Generic InterPro-to-GO membrane localization. Uninformative given that the specific mitochondrial inner-membrane localization is experimentally established.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> GO:0016020 (membrane) is an over-general parent; the informative and correct localization GO:0005743 (mitochondrial inner membrane) is already annotated.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030421" target="_blank" class="term-link">
+                                    GO:0030421
+                                </a>
+                            </span>
+                            <span class="term-label">defecation</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000117
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q9BKU4" data-a="GO:0030421" data-r="GO_REF:0000117" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic (ARBA) annotation mirroring the WB IMP behavioural phenotype.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Redundant with the experimental IMP annotation (PMID:12794069); altered defecation is a pleiotropic behavioural consequence of mitochondrial dysfunction, not a core molecular role.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0040018" target="_blank" class="term-link">
+                                    GO:0040018
+                                </a>
+                            </span>
+                            <span class="term-label">positive regulation of multicellular organism growth</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000117
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q9BKU4" data-a="GO:0040018" data-r="GO_REF:0000117" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic (ARBA) annotation mirroring the WB IMP body-size/growth phenotype.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Redundant with the experimental IMP annotation (PMID:12794069); reduced growth on prohibitin depletion is a systemic consequence of impaired mitochondrial function, not a dedicated function.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0043051" target="_blank" class="term-link">
+                                    GO:0043051
+                                </a>
+                            </span>
+                            <span class="term-label">regulation of nematode pharyngeal pumping</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000117
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q9BKU4" data-a="GO:0043051" data-r="GO_REF:0000117" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic (ARBA) annotation mirroring the WB IMP behavioural phenotype.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Redundant with the experimental IMP annotation (PMID:12794069); pharyngeal pumping change is a pleiotropic behavioural consequence, not a core function.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0048477" target="_blank" class="term-link">
+                                    GO:0048477
+                                </a>
+                            </span>
+                            <span class="term-label">oogenesis</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000117
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q9BKU4" data-a="GO:0048477" data-r="GO_REF:0000117" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic (ARBA) annotation mirroring the WB IMP germline phenotype.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Redundant with the experimental IMP annotation (PMID:12794069); oogenesis defects are a pleiotropic consequence of losing the essential PHB complex.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005743" target="_blank" class="term-link">
+                                    GO:0005743
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial inner membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/26092086" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:26092086
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Analysis of the effect of the mitochondrial prohibitin compl...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9BKU4" data-a="GO:0005743" data-r="PMID:26092086" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct experimental evidence (ComplexPortal curation) that the PHB complex, of which phb-1 is a subunit, resides in the mitochondrial inner membrane. Core localization.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Established inner-membrane localization; the heterodimer assembles into a ring embedded in the inner mitochondrial membrane.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/26092086" target="_blank" class="term-link">
+                                        PMID:26092086
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">which bind to each other to form a heterodimer that is assembled into a ring-like macromolecular structure at the inner mitochondrial membrane</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0007005" target="_blank" class="term-link">
+                                    GO:0007005
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrion organization</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">NAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/26092086" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:26092086
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Analysis of the effect of the mitochondrial prohibitin compl...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9BKU4" data-a="GO:0007005" data-r="PMID:26092086" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Author-stated involvement of the PHB complex in mitochondrion organization, consistent with the experimental IMP annotation. Core process.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Prohibitin depletion perturbs mitochondrial biogenesis/organization; a well-supported core role.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12794069" target="_blank" class="term-link">
+                                        PMID:12794069
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">a deficiency in PHB proteins results in altered mitochondrial biogenesis in body wall muscle cells</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0035632" target="_blank" class="term-link">
+                                    GO:0035632
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial prohibitin complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/26092086" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:26092086
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Analysis of the effect of the mitochondrial prohibitin compl...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9BKU4" data-a="GO:0035632" data-r="PMID:26092086" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct evidence that phb-1 is part of the mitochondrial prohibitin complex. This complex membership is the defining, primary core annotation for phb-1.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> phb-1 and phb-2 form the obligate ring complex; membership is experimentally established and the two subunits are interdependent for its formation.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/26092086" target="_blank" class="term-link">
+                                        PMID:26092086
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">These two subunits are interdependent for the formation of the complex, leading the absence of one of them to the absence of the whole complex</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0050821" target="_blank" class="term-link">
+                                    GO:0050821
+                                </a>
+                            </span>
+                            <span class="term-label">protein stabilization</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">NAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/26092086" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:26092086
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Analysis of the effect of the mitochondrial prohibitin compl...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9BKU4" data-a="GO:0050821" data-r="PMID:26092086" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Author-stated role of the PHB complex as a membrane-bound chaperone that holds and stabilizes newly synthesized mitochondrial-encoded proteins. This is the closest capture of the complex&#39;s candidate molecular role, though it is a proposed (largely yeast/human-derived) function rather than one biochemically demonstrated in worm.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Represents the proposed complex-level chaperone/holdase activity; retained as a candidate core function, with the caveat that the true molecular mechanism remains debated (see knowledge_gaps).
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/26092086" target="_blank" class="term-link">
+                                        PMID:26092086
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">a membrane-bound chaperone, which holds and stabilizes newly synthesised mitochondrial-encoded proteins</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0035632" target="_blank" class="term-link">
+                                    GO:0035632
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial prohibitin complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/19812672" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:19812672
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Prohibitin couples diapause signalling to mitochondrial meta...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9BKU4" data-a="GO:0035632" data-r="PMID:19812672" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Physical-interaction evidence (with phb-2, WB:WBGene00004015) that phb-1 is part of the mitochondrial prohibitin complex. Direct support for the obligate phb-1/phb-2 partnership.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Confirms the direct phb-1/phb-2 interaction that constitutes the ring complex; a defining core annotation.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/19812672" target="_blank" class="term-link">
+                                        PMID:19812672
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">form a ring-like, high-molecular-mass complex at the inner membrane of mitochondria</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0002082" target="_blank" class="term-link">
+                                    GO:0002082
+                                </a>
+                            </span>
+                            <span class="term-label">regulation of oxidative phosphorylation</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/12794069" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:12794069
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The mitochondrial prohibitin complex is essential for embryo...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q9BKU4" data-a="GO:0002082" data-r="PMID:12794069" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Experimental (RNAi) evidence linking prohibitin depletion to altered oxidative phosphorylation, consistent with the conserved role of the complex in stabilizing respiratory-chain subunits. An indirect, non-core consequence of losing the essential complex.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Full-text-based experimental annotation (retained, not removed); effect on oxidative phosphorylation reflects downstream respiratory-chain destabilization rather than a dedicated regulatory activity of phb-1.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006979" target="_blank" class="term-link">
+                                    GO:0006979
+                                </a>
+                            </span>
+                            <span class="term-label">response to oxidative stress</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/12794069" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:12794069
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The mitochondrial prohibitin complex is essential for embryo...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q9BKU4" data-a="GO:0006979" data-r="PMID:12794069" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Experimental (RNAi) evidence of altered oxidative-stress response upon prohibitin depletion. Pleiotropic consequence of mitochondrial dysfunction.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Retained as an experimental annotation; oxidative-stress phenotype is an indirect consequence of impaired mitochondrial function, not a core role.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0007005" target="_blank" class="term-link">
+                                    GO:0007005
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrion organization</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/12794069" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:12794069
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The mitochondrial prohibitin complex is essential for embryo...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9BKU4" data-a="GO:0007005" data-r="PMID:12794069" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Experimental (RNAi) evidence that prohibitin depletion alters mitochondrial biogenesis/organization in body-wall muscle. Core process for phb-1.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Directly supported by the observed mitochondrial-biogenesis defect; a core function of the complex.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12794069" target="_blank" class="term-link">
+                                        PMID:12794069
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">a deficiency in PHB proteins results in altered mitochondrial biogenesis in body wall muscle cells</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0007283" target="_blank" class="term-link">
+                                    GO:0007283
+                                </a>
+                            </span>
+                            <span class="term-label">spermatogenesis</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/12794069" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:12794069
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The mitochondrial prohibitin complex is essential for embryo...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q9BKU4" data-a="GO:0007283" data-r="PMID:12794069" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Experimental (RNAi) germline phenotype. Pleiotropic developmental consequence of depleting the essential PHB complex.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Retained as an experimental annotation; germline/spermatogenesis defects follow from loss of an essential mitochondrial complex during germline differentiation rather than a dedicated spermatogenesis function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12794069" target="_blank" class="term-link">
+                                        PMID:12794069
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">PHB proteins are essential during embryonic development and are required for somatic and germline differentiation in the larval gonad</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008406" target="_blank" class="term-link">
+                                    GO:0008406
+                                </a>
+                            </span>
+                            <span class="term-label">gonad development</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/12794069" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:12794069
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The mitochondrial prohibitin complex is essential for embryo...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q9BKU4" data-a="GO:0008406" data-r="PMID:12794069" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Experimental (RNAi) evidence of somatic and germline gonad differentiation defects. Pleiotropic developmental consequence.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Retained as an experimental annotation; gonad-development defect reflects the essentiality of the complex in dividing/differentiating tissue, not a dedicated gonadogenesis function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12794069" target="_blank" class="term-link">
+                                        PMID:12794069
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">PHB proteins are essential during embryonic development and are required for somatic and germline differentiation in the larval gonad</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0009792" target="_blank" class="term-link">
+                                    GO:0009792
+                                </a>
+                            </span>
+                            <span class="term-label">embryo development ending in birth or egg hatching</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/12794069" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:12794069
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The mitochondrial prohibitin complex is essential for embryo...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q9BKU4" data-a="GO:0009792" data-r="PMID:12794069" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Experimental (RNAi) embryonic-lethality phenotype. Reflects essentiality of the PHB complex.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Retained as an experimental annotation; embryonic arrest is a consequence of the complex being essential rather than a dedicated embryogenesis function of phb-1.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12794069" target="_blank" class="term-link">
+                                        PMID:12794069
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">PHB proteins are essential during embryonic development and are required for somatic and germline differentiation in the larval gonad</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030421" target="_blank" class="term-link">
+                                    GO:0030421
+                                </a>
+                            </span>
+                            <span class="term-label">defecation</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/12794069" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:12794069
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The mitochondrial prohibitin complex is essential for embryo...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q9BKU4" data-a="GO:0030421" data-r="PMID:12794069" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Experimental (RNAi) behavioural phenotype scored by WormBase curators from the full text. Pleiotropic consequence of mitochondrial dysfunction.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Retained as an experimental annotation (curators read the full text); altered defecation is a pleiotropic behavioural readout, not a core molecular role.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031966" target="_blank" class="term-link">
+                                    GO:0031966
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/12794069" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:12794069
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The mitochondrial prohibitin complex is essential for embryo...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q9BKU4" data-a="GO:0031966" data-r="PMID:12794069" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct experimental evidence of mitochondrial-membrane localization. Correct but less specific than the separately annotated mitochondrial inner membrane, so retained as non-core.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The localization is correct; GO:0005743 (mitochondrial inner membrane) is the more precise term and is also annotated, so this broader term is retained but non-core.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12794069" target="_blank" class="term-link">
+                                        PMID:12794069
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">prohibitins in C. elegans form a high molecular weight complex in the mitochondrial inner membrane similar to that of yeast and humans</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0040018" target="_blank" class="term-link">
+                                    GO:0040018
+                                </a>
+                            </span>
+                            <span class="term-label">positive regulation of multicellular organism growth</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/12794069" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:12794069
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The mitochondrial prohibitin complex is essential for embryo...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q9BKU4" data-a="GO:0040018" data-r="PMID:12794069" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Experimental (RNAi) body-size/growth phenotype. Systemic consequence of impaired mitochondrial function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Retained as an experimental annotation; reduced growth on depletion is a systemic consequence of mitochondrial dysfunction rather than a dedicated growth-promoting activity.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0043051" target="_blank" class="term-link">
+                                    GO:0043051
+                                </a>
+                            </span>
+                            <span class="term-label">regulation of nematode pharyngeal pumping</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/12794069" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:12794069
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The mitochondrial prohibitin complex is essential for embryo...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q9BKU4" data-a="GO:0043051" data-r="PMID:12794069" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Experimental (RNAi) behavioural phenotype. Pleiotropic consequence of mitochondrial dysfunction.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Retained as an experimental annotation; pharyngeal-pumping change is a pleiotropic behavioural readout, not a core molecular role.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0048477" target="_blank" class="term-link">
+                                    GO:0048477
+                                </a>
+                            </span>
+                            <span class="term-label">oogenesis</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/12794069" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:12794069
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The mitochondrial prohibitin complex is essential for embryo...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q9BKU4" data-a="GO:0048477" data-r="PMID:12794069" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Experimental (RNAi) germline phenotype. Pleiotropic developmental consequence of depleting the essential PHB complex.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Retained as an experimental annotation; oogenesis defects follow from loss of an essential mitochondrial complex during germline differentiation.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12794069" target="_blank" class="term-link">
+                                        PMID:12794069
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">PHB proteins are essential during embryonic development and are required for somatic and germline differentiation in the larval gonad</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>phb-1 is a structural constituent of the mitochondrial prohibitin ring complex. It has no known independent catalytic activity; instead its function is to be an obligate subunit that, together with phb-2, assembles into the ring-shaped, high-molecular-weight PHB complex embedded in the mitochondrial inner membrane. The two subunits are interdependent, so phb-1 is required for the existence of the complex itself.</h3>
+                <span class="vote-buttons" data-g="Q9BKU4" data-a="FUNCTION: phb-1 is a structural constituent of the mitochond..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005198" target="_blank" class="term-link">
+                            structural molecule activity
+                        </a>
+                    </span>
+                </div>
+
+
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005743" target="_blank" class="term-link">
+                                mitochondrial inner membrane
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">In Complex:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0035632" target="_blank" class="term-link">
+                            mitochondrial prohibitin complex
+                        </a>
+                    </span>
+                </div>
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/26092086" target="_blank" class="term-link">
+                                PMID:26092086
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">which bind to each other to form a heterodimer that is assembled into a ring-like macromolecular structure at the inner mitochondrial membrane</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/26092086" target="_blank" class="term-link">
+                                PMID:26092086
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">These two subunits are interdependent for the formation of the complex, leading the absence of one of them to the absence of the whole complex</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>As part of the mitochondrial prohibitin complex, phb-1 contributes to organization of the mitochondrial inner membrane and to stabilization of newly synthesized mitochondrial-encoded proteins (a proposed membrane-bound chaperone/scaffold role), and thereby to mitochondrial biogenesis and function. Through this activity the complex acts as a context-dependent modulator of mitochondrial metabolism, fat utilization, and adult lifespan.</h3>
+                <span class="vote-buttons" data-g="Q9BKU4" data-a="FUNCTION: As part of the mitochondrial prohibitin complex, p..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0007005" target="_blank" class="term-link">
+                                mitochondrion organization
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0050821" target="_blank" class="term-link">
+                                protein stabilization
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005743" target="_blank" class="term-link">
+                                mitochondrial inner membrane
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">In Complex:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0035632" target="_blank" class="term-link">
+                            mitochondrial prohibitin complex
+                        </a>
+                    </span>
+                </div>
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/12794069" target="_blank" class="term-link">
+                                PMID:12794069
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">a deficiency in PHB proteins results in altered mitochondrial biogenesis in body wall muscle cells</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/26092086" target="_blank" class="term-link">
+                                PMID:26092086
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">a membrane-bound chaperone, which holds and stabilizes newly synthesised mitochondrial-encoded proteins</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/19812672" target="_blank" class="term-link">
+                                PMID:19812672
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">the mitochondrial prohibitin complex promotes longevity by modulating mitochondrial function and fat metabolism</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000002.md" target="_blank" class="term-link">
+                            GO_REF:0000002
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation through association of InterPro records with GO terms</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
+                            GO_REF:0000033
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Annotation inferences using phylogenetic trees</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
+                            GO_REF:0000044
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000117.md" target="_blank" class="term-link">
+                            GO_REF:0000117
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Electronic Gene Ontology annotations created by ARBA machine learning models</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/12794069" target="_blank" class="term-link">
+                            PMID:12794069
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">The mitochondrial prohibitin complex is essential for embryonic viability and germline function in Caenorhabditis elegans.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/19812672" target="_blank" class="term-link">
+                            PMID:19812672
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Prohibitin couples diapause signalling to mitochondrial metabolism during ageing in C. elegans.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/26092086" target="_blank" class="term-link">
+                            PMID:26092086
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Analysis of the effect of the mitochondrial prohibitin complex, a context-dependent modulator of longevity, on the C. elegans metabolome.</div>
+
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Questions for Experts</h2>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Is the worm PHB complex primarily a chaperone/holdase for nascent mitochondrial-encoded proteins, a membrane/lipid scaffold, or a regulator of inner-membrane proteostasis?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q9BKU4" data-a="Q: Is the worm PHB complex primarily a chaperone/hold..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> What is the direct molecular partnership between the PHB ring and the m-AAA protease (SPG-7/paraplegin) in C. elegans, and does it explain any of the depletion phenotypes?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q9BKU4" data-a="Q: What is the direct molecular partnership between t..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Which prohibitin-dependent metabolic step determines whether depletion shortens or extends lifespan in a given genetic/nutritional context?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q9BKU4" data-a="Q: Which prohibitin-dependent metabolic step determin..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Experiments</h2>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Reconstitute or affinity-purify the worm PHB ring and test in vitro holdase/ chaperone activity against candidate mitochondrial-encoded substrates versus a scaffold/lipid-organizing readout, to discriminate the proposed molecular roles.</p>
+
+
+
+                    <p style="margin-top: 0.5rem;">Type: biochemical reconstitution</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q9BKU4" data-a="EXPERIMENT: Reconstitute or affinity-purify the worm PHB ring ..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Perform proximity-labeling (BioID/TurboID) and lipidomics on tagged phb-1 to map the inner-membrane protein/lipid microdomain organized by the complex.</p>
+
+
+
+                    <p style="margin-top: 0.5rem;">Type: proximity proteomics / lipidomics</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q9BKU4" data-a="EXPERIMENT: Perform proximity-labeling (BioID/TurboID) and lip..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Carry out epistasis and targeted metabolic-flux analysis of phb-1 depletion across wild-type, daf-2, and dietary-restricted backgrounds to localize the node responsible for the opposite longevity outcomes.</p>
+
+
+
+                    <p style="margin-top: 0.5rem;">Type: genetic epistasis / metabolomics</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q9BKU4" data-a="EXPERIMENT: Carry out epistasis and targeted metabolic-flux an..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Knowledge Gaps</h2>
+        <p style="color: #555; font-size: 0.92rem; margin-top: -0.3rem;">
+            What is <em>not</em> known — curated, literature-grounded statements of the open
+            unknowns (the inverse of core functions).
+        </p>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The molecular mechanism of the mitochondrial prohibitin complex is unresolved. It is not established whether the complex acts primarily as a membrane-bound chaperone/holdase for newly synthesized mitochondrial-encoded proteins, as a scaffold that organizes inner-membrane proteins within a defined (cardiolipin/phospholipid) microdomain, or as a regulator of inner-membrane proteostasis (e.g. of the m-AAA protease); nor is the direct molecular activity of phb-1 as a ring subunit expressible as a specific GO molecular function.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span><span class="badge">ONTOLOGY</span>
+                <span class="badge">MF_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> It is firmly established that phb-1 and phb-2 bind each other and assemble into a ring-like, high-molecular-weight complex in the mitochondrial inner membrane, that the two subunits are interdependent (loss of one abolishes the complex), and that depletion is embryonic-lethal, disrupts gonad/germline differentiation, alters mitochondrial biogenesis, and context-dependently modulates lifespan. What is NOT established is the biochemical mechanism by which the complex produces these effects.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Prohibitins are ubiquitous and essential across eukaryotes; resolving whether the complex is fundamentally a chaperone, a membrane scaffold, or a lipid/ proteostasis organizer would explain a large body of pleiotropic phenotypes and the conserved link between mitochondrial membrane organization and ageing. The absence of a GO molecular-function term for a structural ring subunit is why the gene reads as MF-dark despite rich process/localization annotation.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> In vitro reconstitution / structural work on the worm (or conserved) PHB ring to test holdase vs scaffold activity; lipidomic and proximity-labeling mapping of the inner-membrane microdomain the complex organizes; separation-of-function alleles that uncouple candidate activities. In parallel, an ontology term for the structural/scaffolding molecular activity of a prohibitin-type ring subunit.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"the true function of the mitochondrial prohibitin complex remains elusive"</em> — PMID:26092086</li>
+
+                <li><em>"as scaffold proteins that recruit membrane proteins to a specific lipid environment"</em> — PMID:26092086</li>
+
+            </ul>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Proposed term (ontology gap):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><strong>prohibitin complex structural constituent activity</strong> — phb-1/phb-2 and their orthologs have no adequate GO molecular-function term for their role as structural ring subunits and inner-membrane scaffolds. They are currently annotatable only at the complex/process level or with the generic &#39;structural molecule activity&#39;, leaving the gene MF-dark despite a well-defined cellular role.</li>
+
+            </ul>
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The mechanistic basis by which the SAME reduction of the prohibitin complex produces OPPOSITE ageing outcomes is unknown - prohibitin deficiency shortens the lifespan of otherwise wild-type animals yet extends the lifespan of diapause (daf-2), dietary-restricted, and respiration/fat-metabolism-compromised animals. The metabolic node at which the complex converts genetic/nutritional context into opposite longevity responses is undefined.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">RESIDUAL_SUBGAP</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> The context-dependence itself is well documented (life-shortening in wild type vs life-extending in daf-2/DR/mitochondrial mutants), and depletion is known to change ATP levels, fat content, mitochondrial proliferation, and the whole-animal metabolome. The upstream signalling (insulin/IGF-DAF-16, dietary restriction) and the downstream metabolic readouts are mapped, but the causal molecular link through the complex is not.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> This paradox is a clean, conserved example of how mitochondrial membrane organization gates lifespan in a metabolic-state-dependent manner; resolving it would connect prohibitin biology to insulin/IGF and dietary-restriction ageing pathways mechanistically.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Epistasis and metabolic-flux analysis across the opposing backgrounds; identify the prohibitin-dependent metabolic step whose perturbation flips the longevity sign; test candidate mediators (fat mobilization, respiratory-chain assembly).</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"knockdown of prohibitin promotes longevity in diapause mutants or under conditions of dietary restriction"</em> — PMID:19812672</li>
+
+                <li><em>"while it dramatically extends the lifespan of the already long-lived daf-2(e1370) insulin receptor mutants"</em> — PMID:26092086</li>
+
+            </ul>
+
+
+        </div>
+
+    </div>
+
+
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Deep Research Sections -->
+
+    <div class="section">
+        <h2 class="section-title">Deep Research</h2>
+
+        <details class="deep-research-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; gap: 1rem;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Falcon</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(phb-1-deep-research-falcon.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="Q9BKU4" data-a="DEEP_RESEARCH: Falcon" data-r="" data-act="DEEP_RESEARCH" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This deep research is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This deep research needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+
+                <div class="report-meta">
+
+                    <span class="report-meta-text">Comprehensive Research Report: *phb-1* (Prohibitin-1) in *Caenorhabditis elegans*</span>
+
+
+                    <span class="report-badge">Falcon</span>
+
+
+                    <span class="report-badge">Edison Scientific Literature</span>
+
+
+                    <span class="report-badge">33 citations</span>
+
+
+                    <span class="report-badge">2 artifacts</span>
+
+
+                    <span class="report-meta-text">2026-07-03T21:38:36.820966</span>
+
+
+
+                </div>
+
+
+                <div class="artifact-list">
+
+
+
+                    <div class="artifact-link">
+                        <a href="phb-1-deep-research-falcon_artifacts/artifact-00.md" class="term-link">Edison artifact artifact-00</a>
+                        <span>(text/markdown)</span>
+                    </div>
+
+
+
+
+                    <div class="artifact-link">
+                        <a href="phb-1-deep-research-falcon_artifacts/artifact-01.md" class="term-link">Edison artifact artifact-01</a>
+                        <span>(text/markdown)</span>
+                    </div>
+
+
+                </div>
+
+                <p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h1 id="comprehensive-research-report-phb-1-prohibitin-1-in-caenorhabditis-elegans">Comprehensive Research Report: <em>phb-1</em> (Prohibitin-1) in <em>Caenorhabditis elegans</em></h1>
+<h2 id="1-gene-identity-and-protein-overview">1. Gene Identity and Protein Overview</h2>
+<p>The <em>C. elegans</em> gene <em>phb-1</em> (ORF Y37E3.9; UniProt Q9BKU4) encodes mitochondrial prohibitin complex protein 1 (PHB-1), a 32 kDa protein belonging to the evolutionarily conserved prohibitin family and the broader SPFH (stomatin/prohibitin/flotillin/HflK/C) superfamily of membrane scaffold proteins (artalsanz2009prohibitinandmitochondrial pages 1-2, artalsanz2009prohibitinandmitochondrial pages 4-5). PHB-1 contains a conserved PHB/Band_7 (SPFH) domain adjacent to an N-terminal hydrophobic membrane-anchoring region, and a C-terminal coiled-coil domain that mediates heterodimerization with PHB-2 (hernandorodriguez2018mitochondrialqualitycontrol pages 8-10, artalsanz2009prohibitinandmitochondrial pages 1-2). Both PHB-1 and PHB-2 subunits are ubiquitously and abundantly expressed in <em>C. elegans</em> tissues and are interdependent: depletion of either subunit results in the absence of the functional complex (artalsanz2009prohibitinandmitochondrial pages 1-2, artalsanz2009prohibitinandmitochondrial pages 2-3).</p>
+<p>The following table summarizes the key attributes of PHB-1:</p>
+<table>
+<thead>
+<tr>
+<th>Attribute</th>
+<th>Summary</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Protein name</td>
+<td>Mitochondrial prohibitin complex protein 1; Prohibitin-1 (PHB-1) (artalsanz2009prohibitinandmitochondrial pages 1-2, hernandorodriguez2018mitochondrialqualitycontrol pages 8-10)</td>
+</tr>
+<tr>
+<td>Gene name</td>
+<td>phb-1; ORF Y37E3.9 (verified against UniProt target specification; functional literature on C. elegans prohibitin complex is consistent with this identity) (artalsanz2009prohibitinandmitochondrial pages 1-2, artalsanz2009prohibitinandmitochondrial pages 2-3)</td>
+</tr>
+<tr>
+<td>UniProt ID</td>
+<td>Q9BKU4 (from target specification; literature supports the corresponding C. elegans prohibitin-1 identity and function) (artalsanz2009prohibitinandmitochondrial pages 1-2, artalsanz2009prohibitinandmitochondrial pages 2-3)</td>
+</tr>
+<tr>
+<td>Organism</td>
+<td><em>Caenorhabditis elegans</em> (artalsanz2009prohibitinandmitochondrial pages 3-4, hernandorodriguez2018mitochondrialqualitycontrol pages 8-10)</td>
+</tr>
+<tr>
+<td>Protein family</td>
+<td>Prohibitin family; member of the SPFH/Band_7 superfamily of membrane scaffold proteins (artalsanz2009prohibitinandmitochondrial pages 4-5, hernandorodriguez2018mitochondrialqualitycontrol pages 8-10)</td>
+</tr>
+<tr>
+<td>Key domains</td>
+<td>Conserved PHB/SPFH (Band_7) domain with N-terminal hydrophobic/transmembrane anchor and C-terminal coiled-coil region mediating PHB-1/PHB-2 assembly (hernandorodriguez2018mitochondrialqualitycontrol pages 8-10, artalsanz2009prohibitinandmitochondrial pages 1-2)</td>
+</tr>
+<tr>
+<td>Molecular weight</td>
+<td>PHB-1 is ~32 kDa; PHB-2 is ~34 kDa (hernandorodriguez2018mitochondrialqualitycontrol pages 8-10, artalsanz2009prohibitinandmitochondrial pages 1-2)</td>
+</tr>
+<tr>
+<td>Subcellular localization</td>
+<td>Predominantly mitochondrial inner membrane (IMM), with the complex projecting into the intermembrane space/crista lumen; localization within crista-associated membrane regions is implicated in membrane organization (hernandorodriguez2018mitochondrialqualitycontrol pages 8-10, hernandorodriguez2018mitochondrialqualitycontrol pages 10-12, lange2025insituarchitecture pages 2-3)</td>
+</tr>
+<tr>
+<td>Complex partners</td>
+<td>Obligatory heterocomplex with PHB-2; functionally associated with m-AAA proteases, OXPHOS/ATP synthase components, OPA1/cristae machinery, ATAD3/nucleoid-associated factors, and lipid homeostasis pathways (hernandorodriguez2018mitochondrialqualitycontrol pages 16-17, hernandorodriguez2018mitochondrialqualitycontrol pages 8-10)</td>
+</tr>
+<tr>
+<td>Complex stoichiometry</td>
+<td>In C. elegans and earlier models, a ~1 MDa ring-like assembly of ~12–16 PHB-1/PHB-2 heterodimers was proposed; recent in situ human cryo-ET instead resolved a bell-shaped 11-subunit alternating PHB1/PHB2 assembly, refining structural understanding of prohibitin scaffolds (hernandorodriguez2018mitochondrialqualitycontrol pages 8-10, artalsanz2009prohibitinandmitochondrial pages 1-2, lange2025insituarchitecture pages 4-7, lange2025insituarchitecture pages 1-2)</td>
+</tr>
+<tr>
+<td>Primary molecular function</td>
+<td>Membrane-bound scaffold/chaperone rather than enzyme or transporter; stabilizes newly synthesized/assembled IMM proteins, cooperates with m-AAA proteases in membrane protein quality control, helps organize lipid microenvironments, and supports cristae architecture and respiratory chain integrity (hernandorodriguez2018mitochondrialqualitycontrol pages 8-10, artalsanz2009prohibitinandmitochondrial pages 4-5, artalsanz2009prohibitinandmitochondrial pages 3-4, artalsanz2009prohibitinandmitochondrial pages 2-3)</td>
+</tr>
+<tr>
+<td>Key signaling pathway interactions: IIS/DAF-2</td>
+<td>PHB depletion shortens lifespan in wild type but extends lifespan in metabolically compromised animals such as <em>daf-2</em> mutants; PHB influences lipid remodeling, TAG/yolk homeostasis, and ER stress in an insulin-signaling-dependent manner (lourenco2021themitochondrialprohibitin pages 3-5, lourenco2021themitochondrialprohibitin pages 5-7, lourenco2021themitochondrialprohibitin pages 2-3)</td>
+</tr>
+<tr>
+<td>Key signaling pathway interactions: TORC2/SGK-1</td>
+<td>SGK-1 is a major downstream determinant of the prohibitin longevity phenotype; PHB depletion extends lifespan in <em>sgk-1</em> and <em>rict-1</em> mutants, suppresses their mitochondrial and lipogenesis defects, and functionally links PHB to mTORC2-SGK-1 control of mitochondrial homeostasis (cruz‐ruiz2021prohibitindepletionextends pages 1-2, gatsi2014prohibitinmediatedlifespanand pages 8-10, cruz‐ruiz2021prohibitindepletionextends pages 2-4, cruz‐ruiz2021prohibitindepletionextends pages 13-14)</td>
+</tr>
+<tr>
+<td>Key signaling pathway interactions: UPRmt/ATFS-1</td>
+<td>PHB depletion robustly induces the mitochondrial unfolded protein response (UPRmt) in wild type; UPRmt behavior is context dependent in IIS/TORC2 mutants, and ATFS-1-dependent mitochondrial stress signaling contributes to longevity outcomes in PHB-deficient backgrounds (artalsanz2009prohibitinandmitochondrial pages 5-7, fernandezabascal<em>2023twoconservedtranscription pages 4-7, fernandezabascal</em>2023twoconservedtranscription pages 1-4, cruz‐ruiz2021prohibitindepletionextends pages 1-2)</td>
+</tr>
+<tr>
+<td>Lifespan effects</td>
+<td>Depletion of prohibitin shortens wild-type lifespan but extends lifespan in several metabolically compromised backgrounds including <em>daf-2</em>, <em>sgk-1</em>, and <em>rict-1</em> mutants; this is one of the defining context-dependent phenotypes of the PHB complex in <em>C. elegans</em> aging biology (lourenco2021themitochondrialprohibitin pages 2-3, cruz‐ruiz2021prohibitindepletionextends pages 1-2, gatsi2014prohibitinmediatedlifespanand pages 1-2, gatsi2014prohibitinmediatedlifespanand pages 2-3)</td>
+</tr>
+<tr>
+<td>Essential cellular processes</td>
+<td>Embryonic viability, germline function, mitochondrial morphogenesis, cristae maintenance, respiratory chain/OXPHOS biogenesis, mitochondrial proteostasis, lipid homeostasis, nucleoid/mtDNA organization, and mitochondrial quality control; PHB-2 additionally serves as an IMM mitophagy receptor via LC3 interaction, whereas PHB-1 participates in the heterocomplex that supports these functions (artalsanz2009prohibitinandmitochondrial pages 3-4, hernandorodriguez2018mitochondrialqualitycontrol pages 16-17, hernandorodriguez2018mitochondrialqualitycontrol pages 8-10, wei2017prohibitin2is pages 1-3)</td>
+</tr>
+</tbody>
+</table>
+<p><em>Table: This table summarizes the core identity, localization, molecular role, pathway interactions, and phenotypic consequences of PHB-1/prohibitin-1 in </em>C. elegans<em>. It is useful as a compact reference linking the prohibitin complex’s structural role in mitochondria to its context-dependent effects on metabolism, stress signaling, and longevity.</em></p>
+<h2 id="2-structure-and-complex-formation">2. Structure and Complex Formation</h2>
+<p>PHB-1 and PHB-2 associate to form a large, ring-like macromolecular complex of approximately 1 MDa at the mitochondrial inner membrane (hernandorodriguez2018mitochondrialqualitycontrol pages 8-10, artalsanz2009prohibitinandmitochondrial pages 1-2). Earlier biochemical studies estimated that this complex consists of 12–16 PHB-1/PHB-2 heterodimeric building blocks with a diameter of 20–25 nm (artalsanz2009prohibitinandmitochondrial pages 1-2, artalsanz2009prohibitinandmitochondrial pages 3-4). PHB-1 is anchored at the membrane surface via its N-terminal hydrophobic region, while PHB-2 contains a true transmembrane domain (artalsanz2009prohibitinandmitochondrial pages 1-2).</p>
+<p>A landmark structural advance was reported by Lange et al. (2025), who used cryo-electron tomography and subtomogram averaging to determine the in situ architecture of the human prohibitin complex within intact mitochondria. This study revealed a bell-shaped structure consisting of 11 alternating PHB1 and PHB2 molecules (either 6PHB1/5PHB2 or 5PHB1/6PHB2), with a diameter of approximately 190 Å and a height of 84 Å (lange2025insituarchitecture pages 4-7, lange2025insituarchitecture pages 1-2). The N-terminal transmembrane domains anchor the complex in the lipid bilayer, while the C-terminal coiled-coil domains converge at the top of the bell through electrostatic interactions (lange2025insituarchitecture pages 4-7). The study further revealed an average of approximately 43 prohibitin complexes per crista, covering 1–3% of the cristae membrane surface (lange2025insituarchitecture pages 1-2). These structures are enriched at crista membranes and project toward the intermembrane space/crista lumen (lange2025insituarchitecture pages 2-3). This revised stoichiometry (11 subunits rather than 12–16 heterodimers) refines our understanding of prohibitin architecture, though the <em>C. elegans</em> complex stoichiometry has not been independently resolved at this level.</p>
+<h2 id="3-subcellular-localization">3. Subcellular Localization</h2>
+<p>PHB-1 localizes primarily to the inner mitochondrial membrane (IMM), where the complex projects into the intermembrane space (hernandorodriguez2018mitochondrialqualitycontrol pages 8-10, hernandorodriguez2018mitochondrialqualitycontrol pages 10-12, lange2025insituarchitecture pages 2-3). The complex is part of the ER-mitochondria organizing network (ERMIONE), which links the endoplasmic reticulum and both mitochondrial membranes to maintain membrane architecture and homeostasis (hernandorodriguez2018mitochondrialqualitycontrol pages 10-12). PHB-1 has also been reported to interact transiently with peroxisomal and lipid droplet proteins, though its predominant site of action is the IMM (hernandorodriguez2018mitochondrialqualitycontrol pages 10-12). In <em>C. elegans</em>, PHB-1 and PHB-2 are particularly required in tissues with high energy demands and actively proliferating cells, including the germline and body-wall muscle (artalsanz2009prohibitinandmitochondrial pages 3-4).</p>
+<h2 id="4-primary-molecular-function">4. Primary Molecular Function</h2>
+<p>PHB-1 is not an enzyme, transporter, or signaling receptor. Rather, it functions as a <strong>membrane-bound scaffold and holdase/unfoldase-type chaperone</strong> within the inner mitochondrial membrane (hernandorodriguez2018mitochondrialqualitycontrol pages 8-10, artalsanz2009prohibitinandmitochondrial pages 4-5, artalsanz2009prohibitinandmitochondrial pages 3-4). Its precise biochemical activity has remained challenging to define, but converging evidence supports several interrelated functions:</p>
+<h3 id="41-membrane-protein-quality-control-and-oxphos-complex-assembly">4.1. Membrane Protein Quality Control and OXPHOS Complex Assembly</h3>
+<p>PHB-1 physically interacts with mitochondrial m-AAA proteases (including SPG7 and AFG3L1/2) and modulates their activity (hernandorodriguez2018mitochondrialqualitycontrol pages 8-10, hernandorodriguez2018mitochondrialqualitycontrol pages 16-17). The PHB complex protects newly imported and newly synthesized OXPHOS subunits—particularly the highly hydrophobic mitochondrial-encoded subunits of complexes I and IV—from premature protease-mediated degradation, acting as a holdase-type chaperone until proper assembly with nuclear-encoded counterparts can occur (hernandorodriguez2018mitochondrialqualitycontrol pages 8-10, artalsanz2009prohibitinandmitochondrial pages 4-5, artalsanz2009prohibitinandmitochondrial pages 3-4). PHB-1 also associates with ATP synthase subunits, and its loss affects respiratory supercomplex formation (hernandorodriguez2018mitochondrialqualitycontrol pages 16-17, lourenco2021themitochondrialprohibitin pages 12-13).</p>
+<h3 id="42-cristae-morphogenesis-and-opa1-regulation">4.2. Cristae Morphogenesis and OPA1 Regulation</h3>
+<p>The PHB complex stabilizes long isoforms of OPA1 (the <em>C. elegans</em> ortholog is EAT-3), which are essential for mitochondrial inner membrane fusion and cristae junction formation (hernandorodriguez2018mitochondrialqualitycontrol pages 8-10, hernandorodriguez2018mitochondrialqualitycontrol pages 16-17, artalsanz2009prohibitinandmitochondrial pages 4-5). Loss of prohibitins leads to aberrant OPA1 processing, disrupted cristae architecture, and severe mitochondrial fragmentation—transforming normal tubular elongated mitochondria into fragmented structures, as observed in <em>C. elegans</em> body-wall muscle (artalsanz2009prohibitinandmitochondrial pages 3-4, hernandorodriguez2018mitochondrialqualitycontrol pages 8-10). PHB keeps the OMA1 protease in check; loss of PHB releases OMA1 to cleave OPA1 into short isoforms, driving fragmentation (artalsanz2009prohibitinandmitochondrial pages 2-3).</p>
+<h3 id="43-membrane-lipid-organization">4.3. Membrane Lipid Organization</h3>
+<p>PHB-1 functions as a membrane organizer that clusters specific lipids at defined sites within the IMM. Genetic and biochemical evidence demonstrates interactions between prohibitins and the metabolism of cardiolipin and phosphatidylethanolamine (PE), two key mitochondrial phospholipids (hernandorodriguez2018mitochondrialqualitycontrol pages 8-10, hernandorodriguez2018mitochondrialqualitycontrol pages 16-17). Loss of PHB complexes alters cardiolipin acylation and affects cholesterol biosynthesis, linking prohibitin to membrane lipid homeostasis (hernandorodriguez2018mitochondrialqualitycontrol pages 8-10). The PHB/SPFH domain itself may mediate lipid binding, though this has not been definitively demonstrated biochemically (artalsanz2009prohibitinandmitochondrial pages 4-5).</p>
+<h3 id="44-mitochondrial-nucleoid-organization-and-mtdna-maintenance">4.4. Mitochondrial Nucleoid Organization and mtDNA Maintenance</h3>
+<p>PHB-1 associates with mitochondrial nucleoids, the protein-DNA complexes that package mtDNA, together with TFAM, mtSSB, and ATAD3 (hernandorodriguez2018mitochondrialqualitycontrol pages 8-10). Both PHB subunits co-purify with tagged mitochondrial DNA-binding proteins, and depletion of either PHB or ATAD3 dramatically reduces mitochondrial protein synthesis (hernandorodriguez2018mitochondrialqualitycontrol pages 8-10). In mouse neurons, loss of PHB2 destabilizes the mitochondrial genome and leads to respiratory deficiencies, demonstrating that prohibitin scaffolds are required for mtDNA maintenance (hernandorodriguez2018mitochondrialqualitycontrol pages 16-17, lourenco2021themitochondrialprohibitin pages 12-13).</p>
+<h3 id="45-mitophagy-via-phb-2">4.5. Mitophagy (via PHB-2)</h3>
+<p>While PHB-1 itself does not directly bind LC3, its obligate partner PHB-2 has been identified as an inner mitochondrial membrane mitophagy receptor. PHB-2 binds LC3-II through an LC3-interacting region (LIR) motif upon proteasome-dependent rupture of the outer mitochondrial membrane, facilitating Parkin-mediated mitophagy (wei2017prohibitin2is pages 12-13, wei2017prohibitin2is pages 1-3, wei2017prohibitin2is pages 4-5). PHB-1 interacts with LC3-II indirectly through the PHB-1/PHB-2 complex (lahiri2017phb2prohibitin2an pages 1-2). In <em>C. elegans</em>, PHB-2 is essential for clearing paternal mitochondria during embryogenesis, contributing to maternal mitochondrial inheritance (wei2017prohibitin2is pages 12-13, qi2023essentialproteinphb2 pages 5-6). A PINK1-dependent pathway involving PARL and PGAM5 further connects the PHB complex to mitophagy regulation (qi2023essentialproteinphb2 pages 5-6, belser2021roleofprohibitins pages 1-2).</p>
+<h2 id="5-biological-processes-and-signaling-pathways">5. Biological Processes and Signaling Pathways</h2>
+<h3 id="51-essential-role-in-development-and-germline-function">5.1. Essential Role in Development and Germline Function</h3>
+<p>In <em>C. elegans</em>, homozygous <em>phb-1</em> and <em>phb-2</em> deletion mutants are embryonic lethal; animals that develop from heterozygous mothers (due to maternal contribution of PHB protein) grow into sterile adults with severely compromised germline function and strongly induced mitochondrial unfolded protein response (UPRmt) (hernandorodriguez2018mitochondrialqualitycontrol pages 8-10, hernandorodriguez2018mitochondrialqualitycontrol pages 16-17). Post-embryonic depletion impairs germline function with reduced oocyte production (artalsanz2009prohibitinandmitochondrial pages 3-4).</p>
+<h3 id="52-context-dependent-modulation-of-lifespan">5.2. Context-Dependent Modulation of Lifespan</h3>
+<p>One of the most striking and extensively studied phenotypes of PHB-1 is its paradoxical, context-dependent effect on lifespan. PHB depletion shortens the lifespan of wild-type <em>C. elegans</em> but dramatically extends the lifespan of metabolically compromised mutants, including insulin/IGF-1 signaling (IIS) receptor <em>daf-2</em> mutants, TORC2 pathway mutants <em>sgk-1</em> and <em>rict-1</em>, and dietary-restricted animals (fernandezabascal<em>2023twoconservedtranscription pages 4-7, lourenco2021themitochondrialprohibitin pages 2-3, cruz‐ruiz2021prohibitindepletionextends pages 1-2, gatsi2014prohibitinmediatedlifespanand pages 1-2, gatsi2014prohibitinmediatedlifespanand pages 2-3). This paradox has been a major focus of </em>C. elegans* aging research and is summarized in the table below:</p>
+<table>
+<thead>
+<tr>
+<th>Genetic Background</th>
+<th>Lifespan Effect of PHB Depletion</th>
+<th>UPRmt Response</th>
+<th>Mechanism/Notes</th>
+<th>Key Reference</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Wild-type</td>
+<td>Shortens lifespan (fernandezabascal*2023twoconservedtranscription pages 4-7, lourenco2021themitochondrialprohibitin pages 5-7, lourenco2021themitochondrialprohibitin pages 2-3, gatsi2014prohibitinmediatedlifespanand pages 1-2)</td>
+<td>Strongly induced (fernandezabascal<em>2023twoconservedtranscription pages 4-7, fernandezabascal</em>2023twoconservedtranscription pages 1-4, artalsanz2009prohibitinandmitochondrial pages 5-7)</td>
+<td>PHB loss disrupts mitochondrial membrane organization and proteostasis, induces mitochondrial stress, and is generally detrimental in metabolically normal animals (hernandorodriguez2018mitochondrialqualitycontrol pages 8-10, artalsanz2009prohibitinandmitochondrial pages 4-5)</td>
+<td>Gatsi et al. 2014; Fernández-Abascal et al. 2025; Lourenço &amp; Artal-Sanz 2021 (fernandezabascal*2023twoconservedtranscription pages 4-7, lourenco2021themitochondrialprohibitin pages 2-3, gatsi2014prohibitinmediatedlifespanand pages 1-2)</td>
+</tr>
+<tr>
+<td>daf-2(e1370)</td>
+<td>Extends lifespan (fernandezabascal*2023twoconservedtranscription pages 4-7, lourenco2021themitochondrialprohibitin pages 5-7, lourenco2021themitochondrialprohibitin pages 2-3, gatsi2014prohibitinmediatedlifespanand pages 1-2)</td>
+<td>Suppressed/attenuated relative to PHB-depleted wild type (fernandezabascal<em>2023twoconservedtranscription pages 4-7, fernandezabascal</em>2023twoconservedtranscription pages 1-4, gatsi2014prohibitinmediatedlifespanand pages 1-2)</td>
+<td>Canonical example of context dependence: defective IIS buffers some PHB-loss consequences; longevity links to altered lipid/energy metabolism and requires mitochondrial stress signaling components including ATFS-1 in recent work (fernandezabascal*2023twoconservedtranscription pages 4-7, lourenco2021themitochondrialprohibitin pages 3-5, lourenco2021themitochondrialprohibitin pages 5-7)</td>
+<td>Gatsi et al. 2014; Fernández-Abascal et al. 2025; Lourenço &amp; Artal-Sanz 2021 (fernandezabascal*2023twoconservedtranscription pages 4-7, lourenco2021themitochondrialprohibitin pages 3-5, gatsi2014prohibitinmediatedlifespanand pages 1-2)</td>
+</tr>
+<tr>
+<td>sgk-1(ok538)</td>
+<td>Extends lifespan (reported ~18% in one study) (cruz‐ruiz2021prohibitindepletionextends pages 1-2, gatsi2014prohibitinmediatedlifespanand pages 3-4, gatsi2014prohibitinmediatedlifespanand pages 2-3)</td>
+<td>Induced in sgk-1 mutants, but PHB depletion-associated longevity is accompanied by suppressed UPRmt relative to PHB-depleted wild type; later work also shows lifespan extension requires UPRmt and autophagy (gatsi2014prohibitinmediatedlifespanand pages 1-2, cruz‐ruiz2021prohibitindepletionextends pages 2-4)</td>
+<td>PHB depletion suppresses sgk-1 mitochondrial, lipogenesis, yolk/lipoprotein, ROS, and oxygen-consumption defects; indicates strong interaction with TORC2/SGK-1 and membrane-lipid homeostasis (cruz‐ruiz2021prohibitindepletionextends pages 1-2, cruz‐ruiz2021prohibitindepletionextends pages 2-4, cruz‐ruiz2021prohibitindepletionextends pages 13-14)</td>
+<td>Gatsi et al. 2014; de la Cruz-Ruiz et al. 2021 (cruz‐ruiz2021prohibitindepletionextends pages 1-2, gatsi2014prohibitinmediatedlifespanand pages 1-2, cruz‐ruiz2021prohibitindepletionextends pages 2-4)</td>
+</tr>
+<tr>
+<td>rict-1(ft7)</td>
+<td>Extends lifespan (gatsi2014prohibitinmediatedlifespanand pages 1-2, gatsi2014prohibitinmediatedlifespanand pages 2-3)</td>
+<td>UPRmt regulation parallels sgk-1; rict-1 loss suppresses PHB depletion-associated UPRmt and interacts with SGK-1 in a pathway parallel to DAF-2 (gatsi2014prohibitinmediatedlifespanand pages 8-10, gatsi2014prohibitinmediatedlifespanand pages 1-2, gatsi2014prohibitinmediatedlifespanand pages 2-3)</td>
+<td>Supports model that mTORC2/RICT-1-SGK-1 signaling is a major determinant of whether PHB depletion is pro- or anti-longevity (gatsi2014prohibitinmediatedlifespanand pages 8-10, gatsi2014prohibitinmediatedlifespanand pages 6-8, gatsi2014prohibitinmediatedlifespanand pages 2-3)</td>
+<td>Gatsi et al. 2014 (gatsi2014prohibitinmediatedlifespanand pages 8-10, gatsi2014prohibitinmediatedlifespanand pages 1-2, gatsi2014prohibitinmediatedlifespanand pages 2-3)</td>
+</tr>
+<tr>
+<td>Dietary restricted animals</td>
+<td>Extends lifespan (lourenco2021themitochondrialprohibitin pages 2-3)</td>
+<td>Not specified directly in the cited review excerpt (lourenco2021themitochondrialprohibitin pages 2-3)</td>
+<td>Lourenço &amp; Artal-Sanz summarize that PHB depletion can extend lifespan in dietary restriction contexts, reinforcing that PHB effects depend on systemic metabolic state rather than PHB acting as a simple pro- or anti-aging factor (lourenco2021themitochondrialprohibitin pages 2-3, lourenco2021themitochondrialprohibitin pages 7-8)</td>
+<td>Lourenço &amp; Artal-Sanz 2021 (lourenco2021themitochondrialprohibitin pages 2-3, lourenco2021themitochondrialprohibitin pages 7-8)</td>
+</tr>
+</tbody>
+</table>
+<p><em>Table: This table summarizes how prohibitin depletion has opposite effects on lifespan depending on the C. elegans genetic or metabolic background. It is useful for quickly comparing longevity outcomes, UPRmt behavior, and the major mechanistic interpretations across key studies.</em></p>
+<h3 id="53-insulinigf-1-signaling-iis-pathway">5.3. Insulin/IGF-1 Signaling (IIS) Pathway</h3>
+<p>PHB functionally interacts with the IIS pathway at multiple levels. Among the three kinases downstream of DAF-2 (the insulin/IGF-1 receptor), only loss of SGK-1 recapitulates the lifespan extension observed in <em>daf-2</em> mutants upon PHB depletion (gatsi2014prohibitinmediatedlifespanand pages 1-2, gatsi2014prohibitinmediatedlifespanand pages 3-4). PHB depletion in <em>daf-2</em> mutants extends lifespan while attenuating the UPRmt, suggesting a mitochondrial threshold effect where reduced insulin signaling protects against the deleterious consequences of PHB loss (fernandezabascal<em>2023twoconservedtranscription pages 4-7, fernandezabascal</em>2023twoconservedtranscription pages 1-4). PHB depletion also alters glycerolipid and triacylglyceride (TAG) pools in an IIS-dependent manner (lourenco2021themitochondrialprohibitin pages 3-5).</p>
+<h3 id="54-torc2sgk-1-signaling">5.4. TORC2/SGK-1 Signaling</h3>
+<p>SGK-1 receives input from RICT-1/mTORC2, and both operate in a pathway parallel to DAF-2 for the PHB-mediated lifespan phenotype (gatsi2014prohibitinmediatedlifespanand pages 8-10, gatsi2014prohibitinmediatedlifespanand pages 1-2, gatsi2014prohibitinmediatedlifespanand pages 2-3). <em>sgk-1</em> mutants exhibit impaired mitochondrial homeostasis, lipogenesis, and yolk formation due to membrane lipid and sterol homeostasis alterations; remarkably, all these defects are suppressed by PHB depletion (cruz‐ruiz2021prohibitindepletionextends pages 1-2). PHB depletion in <em>sgk-1</em> mutants normalizes mitochondrial size, reduces excessive oxygen consumption and ROS levels, and restores mitochondrial morphology from abnormally swollen to normal architecture (cruz‐ruiz2021prohibitindepletionextends pages 2-4). The lifespan extension in <em>sgk-1</em> mutants upon PHB depletion requires both the UPRmt and autophagy, but not mitophagy (cruz‐ruiz2021prohibitindepletionextends pages 1-2, cruz‐ruiz2021prohibitindepletionextends pages 2-4). The lipid metabolism transcription factor SREBP1/SBP-1 is also required for lifespan extension (cruz‐ruiz2021prohibitindepletionextends pages 1-2).</p>
+<h3 id="55-mitochondrial-unfolded-protein-response-uprmt">5.5. Mitochondrial Unfolded Protein Response (UPRmt)</h3>
+<p>PHB depletion is a potent inducer of the UPRmt in wild-type animals, activating mitochondrial chaperone genes such as <em>hsp-6</em> through the transcription factor ATFS-1 (artalsanz2009prohibitinandmitochondrial pages 4-5, artalsanz2009prohibitinandmitochondrial pages 5-7, fernandezabascal<em>2023twoconservedtranscription pages 4-7, fernandezabascal</em>2023twoconservedtranscription pages 1-4, gatsi2014prohibitinmediatedlifespanand pages 8-10). However, the relationship between UPRmt induction and lifespan is complex: in <em>daf-2</em> mutants, PHB depletion extends lifespan while paradoxically attenuating the UPRmt relative to PHB-depleted wild type (fernandezabascal<em>2023twoconservedtranscription pages 4-7, fernandezabascal</em>2023twoconservedtranscription pages 1-4). A recent genome-wide double RNAi screen identified two new transcription factors, ZNF-622 and TLF-1, as specific regulators of the PHB-mediated mitochondrial stress response, as well as the histone deubiquitinase USP-48 as a differential modulator of the UPRmt and aging in wild-type versus IIS mutant backgrounds (fernandezabascal*2023twoconservedtranscription pages 4-7).</p>
+<h3 id="56-fat-metabolism-and-metabolic-reprogramming">5.6. Fat Metabolism and Metabolic Reprogramming</h3>
+<p>PHB modulates fat content and fatty acid composition, with a trend toward increased shorter/monounsaturated fatty acids and decreased longer/polyunsaturated fatty acids upon PHB depletion (lourenco2021themitochondrialprohibitin pages 2-3). The complex also regulates sphingolipids (sphingomyelin, ceramide) and glycerophospholipids (phosphatidylcholine, phosphatidylethanolamine) in a genetic background-dependent manner (lourenco2021themitochondrialprohibitin pages 2-3). PHB depletion affects carbohydrate and amino acid metabolism, the TCA cycle, and trehalose accumulation, demonstrating broad effects on the <em>C. elegans</em> metabolic network (lourenco2021themitochondrialprohibitin pages 5-7). PHB interacts with the fat mobilization regulator NHR-49 and the fatty acid desaturase FAT-7 (lourenco2021themitochondrialprohibitin pages 7-8). PHB depletion also induces ER stress in wild-type worms, but <em>daf-2</em> mutants are protected from this ER stress, providing a mechanistic link between PHB, mitochondrial function, ER homeostasis, and IIS signaling (lourenco2021themitochondrialprohibitin pages 3-5, lourenco2021themitochondrialprohibitin pages 5-7).</p>
+<h2 id="6-evolutionary-conservation-and-structural-insights">6. Evolutionary Conservation and Structural Insights</h2>
+<p>Prohibitins are among the most highly conserved eukaryotic proteins, with orthologs in yeast, nematodes, insects, and mammals sharing both structural organization and core functions (artalsanz2009prohibitinandmitochondrial pages 1-2, artalsanz2009prohibitinandmitochondrial pages 4-5). The PHB/SPFH domain, the coiled-coil assembly region, and the ring-like supramolecular architecture are conserved features. Cross-species functional complementation experiments demonstrate that <em>Plasmodium falciparum</em> PHBs can complement yeast PHB mutants, underscoring deep functional conservation (artalsanz2009prohibitinandmitochondrial pages 4-5). The recently resolved in situ structure of human prohibitin (bell-shaped, 11 subunits) provides the first high-resolution architectural framework for understanding how prohibitin scaffolds organize the inner mitochondrial membrane across species (lange2025insituarchitecture pages 4-7, lange2025insituarchitecture pages 1-2).</p>
+<h2 id="7-summary">7. Summary</h2>
+<p>PHB-1 in <em>C. elegans</em> is a non-enzymatic, inner mitochondrial membrane scaffold protein that forms an obligate complex with PHB-2. The PHB complex functions as a holdase/chaperone, lipid organizer, and structural scaffold essential for cristae morphogenesis, OXPHOS complex biogenesis, mitochondrial nucleoid stability, and membrane protein quality control. PHB-1 is essential for embryonic development and germline function. Its depletion induces the UPRmt and, depending on the metabolic state of the animal, either shortens or extends lifespan. The complex sits at a central nexus of nutrient-sensing pathways (IIS/DAF-2, TORC2/SGK-1) and mitochondrial stress responses (UPRmt/ATFS-1), modulating lipid metabolism, energy homeostasis, and aging in a context-dependent manner. Through its partner PHB-2, the complex also participates in mitophagy as an inner membrane receptor for LC3. The prohibitin complex thus represents one of the most functionally integrated mitochondrial regulatory assemblies studied in <em>C. elegans</em> biology.</p>
+<p>References</p>
+<ol>
+<li>
+<p>(artalsanz2009prohibitinandmitochondrial pages 1-2): Marta Artal-Sanz and Nektarios Tavernarakis. Prohibitin and mitochondrial biology. Trends in Endocrinology &amp; Metabolism, 20:394-401, Oct 2009. URL: https://doi.org/10.1016/j.tem.2009.04.004, doi:10.1016/j.tem.2009.04.004. This article has 363 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(artalsanz2009prohibitinandmitochondrial pages 4-5): Marta Artal-Sanz and Nektarios Tavernarakis. Prohibitin and mitochondrial biology. Trends in Endocrinology &amp; Metabolism, 20:394-401, Oct 2009. URL: https://doi.org/10.1016/j.tem.2009.04.004, doi:10.1016/j.tem.2009.04.004. This article has 363 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(hernandorodriguez2018mitochondrialqualitycontrol pages 8-10): Blanca Hernando-Rodríguez and Marta Artal-Sanz. Mitochondrial quality control mechanisms and the phb (prohibitin) complex. Cells, Nov 2018. URL: https://doi.org/10.3390/cells7120238, doi:10.3390/cells7120238. This article has 93 citations.</p>
+</li>
+<li>
+<p>(artalsanz2009prohibitinandmitochondrial pages 2-3): Marta Artal-Sanz and Nektarios Tavernarakis. Prohibitin and mitochondrial biology. Trends in Endocrinology &amp; Metabolism, 20:394-401, Oct 2009. URL: https://doi.org/10.1016/j.tem.2009.04.004, doi:10.1016/j.tem.2009.04.004. This article has 363 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(artalsanz2009prohibitinandmitochondrial pages 3-4): Marta Artal-Sanz and Nektarios Tavernarakis. Prohibitin and mitochondrial biology. Trends in Endocrinology &amp; Metabolism, 20:394-401, Oct 2009. URL: https://doi.org/10.1016/j.tem.2009.04.004, doi:10.1016/j.tem.2009.04.004. This article has 363 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(hernandorodriguez2018mitochondrialqualitycontrol pages 10-12): Blanca Hernando-Rodríguez and Marta Artal-Sanz. Mitochondrial quality control mechanisms and the phb (prohibitin) complex. Cells, Nov 2018. URL: https://doi.org/10.3390/cells7120238, doi:10.3390/cells7120238. This article has 93 citations.</p>
+</li>
+<li>
+<p>(lange2025insituarchitecture pages 2-3): Felix Lange, Michael Ratz, Jan-Niklas Dohrke, Maxence Le Vasseur, Dirk Wenzel, Peter Ilgen, Dietmar Riedel, and Stefan Jakobs. In situ architecture of the human prohibitin complex. Nature Cell Biology, 27:633-640, Mar 2025. URL: https://doi.org/10.1038/s41556-025-01620-1, doi:10.1038/s41556-025-01620-1. This article has 39 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(hernandorodriguez2018mitochondrialqualitycontrol pages 16-17): Blanca Hernando-Rodríguez and Marta Artal-Sanz. Mitochondrial quality control mechanisms and the phb (prohibitin) complex. Cells, Nov 2018. URL: https://doi.org/10.3390/cells7120238, doi:10.3390/cells7120238. This article has 93 citations.</p>
+</li>
+<li>
+<p>(lange2025insituarchitecture pages 4-7): Felix Lange, Michael Ratz, Jan-Niklas Dohrke, Maxence Le Vasseur, Dirk Wenzel, Peter Ilgen, Dietmar Riedel, and Stefan Jakobs. In situ architecture of the human prohibitin complex. Nature Cell Biology, 27:633-640, Mar 2025. URL: https://doi.org/10.1038/s41556-025-01620-1, doi:10.1038/s41556-025-01620-1. This article has 39 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(lange2025insituarchitecture pages 1-2): Felix Lange, Michael Ratz, Jan-Niklas Dohrke, Maxence Le Vasseur, Dirk Wenzel, Peter Ilgen, Dietmar Riedel, and Stefan Jakobs. In situ architecture of the human prohibitin complex. Nature Cell Biology, 27:633-640, Mar 2025. URL: https://doi.org/10.1038/s41556-025-01620-1, doi:10.1038/s41556-025-01620-1. This article has 39 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(lourenco2021themitochondrialprohibitin pages 3-5): Artur B. Lourenço and Marta Artal-Sanz. The mitochondrial prohibitin (phb) complex in c. elegans metabolism and ageing regulation. Metabolites, 11:636, Sep 2021. URL: https://doi.org/10.3390/metabo11090636, doi:10.3390/metabo11090636. This article has 16 citations.</p>
+</li>
+<li>
+<p>(lourenco2021themitochondrialprohibitin pages 5-7): Artur B. Lourenço and Marta Artal-Sanz. The mitochondrial prohibitin (phb) complex in c. elegans metabolism and ageing regulation. Metabolites, 11:636, Sep 2021. URL: https://doi.org/10.3390/metabo11090636, doi:10.3390/metabo11090636. This article has 16 citations.</p>
+</li>
+<li>
+<p>(lourenco2021themitochondrialprohibitin pages 2-3): Artur B. Lourenço and Marta Artal-Sanz. The mitochondrial prohibitin (phb) complex in c. elegans metabolism and ageing regulation. Metabolites, 11:636, Sep 2021. URL: https://doi.org/10.3390/metabo11090636, doi:10.3390/metabo11090636. This article has 16 citations.</p>
+</li>
+<li>
+<p>(cruz‐ruiz2021prohibitindepletionextends pages 1-2): Patricia de la Cruz‐Ruiz, Blanca Hernando‐Rodríguez, Mercedes M. Pérez‐Jiménez, María Jesús Rodríguez‐Palero, Manuel D. Martínez‐Bueno, Antoni Pla, Roxani Gatsi, and Marta Artal‐Sanz. Prohibitin depletion extends lifespan of a torc2/sgk‐1 mutant through autophagy and the mitochondrial upr. Aging Cell, May 2021. URL: https://doi.org/10.1111/acel.13359, doi:10.1111/acel.13359. This article has 22 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(gatsi2014prohibitinmediatedlifespanand pages 8-10): Roxani Gatsi, Bettina Schulze, María Jesús Rodríguez-Palero, Blanca Hernando-Rodríguez, Ralf Baumeister, and Marta Artal-Sanz. Prohibitin-mediated lifespan and mitochondrial stress implicate sgk-1, insulin/igf and mtorc2 in c. elegans. PLoS ONE, 9:e107671, Sep 2014. URL: https://doi.org/10.1371/journal.pone.0107671, doi:10.1371/journal.pone.0107671. This article has 55 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(cruz‐ruiz2021prohibitindepletionextends pages 2-4): Patricia de la Cruz‐Ruiz, Blanca Hernando‐Rodríguez, Mercedes M. Pérez‐Jiménez, María Jesús Rodríguez‐Palero, Manuel D. Martínez‐Bueno, Antoni Pla, Roxani Gatsi, and Marta Artal‐Sanz. Prohibitin depletion extends lifespan of a torc2/sgk‐1 mutant through autophagy and the mitochondrial upr. Aging Cell, May 2021. URL: https://doi.org/10.1111/acel.13359, doi:10.1111/acel.13359. This article has 22 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(cruz‐ruiz2021prohibitindepletionextends pages 13-14): Patricia de la Cruz‐Ruiz, Blanca Hernando‐Rodríguez, Mercedes M. Pérez‐Jiménez, María Jesús Rodríguez‐Palero, Manuel D. Martínez‐Bueno, Antoni Pla, Roxani Gatsi, and Marta Artal‐Sanz. Prohibitin depletion extends lifespan of a torc2/sgk‐1 mutant through autophagy and the mitochondrial upr. Aging Cell, May 2021. URL: https://doi.org/10.1111/acel.13359, doi:10.1111/acel.13359. This article has 22 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(artalsanz2009prohibitinandmitochondrial pages 5-7): Marta Artal-Sanz and Nektarios Tavernarakis. Prohibitin and mitochondrial biology. Trends in Endocrinology &amp; Metabolism, 20:394-401, Oct 2009. URL: https://doi.org/10.1016/j.tem.2009.04.004, doi:10.1016/j.tem.2009.04.004. This article has 363 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(fernandezabascal<em>2023twoconservedtranscription pages 4-7): Jesús Fernandez-Abascal</em>, Blanca Hernando-Rodríguez*, María Jesús Rodríguez-Palero, Aitor Jarit-Cabanillas, Manuel D. Martínez-Bueno, Mercedes M. Pérez-Jiménez, Enrique J. Clavijo-Bernal, Aitana Cambón, Ildefonso Cases, and Marta Artal-Sanz. Two conserved transcription factors and a histone deubiquitinase regulate the mitochondrial unfolded protein response and longevity interacting with insulin signalling. Unknown journal, Oct 2025. URL: https://doi.org/10.21203/rs.3.rs-3337719/v1, doi:10.21203/rs.3.rs-3337719/v1.</p>
+</li>
+<li>
+<p>(fernandezabascal<em>2023twoconservedtranscription pages 1-4): Jesús Fernandez-Abascal</em>, Blanca Hernando-Rodríguez*, María Jesús Rodríguez-Palero, Aitor Jarit-Cabanillas, Manuel D. Martínez-Bueno, Mercedes M. Pérez-Jiménez, Enrique J. Clavijo-Bernal, Aitana Cambón, Ildefonso Cases, and Marta Artal-Sanz. Two conserved transcription factors and a histone deubiquitinase regulate the mitochondrial unfolded protein response and longevity interacting with insulin signalling. Unknown journal, Oct 2025. URL: https://doi.org/10.21203/rs.3.rs-3337719/v1, doi:10.21203/rs.3.rs-3337719/v1.</p>
+</li>
+<li>
+<p>(gatsi2014prohibitinmediatedlifespanand pages 1-2): Roxani Gatsi, Bettina Schulze, María Jesús Rodríguez-Palero, Blanca Hernando-Rodríguez, Ralf Baumeister, and Marta Artal-Sanz. Prohibitin-mediated lifespan and mitochondrial stress implicate sgk-1, insulin/igf and mtorc2 in c. elegans. PLoS ONE, 9:e107671, Sep 2014. URL: https://doi.org/10.1371/journal.pone.0107671, doi:10.1371/journal.pone.0107671. This article has 55 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(gatsi2014prohibitinmediatedlifespanand pages 2-3): Roxani Gatsi, Bettina Schulze, María Jesús Rodríguez-Palero, Blanca Hernando-Rodríguez, Ralf Baumeister, and Marta Artal-Sanz. Prohibitin-mediated lifespan and mitochondrial stress implicate sgk-1, insulin/igf and mtorc2 in c. elegans. PLoS ONE, 9:e107671, Sep 2014. URL: https://doi.org/10.1371/journal.pone.0107671, doi:10.1371/journal.pone.0107671. This article has 55 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(wei2017prohibitin2is pages 1-3): Yongjie Wei, Wei-Chung Chiang, Rhea Sumpter, Prashant Mishra, and Beth Levine. Prohibitin 2 is an inner mitochondrial membrane mitophagy receptor. Cell, 168:224-238.e10, Jan 2017. URL: https://doi.org/10.1016/j.cell.2016.11.042, doi:10.1016/j.cell.2016.11.042. This article has 932 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(lourenco2021themitochondrialprohibitin pages 12-13): Artur B. Lourenço and Marta Artal-Sanz. The mitochondrial prohibitin (phb) complex in c. elegans metabolism and ageing regulation. Metabolites, 11:636, Sep 2021. URL: https://doi.org/10.3390/metabo11090636, doi:10.3390/metabo11090636. This article has 16 citations.</p>
+</li>
+<li>
+<p>(wei2017prohibitin2is pages 12-13): Yongjie Wei, Wei-Chung Chiang, Rhea Sumpter, Prashant Mishra, and Beth Levine. Prohibitin 2 is an inner mitochondrial membrane mitophagy receptor. Cell, 168:224-238.e10, Jan 2017. URL: https://doi.org/10.1016/j.cell.2016.11.042, doi:10.1016/j.cell.2016.11.042. This article has 932 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(wei2017prohibitin2is pages 4-5): Yongjie Wei, Wei-Chung Chiang, Rhea Sumpter, Prashant Mishra, and Beth Levine. Prohibitin 2 is an inner mitochondrial membrane mitophagy receptor. Cell, 168:224-238.e10, Jan 2017. URL: https://doi.org/10.1016/j.cell.2016.11.042, doi:10.1016/j.cell.2016.11.042. This article has 932 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(lahiri2017phb2prohibitin2an pages 1-2): Vikramjit Lahiri and Daniel J Klionsky. Phb2/prohibitin 2: an inner membrane mitophagy receptor. Cell Research, 27:311-312, Feb 2017. URL: https://doi.org/10.1038/cr.2017.23, doi:10.1038/cr.2017.23. This article has 62 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(qi2023essentialproteinphb2 pages 5-6): Amanda Qi, Lillie Lamont, Evelyn Liu, Sarina D. Murray, Xiangbing Meng, and Shujie Yang. Essential protein phb2 and its regulatory mechanisms in cancer. Cells, 12:1211, Apr 2023. URL: https://doi.org/10.3390/cells12081211, doi:10.3390/cells12081211. This article has 34 citations.</p>
+</li>
+<li>
+<p>(belser2021roleofprohibitins pages 1-2): Misa Belser and David W. Walker. Role of prohibitins in aging and therapeutic potential against age-related diseases. Frontiers in Genetics, Oct 2021. URL: https://doi.org/10.3389/fgene.2021.714228, doi:10.3389/fgene.2021.714228. This article has 27 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(gatsi2014prohibitinmediatedlifespanand pages 3-4): Roxani Gatsi, Bettina Schulze, María Jesús Rodríguez-Palero, Blanca Hernando-Rodríguez, Ralf Baumeister, and Marta Artal-Sanz. Prohibitin-mediated lifespan and mitochondrial stress implicate sgk-1, insulin/igf and mtorc2 in c. elegans. PLoS ONE, 9:e107671, Sep 2014. URL: https://doi.org/10.1371/journal.pone.0107671, doi:10.1371/journal.pone.0107671. This article has 55 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(gatsi2014prohibitinmediatedlifespanand pages 6-8): Roxani Gatsi, Bettina Schulze, María Jesús Rodríguez-Palero, Blanca Hernando-Rodríguez, Ralf Baumeister, and Marta Artal-Sanz. Prohibitin-mediated lifespan and mitochondrial stress implicate sgk-1, insulin/igf and mtorc2 in c. elegans. PLoS ONE, 9:e107671, Sep 2014. URL: https://doi.org/10.1371/journal.pone.0107671, doi:10.1371/journal.pone.0107671. This article has 55 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(lourenco2021themitochondrialprohibitin pages 7-8): Artur B. Lourenço and Marta Artal-Sanz. The mitochondrial prohibitin (phb) complex in c. elegans metabolism and ageing regulation. Metabolites, 11:636, Sep 2021. URL: https://doi.org/10.3390/metabo11090636, doi:10.3390/metabo11090636. This article has 16 citations.</p>
+</li>
+</ol>
+<h2 id="artifacts">Artifacts</h2>
+<ul>
+<li><a href="phb-1-deep-research-falcon_artifacts/artifact-00.md">Edison artifact artifact-00</a></li>
+<li><a href="phb-1-deep-research-falcon_artifacts/artifact-01.md">Edison artifact artifact-01</a></li>
+</ul>
+<h2 id="citations">Citations</h2>
+<ol>
+<li>artalsanz2009prohibitinandmitochondrial pages 1-2</li>
+<li>lange2025insituarchitecture pages 4-7</li>
+<li>lange2025insituarchitecture pages 1-2</li>
+<li>lange2025insituarchitecture pages 2-3</li>
+<li>hernandorodriguez2018mitochondrialqualitycontrol pages 10-12</li>
+<li>artalsanz2009prohibitinandmitochondrial pages 3-4</li>
+<li>artalsanz2009prohibitinandmitochondrial pages 2-3</li>
+<li>hernandorodriguez2018mitochondrialqualitycontrol pages 8-10</li>
+<li>artalsanz2009prohibitinandmitochondrial pages 4-5</li>
+<li>lourenco2021themitochondrialprohibitin pages 2-3</li>
+<li>lourenco2021themitochondrialprohibitin pages 3-5</li>
+<li>lourenco2021themitochondrialprohibitin pages 5-7</li>
+<li>lourenco2021themitochondrialprohibitin pages 7-8</li>
+<li>hernandorodriguez2018mitochondrialqualitycontrol pages 16-17</li>
+<li>gatsi2014prohibitinmediatedlifespanand pages 8-10</li>
+<li>artalsanz2009prohibitinandmitochondrial pages 5-7</li>
+<li>gatsi2014prohibitinmediatedlifespanand pages 1-2</li>
+<li>gatsi2014prohibitinmediatedlifespanand pages 2-3</li>
+<li>lourenco2021themitochondrialprohibitin pages 12-13</li>
+<li>belser2021roleofprohibitins pages 1-2</li>
+<li>gatsi2014prohibitinmediatedlifespanand pages 3-4</li>
+<li>gatsi2014prohibitinmediatedlifespanand pages 6-8</li>
+<li>https://doi.org/10.1016/j.tem.2009.04.004,</li>
+<li>https://doi.org/10.3390/cells7120238,</li>
+<li>https://doi.org/10.1038/s41556-025-01620-1,</li>
+<li>https://doi.org/10.3390/metabo11090636,</li>
+<li>https://doi.org/10.1111/acel.13359,</li>
+<li>https://doi.org/10.1371/journal.pone.0107671,</li>
+<li>https://doi.org/10.21203/rs.3.rs-3337719/v1,</li>
+<li>https://doi.org/10.1016/j.cell.2016.11.042,</li>
+<li>https://doi.org/10.1038/cr.2017.23,</li>
+<li>https://doi.org/10.3390/cells12081211,</li>
+<li>https://doi.org/10.3389/fgene.2021.714228,</li>
+</ol>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(phb-1-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="Q9BKU4" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="phb-1-caenorhabditis-elegans-research-notes">phb-1 (Caenorhabditis elegans) — research notes</h1>
+<p>UniProt: Q9BKU4 (PHB1_CAEEL). WormBase: WBGene00004014 / Y37E3.9.<br />
+Gene name: phb-1 ("Mitochondrial prohibitin complex protein 1", prohibitin-1).<br />
+275 aa; single Band_7/SPFH (prohibitin/stomatin) domain (PF01145; IPR000163);<br />
+predicted coiled coil (residues 180–213). PANTHER family PTHR23222 (PROHIBITIN),<br />
+subfamily PTHR23222:SF0 (PROHIBITIN 1). ComplexPortal CPX-4114 (Prohibitin complex).</p>
+<h2 id="one-line-summary">One-line summary</h2>
+<p>phb-1 is one of the two obligate subunits (with phb-2) of the mitochondrial<br />
+prohibitin (PHB) complex, a ring-shaped, high-molecular-weight assembly in the<br />
+mitochondrial inner membrane. The complex — not the isolated subunit — is the<br />
+functional unit; loss of either subunit abolishes the whole complex.</p>
+<h2 id="known-well-supported">KNOWN (well supported)</h2>
+<ul>
+<li>
+<p><strong>Obligate heterodimeric/ring complex with phb-2 in the mitochondrial inner<br />
+  membrane.</strong> "Prohibitins in eukaryotes consist of two subunits (PHB1 and PHB2)<br />
+  that together form a high molecular weight complex in the mitochondrial inner<br />
+  membrane" and, in worm, "prohibitins in C. elegans form a high molecular weight<br />
+  complex in the mitochondrial inner membrane similar to that of yeast and humans"<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/12794069" title="prohibitins in C. elegans form a high molecular weight complex in the mitochondrial inner membrane similar to that of yeast and humans">PMID:12794069</a>.<br />
+  The two subunits "bind to each other to form a heterodimer that is assembled into<br />
+  a ring-like macromolecular structure at the inner mitochondrial membrane" and are<br />
+  "interdependent for the formation of the complex, leading the absence of one of<br />
+  them to the absence of the whole complex"<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/26092086" title="which bind to each other to form a heterodimer that is assembled into a ring-like macromolecular structure at the inner mitochondrial membrane">PMID:26092086</a><br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/26092086" title="These two subunits are interdependent for the formation of the complex, leading the absence of one of them to the absence of the whole complex">PMID:26092086</a>.<br />
+  Basis for GO:0035632 (mitochondrial prohibitin complex), GO:0005743 (mitochondrial<br />
+  inner membrane). The IPI part_of annotation (PMID:19812672) is with phb-2<br />
+  (WB:WBGene00004015).</p>
+</li>
+<li>
+<p><strong>Essential for embryonic viability and germline/gonad development.</strong> RNAi against<br />
+  phb-1 or phb-2 "PHB proteins are essential during embryonic development and are<br />
+  required for somatic and germline differentiation in the larval gonad"<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/12794069" title="PHB proteins are essential during embryonic development and are required for somatic and germline differentiation in the larval gonad">PMID:12794069</a>.<br />
+  Restated later: prohibitin depletion "gives rise to a wide range of somatic and<br />
+  germline defects, spanning from complete sterility to severely reduce brood sizes<br />
+  and a morphologically abnormal somatic gonad"<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/26092086" title="gives rise to a wide range of somatic and germline defects, spanning from complete sterility to severely reduce brood sizes and a morphologically abnormal somatic gonad">PMID:26092086</a>.<br />
+  Basis for the WB IMP annotations to embryo development (GO:0009792), gonad<br />
+  development (GO:0008406), oogenesis (GO:0048477), spermatogenesis (GO:0007283).</p>
+</li>
+<li>
+<p><strong>Altered mitochondrial biogenesis / organization on depletion.</strong> "a deficiency in<br />
+  PHB proteins results in altered mitochondrial biogenesis in body wall muscle<br />
+  cells" <a href="https://pubmed.ncbi.nlm.nih.gov/12794069" title="a deficiency in PHB proteins results in altered mitochondrial biogenesis in body wall muscle cells">PMID:12794069</a>.<br />
+  Basis for GO:0007005 (mitochondrion organization). PHB-2 knockdown "influences ...<br />
+  mitochondrial proliferation" <a href="https://pubmed.ncbi.nlm.nih.gov/19812672" title="animal fat content and mitochondrial proliferation in a genetic-background- and age-specific manner">PMID:19812672</a>.</p>
+</li>
+<li>
+<p><strong>Context-dependent modulator of longevity, coupling to insulin/diapause signalling<br />
+  and fat metabolism.</strong> "the mitochondrial prohibitin complex promotes longevity by<br />
+  modulating mitochondrial function and fat metabolism in the nematode Caenorhabditis<br />
+  elegans"; "prohibitin deficiency shortens the lifespan of otherwise wild-type<br />
+  animals" but "knockdown of prohibitin promotes longevity in diapause mutants or<br />
+  under conditions of dietary restriction"<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/19812672" title="prohibitin deficiency shortens the lifespan of otherwise wild-type">PMID:19812672</a><br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/19812672" title="knockdown of prohibitin promotes longevity in diapause mutants or under conditions of dietary restriction">PMID:19812672</a>.<br />
+  Later restated with genotype: "prohibitin deficiency shortens the lifespan of<br />
+  otherwise wild type nematodes, while it dramatically extends the lifespan of the<br />
+  already long-lived daf-2(e1370) insulin receptor mutants"<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/26092086" title="while it dramatically extends the lifespan of the already long-lived daf-2(e1370) insulin receptor mutants">PMID:26092086</a>.<br />
+  Depletion "influences ATP levels, animal fat content and mitochondrial<br />
+  proliferation in a genetic-background- and age-specific manner"<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/19812672" title="Depletion of prohibitin influences ATP levels, animal fat content and mitochondrial proliferation">PMID:19812672</a>.</p>
+</li>
+<li>
+<p><strong>Proposed complex-level molecular roles (from yeast/mammalian work, invoked for<br />
+  the worm complex):</strong> membrane-bound chaperone that stabilizes newly synthesized<br />
+  mitochondrial-encoded respiratory subunits, and/or membrane scaffold that recruits<br />
+  membrane proteins to a specific lipid environment.<br />
+  "The PHB complex has been shown to play a role in the stabilization of newly<br />
+  synthesized subunits of mitochondrial respiratory enzymes in the yeast<br />
+  Saccharomyces cerevisiae"<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/12794069" title="the stabilization of newly synthesized subunits of mitochondrial respiratory enzymes in the yeast Saccharomyces cerevisiae">PMID:12794069</a>.<br />
+  "Several roles have been proposed for the mitochondrial prohibitin complex,<br />
+  including a role as a membrane-bound chaperone, which holds and stabilizes newly<br />
+  synthesised mitochondrial-encoded proteins ... and as scaffold proteins that<br />
+  recruit membrane proteins to a specific lipid environment"<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/26092086" title="a membrane-bound chaperone, which holds and stabilizes newly synthesised mitochondrial-encoded proteins">PMID:26092086</a><br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/26092086" title="as scaffold proteins that recruit membrane proteins to a specific lipid environment">PMID:26092086</a>.<br />
+  Basis for GO:0050821 (protein stabilization, NAS). Note the qualifier: these are<br />
+<em>proposed</em> roles imported largely from yeast/human, not directly demonstrated<br />
+  biochemically in worm.</p>
+</li>
+</ul>
+<h2 id="not-known-debated-knowledge-gaps">NOT known / debated (knowledge gaps)</h2>
+<ul>
+<li>
+<p><strong>The molecular mechanism of the prohibitin complex is genuinely unresolved.</strong><br />
+  The 2015 metabolome paper states plainly: "the true function of the mitochondrial<br />
+  prohibitin complex remains elusive"<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/26092086" title="the true function of the mitochondrial prohibitin complex remains elusive">PMID:26092086</a>.<br />
+  Whether the complex works primarily as (a) a membrane-bound chaperone/holdase for<br />
+  nascent inner-membrane proteins, (b) a scaffold that organizes a specific<br />
+  cardiolipin/phospholipid microdomain and recruits client membrane proteins, or<br />
+  (c) a regulator of the m-AAA protease (SPG-7/paraplegin) is not settled — the<br />
+  literature proposes all three but demonstrates none as <em>the</em> mechanism in worm.<br />
+  This is both a genuine biology gap and an ontology gap: "be the structural PHB<br />
+  ring / organize an IMM lipid-protein microdomain" has no adequate GO molecular<br />
+  function term, so a structural subunit reads as MF-dark.</p>
+</li>
+<li>
+<p><strong>How the SAME depletion produces OPPOSITE ageing outcomes</strong> (life-shortening in WT<br />
+  vs life-extending in daf-2 / DR / mitochondrial mutants) is mechanistically<br />
+  unexplained — the metabolic node the complex sits on is not defined.</p>
+</li>
+</ul>
+<h2 id="annotation-relevant-reasoning">Annotation-relevant reasoning</h2>
+<ul>
+<li>The 11 WB IMP annotations (PMID:12794069) and the 11 ARBA IEA annotations<br />
+  (GO_REF:0000117) are pairwise redundant on the same term set (regulation of<br />
+  oxidative phosphorylation, response to oxidative stress, mitochondrion<br />
+  organization, spermatogenesis, gonad development, embryo development, defecation,<br />
+  positive regulation of multicellular organism growth, regulation of nematode<br />
+  pharyngeal pumping, oogenesis). The ARBA rules appear to recapitulate the C.<br />
+  elegans phenotype literature. The IEA rows are redundant electronic echoes of the<br />
+  experimental IMP rows.</li>
+<li>Many of the IMP phenotype terms (defecation, pharyngeal pumping, positive<br />
+  regulation of growth, spermatogenesis, oogenesis, oxidative stress response) are<br />
+<strong>downstream/pleiotropic consequences</strong> of losing an essential mitochondrial<br />
+  complex, not evidence of a dedicated phb-1 role in each named process. These are<br />
+  best kept as NON-core (pleiotropy of an essential mito gene) rather than as core<br />
+  functions. The abstract of PMID:12794069 supports embryonic + germline/gonad +<br />
+  mitochondrial biogenesis phenotypes directly; the more specific behavioural terms<br />
+  (defecation, pharyngeal pumping) are in the full text, which curators read — do<br />
+  not REMOVE, keep as non-core.</li>
+<li>Core: complex membership (GO:0035632), IMM localization (GO:0005743),<br />
+  mitochondrion organization (GO:0007005), protein stabilization (GO:0050821 —<br />
+  complex-level chaperone role). Structural-subunit MF ≈ structural molecule<br />
+  activity (GO:0005198); the complex's true activity is the ontology/biology gap.</li>
+</ul>
+<h2 id="provenance-sources">Provenance / sources</h2>
+<ul>
+<li>PMID:12794069 — Artal-Sanz et al. 2003, J Biol Chem (RNAi phenotype; complex; IMM).<br />
+  Abstract-only in cache; curators (WB) read full text for the IMP/IDA rows.</li>
+<li>PMID:19812672 — Artal-Sanz &amp; Tavernarakis 2009, Nature (longevity/diapause/fat).<br />
+  Abstract-only in cache. Source of IPI complex annotation (with phb-2).</li>
+<li>PMID:26092086 — Lourenço et al. 2015, BBA Bioenergetics (metabolome; full text in<br />
+  cache). Source of ComplexPortal IDA/NAS rows; richest verbatim source.</li>
+<li>UniProt Q9BKU4; PANTHER PTHR23222; ComplexPortal CPX-4114.</li>
+</ul>
+<h2 id="falcon-deep-research-synthesis-phb-1-deep-research-falconmd-33-citations">Falcon deep-research synthesis (phb-1-deep-research-falcon.md, 33 citations)</h2>
+<p>The falcon report (Edison Scientific; genuine, 20-min run) reinforces and enriches<br />
+the picture above. Additional mechanistic context (grounded in review/primary<br />
+literature cited there; not all in our cached PMIDs, so used as context only, not as<br />
+verbatim supporting_text in the YAML):</p>
+<ul>
+<li><strong>Membrane-bound scaffold + holdase/chaperone</strong>: "PHB-1 is not an enzyme,<br />
+  transporter, or signaling receptor. Rather, it functions as a membrane-bound<br />
+  scaffold and holdase/unfoldase-type chaperone within the inner mitochondrial<br />
+  membrane" and "Its precise biochemical activity has remained challenging to<br />
+  define" — direct confirmation of the MF-dark ontology/biology gap I recorded.</li>
+<li><strong>m-AAA protease / OPA1 / cristae</strong>: the complex physically interacts with the<br />
+  m-AAA proteases (SPG-7/paraplegin; AFG3L2) and restrains OMA1, stabilizing long<br />
+  OPA1 (worm EAT-3) isoforms; loss → aberrant OPA1 processing, cristae disruption,<br />
+  mitochondrial fragmentation (matches the "altered mitochondrial biogenesis"<br />
+  phenotype in Artal-Sanz 2003). [Hernando-Rodríguez &amp; Artal-Sanz 2018, Cells;<br />
+  DOI 10.3390/cells7120238]</li>
+<li><strong>Lipid organization</strong>: interacts with cardiolipin / phosphatidylethanolamine<br />
+  metabolism; the SPFH domain may bind lipids (not biochemically proven) — one arm<br />
+  of the scaffold-vs-chaperone-vs-lipid-organizer debate.</li>
+<li><strong>Nucleoid / mtDNA</strong>: associates with nucleoids (with ATAD3/TFAM); depletion<br />
+  reduces mitochondrial protein synthesis.</li>
+<li><strong>Mitophagy is via PHB-2, not phb-1 directly</strong>: PHB-2 is the IMM LC3 receptor<br />
+  (LIR motif); phb-1 participates only through the heterocomplex. This is why<br />
+  phb-1 appears in the CAEEL_MITOPHAGY flagship (as part of import/proteostasis).<br />
+  [Wei et al. 2017, Cell]</li>
+<li><strong>Context-dependent longevity mechanism</strong> (the second knowledge gap): PHB<br />
+  depletion shortens WT lifespan but extends it in daf-2 (IIS), sgk-1 and rict-1<br />
+  (TORC2) mutants and under dietary restriction; SGK-1 is a major determinant;<br />
+  requires UPRmt + autophagy (not mitophagy) and SREBP/SBP-1; strongly induces<br />
+  UPRmt via ATFS-1. [Gatsi 2014 PLoS ONE 10.1371/journal.pone.0107671;<br />
+  de la Cruz-Ruiz 2021 Aging Cell 10.1111/acel.13359; Lourenço &amp; Artal-Sanz 2021<br />
+  Metabolites 10.3390/metabo11090636]</li>
+<li><strong>2025 in situ structure</strong>: cryo-ET resolved the human PHB complex as a<br />
+  bell-shaped 11-subunit alternating PHB1/PHB2 assembly (~190 Å), refining the<br />
+  older "12–16 heterodimer ~1 MDa ring" model; worm stoichiometry not independently<br />
+  resolved. [Lange et al. 2025, Nat Cell Biol 10.1038/s41556-025-01620-1]</li>
+</ul>
+<p>None of these change the GOA annotation actions; they corroborate keeping the<br />
+complex/localization/mito-organization/protein-stabilization terms as core and the<br />
+developmental/behavioural terms as pleiotropic non-core, and they sharpen the two<br />
+recorded knowledge gaps (mechanism; opposite-longevity node).</p>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: Q9BKU4
+gene_symbol: phb-1
+product_type: PROTEIN
+status: COMPLETE
+taxon:
+  id: NCBITaxon:6239
+  label: Caenorhabditis elegans
+description: &gt;-
+  phb-1 encodes prohibitin-1, one of the two subunits (with phb-2) of the
+  mitochondrial prohibitin (PHB) complex, a ring-shaped, high-molecular-weight
+  assembly embedded in the inner mitochondrial membrane. PHB-1 and PHB-2 are
+  mutually dependent: they bind each other to form heterodimers that oligomerize
+  into the ring, and loss of either subunit destabilizes the entire complex. The
+  protein belongs to the SPFH/Band-7 (stomatin/prohibitin) superfamily. The
+  complex is proposed to act as a membrane-bound chaperone that holds and
+  stabilizes newly synthesized mitochondrial-encoded respiratory-chain proteins
+  and/or as a scaffold that organizes inner-membrane proteins within a defined
+  lipid environment. In C. elegans the complex is essential: depletion of phb-1
+  blocks embryonic development, disrupts somatic and germline differentiation of
+  the gonad, and alters mitochondrial biogenesis in body-wall muscle. Beyond this
+  essential developmental role, the prohibitin complex is a context-dependent
+  modulator of ageing that couples mitochondrial metabolism and fat utilization to
+  insulin/IGF (daf-2) and dietary-restriction signalling: its depletion shortens
+  the lifespan of otherwise wild-type animals but extends the lifespan of diapause,
+  dietary-restricted, and respiration- or fat-metabolism-compromised animals.
+existing_annotations:
+- term:
+    id: GO:0005739
+    label: mitochondrion
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: is_active_in
+  review:
+    summary: &gt;-
+      Correct but general mitochondrial localization inferred phylogenetically.
+      The more specific inner-membrane and prohibitin-complex localizations are
+      experimentally supported and separately annotated, so this broad term is
+      retained as non-core.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      phb-1 is a bona fide mitochondrial protein, so the term is not wrong, but
+      GO:0005743 (mitochondrial inner membrane) and GO:0035632 (mitochondrial
+      prohibitin complex) are the informative, experimentally supported
+      localizations for this subunit.
+- term:
+    id: GO:0007005
+    label: mitochondrion organization
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Phylogenetic inference that phb-1 acts in mitochondrion organization,
+      corroborated by experimental (IMP) and author-statement (NAS) annotations
+      for the same term. A core process for this gene.
+    action: ACCEPT
+    reason: &gt;-
+      Consistent with the experimentally demonstrated requirement of the PHB
+      complex for normal mitochondrial biogenesis/organization.
+    supported_by:
+    - reference_id: PMID:12794069
+      supporting_text: &gt;-
+        a deficiency in PHB proteins results in altered mitochondrial biogenesis
+        in body wall muscle cells
+      reference_section_type: ABSTRACT
+- term:
+    id: GO:0002082
+    label: regulation of oxidative phosphorylation
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000117
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Electronic (ARBA) annotation that mirrors the experimental WB IMP annotation
+      to the same term. Biologically defensible given the conserved role of
+      prohibitins in stabilizing respiratory-chain subunits, but it is a downstream
+      consequence of complex loss rather than a dedicated phb-1 activity.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Redundant electronic echo of the experimental IMP annotation (PMID:12794069);
+      effect on oxidative phosphorylation is an indirect consequence of losing an
+      essential inner-membrane complex, so it is non-core.
+- term:
+    id: GO:0005743
+    label: mitochondrial inner membrane
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000044
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Electronic subcellular-location mapping to the mitochondrial inner membrane,
+      independently confirmed by experimental IDA evidence. This is the correct,
+      core localization of the PHB complex.
+    action: ACCEPT
+    reason: &gt;-
+      The inner-membrane localization is experimentally established (see the
+      ComplexPortal IDA annotation) and matches the UniProt SUBCELLULAR LOCATION.
+    supported_by:
+    - reference_id: PMID:12794069
+      supporting_text: &gt;-
+        prohibitins in C. elegans form a high molecular weight complex in the
+        mitochondrial inner membrane similar to that of yeast and humans
+      reference_section_type: ABSTRACT
+- term:
+    id: GO:0006979
+    label: response to oxidative stress
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000117
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Electronic (ARBA) annotation mirroring the WB IMP annotation. Altered
+      oxidative-stress sensitivity is a plausible but indirect consequence of
+      impaired mitochondrial function in prohibitin-depleted animals.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Redundant with the experimental IMP annotation (PMID:12794069); pleiotropic
+      downstream phenotype of an essential mitochondrial gene, not a core function.
+- term:
+    id: GO:0007283
+    label: spermatogenesis
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000117
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Electronic (ARBA) annotation mirroring the WB IMP germline phenotype.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Redundant with the experimental IMP annotation (PMID:12794069); germline/
+      spermatogenesis defects are a pleiotropic consequence of depleting an
+      essential mitochondrial complex, not a dedicated phb-1 function.
+- term:
+    id: GO:0008406
+    label: gonad development
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000117
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Electronic (ARBA) annotation mirroring the WB IMP gonad phenotype.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Redundant with the experimental IMP annotation (PMID:12794069); pleiotropic
+      developmental consequence of losing the essential PHB complex.
+- term:
+    id: GO:0009792
+    label: embryo development ending in birth or egg hatching
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000117
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Electronic (ARBA) annotation mirroring the WB IMP embryonic-lethality
+      phenotype.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Redundant with the experimental IMP annotation (PMID:12794069); embryonic
+      arrest reflects the essentiality of the complex rather than a dedicated
+      embryogenesis function of phb-1.
+- term:
+    id: GO:0016020
+    label: membrane
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Generic InterPro-to-GO membrane localization. Uninformative given that the
+      specific mitochondrial inner-membrane localization is experimentally
+      established.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      GO:0016020 (membrane) is an over-general parent; the informative and correct
+      localization GO:0005743 (mitochondrial inner membrane) is already annotated.
+- term:
+    id: GO:0030421
+    label: defecation
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000117
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Electronic (ARBA) annotation mirroring the WB IMP behavioural phenotype.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Redundant with the experimental IMP annotation (PMID:12794069); altered
+      defecation is a pleiotropic behavioural consequence of mitochondrial
+      dysfunction, not a core molecular role.
+- term:
+    id: GO:0040018
+    label: positive regulation of multicellular organism growth
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000117
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Electronic (ARBA) annotation mirroring the WB IMP body-size/growth
+      phenotype.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Redundant with the experimental IMP annotation (PMID:12794069); reduced
+      growth on prohibitin depletion is a systemic consequence of impaired
+      mitochondrial function, not a dedicated function.
+- term:
+    id: GO:0043051
+    label: regulation of nematode pharyngeal pumping
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000117
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Electronic (ARBA) annotation mirroring the WB IMP behavioural phenotype.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Redundant with the experimental IMP annotation (PMID:12794069); pharyngeal
+      pumping change is a pleiotropic behavioural consequence, not a core function.
+- term:
+    id: GO:0048477
+    label: oogenesis
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000117
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Electronic (ARBA) annotation mirroring the WB IMP germline phenotype.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Redundant with the experimental IMP annotation (PMID:12794069); oogenesis
+      defects are a pleiotropic consequence of losing the essential PHB complex.
+- term:
+    id: GO:0005743
+    label: mitochondrial inner membrane
+  evidence_type: IDA
+  original_reference_id: PMID:26092086
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Direct experimental evidence (ComplexPortal curation) that the PHB complex,
+      of which phb-1 is a subunit, resides in the mitochondrial inner membrane.
+      Core localization.
+    action: ACCEPT
+    reason: &gt;-
+      Established inner-membrane localization; the heterodimer assembles into a
+      ring embedded in the inner mitochondrial membrane.
+    supported_by:
+    - reference_id: PMID:26092086
+      supporting_text: &gt;-
+        which bind to each other to form a heterodimer that is assembled into a
+        ring-like macromolecular structure at the inner mitochondrial membrane
+      reference_section_type: INTRODUCTION
+- term:
+    id: GO:0007005
+    label: mitochondrion organization
+  evidence_type: NAS
+  original_reference_id: PMID:26092086
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Author-stated involvement of the PHB complex in mitochondrion organization,
+      consistent with the experimental IMP annotation. Core process.
+    action: ACCEPT
+    reason: &gt;-
+      Prohibitin depletion perturbs mitochondrial biogenesis/organization; a
+      well-supported core role.
+    supported_by:
+    - reference_id: PMID:12794069
+      supporting_text: &gt;-
+        a deficiency in PHB proteins results in altered mitochondrial biogenesis
+        in body wall muscle cells
+      reference_section_type: ABSTRACT
+- term:
+    id: GO:0035632
+    label: mitochondrial prohibitin complex
+  evidence_type: IDA
+  original_reference_id: PMID:26092086
+  qualifier: part_of
+  review:
+    summary: &gt;-
+      Direct evidence that phb-1 is part of the mitochondrial prohibitin complex.
+      This complex membership is the defining, primary core annotation for phb-1.
+    action: ACCEPT
+    reason: &gt;-
+      phb-1 and phb-2 form the obligate ring complex; membership is experimentally
+      established and the two subunits are interdependent for its formation.
+    supported_by:
+    - reference_id: PMID:26092086
+      supporting_text: &gt;-
+        These two subunits are interdependent for the formation of the complex,
+        leading the absence of one of them to the absence of the whole complex
+      reference_section_type: INTRODUCTION
+- term:
+    id: GO:0050821
+    label: protein stabilization
+  evidence_type: NAS
+  original_reference_id: PMID:26092086
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Author-stated role of the PHB complex as a membrane-bound chaperone that
+      holds and stabilizes newly synthesized mitochondrial-encoded proteins. This
+      is the closest capture of the complex&#39;s candidate molecular role, though it
+      is a proposed (largely yeast/human-derived) function rather than one
+      biochemically demonstrated in worm.
+    action: ACCEPT
+    reason: &gt;-
+      Represents the proposed complex-level chaperone/holdase activity; retained
+      as a candidate core function, with the caveat that the true molecular
+      mechanism remains debated (see knowledge_gaps).
+    supported_by:
+    - reference_id: PMID:26092086
+      supporting_text: &gt;-
+        a membrane-bound chaperone, which holds and stabilizes newly synthesised
+        mitochondrial-encoded proteins
+      reference_section_type: INTRODUCTION
+- term:
+    id: GO:0035632
+    label: mitochondrial prohibitin complex
+  evidence_type: IPI
+  original_reference_id: PMID:19812672
+  qualifier: part_of
+  review:
+    summary: &gt;-
+      Physical-interaction evidence (with phb-2, WB:WBGene00004015) that phb-1 is
+      part of the mitochondrial prohibitin complex. Direct support for the obligate
+      phb-1/phb-2 partnership.
+    action: ACCEPT
+    reason: &gt;-
+      Confirms the direct phb-1/phb-2 interaction that constitutes the ring
+      complex; a defining core annotation.
+    supported_by:
+    - reference_id: PMID:19812672
+      supporting_text: &gt;-
+        form a ring-like, high-molecular-mass complex at the inner membrane of
+        mitochondria
+      reference_section_type: ABSTRACT
+- term:
+    id: GO:0002082
+    label: regulation of oxidative phosphorylation
+  evidence_type: IMP
+  original_reference_id: PMID:12794069
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Experimental (RNAi) evidence linking prohibitin depletion to altered
+      oxidative phosphorylation, consistent with the conserved role of the complex
+      in stabilizing respiratory-chain subunits. An indirect, non-core consequence
+      of losing the essential complex.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Full-text-based experimental annotation (retained, not removed); effect on
+      oxidative phosphorylation reflects downstream respiratory-chain destabilization
+      rather than a dedicated regulatory activity of phb-1.
+- term:
+    id: GO:0006979
+    label: response to oxidative stress
+  evidence_type: IMP
+  original_reference_id: PMID:12794069
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Experimental (RNAi) evidence of altered oxidative-stress response upon
+      prohibitin depletion. Pleiotropic consequence of mitochondrial dysfunction.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Retained as an experimental annotation; oxidative-stress phenotype is an
+      indirect consequence of impaired mitochondrial function, not a core role.
+- term:
+    id: GO:0007005
+    label: mitochondrion organization
+  evidence_type: IMP
+  original_reference_id: PMID:12794069
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Experimental (RNAi) evidence that prohibitin depletion alters mitochondrial
+      biogenesis/organization in body-wall muscle. Core process for phb-1.
+    action: ACCEPT
+    reason: &gt;-
+      Directly supported by the observed mitochondrial-biogenesis defect; a core
+      function of the complex.
+    supported_by:
+    - reference_id: PMID:12794069
+      supporting_text: &gt;-
+        a deficiency in PHB proteins results in altered mitochondrial biogenesis
+        in body wall muscle cells
+      reference_section_type: ABSTRACT
+- term:
+    id: GO:0007283
+    label: spermatogenesis
+  evidence_type: IMP
+  original_reference_id: PMID:12794069
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Experimental (RNAi) germline phenotype. Pleiotropic developmental
+      consequence of depleting the essential PHB complex.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Retained as an experimental annotation; germline/spermatogenesis defects
+      follow from loss of an essential mitochondrial complex during germline
+      differentiation rather than a dedicated spermatogenesis function.
+    supported_by:
+    - reference_id: PMID:12794069
+      supporting_text: &gt;-
+        PHB proteins are essential during embryonic development and are required
+        for somatic and germline differentiation in the larval gonad
+      reference_section_type: ABSTRACT
+- term:
+    id: GO:0008406
+    label: gonad development
+  evidence_type: IMP
+  original_reference_id: PMID:12794069
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Experimental (RNAi) evidence of somatic and germline gonad differentiation
+      defects. Pleiotropic developmental consequence.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Retained as an experimental annotation; gonad-development defect reflects the
+      essentiality of the complex in dividing/differentiating tissue, not a
+      dedicated gonadogenesis function.
+    supported_by:
+    - reference_id: PMID:12794069
+      supporting_text: &gt;-
+        PHB proteins are essential during embryonic development and are required
+        for somatic and germline differentiation in the larval gonad
+      reference_section_type: ABSTRACT
+- term:
+    id: GO:0009792
+    label: embryo development ending in birth or egg hatching
+  evidence_type: IMP
+  original_reference_id: PMID:12794069
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Experimental (RNAi) embryonic-lethality phenotype. Reflects essentiality of
+      the PHB complex.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Retained as an experimental annotation; embryonic arrest is a consequence of
+      the complex being essential rather than a dedicated embryogenesis function
+      of phb-1.
+    supported_by:
+    - reference_id: PMID:12794069
+      supporting_text: &gt;-
+        PHB proteins are essential during embryonic development and are required
+        for somatic and germline differentiation in the larval gonad
+      reference_section_type: ABSTRACT
+- term:
+    id: GO:0030421
+    label: defecation
+  evidence_type: IMP
+  original_reference_id: PMID:12794069
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Experimental (RNAi) behavioural phenotype scored by WormBase curators from
+      the full text. Pleiotropic consequence of mitochondrial dysfunction.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Retained as an experimental annotation (curators read the full text); altered
+      defecation is a pleiotropic behavioural readout, not a core molecular role.
+- term:
+    id: GO:0031966
+    label: mitochondrial membrane
+  evidence_type: IDA
+  original_reference_id: PMID:12794069
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Direct experimental evidence of mitochondrial-membrane localization. Correct
+      but less specific than the separately annotated mitochondrial inner membrane,
+      so retained as non-core.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      The localization is correct; GO:0005743 (mitochondrial inner membrane) is the
+      more precise term and is also annotated, so this broader term is retained but
+      non-core.
+    supported_by:
+    - reference_id: PMID:12794069
+      supporting_text: &gt;-
+        prohibitins in C. elegans form a high molecular weight complex in the
+        mitochondrial inner membrane similar to that of yeast and humans
+      reference_section_type: ABSTRACT
+- term:
+    id: GO:0040018
+    label: positive regulation of multicellular organism growth
+  evidence_type: IMP
+  original_reference_id: PMID:12794069
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Experimental (RNAi) body-size/growth phenotype. Systemic consequence of
+      impaired mitochondrial function.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Retained as an experimental annotation; reduced growth on depletion is a
+      systemic consequence of mitochondrial dysfunction rather than a dedicated
+      growth-promoting activity.
+- term:
+    id: GO:0043051
+    label: regulation of nematode pharyngeal pumping
+  evidence_type: IMP
+  original_reference_id: PMID:12794069
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Experimental (RNAi) behavioural phenotype. Pleiotropic consequence of
+      mitochondrial dysfunction.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Retained as an experimental annotation; pharyngeal-pumping change is a
+      pleiotropic behavioural readout, not a core molecular role.
+- term:
+    id: GO:0048477
+    label: oogenesis
+  evidence_type: IMP
+  original_reference_id: PMID:12794069
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Experimental (RNAi) germline phenotype. Pleiotropic developmental
+      consequence of depleting the essential PHB complex.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Retained as an experimental annotation; oogenesis defects follow from loss of
+      an essential mitochondrial complex during germline differentiation.
+    supported_by:
+    - reference_id: PMID:12794069
+      supporting_text: &gt;-
+        PHB proteins are essential during embryonic development and are required
+        for somatic and germline differentiation in the larval gonad
+      reference_section_type: ABSTRACT
+core_functions:
+- description: &gt;-
+    phb-1 is a structural constituent of the mitochondrial prohibitin ring
+    complex. It has no known independent catalytic activity; instead its function
+    is to be an obligate subunit that, together with phb-2, assembles into the
+    ring-shaped, high-molecular-weight PHB complex embedded in the mitochondrial
+    inner membrane. The two subunits are interdependent, so phb-1 is required for
+    the existence of the complex itself.
+  molecular_function:
+    id: GO:0005198
+    label: structural molecule activity
+  locations:
+  - id: GO:0005743
+    label: mitochondrial inner membrane
+  in_complex:
+    id: GO:0035632
+    label: mitochondrial prohibitin complex
+  supported_by:
+  - reference_id: PMID:26092086
+    supporting_text: &gt;-
+      which bind to each other to form a heterodimer that is assembled into a
+      ring-like macromolecular structure at the inner mitochondrial membrane
+    reference_section_type: INTRODUCTION
+  - reference_id: PMID:26092086
+    supporting_text: &gt;-
+      These two subunits are interdependent for the formation of the complex,
+      leading the absence of one of them to the absence of the whole complex
+    reference_section_type: INTRODUCTION
+- description: &gt;-
+    As part of the mitochondrial prohibitin complex, phb-1 contributes to
+    organization of the mitochondrial inner membrane and to stabilization of
+    newly synthesized mitochondrial-encoded proteins (a proposed membrane-bound
+    chaperone/scaffold role), and thereby to mitochondrial biogenesis and function.
+    Through this activity the complex acts as a context-dependent modulator of
+    mitochondrial metabolism, fat utilization, and adult lifespan.
+  directly_involved_in:
+  - id: GO:0007005
+    label: mitochondrion organization
+  - id: GO:0050821
+    label: protein stabilization
+  locations:
+  - id: GO:0005743
+    label: mitochondrial inner membrane
+  in_complex:
+    id: GO:0035632
+    label: mitochondrial prohibitin complex
+  supported_by:
+  - reference_id: PMID:12794069
+    supporting_text: &gt;-
+      a deficiency in PHB proteins results in altered mitochondrial biogenesis in
+      body wall muscle cells
+    reference_section_type: ABSTRACT
+  - reference_id: PMID:26092086
+    supporting_text: &gt;-
+      a membrane-bound chaperone, which holds and stabilizes newly synthesised
+      mitochondrial-encoded proteins
+    reference_section_type: INTRODUCTION
+  - reference_id: PMID:19812672
+    supporting_text: &gt;-
+      the mitochondrial prohibitin complex promotes longevity by modulating
+      mitochondrial function and fat metabolism
+    reference_section_type: ABSTRACT
+knowledge_gaps:
+- gap_statement: &gt;-
+    The molecular mechanism of the mitochondrial prohibitin complex is
+    unresolved. It is not established whether the complex acts primarily as a
+    membrane-bound chaperone/holdase for newly synthesized mitochondrial-encoded
+    proteins, as a scaffold that organizes inner-membrane proteins within a
+    defined (cardiolipin/phospholipid) microdomain, or as a regulator of
+    inner-membrane proteostasis (e.g. of the m-AAA protease); nor is the direct
+    molecular activity of phb-1 as a ring subunit expressible as a specific GO
+    molecular function.
+  boundary: &gt;-
+    It is firmly established that phb-1 and phb-2 bind each other and assemble into
+    a ring-like, high-molecular-weight complex in the mitochondrial inner membrane,
+    that the two subunits are interdependent (loss of one abolishes the complex),
+    and that depletion is embryonic-lethal, disrupts gonad/germline differentiation,
+    alters mitochondrial biogenesis, and context-dependently modulates lifespan.
+    What is NOT established is the biochemical mechanism by which the complex
+    produces these effects.
+  gap_kind:
+  - BIOLOGY
+  - ONTOLOGY
+  dark_aspect: MF_DARK
+  status: OPEN
+  significance: &gt;-
+    Prohibitins are ubiquitous and essential across eukaryotes; resolving whether
+    the complex is fundamentally a chaperone, a membrane scaffold, or a lipid/
+    proteostasis organizer would explain a large body of pleiotropic phenotypes and
+    the conserved link between mitochondrial membrane organization and ageing. The
+    absence of a GO molecular-function term for a structural ring subunit is why the
+    gene reads as MF-dark despite rich process/localization annotation.
+  resolution: &gt;-
+    In vitro reconstitution / structural work on the worm (or conserved) PHB ring to
+    test holdase vs scaffold activity; lipidomic and proximity-labeling mapping of
+    the inner-membrane microdomain the complex organizes; separation-of-function
+    alleles that uncouple candidate activities. In parallel, an ontology term for
+    the structural/scaffolding molecular activity of a prohibitin-type ring subunit.
+  provenance:
+  - reference_id: PMID:26092086
+    supporting_text: &gt;-
+      the true function of the mitochondrial prohibitin complex remains elusive
+    reference_section_type: ABSTRACT
+  - reference_id: PMID:26092086
+    supporting_text: &gt;-
+      as scaffold proteins that recruit membrane proteins to a specific lipid
+      environment
+    reference_section_type: INTRODUCTION
+  proposed_terms:
+  - proposed_name: prohibitin complex structural constituent activity
+    proposed_definition: &gt;-
+      A structural molecule activity of a prohibitin-family (SPFH/Band-7) protein by
+      which it acts as an obligate subunit of the ring-shaped mitochondrial
+      prohibitin complex, contributing to the assembly and integrity of a
+      membrane-bound scaffold/holdase in the inner mitochondrial membrane, without
+      itself catalyzing a known biochemical reaction.
+    justification: &gt;-
+      phb-1/phb-2 and their orthologs have no adequate GO molecular-function term
+      for their role as structural ring subunits and inner-membrane scaffolds. They
+      are currently annotatable only at the complex/process level or with the
+      generic &#39;structural molecule activity&#39;, leaving the gene MF-dark despite a
+      well-defined cellular role.
+    proposed_parent:
+      id: GO:0005198
+      label: structural molecule activity
+- gap_statement: &gt;-
+    The mechanistic basis by which the SAME reduction of the prohibitin complex
+    produces OPPOSITE ageing outcomes is unknown - prohibitin deficiency shortens
+    the lifespan of otherwise wild-type animals yet extends the lifespan of
+    diapause (daf-2), dietary-restricted, and respiration/fat-metabolism-compromised
+    animals. The metabolic node at which the complex converts genetic/nutritional
+    context into opposite longevity responses is undefined.
+  boundary: &gt;-
+    The context-dependence itself is well documented (life-shortening in wild type
+    vs life-extending in daf-2/DR/mitochondrial mutants), and depletion is known to
+    change ATP levels, fat content, mitochondrial proliferation, and the whole-animal
+    metabolome. The upstream signalling (insulin/IGF-DAF-16, dietary restriction) and
+    the downstream metabolic readouts are mapped, but the causal molecular link
+    through the complex is not.
+  gap_kind:
+  - BIOLOGY
+  dark_aspect: RESIDUAL_SUBGAP
+  status: OPEN
+  significance: &gt;-
+    This paradox is a clean, conserved example of how mitochondrial membrane
+    organization gates lifespan in a metabolic-state-dependent manner; resolving it
+    would connect prohibitin biology to insulin/IGF and dietary-restriction ageing
+    pathways mechanistically.
+  resolution: &gt;-
+    Epistasis and metabolic-flux analysis across the opposing backgrounds; identify
+    the prohibitin-dependent metabolic step whose perturbation flips the longevity
+    sign; test candidate mediators (fat mobilization, respiratory-chain assembly).
+  provenance:
+  - reference_id: PMID:19812672
+    supporting_text: &gt;-
+      knockdown of prohibitin promotes longevity in diapause mutants or under
+      conditions of dietary restriction
+    reference_section_type: ABSTRACT
+  - reference_id: PMID:26092086
+    supporting_text: &gt;-
+      while it dramatically extends the lifespan of the already long-lived
+      daf-2(e1370) insulin receptor mutants
+    reference_section_type: INTRODUCTION
+suggested_questions:
+- question: &gt;-
+    Is the worm PHB complex primarily a chaperone/holdase for nascent
+    mitochondrial-encoded proteins, a membrane/lipid scaffold, or a regulator of
+    inner-membrane proteostasis?
+- question: &gt;-
+    What is the direct molecular partnership between the PHB ring and the m-AAA
+    protease (SPG-7/paraplegin) in C. elegans, and does it explain any of the
+    depletion phenotypes?
+- question: &gt;-
+    Which prohibitin-dependent metabolic step determines whether depletion shortens
+    or extends lifespan in a given genetic/nutritional context?
+suggested_experiments:
+- description: &gt;-
+    Reconstitute or affinity-purify the worm PHB ring and test in vitro holdase/
+    chaperone activity against candidate mitochondrial-encoded substrates versus a
+    scaffold/lipid-organizing readout, to discriminate the proposed molecular roles.
+  experiment_type: biochemical reconstitution
+- description: &gt;-
+    Perform proximity-labeling (BioID/TurboID) and lipidomics on tagged phb-1 to map
+    the inner-membrane protein/lipid microdomain organized by the complex.
+  experiment_type: proximity proteomics / lipidomics
+- description: &gt;-
+    Carry out epistasis and targeted metabolic-flux analysis of phb-1 depletion
+    across wild-type, daf-2, and dietary-restricted backgrounds to localize the node
+    responsible for the opposite longevity outcomes.
+  experiment_type: genetic epistasis / metabolomics
+references:
+- id: GO_REF:0000002
+  title: Gene Ontology annotation through association of InterPro records with GO
+    terms
+  findings: []
+- id: GO_REF:0000033
+  title: Annotation inferences using phylogenetic trees
+  findings: []
+- id: GO_REF:0000044
+  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location
+    vocabulary mapping, accompanied by conservative changes to GO terms applied by
+    UniProt
+  findings: []
+- id: GO_REF:0000117
+  title: Electronic Gene Ontology annotations created by ARBA machine learning models
+  findings: []
+- id: PMID:12794069
+  title: The mitochondrial prohibitin complex is essential for embryonic viability
+    and germline function in Caenorhabditis elegans.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PubMed-verified primary paper (Artal-Sanz et al. 2003, J Biol Chem). Source of
+      the WormBase experimental (IMP/IDA) annotations. The abstract directly supports
+      inner-membrane high-molecular-weight complex formation, embryonic essentiality,
+      germline/somatic gonad differentiation defects, and altered mitochondrial
+      biogenesis; the more specific behavioural terms (defecation, pharyngeal pumping)
+      derive from the full text read by curators.
+- id: PMID:19812672
+  title: Prohibitin couples diapause signalling to mitochondrial metabolism during
+    ageing in C. elegans.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PubMed-verified primary paper (Artal-Sanz &amp; Tavernarakis 2009, Nature). Source
+      of the physical-interaction (IPI, with phb-2) complex annotation and of the
+      context-dependent longevity role. Abstract supports the ring-like inner-membrane
+      complex and the opposite lifespan outcomes in wild-type vs diapause/DR animals.
+- id: PMID:26092086
+  title: Analysis of the effect of the mitochondrial prohibitin complex, a context-dependent
+    modulator of longevity, on the C. elegans metabolome.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PubMed-verified primary paper with full text in cache (Lourenço et al. 2015, BBA
+      Bioenergetics). Source of the ComplexPortal IDA/NAS annotations and the richest
+      verbatim source for complex architecture (heterodimeric ring, subunit
+      interdependence), the proposed chaperone/scaffold molecular roles, and the
+      explicit statement that the true function of the complex remains elusive.
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/genes/worm/ppgn-1/ppgn-1-ai-review.html
+++ b/genes/worm/ppgn-1/ppgn-1-ai-review.html
@@ -1,0 +1,3279 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>ppgn-1 - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        .propagation-review {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f8fafc;
+            border-left: 3px solid #64748b;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .propagation-title {
+            font-weight: 600;
+            color: #334155;
+            margin-bottom: 0.25rem;
+        }
+
+        .propagation-row {
+            margin-top: 0.25rem;
+        }
+
+        .propagation-source {
+            margin-top: 0.5rem;
+            padding-top: 0.5rem;
+            border-top: 1px solid #e5e7eb;
+        }
+
+        .propagation-source-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #1d4ed8;
+        }
+
+        .propagation-comment {
+            color: #4b5563;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>ppgn-1</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/G5EDB6" target="_blank" class="term-link">
+                        G5EDB6
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Caenorhabditis elegans</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-draft">
+                    DRAFT
+                </span>
+            </div>
+
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "ppgn-1";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="G5EDB6" data-a="DESCRIPTION: ppgn-1 (Y38F2AR.7) encodes the Caenorhabditis eleg..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>ppgn-1 (Y38F2AR.7) encodes the Caenorhabditis elegans paraplegin-subfamily subunit of the mitochondrial m-AAA protease, an ATP-dependent proteolytic machine embedded in the inner mitochondrial membrane. The protein has the diagnostic two-module architecture of this family: an N-terminal AAA+ ATPase module that uses ATP binding and hydrolysis to unfold and translocate substrates, and a C-terminal M41 (FtsH-type) zinc-metallopeptidase module that cleaves peptide bonds; the catalytic residues of both modules (Walker A P-loop GPPGCGKT, Walker B IIYIDE, and the HExxH zinc-binding motif HEAGH) are intact in the ppgn-1 sequence. It is predicted to be an integral, multi-pass inner-membrane protein with matrix-facing catalytic domains and an N-terminal mitochondrial targeting region. Within the conserved m-AAA complex, family members carry out two coupled activities: quality-control degradation of misfolded or unassembled inner-membrane proteins, and regulated proteolytic maturation of specific substrates (the paradigm being processing of the ribosomal protein MrpL32 to control mitochondrial ribosome assembly and translation). The orthologous human subunit is paraplegin (SPG7), whose loss causes autosomal-recessive hereditary spastic paraplegia. The specific in vivo role, substrates, and complex partners of ppgn-1 in C. elegans have not been experimentally determined; C. elegans additionally carries the well-studied AFG3L2-type m-AAA subunit spg-7.</p>
+    </div>
+
+
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0034982" target="_blank" class="term-link">
+                                    GO:0034982
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial protein processing</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="G5EDB6" data-a="GO:0034982" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetic (IBA) propagation of the conserved m-AAA processing role from paraplegin/AFG3L2 orthologs. Consistent with ppgn-1&#39;s intact M41 protease domain and the family paradigm of regulated substrate maturation (e.g. MrpL32). Retained as a core function, with the caveat that no C. elegans substrate has been shown.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> ppgn-1 is a clear paraplegin-subfamily m-AAA subunit (PANTHER PTHR43655:SF8) with a complete M41 zinc-peptidase module (HExxH motif HEAGH intact at residue 555), so the conserved processing activity is appropriately propagated. The direct substrate in the worm is unknown (see knowledge_gaps).
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/16239145" target="_blank" class="term-link">
+                                        PMID:16239145
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The mitochondrial ribosomal protein MrpL32 is processed by the m-AAA protease, allowing its association with preassembled ribosomal particles and completion of ribosome assembly in close proximity to the inner membrane.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005745" target="_blank" class="term-link">
+                                    GO:0005745
+                                </a>
+                            </span>
+                            <span class="term-label">m-AAA complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="G5EDB6" data-a="GO:0005745" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IBA propagation that ppgn-1 is a subunit of the inner-membrane m-AAA protease complex. Well supported by orthology to paraplegin (a conserved m-AAA subunit) and by the shared two-module (AAA+ + M41) architecture. Core.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Paraplegin is a conserved subunit of the m-AAA complex; ppgn-1 is its C. elegans ortholog. The specific composition of the worm complex (homo-oligomer vs hetero-oligomer with the AFG3L2-type subunit spg-7) is not experimentally established.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/16647881" target="_blank" class="term-link">
+                                        PMID:16647881
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">paraplegin, which is a conserved subunit of the ubiquitous and ATP-dependent m-AAA protease in mitochondria.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004222" target="_blank" class="term-link">
+                                    GO:0004222
+                                </a>
+                            </span>
+                            <span class="term-label">metalloendopeptidase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="G5EDB6" data-a="GO:0004222" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IBA propagation of zinc-dependent endopeptidase activity from the family. Directly corroborated for the ppgn-1 sequence by the intact M41 HExxH zinc-binding catalytic motif (HEAGH at residue 555, within the Peptidase_M41 domain). Core molecular function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The C-terminal M41 peptidase domain (InterPro IPR000642) and the intact HExxH motif support metalloendopeptidase chemistry for this specific protein, not merely by family membership.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9635427" target="_blank" class="term-link">
+                                        PMID:9635427
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Paraplegin is highly homologous to the yeast mitochondrial ATPases, AFG3, RCA1, and YME1, which have both proteolytic and chaperon-like activities at the inner mitochondrial membrane.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004176" target="_blank" class="term-link">
+                                    GO:0004176
+                                </a>
+                            </span>
+                            <span class="term-label">ATP-dependent peptidase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="G5EDB6" data-a="GO:0004176" data-r="GO_REF:0000002" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> InterPro (IEA) assignment of ATP-dependent peptidase activity. This is the most complete single molecular-function term for an m-AAA protease because it captures the coupling of the AAA+ ATPase to the M41 peptidase. Supported by the intact Walker A/B (GPPGCGKT, IIYIDE) and HExxH motifs in the ppgn-1 sequence. Core.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> ppgn-1 has both an intact AAA+ ATPase module (Walker A GPPGCGKT at 325, Walker B IIYIDE at 380) and an intact M41 peptidase module (HExxH at 555), the defining combination for ATP-dependent proteolysis.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/16239145" target="_blank" class="term-link">
+                                        PMID:16239145
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">AAA proteases comprise a conserved family of membrane bound ATP-dependent proteases that ensures the quality control of mitochondrial inner-membrane proteins.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004222" target="_blank" class="term-link">
+                                    GO:0004222
+                                </a>
+                            </span>
+                            <span class="term-label">metalloendopeptidase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="G5EDB6" data-a="GO:0004222" data-r="GO_REF:0000002" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Second annotation of metalloendopeptidase activity, here from the InterPro M41 signature (IEA). Same well-supported molecular function as the IBA annotation above; kept as a corroborating electronic assignment.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Redundant with the IBA metalloendopeptidase annotation but independently supported by the InterPro Peptidase_M41 signature (IPR000642) and the intact HExxH motif.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005524" target="_blank" class="term-link">
+                                    GO:0005524
+                                </a>
+                            </span>
+                            <span class="term-label">ATP binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="G5EDB6" data-a="GO:0005524" data-r="GO_REF:0000002" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> InterPro (IEA) assignment of ATP binding, an activity of the AAA+ module. Corroborated by the intact Walker A P-loop (GPPGCGKT at residue 325) in the ppgn-1 sequence. A component activity of the ATP-dependent protease.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The N-terminal AAA+ ATPase domain (SMART SM00382; InterPro IPR003959) with an intact Walker A motif provides a direct structural basis for ATP binding.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005739" target="_blank" class="term-link">
+                                    GO:0005739
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrion</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000044
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="G5EDB6" data-a="GO:0005739" data-r="GO_REF:0000044" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Subcellular-location mapping (IEA) to mitochondrion. Correct but non-specific: the family resides in the inner mitochondrial membrane, captured more precisely in core_functions (GO:0005743). Retained but marked non-core because it is a generic parent of the informative location.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Consistent with the orthologous localization (paraplegin localizes to mitochondria) and with two predicted TM helices; the more informative term is mitochondrial inner membrane, so this generic term is not the core localization statement.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9635427" target="_blank" class="term-link">
+                                        PMID:9635427
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Immunofluorescence analysis and import experiments showed that Paraplegin localizes to mitochondria.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006508" target="_blank" class="term-link">
+                                    GO:0006508
+                                </a>
+                            </span>
+                            <span class="term-label">proteolysis</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="G5EDB6" data-a="GO:0006508" data-r="GO_REF:0000002" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> InterPro (IEA) generic proteolysis term. Correct but uninformative: the specific biological roles (protein quality-control degradation and mitochondrial protein processing) are captured in core_functions. Retained as a non-core parent term.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> GO:0006508 is a high-level parent of the specific m-AAA processes; it is not wrong, but the informative annotations are mitochondrial protein processing (GO:0034982) and protein quality control (GO:0006515).
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016020" target="_blank" class="term-link">
+                                    GO:0016020
+                                </a>
+                            </span>
+                            <span class="term-label">membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000044
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="G5EDB6" data-a="GO:0016020" data-r="GO_REF:0000044" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Subcellular-location mapping (IEA) to the generic term membrane. The protein is a multi-pass integral membrane protein, but the informative location is the mitochondrial inner membrane (GO:0005743), used in core_functions. Non-core parent.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct (two predicted TM helices at 111-133 and 225-245; UniProt multi-pass membrane protein) but far too generic to be a core localization statement.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016887" target="_blank" class="term-link">
+                                    GO:0016887
+                                </a>
+                            </span>
+                            <span class="term-label">ATP hydrolysis activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="G5EDB6" data-a="GO:0016887" data-r="GO_REF:0000002" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> InterPro (IEA) assignment of ATP hydrolysis activity, the motor activity of the AAA+ module that drives substrate unfolding/translocation. Corroborated by the intact Walker B motif (IIYIDE at residue 380) in the ppgn-1 sequence. A component activity of the ATP-dependent protease.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The AAA+ ATPase module with intact Walker A and Walker B motifs supports ATP hydrolysis; this is the energy-providing half of the ATP-dependent protease.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005743" target="_blank" class="term-link">
+                                    GO:0005743
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial inner membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ISS</span>
+
+
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-new">
+                            NEW
+                        </span>
+                        <span class="vote-buttons" data-g="G5EDB6" data-a="GO:0005743" data-r="" data-act="NEW">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Proposed refinement of the generic mitochondrion/membrane localizations to the specific compartment where m-AAA proteases reside. Inferred from orthology to paraplegin and from the two predicted TM helices flanking matrix-facing catalytic domains (canonical m-AAA topology).
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The generic GOA terms (GO:0005739 mitochondrion, GO:0016020 membrane) understate the known compartment. The m-AAA protease is an integral protein of the mitochondrial inner membrane; this ISS annotation captures the informative location while the worm-specific topology remains to be experimentally mapped.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/16647881" target="_blank" class="term-link">
+                                        PMID:16647881
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The m-AAA protease carries out protein quality control in the inner membrane of the mitochondria</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006515" target="_blank" class="term-link">
+                                    GO:0006515
+                                </a>
+                            </span>
+                            <span class="term-label">protein quality control for misfolded or incompletely synthesized proteins</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ISS</span>
+
+
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-new">
+                            NEW
+                        </span>
+                        <span class="vote-buttons" data-g="G5EDB6" data-a="GO:0006515" data-r="" data-act="NEW">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Proposed refinement of the generic proteolysis annotation to the specific quality-control process performed by the m-AAA protease: ATP-dependent degradation of misfolded/unassembled inner-membrane proteins. Inferred from orthology and the intact AAA+ + M41 catalytic modules.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> GO:0006508 (proteolysis) is uninformative; the conserved biological role of the family is inner-membrane protein quality control. This ISS annotation records that specific process, complementing the mitochondrial protein processing (GO:0034982) role. The endogenous worm substrates are not yet identified.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/16239145" target="_blank" class="term-link">
+                                        PMID:16239145
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">AAA proteases comprise a conserved family of membrane bound ATP-dependent proteases that ensures the quality control of mitochondrial inner-membrane proteins.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>ATP-dependent proteolytic quality control of the inner mitochondrial membrane. As a subunit of the m-AAA protease, ppgn-1 couples ATP-driven substrate unfolding and translocation (AAA+ module) to zinc-dependent peptide-bond hydrolysis (M41 module) to degrade misfolded or unassembled inner-membrane proteins to peptides. Inferred from orthology to paraplegin/AFG3L2 and from the intact Walker A/B and HExxH catalytic motifs in the ppgn-1 sequence; the endogenous C. elegans substrates are not yet identified.</h3>
+                <span class="vote-buttons" data-g="G5EDB6" data-a="FUNCTION: ATP-dependent proteolytic quality control of the i..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004176" target="_blank" class="term-link">
+                            ATP-dependent peptidase activity
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006515" target="_blank" class="term-link">
+                                protein quality control for misfolded or incompletely synthesized proteins
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005743" target="_blank" class="term-link">
+                                mitochondrial inner membrane
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">In Complex:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005745" target="_blank" class="term-link">
+                            m-AAA complex
+                        </a>
+                    </span>
+                </div>
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/16239145" target="_blank" class="term-link">
+                                PMID:16239145
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">AAA proteases comprise a conserved family of membrane bound ATP-dependent proteases that ensures the quality control of mitochondrial inner-membrane proteins.</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/21610694" target="_blank" class="term-link">
+                                PMID:21610694
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">m-AAA proteases exert dual functions in the mitochondrial inner membrane: they mediate the processing of specific regulatory proteins and ensure protein quality control degrading misfolded polypeptides to peptides.</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>Regulated proteolytic maturation (processing) of specific mitochondrial substrates. Beyond bulk degradation, m-AAA proteases perform limited, sequence-specific cleavage that matures regulatory substrates; the conserved paradigm is processing of the ribosomal protein MrpL32, which is required for mitochondrial ribosome assembly and translation. ppgn-1 is inferred to contribute this metalloendopeptidase-based processing activity within the worm m-AAA complex; the specific worm substrate(s) remain undetermined.</h3>
+                <span class="vote-buttons" data-g="G5EDB6" data-a="FUNCTION: Regulated proteolytic maturation (processing) of s..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004222" target="_blank" class="term-link">
+                            metalloendopeptidase activity
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0034982" target="_blank" class="term-link">
+                                mitochondrial protein processing
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005743" target="_blank" class="term-link">
+                                mitochondrial inner membrane
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">In Complex:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005745" target="_blank" class="term-link">
+                            m-AAA complex
+                        </a>
+                    </span>
+                </div>
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/16239145" target="_blank" class="term-link">
+                                PMID:16239145
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">The mitochondrial ribosomal protein MrpL32 is processed by the m-AAA protease, allowing its association with preassembled ribosomal particles and completion of ribosome assembly in close proximity to the inner membrane.</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000002.md" target="_blank" class="term-link">
+                            GO_REF:0000002
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation through association of InterPro records with GO terms</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
+                            GO_REF:0000033
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Annotation inferences using phylogenetic trees</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
+                            GO_REF:0000044
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/9635427" target="_blank" class="term-link">
+                            PMID:9635427
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Spastic paraplegia and OXPHOS impairment caused by mutations in paraplegin, a nuclear-encoded mitochondrial metalloprotease.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Paraplegin (the ortholog of ppgn-1) is a nuclear-encoded mitochondrial metalloprotease homologous to the yeast mitochondrial AAA ATPases (AFG3, RCA1, YME1) that combine proteolytic and chaperone-like activities at the inner mitochondrial membrane, and it localizes to mitochondria.</div>
+
+                        <div class="finding-text">"Paraplegin is highly homologous to the yeast mitochondrial ATPases, AFG3, RCA1, and YME1, which have both proteolytic and chaperon-like activities at the inner mitochondrial membrane."</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/16239145" target="_blank" class="term-link">
+                            PMID:16239145
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">The m-AAA protease defective in hereditary spastic paraplegia controls ribosome assembly in mitochondria.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">AAA proteases are a conserved family of membrane-bound ATP-dependent proteases that ensure quality control of mitochondrial inner-membrane proteins, and the m-AAA protease processes the ribosomal protein MrpL32 to allow completion of ribosome assembly at the inner membrane.</div>
+
+                        <div class="finding-text">"AAA proteases comprise a conserved family of membrane bound ATP-dependent proteases that ensures the quality control of mitochondrial inner-membrane proteins."</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/16647881" target="_blank" class="term-link">
+                            PMID:16647881
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Translating m-AAA protease function in mitochondria to hereditary spastic paraplegia.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Paraplegin is a conserved subunit of the ubiquitous, ATP-dependent m-AAA protease in mitochondria, which carries out protein quality control in the inner mitochondrial membrane.</div>
+
+                        <div class="finding-text">"paraplegin, which is a conserved subunit of the ubiquitous and ATP-dependent m-AAA protease in mitochondria."</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/21610694" target="_blank" class="term-link">
+                            PMID:21610694
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Presequence-dependent folding ensures MrpL32 processing by the m-AAA protease in mitochondria.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">m-AAA proteases have dual functions in the inner mitochondrial membrane: regulated processing of specific substrates and quality-control degradation of misfolded polypeptides to peptides.</div>
+
+                        <div class="finding-text">"m-AAA proteases exert dual functions in the mitochondrial inner membrane: they mediate the processing of specific regulatory proteins and ensure protein quality control degrading misfolded polypeptides to peptides."</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Questions for Experts</h2>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Does ppgn-1 form a functional m-AAA protease complex on its own, or does it require the AFG3L2-type subunit spg-7, and are the two subunits functionally redundant in C. elegans?</p>
+
+                    <p style="margin-top: 0.5rem;"><em>Suggested experts: C. elegans mitochondrial biologists, m-AAA protease / AAA+ protease structural biochemists</em></p>
+
+                </div>
+                <span class="vote-buttons" data-g="G5EDB6" data-a="Q: Does ppgn-1 form a functional m-AAA protease compl..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> What are the endogenous substrates of ppgn-1 in C. elegans, and does it mature a MrpL32 homolog to regulate mitochondrial ribosome assembly as in yeast and mouse?</p>
+
+                    <p style="margin-top: 0.5rem;"><em>Suggested experts: Mitochondrial proteostasis / ribosome assembly researchers</em></p>
+
+                </div>
+                <span class="vote-buttons" data-g="G5EDB6" data-a="Q: What are the endogenous substrates of ppgn-1 in C...." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Experiments</h2>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Generate a ppgn-1 null allele (CRISPR) and, in parallel with spg-7 RNAi/mutant, assay respiration, mitochondrial morphology, UPRmt (hsp-6p::GFP), fertility and lifespan to determine ppgn-1&#39;s non-redundant contribution.</p>
+
+
+
+                    <p style="margin-top: 0.5rem;">Type: Reverse genetics / phenotyping</p>
+
+                </div>
+                <span class="vote-buttons" data-g="G5EDB6" data-a="EXPERIMENT: Generate a ppgn-1 null allele (CRISPR) and, in par..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Endogenously tag ppgn-1, purify from worm mitochondria, and identify complex partners (test for spg-7 hetero-oligomerization) and, using a catalytically dead HExxH mutant as a substrate trap, capture processed/degraded substrates.</p>
+
+
+
+                    <p style="margin-top: 0.5rem;">Type: Affinity purification / mass spectrometry</p>
+
+                </div>
+                <span class="vote-buttons" data-g="G5EDB6" data-a="EXPERIMENT: Endogenously tag ppgn-1, purify from worm mitochon..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Determine ppgn-1 tissue expression and sub-mitochondrial topology with an endogenous fluorescent tag and protease-protection assays, to confirm the predicted inner-membrane, matrix-facing catalytic-domain topology.</p>
+
+
+
+                    <p style="margin-top: 0.5rem;">Type: Localization</p>
+
+                </div>
+                <span class="vote-buttons" data-g="G5EDB6" data-a="EXPERIMENT: Determine ppgn-1 tissue expression and sub-mitocho..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Knowledge Gaps</h2>
+        <p style="color: #555; font-size: 0.92rem; margin-top: -0.3rem;">
+            What is <em>not</em> known — curated, literature-grounded statements of the open
+            unknowns (the inverse of core functions).
+        </p>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> ppgn-1 has no experimental functional characterization in C. elegans: no loss-of-function (mutant or RNAi) phenotype, no localization, and no biochemical assay has been reported for this gene. Every GO annotation is phylogenetic (IBA) or electronic (IEA), and the only UniProt-linked reference is an unpublished nucleotide sequence submission.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">WHOLLY_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> The protein is confidently a paraplegin-subfamily m-AAA protease subunit (PANTHER PTHR43655:SF8; AAA+ + M41 architecture) with intact catalytic motifs, and the human ortholog paraplegin (SPG7) and yeast/mouse orthologs are well characterized. What is missing is any direct evidence for ppgn-1 itself in the worm.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Without any worm-level data, ppgn-1&#39;s function is entirely an orthology inference; its non-redundant contribution (if any) to C. elegans mitochondrial physiology is unknown.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Generate and phenotype a ppgn-1 deletion/RNAi allele (respiration, mitochondrial morphology, UPRmt reporters, fertility, lifespan), and determine its expression and subcellular localization with an endogenous tag.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"Paraplegin is highly homologous to the yeast mitochondrial ATPases, AFG3, RCA1, and YME1, which have both proteolytic and chaperon-like activities at the inner mitochondrial membrane."</em> — PMID:9635427</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The endogenous substrate(s) of ppgn-1 in C. elegans are unidentified. It is unknown whether the worm protease matures a functional homolog of MrpL32 (regulated processing) and/or which misfolded inner-membrane proteins it degrades (quality control), and whether ppgn-1 and the AFG3L2-type subunit spg-7 act on the same or distinct substrate sets.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">MF_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> The conserved m-AAA protease has a defined dual activity (processing vs degradation), and MrpL32 maturation is the textbook processing substrate in yeast and mouse. ppgn-1 retains an intact HExxH metallopeptidase active site, so it is catalytically capable in principle.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Substrate identity is what distinguishes a housekeeping protease from a specific regulatory node; it is the rate-limiting unknown for placing ppgn-1 in a pathway.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Substrate-trapping (catalytically inactive HExxH mutant) plus comparative proteomics of ppgn-1 vs spg-7 loss-of-function to identify processed/stabilized substrates.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"m-AAA proteases exert dual functions in the mitochondrial inner membrane: they mediate the processing of specific regulatory proteins and ensure protein quality control degrading misfolded polypeptides to peptides."</em> — PMID:21610694</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The oligomeric composition of the C. elegans m-AAA complex containing ppgn-1 is undetermined: whether ppgn-1 forms a homo-oligomer, assembles into a hetero-oligomer with the AFG3L2-type subunit spg-7, and whether the two worm subunits are functionally redundant, is untested.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">RESIDUAL_SUBGAP</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> In mammals the m-AAA protease is a hexamer of paraplegin (SPG7) and/or AFG3L2, and one catalytically dead subunit can be tolerated within an otherwise active complex. C. elegans has both a paraplegin-type (ppgn-1) and an AFG3L2-type (spg-7) subunit, but their assembly relationship is not reported.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Complex composition determines whether ppgn-1 loss can be buffered by spg-7 and how to interpret single-gene phenotypes.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Co-immunoprecipitation / blue-native PAGE of endogenously tagged ppgn-1 and spg-7, and epistasis/double-mutant analysis to test redundancy.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"paraplegin, which is a conserved subunit of the ubiquitous and ATP-dependent m-AAA protease in mitochondria."</em> — PMID:16647881</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> Whether ppgn-1 (as opposed to its paralog spg-7) contributes to any organismal process in C. elegans - the mitochondrial unfolded-protein response, respiration, mitochondrial dynamics, fertility, longevity, or stress/pathogen resistance - is unknown. The large C. elegans mito-protease functional literature concerns spg-7 and cannot be attributed to ppgn-1.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">BP_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> Loss of m-AAA proteases across organisms causes respiratory deficiency, altered mitochondrial morphology and axonal degeneration; none of these readouts has been tested specifically for ppgn-1 in the worm.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Assigning ppgn-1 a biological process (vs treating it as a redundant paralog) requires worm phenotypes; this determines its relevance to mitochondrial surveillance and stress signaling.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Test ppgn-1 loss-of-function against UPRmt (hsp-6p::GFP), respiration, mitochondrial morphology, and pathogen/stress-resistance assays, side by side with spg-7.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"Inactivation of AAA proteases causes pleiotropic phenotypes in various organisms, including respiratory deficiencies, mitochondrial morphology defects, and axonal degeneration in hereditary spastic paraplegia (HSP)."</em> — PMID:16239145</li>
+
+            </ul>
+
+
+        </div>
+
+    </div>
+
+
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Deep Research Sections -->
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(ppgn-1-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="G5EDB6" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="ppgn-1-y38f2ar7-wbgene00021425-uniprot-g5edb6-research-notes">ppgn-1 (Y38F2AR.7 / WBGene00021425 / UniProt G5EDB6) — research notes</h1>
+<p>Research journal for the AI GO-annotation review. Provenance is recorded inline as<br />
+<code>[PMID:xxxx "verbatim quote"]</code>. This is a <strong>dark gene</strong>: the deliverable is a precise,<br />
+defensible statement of what is and is not known.</p>
+<h2 id="1-identity-verified-from-the-uniprot-record">1. Identity (verified from the UniProt record)</h2>
+<ul>
+<li>UniProt <strong>G5EDB6</strong> (TrEMBL, unreviewed), <em>Caenorhabditis elegans</em>, NCBITaxon:6239.</li>
+<li>Gene symbol <strong>ppgn-1</strong>; ORF <strong>Y38F2AR.7</strong>; WormBase <strong>WBGene00021425</strong>; RefSeq NP_500191.3.</li>
+<li>Protein name (UniProt SubName): <strong>Paraplegin</strong>. 747 aa, 82.8 kDa.</li>
+<li>The <em>only</em> primary reference on the UniProt entry is an unpublished nucleotide-sequence<br />
+  submission: Yamanaka, Yamada-Inagawa, Nishizono, Ogura (2006), title "Paraplegin<br />
+  homologue in C. elegans" (EMBL AB257343 / BAE96353.1). No functional paper.</li>
+<li>Domain architecture (UniProt/InterPro): N-terminal <strong>AAA+ ATPase</strong> module<br />
+  (AAA+ core IPR003959; AAA_lid_3 IPR041569; SMART AAA domain 317–462) and C-terminal<br />
+<strong>peptidase M41</strong> zinc-metallopeptidase module (IPR000642). Two predicted TM helices<br />
+  (Phobius: 111–133 and 225–245). N-terminal disordered/basic region 41–101 (matrix<br />
+  targeting/presequence-like). Cofactor Zn²⁺ (ARBA). SubCellular: Mitochondrion,<br />
+  multi-pass membrane protein.</li>
+<li>PANTHER classification: <strong>PTHR43655</strong> "ATP-DEPENDENT PROTEASE", subfamily<br />
+<strong>PTHR43655:SF8 PARAPLEGIN</strong>. MEROPS peptidase clan/family <strong>M41.A12</strong>.</li>
+<li>Reactome (electronic, projected): R-CEL-8949664 "Processing of SMDT1";<br />
+  R-CEL-9837999 "Mitochondrial protein degradation".</li>
+</ul>
+<p><strong>Bottom line on identity:</strong> despite the surrounding project framing, ppgn-1 is NOT an<br />
+epidermal/innate-immune/wound gene. It is the <em>C. elegans</em> <strong>paraplegin-subfamily<br />
+subunit of the mitochondrial m-AAA protease</strong> — an ATP-dependent, membrane-embedded<br />
+zinc metalloprotease of the inner mitochondrial membrane. All curation below is against<br />
+that identity.</p>
+<h2 id="2-what-the-m-aaa-protease-family-does-known-orthologuefamily-biology">2. What the m-AAA protease family does (KNOWN — orthologue/family biology)</h2>
+<p>The family is well characterised in yeast, mouse and human; ppgn-1's GO annotations are<br />
+IBA/IEA propagations from these orthologues.</p>
+<ul>
+<li>m-AAA proteases are a conserved, membrane-bound, ATP-dependent proteolytic machine of<br />
+  the mitochondrial inner membrane that performs protein quality control:<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/16239145" title="AAA proteases comprise a conserved family of membrane bound ATP-dependent proteases that ensures the quality control of mitochondrial inner-membrane proteins">PMID:16239145</a>.</li>
+<li>Human <strong>paraplegin</strong> (SPG7) is a bona fide subunit of this complex, and the complex is<br />
+  ATP-dependent: <a href="https://pubmed.ncbi.nlm.nih.gov/16647881" title="paraplegin, which is a conserved subunit of the ubiquitous and ATP-dependent m-AAA protease in mitochondria">PMID:16647881</a><br />
+  and <a href="https://pubmed.ncbi.nlm.nih.gov/16647881" title="The m-AAA protease carries out protein quality control in the inner membrane of the mitochondria">PMID:16647881</a>.</li>
+<li>The founding paper established paraplegin as a nuclear-encoded mitochondrial<br />
+  metalloprotease homologous to the yeast AAA ATPases with dual proteolytic + chaperone<br />
+  activity: <a href="https://pubmed.ncbi.nlm.nih.gov/9635427" title="Paraplegin is highly homologous to the yeast mitochondrial ATPases, AFG3, RCA1, and YME1, which have both proteolytic and chaperon-like activities at the inner mitochondrial membrane">PMID:9635427</a><br />
+  and localises to mitochondria: <a href="https://pubmed.ncbi.nlm.nih.gov/9635427" title="Immunofluorescence analysis and import experiments showed that Paraplegin localizes to mitochondria">PMID:9635427</a>.</li>
+<li>Besides bulk degradation, the m-AAA protease has a <strong>regulated processing</strong> role: it<br />
+  matures specific substrates. The conserved paradigm is maturation of the ribosomal<br />
+  protein MrpL32: <a href="https://pubmed.ncbi.nlm.nih.gov/16239145" title="The mitochondrial ribosomal protein MrpL32 is processed by the m-AAA protease, allowing its association with preassembled ribosomal particles and completion of ribosome assembly in close proximity to the inner membrane">PMID:16239145</a>.<br />
+  This dual degrade-vs-process behaviour is explicit in the literature:<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/21610694" title="m-AAA proteases exert dual functions in the mitochondrial inner membrane: they mediate the processing of specific regulatory proteins and ensure protein quality control degrading misfolded polypeptides to peptides">PMID:21610694</a>.</li>
+<li>Loss of function is pleiotropic across organisms (respiration, mito morphology, axon<br />
+  degeneration): <a href="https://pubmed.ncbi.nlm.nih.gov/16239145" title="Inactivation of AAA proteases causes pleiotropic phenotypes in various organisms, including respiratory deficiencies, mitochondrial morphology defects, and axonal degeneration in hereditary spastic paraplegia (HSP)">PMID:16239145</a>.</li>
+<li>In mammals the physiological complex is a hetero-/homo-hexamer of paraplegin (SPG7)<br />
+  and/or AFG3L2 (WITH/FROM of the ppgn-1 IBA annotations lists human SPG7 = UniProtKB<br />
+  Q9UQ90 and AFG3L2 = UniProtKB Q9Y4W6, plus mouse Afg3l1/Afg3l2 and yeast Yta10/Yta12).</li>
+</ul>
+<h2 id="3-bioinformatic-verification-for-this-protein-known-from-ppgn-1-sequence">3. Bioinformatic verification for THIS protein (KNOWN — from ppgn-1 sequence)</h2>
+<p>To guard against propagating enzyme annotations onto a possible pseudoenzyme, I scanned<br />
+the ppgn-1 sequence itself (see <code>ppgn-1-bioinformatics/</code>, reproducible<br />
+<code>analyze_motifs.py</code>). All three catalytic motifs are intact and correctly ordered:</p>
+<ul>
+<li>Walker A / P-loop <strong>GPPGCGKT</strong> at 325 (ATP binding).</li>
+<li>Walker B <strong>IIYIDE</strong> at 380 (Mg-ATP hydrolysis).</li>
+<li><strong>HExxH</strong> zinc-binding catalytic motif <strong>HEAGH</strong> at 555, within the M41 domain,<br />
+  followed downstream by an acidic residue (…MLEHT<strong>D</strong>) — a complete FtsH-type Zn²⁺<br />
+  active site.</li>
+</ul>
+<p>Interpretation: ppgn-1 is a <strong>catalytically competent</strong> m-AAA protease at the sequence<br />
+level, not a degenerate pseudoenzyme. This supports the enzymatic GO terms for this<br />
+specific protein, not merely by family membership. See<br />
+<code>file:worm/ppgn-1/ppgn-1-bioinformatics/RESULTS.md</code>.</p>
+<h2 id="4-c-elegans-context-and-the-paralog-trap-not-known-for-ppgn-1">4. C. elegans context — and the paralog trap (NOT-known for ppgn-1)</h2>
+<ul>
+<li><em>C. elegans</em> has (at least) two m-AAA protease subunit genes: the well-studied<br />
+<strong>spg-7</strong> (WBGene00004978; the AFG3L2-type subunit, and the gene whose RNAi is the<br />
+  canonical trigger of the mitochondrial unfolded-protein response, UPR^mt, and of<br />
+  detoxification/immune gene induction — WormBase/literature summaries) and the<br />
+  understudied <strong>ppgn-1</strong> (paraplegin subfamily, this gene).</li>
+<li><strong>Crucial curation caveat:</strong> the large <em>C. elegans</em> mitochondrial-protease functional<br />
+  literature (UPR^mt, drug resistance, detoxification, pathogen resistance) is about<br />
+<strong>spg-7</strong>, NOT ppgn-1. None of it can be attributed to ppgn-1. The GOA annotations for<br />
+  ppgn-1 are correctly all IBA/IEA (no experimental evidence code), reflecting this.</li>
+<li>WITH/FROM of the ppgn-1 IBA annotations includes WB:WBGene00004978 (spg-7) as a<br />
+  co-orthologue in the PANTHER tree, i.e. the two worm genes are placed together in the<br />
+  m-AAA clade.</li>
+</ul>
+<h2 id="5-explicit-known-vs-not-known-ledger-for-ppgn-1">5. Explicit KNOWN vs NOT-known ledger for ppgn-1</h2>
+<p>KNOWN (high confidence, from orthology + domain/motif evidence):<br />
+- Encodes a paraplegin-subfamily m-AAA protease subunit (AAA+ ATPase + M41 Zn-peptidase).<br />
+- Retains intact ATP-binding (Walker A), ATP-hydrolysis (Walker B) and Zn-peptidase<br />
+  (HExxH) catalytic motifs → catalytically competent in principle.<br />
+- Predicted mitochondrial, integral inner-membrane (two TM helices), matrix-facing<br />
+  catalytic domains — the canonical m-AAA topology.<br />
+- Family function: ATP-dependent proteolytic quality control + regulated processing of<br />
+  inner-membrane / matrix substrates.</p>
+<p>NOT KNOWN (the real gaps for ppgn-1 specifically):<br />
+- <strong>No</strong> <em>C. elegans</em> experimental characterisation of ppgn-1: no mutant/RNAi phenotype,<br />
+  no localisation, no biochemistry has been reported for this gene (all GO evidence is<br />
+  IBA/IEA; the only UniProt reference is an unpublished sequence submission).<br />
+- <strong>Substrates unknown</strong>: which inner-membrane proteins ppgn-1 degrades or matures in the<br />
+  worm is undetermined (no worm equivalent of the MrpL32 result attributed to ppgn-1).<br />
+- <strong>Complex composition unknown</strong>: whether ppgn-1 assembles with the AFG3L2-type subunit<br />
+  spg-7 into a hetero-hexamer, forms a homo-oligomer, or is catalytically redundant with<br />
+  spg-7 is untested.<br />
+- <strong>Physiological role unknown</strong>: whether ppgn-1 (as opposed to spg-7) contributes to<br />
+  UPR^mt, respiration, mitochondrial morphology, fertility, longevity, stress/pathogen<br />
+  responses, or is functionally dispensable, is unknown.<br />
+- <strong>Regulation unknown</strong>: expression, tissue distribution (Bgee: "Expressed in germ line<br />
+  and 4 other cell types" — coarse, electronic), and conditions under which it acts are<br />
+  uncharacterised.</p>
+<h2 id="6-annotation-review-plan-summary">6. Annotation-review plan (summary)</h2>
+<p>All 10 GOA annotations are IBA/IEA and are consistent with a catalytically competent<br />
+paraplegin-subfamily m-AAA protease; none is contradicted, so none is REMOVEd.<br />
+- Core, well-supported family propagations → ACCEPT: mitochondrial protein processing<br />
+  (IBA), m-AAA complex (IBA), metalloendopeptidase activity (IBA + IEA), ATP-dependent<br />
+  peptidase activity (IEA), ATP binding (IEA), ATP hydrolysis activity (IEA).<br />
+- Correct but non-specific / non-core → KEEP_AS_NON_CORE with a note: proteolysis<br />
+  (GO:0006508, generic parent of the specific processing/QC role), mitochondrion<br />
+  (GO:0005739, generic parent of inner membrane), membrane (GO:0016020, generic parent<br />
+  of inner membrane).<br />
+- The persistent uncertainty (no worm data) is captured in <code>knowledge_gaps</code>, not by<br />
+  down-grading correct family propagations.</p>
+<h2 id="7-deep-research-status">7. Deep research status</h2>
+<p><code>just deep-research-falcon worm ppgn-1 --fallback perplexity-lite</code> was run FOREGROUND and<br />
+retried. Falcon timed out at the 600 s server limit on both attempts; the perplexity-lite<br />
+fallback returned HTTP 401 (account quota exhausted). No <code>-deep-research-*.md</code> file was<br />
+produced. Per repo policy I did not fabricate one. This review therefore rests on the<br />
+UniProt/InterPro record, the GOA evidence codes, the primary m-AAA/paraplegin literature<br />
+cited above (PubMed-verified, cached in <code>publications/</code>), and the reproducible sequence<br />
+analysis in <code>ppgn-1-bioinformatics/</code>.</p>
+            </div>
+        </details>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Bioinformatics Results</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(RESULTS.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="G5EDB6" data-a="DOC: Bioinformatics Results" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="ppgn-1-g5edb6-catalytic-motif-analysis">ppgn-1 (G5EDB6) — catalytic motif analysis</h1>
+<h2 id="question">Question</h2>
+<p>The GO annotations for ppgn-1 (Y38F2AR.7, <em>C. elegans</em> paraplegin subfamily) are all<br />
+IBA/IEA — propagated from the m-AAA protease family, with no <em>C. elegans</em> experimental<br />
+support. A legitimate worry for any family propagation is that the target is a<br />
+<strong>pseudoenzyme</strong>: a fold-retaining paralog that has lost the catalytic residues (cf.<br />
+human AFG3L1P pseudogene, or the peptidase-dead YME1L variants). If ppgn-1 had lost its<br />
+Walker A/B or HExxH residues, the enzymatic annotations (metalloendopeptidase, ATP<br />
+binding, ATP hydrolysis, ATP-dependent peptidase) would be over-annotations for this<br />
+specific protein even though they are correct for the family.</p>
+<h2 id="method">Method</h2>
+<p><code>analyze_motifs.py</code> parses the amino-acid sequence directly from <code>../ppgn-1-uniprot.txt</code><br />
+(nothing hard-coded) and scans for the three diagnostic motifs of an m-AAA protease:</p>
+<ul>
+<li><strong>Walker A / P-loop</strong> (<code>G-x(4)-G-K-[S/T]</code>) — binds the β/γ phosphates of ATP.</li>
+<li><strong>Walker B</strong> (<code>hhhh-D-E</code>) — the Asp/Glu that coordinate Mg²⁺ and activate water for ATP hydrolysis.</li>
+<li><strong>HExxH</strong> — the M41/FtsH zinc-binding catalytic motif (two His coordinate the catalytic Zn²⁺; the Glu polarises the attacking water).</li>
+</ul>
+<p>Run with <code>uv run python analyze_motifs.py</code>.</p>
+<h2 id="result-reproducible">Result (reproducible)</h2>
+<div class="codehilite"><pre><span></span><code><span class="n">length</span><span class="o">:</span><span class="w"> </span><span class="mi">747</span><span class="w"> </span><span class="n">aa</span>
+<span class="n">Walker</span><span class="w"> </span><span class="n">A</span><span class="w"> </span><span class="o">(</span><span class="n">P</span><span class="o">-</span><span class="n">loop</span><span class="o">,</span><span class="w"> </span><span class="n">ATP</span><span class="w"> </span><span class="n">binding</span><span class="o">):</span><span class="w">            </span><span class="n">FOUND</span><span class="w"> </span><span class="n">at</span><span class="w"> </span><span class="mi">325</span><span class="w"> </span><span class="o">-&gt;</span><span class="w"> </span><span class="n">GPPGCGKT</span>
+<span class="n">Walker</span><span class="w"> </span><span class="n">B</span><span class="w"> </span><span class="o">(</span><span class="n">Mg</span><span class="o">-</span><span class="n">ATP</span><span class="w"> </span><span class="n">hydrolysis</span><span class="o">):</span><span class="w">              </span><span class="n">FOUND</span><span class="w"> </span><span class="n">at</span><span class="w"> </span><span class="mi">380</span><span class="w"> </span><span class="o">-&gt;</span><span class="w"> </span><span class="n">IIYIDE</span>
+<span class="n">HExxH</span><span class="w"> </span><span class="o">(</span><span class="n">M41</span><span class="w"> </span><span class="n">zinc</span><span class="o">-</span><span class="n">binding</span><span class="w"> </span><span class="n">catalytic</span><span class="w"> </span><span class="n">motif</span><span class="o">):</span><span class="w">  </span><span class="n">FOUND</span><span class="w"> </span><span class="n">at</span><span class="w"> </span><span class="mi">555</span><span class="w"> </span><span class="o">-&gt;</span><span class="w"> </span><span class="n">HEAGH</span>
+<span class="n">HExxH</span><span class="w"> </span><span class="n">context</span><span class="w"> </span><span class="o">[</span><span class="mi">555</span><span class="o">..</span><span class="mi">589</span><span class="o">]:</span><span class="w"> </span><span class="n">HEAGHALVGWMLEHTDALLKVTIIPRTSAALGFAQ</span>
+</code></pre></div>
+
+<p>All three catalytic elements are intact and in the expected order (AAA+ ATPase module<br />
+N-terminal, M41 peptidase module C-terminal), consistent with the domain architecture<br />
+UniProt/InterPro annotate (AAA+ core IPR003959; Peptidase M41 IPR000642). The HExxH lies<br />
+within the M41 domain and is followed downstream by an acidic residue (…MLEHT<strong>D</strong>),<br />
+consistent with a complete FtsH-type Zn²⁺ active site.</p>
+<h2 id="interpretation">Interpretation</h2>
+<p>At the sequence level ppgn-1 is a <strong>catalytically competent</strong> m-AAA protease subunit, not<br />
+a degenerate pseudoenzyme: it retains the residues required for both ATP binding/hydrolysis<br />
+and zinc-dependent peptide-bond cleavage. This supports (for this specific protein, not<br />
+merely by family membership) the molecular-function annotations <code>ATP binding</code>,<br />
+<code>ATP hydrolysis activity</code>, <code>metalloendopeptidase activity</code>, and <code>ATP-dependent peptidase
+activity</code>.</p>
+<h2 id="caveats-what-this-does-not-show">Caveats / what this does NOT show</h2>
+<ul>
+<li>Motif presence proves catalytic <em>potential</em>, not that the enzyme is active <em>in vivo</em>,<br />
+  what its physiological substrates are, or which partner subunit(s) it assembles with.</li>
+<li>It does not establish whether ppgn-1 is catalytically required in a complex or serves a<br />
+  more structural role alongside the <em>C. elegans</em> AFG3L2-type subunit (spg-7). Mammalian<br />
+  m-AAA complexes tolerate one catalytically dead subunit within an otherwise active<br />
+  hexamer.</li>
+<li>Sub-mitochondrial topology (matrix-facing catalytic domains flanked by two TM helices)<br />
+  is inferred from UniProt Phobius predictions, not experimentally mapped here.</li>
+</ul>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: G5EDB6
+gene_symbol: ppgn-1
+product_type: PROTEIN
+status: DRAFT
+taxon:
+  id: NCBITaxon:6239
+  label: Caenorhabditis elegans
+description: &gt;-
+  ppgn-1 (Y38F2AR.7) encodes the Caenorhabditis elegans paraplegin-subfamily subunit
+  of the mitochondrial m-AAA protease, an ATP-dependent proteolytic machine embedded in
+  the inner mitochondrial membrane. The protein has the diagnostic two-module
+  architecture of this family: an N-terminal AAA+ ATPase module that uses ATP binding and
+  hydrolysis to unfold and translocate substrates, and a C-terminal M41 (FtsH-type)
+  zinc-metallopeptidase module that cleaves peptide bonds; the catalytic residues of both
+  modules (Walker A P-loop GPPGCGKT, Walker B IIYIDE, and the HExxH zinc-binding motif
+  HEAGH) are intact in the ppgn-1 sequence. It is predicted to be an integral, multi-pass
+  inner-membrane protein with matrix-facing catalytic domains and an N-terminal
+  mitochondrial targeting region. Within the conserved m-AAA complex, family members
+  carry out two coupled activities: quality-control degradation of misfolded or
+  unassembled inner-membrane proteins, and regulated proteolytic maturation of specific
+  substrates (the paradigm being processing of the ribosomal protein MrpL32 to control
+  mitochondrial ribosome assembly and translation). The orthologous human subunit is
+  paraplegin (SPG7), whose loss causes autosomal-recessive hereditary spastic paraplegia.
+  The specific in vivo role, substrates, and complex partners of ppgn-1 in C. elegans
+  have not been experimentally determined; C. elegans additionally carries the
+  well-studied AFG3L2-type m-AAA subunit spg-7.
+references:
+- id: GO_REF:0000002
+  title: Gene Ontology annotation through association of InterPro records with GO terms
+  findings: []
+- id: GO_REF:0000033
+  title: Annotation inferences using phylogenetic trees
+  findings: []
+- id: GO_REF:0000044
+  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location
+    vocabulary mapping, accompanied by conservative changes to GO terms applied by
+    UniProt
+  findings: []
+- id: PMID:9635427
+  title: &#34;Spastic paraplegia and OXPHOS impairment caused by mutations in paraplegin,
+    a nuclear-encoded mitochondrial metalloprotease.&#34;
+  findings:
+  - statement: &gt;-
+      Paraplegin (the ortholog of ppgn-1) is a nuclear-encoded mitochondrial
+      metalloprotease homologous to the yeast mitochondrial AAA ATPases (AFG3, RCA1,
+      YME1) that combine proteolytic and chaperone-like activities at the inner
+      mitochondrial membrane, and it localizes to mitochondria.
+    supporting_text: &gt;-
+      Paraplegin is highly homologous to the yeast mitochondrial ATPases, AFG3, RCA1,
+      and YME1, which have both proteolytic and chaperon-like activities at the inner
+      mitochondrial membrane.
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PubMed-verified founding paper defining paraplegin as the mitochondrial m-AAA
+      metalloprotease subunit orthologous to ppgn-1; establishes family identity,
+      mitochondrial localization, and dual protease/chaperone character. Concerns human
+      SPG7, not C. elegans ppgn-1, so it supports the annotations by orthology only.
+- id: PMID:16239145
+  title: &#34;The m-AAA protease defective in hereditary spastic paraplegia controls ribosome
+    assembly in mitochondria.&#34;
+  findings:
+  - statement: &gt;-
+      AAA proteases are a conserved family of membrane-bound ATP-dependent proteases that
+      ensure quality control of mitochondrial inner-membrane proteins, and the m-AAA
+      protease processes the ribosomal protein MrpL32 to allow completion of ribosome
+      assembly at the inner membrane.
+    supporting_text: &gt;-
+      AAA proteases comprise a conserved family of membrane bound ATP-dependent proteases
+      that ensures the quality control of mitochondrial inner-membrane proteins.
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PubMed-verified; defines the conserved MF/BP of the family (ATP-dependent
+      inner-membrane quality control and the MrpL32 processing paradigm) that the ppgn-1
+      IBA annotations propagate. Yeast/mouse study, not C. elegans.
+- id: PMID:16647881
+  title: &#34;Translating m-AAA protease function in mitochondria to hereditary spastic paraplegia.&#34;
+  findings:
+  - statement: &gt;-
+      Paraplegin is a conserved subunit of the ubiquitous, ATP-dependent m-AAA protease
+      in mitochondria, which carries out protein quality control in the inner
+      mitochondrial membrane.
+    supporting_text: &gt;-
+      paraplegin, which is a conserved subunit of the ubiquitous and ATP-dependent m-AAA
+      protease in mitochondria.
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PubMed-verified review supporting the m-AAA complex membership (part_of GO:0005745)
+      and the inner-membrane quality-control role by orthology to paraplegin.
+- id: PMID:21610694
+  title: &#34;Presequence-dependent folding ensures MrpL32 processing by the m-AAA protease
+    in mitochondria.&#34;
+  findings:
+  - statement: &gt;-
+      m-AAA proteases have dual functions in the inner mitochondrial membrane: regulated
+      processing of specific substrates and quality-control degradation of misfolded
+      polypeptides to peptides.
+    supporting_text: &gt;-
+      m-AAA proteases exert dual functions in the mitochondrial inner membrane: they
+      mediate the processing of specific regulatory proteins and ensure protein quality
+      control degrading misfolded polypeptides to peptides.
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PubMed-verified; articulates the processing-vs-degradation dual role underlying the
+      distinction between the two core functions. Yeast substrate mechanism, not worm.
+existing_annotations:
+- term:
+    id: GO:0034982
+    label: mitochondrial protein processing
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Phylogenetic (IBA) propagation of the conserved m-AAA processing role from
+      paraplegin/AFG3L2 orthologs. Consistent with ppgn-1&#39;s intact M41 protease domain
+      and the family paradigm of regulated substrate maturation (e.g. MrpL32). Retained
+      as a core function, with the caveat that no C. elegans substrate has been shown.
+    action: ACCEPT
+    reason: &gt;-
+      ppgn-1 is a clear paraplegin-subfamily m-AAA subunit (PANTHER PTHR43655:SF8) with a
+      complete M41 zinc-peptidase module (HExxH motif HEAGH intact at residue 555), so the
+      conserved processing activity is appropriately propagated. The direct substrate in
+      the worm is unknown (see knowledge_gaps).
+    supported_by:
+    - reference_id: PMID:16239145
+      supporting_text: &gt;-
+        The mitochondrial ribosomal protein MrpL32 is processed by the m-AAA protease,
+        allowing its association with preassembled ribosomal particles and completion of
+        ribosome assembly in close proximity to the inner membrane.
+- term:
+    id: GO:0005745
+    label: m-AAA complex
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: part_of
+  review:
+    summary: &gt;-
+      IBA propagation that ppgn-1 is a subunit of the inner-membrane m-AAA protease
+      complex. Well supported by orthology to paraplegin (a conserved m-AAA subunit) and
+      by the shared two-module (AAA+ + M41) architecture. Core.
+    action: ACCEPT
+    reason: &gt;-
+      Paraplegin is a conserved subunit of the m-AAA complex; ppgn-1 is its C. elegans
+      ortholog. The specific composition of the worm complex (homo-oligomer vs
+      hetero-oligomer with the AFG3L2-type subunit spg-7) is not experimentally
+      established.
+    supported_by:
+    - reference_id: PMID:16647881
+      supporting_text: &gt;-
+        paraplegin, which is a conserved subunit of the ubiquitous and ATP-dependent
+        m-AAA protease in mitochondria.
+- term:
+    id: GO:0004222
+    label: metalloendopeptidase activity
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: enables
+  review:
+    summary: &gt;-
+      IBA propagation of zinc-dependent endopeptidase activity from the family. Directly
+      corroborated for the ppgn-1 sequence by the intact M41 HExxH zinc-binding catalytic
+      motif (HEAGH at residue 555, within the Peptidase_M41 domain). Core molecular
+      function.
+    action: ACCEPT
+    reason: &gt;-
+      The C-terminal M41 peptidase domain (InterPro IPR000642) and the intact HExxH motif
+      support metalloendopeptidase chemistry for this specific protein, not merely by
+      family membership.
+    supported_by:
+    - reference_id: PMID:9635427
+      supporting_text: &gt;-
+        Paraplegin is highly homologous to the yeast mitochondrial ATPases, AFG3, RCA1,
+        and YME1, which have both proteolytic and chaperon-like activities at the inner
+        mitochondrial membrane.
+- term:
+    id: GO:0004176
+    label: ATP-dependent peptidase activity
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: enables
+  review:
+    summary: &gt;-
+      InterPro (IEA) assignment of ATP-dependent peptidase activity. This is the most
+      complete single molecular-function term for an m-AAA protease because it captures
+      the coupling of the AAA+ ATPase to the M41 peptidase. Supported by the intact
+      Walker A/B (GPPGCGKT, IIYIDE) and HExxH motifs in the ppgn-1 sequence. Core.
+    action: ACCEPT
+    reason: &gt;-
+      ppgn-1 has both an intact AAA+ ATPase module (Walker A GPPGCGKT at 325, Walker B
+      IIYIDE at 380) and an intact M41 peptidase module (HExxH at 555), the defining
+      combination for ATP-dependent proteolysis.
+    supported_by:
+    - reference_id: PMID:16239145
+      supporting_text: &gt;-
+        AAA proteases comprise a conserved family of membrane bound ATP-dependent
+        proteases that ensures the quality control of mitochondrial inner-membrane
+        proteins.
+- term:
+    id: GO:0004222
+    label: metalloendopeptidase activity
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Second annotation of metalloendopeptidase activity, here from the InterPro M41
+      signature (IEA). Same well-supported molecular function as the IBA annotation
+      above; kept as a corroborating electronic assignment.
+    action: ACCEPT
+    reason: &gt;-
+      Redundant with the IBA metalloendopeptidase annotation but independently supported
+      by the InterPro Peptidase_M41 signature (IPR000642) and the intact HExxH motif.
+- term:
+    id: GO:0005524
+    label: ATP binding
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: enables
+  review:
+    summary: &gt;-
+      InterPro (IEA) assignment of ATP binding, an activity of the AAA+ module.
+      Corroborated by the intact Walker A P-loop (GPPGCGKT at residue 325) in the ppgn-1
+      sequence. A component activity of the ATP-dependent protease.
+    action: ACCEPT
+    reason: &gt;-
+      The N-terminal AAA+ ATPase domain (SMART SM00382; InterPro IPR003959) with an
+      intact Walker A motif provides a direct structural basis for ATP binding.
+- term:
+    id: GO:0005739
+    label: mitochondrion
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000044
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Subcellular-location mapping (IEA) to mitochondrion. Correct but non-specific: the
+      family resides in the inner mitochondrial membrane, captured more precisely in
+      core_functions (GO:0005743). Retained but marked non-core because it is a generic
+      parent of the informative location.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Consistent with the orthologous localization (paraplegin localizes to mitochondria)
+      and with two predicted TM helices; the more informative term is mitochondrial inner
+      membrane, so this generic term is not the core localization statement.
+    supported_by:
+    - reference_id: PMID:9635427
+      supporting_text: &gt;-
+        Immunofluorescence analysis and import experiments showed that Paraplegin
+        localizes to mitochondria.
+- term:
+    id: GO:0006508
+    label: proteolysis
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      InterPro (IEA) generic proteolysis term. Correct but uninformative: the specific
+      biological roles (protein quality-control degradation and mitochondrial protein
+      processing) are captured in core_functions. Retained as a non-core parent term.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      GO:0006508 is a high-level parent of the specific m-AAA processes; it is not wrong,
+      but the informative annotations are mitochondrial protein processing (GO:0034982)
+      and protein quality control (GO:0006515).
+- term:
+    id: GO:0016020
+    label: membrane
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000044
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Subcellular-location mapping (IEA) to the generic term membrane. The protein is a
+      multi-pass integral membrane protein, but the informative location is the
+      mitochondrial inner membrane (GO:0005743), used in core_functions. Non-core parent.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Correct (two predicted TM helices at 111-133 and 225-245; UniProt multi-pass
+      membrane protein) but far too generic to be a core localization statement.
+- term:
+    id: GO:0016887
+    label: ATP hydrolysis activity
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: enables
+  review:
+    summary: &gt;-
+      InterPro (IEA) assignment of ATP hydrolysis activity, the motor activity of the
+      AAA+ module that drives substrate unfolding/translocation. Corroborated by the
+      intact Walker B motif (IIYIDE at residue 380) in the ppgn-1 sequence. A component
+      activity of the ATP-dependent protease.
+    action: ACCEPT
+    reason: &gt;-
+      The AAA+ ATPase module with intact Walker A and Walker B motifs supports ATP
+      hydrolysis; this is the energy-providing half of the ATP-dependent protease.
+- term:
+    id: GO:0005743
+    label: mitochondrial inner membrane
+  evidence_type: ISS
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Proposed refinement of the generic mitochondrion/membrane localizations to the
+      specific compartment where m-AAA proteases reside. Inferred from orthology to
+      paraplegin and from the two predicted TM helices flanking matrix-facing catalytic
+      domains (canonical m-AAA topology).
+    action: NEW
+    reason: &gt;-
+      The generic GOA terms (GO:0005739 mitochondrion, GO:0016020 membrane) understate the
+      known compartment. The m-AAA protease is an integral protein of the mitochondrial
+      inner membrane; this ISS annotation captures the informative location while the
+      worm-specific topology remains to be experimentally mapped.
+    supported_by:
+    - reference_id: PMID:16647881
+      supporting_text: &gt;-
+        The m-AAA protease carries out protein quality control in the inner membrane of
+        the mitochondria
+- term:
+    id: GO:0006515
+    label: protein quality control for misfolded or incompletely synthesized proteins
+  evidence_type: ISS
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Proposed refinement of the generic proteolysis annotation to the specific
+      quality-control process performed by the m-AAA protease: ATP-dependent degradation
+      of misfolded/unassembled inner-membrane proteins. Inferred from orthology and the
+      intact AAA+ + M41 catalytic modules.
+    action: NEW
+    reason: &gt;-
+      GO:0006508 (proteolysis) is uninformative; the conserved biological role of the
+      family is inner-membrane protein quality control. This ISS annotation records that
+      specific process, complementing the mitochondrial protein processing (GO:0034982)
+      role. The endogenous worm substrates are not yet identified.
+    supported_by:
+    - reference_id: PMID:16239145
+      supporting_text: &gt;-
+        AAA proteases comprise a conserved family of membrane bound ATP-dependent
+        proteases that ensures the quality control of mitochondrial inner-membrane
+        proteins.
+core_functions:
+- description: &gt;-
+    ATP-dependent proteolytic quality control of the inner mitochondrial membrane. As a
+    subunit of the m-AAA protease, ppgn-1 couples ATP-driven substrate unfolding and
+    translocation (AAA+ module) to zinc-dependent peptide-bond hydrolysis (M41 module) to
+    degrade misfolded or unassembled inner-membrane proteins to peptides. Inferred from
+    orthology to paraplegin/AFG3L2 and from the intact Walker A/B and HExxH catalytic
+    motifs in the ppgn-1 sequence; the endogenous C. elegans substrates are not yet
+    identified.
+  molecular_function:
+    id: GO:0004176
+    label: ATP-dependent peptidase activity
+  directly_involved_in:
+  - id: GO:0006515
+    label: protein quality control for misfolded or incompletely synthesized proteins
+  locations:
+  - id: GO:0005743
+    label: mitochondrial inner membrane
+  in_complex:
+    id: GO:0005745
+    label: m-AAA complex
+  supported_by:
+  - reference_id: PMID:16239145
+    supporting_text: &gt;-
+      AAA proteases comprise a conserved family of membrane bound ATP-dependent proteases
+      that ensures the quality control of mitochondrial inner-membrane proteins.
+  - reference_id: PMID:21610694
+    supporting_text: &gt;-
+      m-AAA proteases exert dual functions in the mitochondrial inner membrane: they
+      mediate the processing of specific regulatory proteins and ensure protein quality
+      control degrading misfolded polypeptides to peptides.
+- description: &gt;-
+    Regulated proteolytic maturation (processing) of specific mitochondrial substrates.
+    Beyond bulk degradation, m-AAA proteases perform limited, sequence-specific cleavage
+    that matures regulatory substrates; the conserved paradigm is processing of the
+    ribosomal protein MrpL32, which is required for mitochondrial ribosome assembly and
+    translation. ppgn-1 is inferred to contribute this metalloendopeptidase-based
+    processing activity within the worm m-AAA complex; the specific worm substrate(s)
+    remain undetermined.
+  molecular_function:
+    id: GO:0004222
+    label: metalloendopeptidase activity
+  directly_involved_in:
+  - id: GO:0034982
+    label: mitochondrial protein processing
+  locations:
+  - id: GO:0005743
+    label: mitochondrial inner membrane
+  in_complex:
+    id: GO:0005745
+    label: m-AAA complex
+  supported_by:
+  - reference_id: PMID:16239145
+    supporting_text: &gt;-
+      The mitochondrial ribosomal protein MrpL32 is processed by the m-AAA protease,
+      allowing its association with preassembled ribosomal particles and completion of
+      ribosome assembly in close proximity to the inner membrane.
+knowledge_gaps:
+- gap_statement: &gt;-
+    ppgn-1 has no experimental functional characterization in C. elegans: no
+    loss-of-function (mutant or RNAi) phenotype, no localization, and no biochemical
+    assay has been reported for this gene. Every GO annotation is phylogenetic (IBA) or
+    electronic (IEA), and the only UniProt-linked reference is an unpublished nucleotide
+    sequence submission.
+  boundary: &gt;-
+    The protein is confidently a paraplegin-subfamily m-AAA protease subunit (PANTHER
+    PTHR43655:SF8; AAA+ + M41 architecture) with intact catalytic motifs, and the human
+    ortholog paraplegin (SPG7) and yeast/mouse orthologs are well characterized. What is
+    missing is any direct evidence for ppgn-1 itself in the worm.
+  gap_kind:
+  - BIOLOGY
+  dark_aspect: WHOLLY_DARK
+  status: OPEN
+  significance: &gt;-
+    Without any worm-level data, ppgn-1&#39;s function is entirely an orthology inference; its
+    non-redundant contribution (if any) to C. elegans mitochondrial physiology is unknown.
+  resolution: &gt;-
+    Generate and phenotype a ppgn-1 deletion/RNAi allele (respiration, mitochondrial
+    morphology, UPRmt reporters, fertility, lifespan), and determine its expression and
+    subcellular localization with an endogenous tag.
+  provenance:
+  - reference_id: PMID:9635427
+    supporting_text: &gt;-
+      Paraplegin is highly homologous to the yeast mitochondrial ATPases, AFG3, RCA1,
+      and YME1, which have both proteolytic and chaperon-like activities at the inner
+      mitochondrial membrane.
+- gap_statement: &gt;-
+    The endogenous substrate(s) of ppgn-1 in C. elegans are unidentified. It is unknown
+    whether the worm protease matures a functional homolog of MrpL32 (regulated
+    processing) and/or which misfolded inner-membrane proteins it degrades (quality
+    control), and whether ppgn-1 and the AFG3L2-type subunit spg-7 act on the same or
+    distinct substrate sets.
+  boundary: &gt;-
+    The conserved m-AAA protease has a defined dual activity (processing vs degradation),
+    and MrpL32 maturation is the textbook processing substrate in yeast and mouse. ppgn-1
+    retains an intact HExxH metallopeptidase active site, so it is catalytically capable
+    in principle.
+  gap_kind:
+  - BIOLOGY
+  dark_aspect: MF_DARK
+  status: OPEN
+  significance: &gt;-
+    Substrate identity is what distinguishes a housekeeping protease from a specific
+    regulatory node; it is the rate-limiting unknown for placing ppgn-1 in a pathway.
+  resolution: &gt;-
+    Substrate-trapping (catalytically inactive HExxH mutant) plus comparative proteomics
+    of ppgn-1 vs spg-7 loss-of-function to identify processed/stabilized substrates.
+  provenance:
+  - reference_id: PMID:21610694
+    supporting_text: &gt;-
+      m-AAA proteases exert dual functions in the mitochondrial inner membrane: they
+      mediate the processing of specific regulatory proteins and ensure protein quality
+      control degrading misfolded polypeptides to peptides.
+- gap_statement: &gt;-
+    The oligomeric composition of the C. elegans m-AAA complex containing ppgn-1 is
+    undetermined: whether ppgn-1 forms a homo-oligomer, assembles into a hetero-oligomer
+    with the AFG3L2-type subunit spg-7, and whether the two worm subunits are
+    functionally redundant, is untested.
+  boundary: &gt;-
+    In mammals the m-AAA protease is a hexamer of paraplegin (SPG7) and/or AFG3L2, and one
+    catalytically dead subunit can be tolerated within an otherwise active complex. C.
+    elegans has both a paraplegin-type (ppgn-1) and an AFG3L2-type (spg-7) subunit, but
+    their assembly relationship is not reported.
+  gap_kind:
+  - BIOLOGY
+  dark_aspect: RESIDUAL_SUBGAP
+  status: OPEN
+  significance: &gt;-
+    Complex composition determines whether ppgn-1 loss can be buffered by spg-7 and how to
+    interpret single-gene phenotypes.
+  resolution: &gt;-
+    Co-immunoprecipitation / blue-native PAGE of endogenously tagged ppgn-1 and spg-7, and
+    epistasis/double-mutant analysis to test redundancy.
+  provenance:
+  - reference_id: PMID:16647881
+    supporting_text: &gt;-
+      paraplegin, which is a conserved subunit of the ubiquitous and ATP-dependent m-AAA
+      protease in mitochondria.
+- gap_statement: &gt;-
+    Whether ppgn-1 (as opposed to its paralog spg-7) contributes to any organismal process
+    in C. elegans - the mitochondrial unfolded-protein response, respiration, mitochondrial
+    dynamics, fertility, longevity, or stress/pathogen resistance - is unknown. The large
+    C. elegans mito-protease functional literature concerns spg-7 and cannot be attributed
+    to ppgn-1.
+  boundary: &gt;-
+    Loss of m-AAA proteases across organisms causes respiratory deficiency, altered
+    mitochondrial morphology and axonal degeneration; none of these readouts has been
+    tested specifically for ppgn-1 in the worm.
+  gap_kind:
+  - BIOLOGY
+  dark_aspect: BP_DARK
+  status: OPEN
+  significance: &gt;-
+    Assigning ppgn-1 a biological process (vs treating it as a redundant paralog) requires
+    worm phenotypes; this determines its relevance to mitochondrial surveillance and
+    stress signaling.
+  resolution: &gt;-
+    Test ppgn-1 loss-of-function against UPRmt (hsp-6p::GFP), respiration, mitochondrial
+    morphology, and pathogen/stress-resistance assays, side by side with spg-7.
+  provenance:
+  - reference_id: PMID:16239145
+    supporting_text: &gt;-
+      Inactivation of AAA proteases causes pleiotropic phenotypes in various organisms,
+      including respiratory deficiencies, mitochondrial morphology defects, and axonal
+      degeneration in hereditary spastic paraplegia (HSP).
+suggested_questions:
+- question: &gt;-
+    Does ppgn-1 form a functional m-AAA protease complex on its own, or does it require
+    the AFG3L2-type subunit spg-7, and are the two subunits functionally redundant in
+    C. elegans?
+  experts:
+  - C. elegans mitochondrial biologists
+  - m-AAA protease / AAA+ protease structural biochemists
+- question: &gt;-
+    What are the endogenous substrates of ppgn-1 in C. elegans, and does it mature a
+    MrpL32 homolog to regulate mitochondrial ribosome assembly as in yeast and mouse?
+  experts:
+  - Mitochondrial proteostasis / ribosome assembly researchers
+suggested_experiments:
+- experiment_type: Reverse genetics / phenotyping
+  description: &gt;-
+    Generate a ppgn-1 null allele (CRISPR) and, in parallel with spg-7 RNAi/mutant, assay
+    respiration, mitochondrial morphology, UPRmt (hsp-6p::GFP), fertility and lifespan to
+    determine ppgn-1&#39;s non-redundant contribution.
+- experiment_type: Affinity purification / mass spectrometry
+  description: &gt;-
+    Endogenously tag ppgn-1, purify from worm mitochondria, and identify complex partners
+    (test for spg-7 hetero-oligomerization) and, using a catalytically dead HExxH mutant
+    as a substrate trap, capture processed/degraded substrates.
+- experiment_type: Localization
+  description: &gt;-
+    Determine ppgn-1 tissue expression and sub-mitochondrial topology with an endogenous
+    fluorescent tag and protease-protection assays, to confirm the predicted inner-membrane,
+    matrix-facing catalytic-domain topology.
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/genes/worm/sod-2/sod-2-ai-review.html
+++ b/genes/worm/sod-2/sod-2-ai-review.html
@@ -1,0 +1,3828 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>sod-2 - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        .propagation-review {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f8fafc;
+            border-left: 3px solid #64748b;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .propagation-title {
+            font-weight: 600;
+            color: #334155;
+            margin-bottom: 0.25rem;
+        }
+
+        .propagation-row {
+            margin-top: 0.25rem;
+        }
+
+        .propagation-source {
+            margin-top: 0.5rem;
+            padding-top: 0.5rem;
+            border-top: 1px solid #e5e7eb;
+        }
+
+        .propagation-source-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #1d4ed8;
+        }
+
+        .propagation-comment {
+            color: #4b5563;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>sod-2</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/P31161" target="_blank" class="term-link">
+                        P31161
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Caenorhabditis elegans</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-complete">
+                    COMPLETE
+                </span>
+            </div>
+
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "sod-2";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="P31161" data-a="DESCRIPTION: sod-2 encodes the principal manganese-dependent su..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>sod-2 encodes the principal manganese-dependent superoxide dismutase (MnSOD) of the Caenorhabditis elegans mitochondrion. The nuclear-encoded precursor carries an N-terminal mitochondrial transit peptide that directs import into the mitochondrial matrix, where the mature chain assembles into the characteristic iron/manganese superoxide dismutase fold and binds one catalytic Mn(2+) ion per subunit. The enzyme dismutates the superoxide anion radical, a by-product of the respiratory electron transport chain, into hydrogen peroxide and molecular oxygen (2 superoxide + 2 H+ -&gt; H2O2 + O2; EC 1.15.1.1), providing a first line of antioxidant defense within the organelle. C. elegans has a second, closely related mitochondrial MnSOD, sod-3 (~86% identical), which is expressed at low basal levels and is strongly induced by the DAF-16/FOXO branch of insulin/IGF-1 signalling; sod-2 is the constitutively expressed and quantitatively dominant mitochondrial isoform. Beyond bulk matrix scavenging, SOD-2 physically associates with the respiratory-chain supercomplex I:III:IV, positioning it to detoxify superoxide at its site of production and potentially to influence supercomplex stability and complex I/II activity. Counterintuitively for a core antioxidant enzyme, loss of sod-2 does not shorten and in several mitochondrial-mutant backgrounds can extend C. elegans lifespan, a finding central to debates over the role of reactive oxygen species in aging. The enzyme&#39;s hydrogen peroxide product also serves as a signalling molecule: it contributes to a RAS-dependent ROS-signalling program linked to longevity and is required for sperm pseudopod extension during sperm activation.</p>
+    </div>
+
+
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005739" target="_blank" class="term-link">
+                                    GO:0005739
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrion</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P31161" data-a="GO:0005739" data-r="GO_REF:0000033" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetic (IBA) inference that SOD-2 is active in the mitochondrion. Correct but less specific than the mitochondrial matrix, which is where this MnSOD acts.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Consistent with the mitochondrial transit peptide and with experimental localization, but generic relative to mitochondrial matrix (GO:0005759), which is retained as the core location. Kept as a correct, less-specific companion term.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004784" target="_blank" class="term-link">
+                                    GO:0004784
+                                </a>
+                            </span>
+                            <span class="term-label">superoxide dismutase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P31161" data-a="GO:0004784" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetic (IBA) inference of superoxide dismutase activity. This is the core molecular function of SOD-2 and is directly confirmed experimentally.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> SOD-2 is an experimentally validated manganese superoxide dismutase; the IBA call is fully concordant with the IDA evidence (PMID:9353332) and with the Fe/Mn-SOD family assignment. Core function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9353332" target="_blank" class="term-link">
+                                        PMID:9353332
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The expressed enzymes, which were not inhibited by hydrogen peroxide or cyanide, are dimeric, show quite different electrophoretic mobilities and isoelectric points, but exhibit comparable specific activities.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030145" target="_blank" class="term-link">
+                                    GO:0030145
+                                </a>
+                            </span>
+                            <span class="term-label">manganese ion binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P31161" data-a="GO:0030145" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetic (IBA) inference of manganese ion binding, the catalytic cofactor of this MnSOD. Concordant with the UniProt Mn(2+) cofactor and Mn-ligand residues, and with the enzyme&#39;s Mn-type biochemistry.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct and specific metal-binding function: this is a Mn-type (not Fe- or Cu/Zn-type) SOD, insensitive to hydrogen peroxide and cyanide, binding one Mn(2+) per subunit. Core cofactor-binding function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9353332" target="_blank" class="term-link">
+                                        PMID:9353332
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The expressed enzymes, which were not inhibited by hydrogen peroxide or cyanide, are dimeric, show quite different electrophoretic mobilities and isoelectric points, but exhibit comparable specific activities.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004784" target="_blank" class="term-link">
+                                    GO:0004784
+                                </a>
+                            </span>
+                            <span class="term-label">superoxide dismutase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000120
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P31161" data-a="GO:0004784" data-r="GO_REF:0000120" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic (IEA) assignment of superoxide dismutase activity from combined automated methods (ARBA/InterPro/EC/RHEA mapping). Redundant with the experimental IDA and phylogenetic IBA calls for the same core function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Same core molecular function as the IDA/IBA annotations; the EC 1.15.1.1 / RHEA:20696 mapping is correct for this enzyme. Retained as concordant supporting evidence.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005759" target="_blank" class="term-link">
+                                    GO:0005759
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial matrix</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000044
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P31161" data-a="GO:0005759" data-r="GO_REF:0000044" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic (SubCell) localization to the mitochondrial matrix, matching the UniProt subcellular location and the N-terminal mitochondrial transit peptide. This is the core site of SOD-2 action.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct and appropriately specific localization for a matrix MnSOD; supported by the transit peptide and by the primary-mtSOD role. Core location.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9353332" target="_blank" class="term-link">
+                                        PMID:9353332
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Both deduced protein sequences contain the expected N-terminal mitochondrial transit peptides.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006801" target="_blank" class="term-link">
+                                    GO:0006801
+                                </a>
+                            </span>
+                            <span class="term-label">superoxide metabolic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P31161" data-a="GO:0006801" data-r="GO_REF:0000002" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic (InterPro2GO) assignment to the general superoxide metabolic process. Correct but less specific than removal of superoxide radicals (GO:0019430), which is the experimentally supported process.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Accurate parent process, but subsumed by the more specific removal of superoxide radicals term retained as core. Kept as a correct, less-informative companion.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0046872" target="_blank" class="term-link">
+                                    GO:0046872
+                                </a>
+                            </span>
+                            <span class="term-label">metal ion binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P31161" data-a="GO:0046872" data-r="GO_REF:0000002" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic (InterPro2GO) generic metal-ion-binding annotation. Subsumed by the specific manganese ion binding (GO:0030145) term.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct but uninformative parent of manganese ion binding; the specific Mn(2+) term is retained as core. Kept as a non-core, less-specific companion.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0098803" target="_blank" class="term-link">
+                                    GO:0098803
+                                </a>
+                            </span>
+                            <span class="term-label">respiratory chain complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000117
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P31161" data-a="GO:0098803" data-r="GO_REF:0000117" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic (ARBA) assertion that SOD-2 is part_of the respiratory chain complex. SOD-2 is a soluble matrix MnSOD that physically associates with supercomplex I:III:IV (see the experimental located_in annotation), but it is not a canonical structural subunit of an electron-transport complex, so the part_of qualifier overstates the relationship.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The experimentally supported relationship is association/co-localization with the I:III:IV supercomplex (PMID:23895727, located_in), consistent with local superoxide scavenging and possible supercomplex stabilization; SOD-2 does not carry out or structurally constitute electron transport. The automated part_of qualifier is an over-generalization, so this is retained only as a non-core companion to the experimental located_in annotation rather than as evidence of structural subunit membership.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/23895727" target="_blank" class="term-link">
+                                        PMID:23895727
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Western blots of BNGs indicated that SOD-2 co-localized with the I:III:IV supercomplex (Figure 4D).</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004784" target="_blank" class="term-link">
+                                    GO:0004784
+                                </a>
+                            </span>
+                            <span class="term-label">superoxide dismutase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/9353332" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:9353332
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Cloning, expression, and characterization of two manganese s...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P31161" data-a="GO:0004784" data-r="PMID:9353332" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct assay (IDA) of superoxide dismutase activity: the mature SOD-2 protein was expressed in SOD-deficient E. coli and shown to be an active, Mn-type dismutase. This is the primary experimental evidence for the core function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Gold-standard experimental support for the defining molecular function. Insensitivity to hydrogen peroxide and cyanide confirms the Mn-type (not Fe- or Cu/Zn-type) mechanism. Core function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9353332" target="_blank" class="term-link">
+                                        PMID:9353332
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The expressed enzymes, which were not inhibited by hydrogen peroxide or cyanide, are dimeric, show quite different electrophoretic mobilities and isoelectric points, but exhibit comparable specific activities.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:worm/sod-2/sod-2-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Primary mitochondrial Mn-superoxide dismutase that converts superoxide to hydrogen peroxide and oxygen</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0019430" target="_blank" class="term-link">
+                                    GO:0019430
+                                </a>
+                            </span>
+                            <span class="term-label">removal of superoxide radicals</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/9353332" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:9353332
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Cloning, expression, and characterization of two manganese s...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P31161" data-a="GO:0019430" data-r="PMID:9353332" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> SOD-2 removes superoxide radicals: heterologous expression of the worm enzyme rescued SOD-deficient E. coli from methyl-viologen (paraquat) oxidative stress. This is the core biological process the enzyme serves.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Functionally correct core process. The evidence is heterologous complementation (protection of SOD-null E. coli against a superoxide generator) rather than a worm loss-of-function phenotype, but it directly demonstrates superoxide-radical removal by the SOD-2 protein. Core process.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9353332" target="_blank" class="term-link">
+                                        PMID:9353332
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Both proteins were shown to be active in E. coli, providing similar protection against methyl viologen-induced oxidative stress.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0098803" target="_blank" class="term-link">
+                                    GO:0098803
+                                </a>
+                            </span>
+                            <span class="term-label">respiratory chain complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/23895727" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:23895727
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Novel interactions between mitochondrial superoxide dismutas...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P31161" data-a="GO:0098803" data-r="PMID:23895727" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct assay (IDA) showing SOD-2 co-localizes with mitochondrial supercomplex I:III:IV by blue-native gel Western blotting. A genuine, sod-2-specific localization finding, but a peripheral association rather than the enzyme&#39;s core identity.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Experimentally supported association of SOD-2 with the I:III:IV supercomplex, consistent with local scavenging of superoxide at its site of production and a possible supercomplex-stabilizing role. Retained with the located_in qualifier as a real but non-core localization (SOD-2&#39;s core identity is a matrix MnSOD, not a structural ETC subunit).
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/23895727" target="_blank" class="term-link">
+                                        PMID:23895727
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Western blots of BNGs indicated that SOD-2 co-localized with the I:III:IV supercomplex (Figure 4D).</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005739" target="_blank" class="term-link">
+                                    GO:0005739
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrion</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">HDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/20188671" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:20188671
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The matrix peptide exporter HAF-1 signals a mitochondrial UP...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P31161" data-a="GO:0005739" data-r="PMID:20188671" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> High-throughput direct-assay (HDA) mitochondrial-proteome localization of SOD-2. Correct but generic relative to the mitochondrial matrix term.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Mitochondrial localization of this MnSOD is biologically unambiguous and concordant with the transit peptide and matrix localization; retained as a correct, less-specific companion to mitochondrial matrix (GO:0005759). The cited abstract concerns the mtUPR and does not mention sod-2, so no sod-2-specific verbatim quote is available for the HDA dataset.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>SOD-2 is a mitochondrial matrix manganese superoxide dismutase that catalyzes the dismutation of the superoxide anion radical to hydrogen peroxide and molecular oxygen (2 superoxide + 2 H+ -&gt; H2O2 + O2; EC 1.15.1.1), the core antioxidant defense of the mitochondrial matrix and the primary constitutively expressed mtSOD of C. elegans.</h3>
+                <span class="vote-buttons" data-g="P31161" data-a="FUNCTION: SOD-2 is a mitochondrial matrix manganese superoxi..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004784" target="_blank" class="term-link">
+                            superoxide dismutase activity
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0019430" target="_blank" class="term-link">
+                                removal of superoxide radicals
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005759" target="_blank" class="term-link">
+                                mitochondrial matrix
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/9353332" target="_blank" class="term-link">
+                                PMID:9353332
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">The expressed enzymes, which were not inhibited by hydrogen peroxide or cyanide, are dimeric, show quite different electrophoretic mobilities and isoelectric points, but exhibit comparable specific activities.</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/9353332" target="_blank" class="term-link">
+                                PMID:9353332
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">Both proteins were shown to be active in E. coli, providing similar protection against methyl viologen-induced oxidative stress.</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>SOD-2 binds one catalytic manganese (Mn2+) ion per subunit, the redox-active cofactor required for the dismutase mechanism. Its Mn-type identity is established by insensitivity to hydrogen peroxide and cyanide, which inhibit Fe-type and Cu/Zn-type SODs respectively.</h3>
+                <span class="vote-buttons" data-g="P31161" data-a="FUNCTION: SOD-2 binds one catalytic manganese (Mn2+) ion per..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030145" target="_blank" class="term-link">
+                            manganese ion binding
+                        </a>
+                    </span>
+                </div>
+
+
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005759" target="_blank" class="term-link">
+                                mitochondrial matrix
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/9353332" target="_blank" class="term-link">
+                                PMID:9353332
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">The expressed enzymes, which were not inhibited by hydrogen peroxide or cyanide, are dimeric, show quite different electrophoretic mobilities and isoelectric points, but exhibit comparable specific activities.</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000002.md" target="_blank" class="term-link">
+                            GO_REF:0000002
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation through association of InterPro records with GO terms</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
+                            GO_REF:0000033
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Annotation inferences using phylogenetic trees</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
+                            GO_REF:0000044
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000117.md" target="_blank" class="term-link">
+                            GO_REF:0000117
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Electronic Gene Ontology annotations created by ARBA machine learning models</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000120.md" target="_blank" class="term-link">
+                            GO_REF:0000120
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Combined Automated Annotation using Multiple IEA Methods</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/19197346" target="_blank" class="term-link">
+                            PMID:19197346
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Deletion of the mitochondrial superoxide dismutase sod-2 extends lifespan in Caenorhabditis elegans.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Seminal demonstration that deleting the primary mitochondrial MnSOD sod-2 extends C. elegans lifespan despite increased protein oxidative damage and heightened sensitivity to oxidative stress, directly challenging the oxidative-damage theory of aging. sod-2 mutants phenocopy long-lived mitochondrial mutants (slow development, small brood, reduced respiration).</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/28724632" target="_blank" class="term-link">
+                            PMID:28724632
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Hydrogen peroxide produced by superoxide dismutase SOD-2 activates sperm in Caenorhabditis elegans.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">SOD-2-generated hydrogen peroxide acts as a positive signaling molecule required for sperm pseudopod extension during activation; sod-2 (not sod-1) is the specific SOD required, linking SOD-2 enzymatic output to fertility.</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/36449615" target="_blank" class="term-link">
+                            PMID:36449615
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Stimulation of RAS-dependent ROS signaling extends longevity by modulating a developmental program of global gene expression.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Proposes the RAS-dependent ROS signaling (RDRS) mechanism for sod-2 longevity: loss of SOD-2 raises mitochondrial superoxide, which is converted by cytosolic SOD-1 to hydrogen peroxide that oxidizes a redox-sensitive cysteine of LET-60/RAS, driving a global developmental gene-expression program; the lifespan extension requires SOD-1.</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/20188671" target="_blank" class="term-link">
+                            PMID:20188671
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">The matrix peptide exporter HAF-1 signals a mitochondrial UPR by activating the transcription factor ZC376.7 in C. elegans.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">High-throughput direct-assay (mass-spectrometry) source underlying the GOA mitochondrion localization annotation for SOD-2. The cached abstract concerns HAF-1/ClpP-mediated mitochondrial unfolded protein response signalling and does not itself discuss sod-2; the annotation reflects detection of SOD-2 in a mitochondrial proteome dataset.</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/23895727" target="_blank" class="term-link">
+                            PMID:23895727
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Novel interactions between mitochondrial superoxide dismutases and the electron transport chain.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">SOD-2 is the primary mitochondrial superoxide dismutase and co-localizes by blue-native gel with the respiratory supercomplex I:III:IV; loss of SOD-2 specifically lowers complex I and II activity and destabilizes supercomplex formation. sod-2 single mutants have a normal lifespan, but loss of sod-2 can extend the lifespan of some electron-transport-chain mutants.</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/9353332" target="_blank" class="term-link">
+                            PMID:9353332
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Cloning, expression, and characterization of two manganese superoxide dismutases from Caenorhabditis elegans.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Cloned sod-2 and sod-3, showed both encode mitochondrial (transit-peptide bearing) manganese-type superoxide dismutases, and directly measured their enzymatic activity after heterologous expression in SOD-deficient E. coli (Mn-type: insensitive to hydrogen peroxide and cyanide; dimeric; protective against paraquat/methyl-viologen oxidative stress).</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Questions for Experts</h2>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> By what mechanism does loss of the primary mitochondrial antioxidant SOD-2 fail to shorten, and in some backgrounds extend, C. elegans lifespan — is superoxide acting as a pro-longevity signal (mitohormesis), or is the effect mediated by metabolic slowing and supercomplex remodeling?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P31161" data-a="Q: By what mechanism does loss of the primary mitocho..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> What is the functional division of labour between the two nearly identical mitochondrial MnSODs, SOD-2 (constitutive, dominant) and SOD-3 (DAF-16-inducible, low basal), given their non-redundant and sometimes opposite genetic interactions with electron-transport-chain mutants?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P31161" data-a="Q: What is the functional division of labour between ..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Is SOD-2&#39;s association with respiratory supercomplex I:III:IV purely a positioning device for local superoxide scavenging, or does SOD-2 also act as a structural stabilizer of the supercomplex independent of its catalytic activity?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P31161" data-a="Q: Is SOD-2&#39;s association with respiratory supercompl..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Experiments</h2>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Catalytically-dead (metal-ligand mutant) versus wild-type sod-2 rescue in a sod-2 null, scoring lifespan, complex I/II activity, and supercomplex formation, to separate the scavenging function from a possible structural role.</p>
+
+
+
+                </div>
+                <span class="vote-buttons" data-g="P31161" data-a="EXPERIMENT: Catalytically-dead (metal-ligand mutant) versus wi..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Quantitative, isoform-resolved proteomics and tagged-allele localization of SOD-2 versus SOD-3 across tissues and stress conditions to define their non-redundant contributions and supercomplex occupancy.</p>
+
+
+
+                </div>
+                <span class="vote-buttons" data-g="P31161" data-a="EXPERIMENT: Quantitative, isoform-resolved proteomics and tagg..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Genetic-epistasis and redox-biosensor (e.g. mitochondrial roGFP/HyPer) analysis of sod-2 loss in long-lived ETC mutants to test whether a superoxide/ROS signal, rather than bulk oxidative damage, mediates the lifespan extension.</p>
+
+
+
+                </div>
+                <span class="vote-buttons" data-g="P31161" data-a="EXPERIMENT: Genetic-epistasis and redox-biosensor (e.g. mitoch..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Knowledge Gaps</h2>
+        <p style="color: #555; font-size: 0.92rem; margin-top: -0.3rem;">
+            What is <em>not</em> known — curated, literature-grounded statements of the open
+            unknowns (the inverse of core functions).
+        </p>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> How loss of the primary mitochondrial superoxide dismutase SOD-2 extends C. elegans lifespan is only partly resolved. A specific mechanism has been proposed — a RAS-dependent ROS-signalling (RDRS) pathway in which elevated mitochondrial superoxide is converted by cytosolic SOD-1 to hydrogen peroxide that oxidizes a redox-sensitive cysteine of LET-60/RAS — but how much of the longevity effect is attributable to this ROS signal versus to the concurrent reduction in respiration, altered mitochondrial supercomplex stability, and developmental/metabolic slowing remains undetermined, as does why the same loss shortens lifespan once mitochondrial dysfunction exceeds a threshold.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">NARROWING</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">BP_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> It is firmly established that SOD-2 is an active mitochondrial MnSOD and the primary mitochondrial superoxide scavenger, that sod-2 single mutants are not short-lived and are in fact long-lived despite increased protein oxidative damage, that deletion of sod-2 markedly increases lifespan in clk-1 but decreases it in isp-1 backgrounds, that loss of sod-2 lowers complex I/II activity and supercomplex formation, and that a RDRS mechanism requiring SOD-1 can account for part of the extension. What is not established is the causal weighting of the signalling versus metabolic contributions.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> This is a central, counterintuitive case in the debate over the free-radical / oxidative-damage theory of aging: a core antioxidant enzyme whose removal does not shorten and can extend life. Resolving the causal weighting would clarify when mitochondrial superoxide acts as a damaging agent versus a pro-longevity signal.</p>
+
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"we find that sod-2 mutants are long-lived despite a significant increase in oxidatively damaged proteins"</em> — PMID:19197346</li>
+
+                <li><em>"deletion of sod-2 extends worm lifespan by altering mitochondrial function"</em> — PMID:19197346</li>
+
+                <li><em>"RDRS is regulated by negative feedback from the superoxide dismutase 1 (SOD-1)-dependent conversion of superoxide into cytoplasmic hydrogen peroxide, which, in turn, acts on a redox-sensitive cysteine (C118) of RAS"</em> — PMID:36449615</li>
+
+                <li><em>"no single component of mitochondrial physiology that we studied correlates simply with lifespan"</em> — PMID:23895727</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The functional division of labour between the two nearly identical mitochondrial manganese superoxide dismutases, SOD-2 and SOD-3, is undefined. It is unknown why C. elegans maintains both, what distinguishes their substrates or sub-mitochondrial contexts, and why loss of sod-2 versus sod-3 produces different (sometimes opposite) genetic interactions with electron-transport-chain mutants.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">RESIDUAL_SUBGAP</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> It is established that sod-2 and sod-3 are ~86% identical mitochondrial MnSODs, that sod-2 is constitutively expressed and dominant while sod-3 is expressed at low basal levels and induced by DAF-16/insulin signalling, that both associate with supercomplex I:III:IV, and that they are functionally non-redundant (loss of sod-2 versus sod-3 produces different genetic interactions with ETC mutants, and sod-2 but not sod-1 is specifically required for H2O2-dependent sperm activation). What is not established is the mechanistic basis of the non-redundancy at the level of substrate, sub-mitochondrial context, or partner; the authors of the key ETC study explicitly state that the sod-3/supercomplex relationship was still under investigation.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Two paralogous mitochondrial MnSODs with divergent, non-redundant phenotypes are a clean model for how gene duplication partitions an antioxidant function; the division of labour also determines which isoform is limiting under which stress.</p>
+
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"Studies are now being undertaken to characterize the interaction of sod3 with supercomplex I:III:IV formation"</em> — PMID:23895727</li>
+
+                <li><em>"sod-2 is required for pseudopod extension"</em> — PMID:28724632</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> Whether SOD-2&#39;s association with respiratory supercomplex I:III:IV reflects only local superoxide scavenging at the site of ROS production, or whether SOD-2 also acts as a direct structural stabilizer of the supercomplex independent of its catalytic activity, is undetermined.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">RESIDUAL_SUBGAP</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> It is established that SOD-2 co-localizes with the I:III:IV supercomplex by blue-native gel and that sod-2 loss reduces supercomplex formation and complex I activity. The open question is causality/mechanism: complex I function falls out of proportion to the measured ROS damage, so a catalysis-independent structural role remains possible but unproven.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Distinguishing a scavenging role from a structural role would determine whether MnSOD is a modular antioxidant or an integral stabilizer of the electron transport chain, with implications for how supercomplex integrity is maintained.</p>
+
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"it is also possible that the mtSODs may directly serve as stabilizing factors in the I:III:IV supercomplex"</em> — PMID:23895727</li>
+
+            </ul>
+
+
+        </div>
+
+    </div>
+
+
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Deep Research Sections -->
+
+    <div class="section">
+        <h2 class="section-title">Deep Research</h2>
+
+        <details class="deep-research-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; gap: 1rem;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Falcon</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(sod-2-deep-research-falcon.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="P31161" data-a="DEEP_RESEARCH: Falcon" data-r="" data-act="DEEP_RESEARCH" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This deep research is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This deep research needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+
+                <div class="report-meta">
+
+                    <span class="report-meta-text">Comprehensive Research Report: *C. elegans* sod-2 (MnSOD-2, UniProt P31161)</span>
+
+
+                    <span class="report-badge">Falcon</span>
+
+
+                    <span class="report-badge">Edison Scientific Literature</span>
+
+
+                    <span class="report-badge">33 citations</span>
+
+
+                    <span class="report-badge">2 artifacts</span>
+
+
+                    <span class="report-meta-text">2026-07-04T15:38:25.554496</span>
+
+
+
+                </div>
+
+
+                <div class="artifact-list">
+
+
+
+                    <div class="artifact-link">
+                        <a href="sod-2-deep-research-falcon_artifacts/artifact-00.md" class="term-link">Edison artifact artifact-00</a>
+                        <span>(text/markdown)</span>
+                    </div>
+
+
+
+
+                    <div class="artifact-link">
+                        <a href="sod-2-deep-research-falcon_artifacts/artifact-01.md" class="term-link">Edison artifact artifact-01</a>
+                        <span>(text/markdown)</span>
+                    </div>
+
+
+                </div>
+
+                <p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h1 id="comprehensive-research-report-c-elegans-sod-2-mnsod-2-uniprot-p31161">Comprehensive Research Report: <em>C. elegans</em> sod-2 (MnSOD-2, UniProt P31161)</h1>
+<h2 id="1-gene-and-protein-identity">1. Gene and Protein Identity</h2>
+<p>The gene <strong>sod-2</strong> (synonym: <strong>sdm-1</strong>; ORF name: <strong>F10D11.1</strong>) in <em>Caenorhabditis elegans</em> encodes <strong>Superoxide dismutase [Mn] 1, mitochondrial</strong> (EC 1.15.1.1), a member of the iron/manganese superoxide dismutase family. The gene is located on <strong>chromosome I</strong> and produces a precursor protein that is processed upon mitochondrial import (hunter1997cloningexpressionand pages 1-1). <em>C. elegans</em> possesses five superoxide dismutase genes: the cytoplasmic Cu/ZnSODs sod-1 and sod-5, the mitochondrial MnSODs sod-2 and sod-3, and the extracellular Cu/ZnSOD sod-4 (braeckman2016invivodetection pages 2-3). SOD-2 and SOD-3 are the products of a relatively recent gene duplication event, sharing 86.3% sequence identity (91.8% conservative identity), though their cDNAs are only 75.2% identical and the two proteins display distinct electrophoretic mobilities and isoelectric points (hunter1997cloningexpressionand pages 1-1, hunter1997cloningexpressionand pages 4-5).</p>
+<p>The following table summarizes the key biochemical and functional properties of SOD-2:</p>
+<table>
+<thead>
+<tr>
+<th>Property</th>
+<th>SOD-2 summary</th>
+<th>Evidence</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Gene name</td>
+<td><strong>sod-2</strong>; historical synonym <strong>sdm-1</strong></td>
+<td>(hunter1997cloningexpressionand pages 6-7, hunter1997cloningexpressionand pages 1-2)</td>
+</tr>
+<tr>
+<td>Protein name</td>
+<td><strong>Manganese superoxide dismutase / mitochondrial superoxide dismutase (MnSOD)</strong></td>
+<td>(hunter1997cloningexpressionand pages 6-7, hunter1997cloningexpressionand pages 1-1)</td>
+</tr>
+<tr>
+<td>UniProt accession</td>
+<td><strong>P31161</strong></td>
+<td>(hunter1997cloningexpressionand pages 6-7)</td>
+</tr>
+<tr>
+<td>Organism</td>
+<td><strong>Caenorhabditis elegans</strong></td>
+<td>(hunter1997cloningexpressionand pages 6-7, hunter1997cloningexpressionand pages 1-2)</td>
+</tr>
+<tr>
+<td>Enzyme class</td>
+<td><strong>Superoxide dismutase, EC 1.15.1.1</strong></td>
+<td>(hunter1997cloningexpressionand pages 1-1, hunter1997cloningexpressionand pages 1-2)</td>
+</tr>
+<tr>
+<td>Catalytic reaction</td>
+<td>Catalyzes dismutation of <strong>superoxide anion (O2•−)</strong> to <strong>hydrogen peroxide (H2O2)</strong> and <strong>oxygen (O2)</strong></td>
+<td>(hunter1997cloningexpressionand pages 1-1, sakamoto2017hydrogenperoxideproduced pages 1-2)</td>
+</tr>
+<tr>
+<td>Physiologic substrate specificity</td>
+<td>Primary substrate is <strong>superoxide radical</strong> generated in mitochondria; product H2O2 can serve signaling roles</td>
+<td>(raamsdonk2009deletionofthe pages 2-3, sakamoto2017hydrogenperoxideproduced pages 10-11, branicky2022stimulationofrasdependent pages 2-3)</td>
+</tr>
+<tr>
+<td>Metal cofactor</td>
+<td><strong>Manganese (Mn)</strong></td>
+<td>(hunter1997cloningexpressionand pages 6-7, hunter1997cloningexpressionand pages 1-1)</td>
+</tr>
+<tr>
+<td>Molecular mass, monomer</td>
+<td><strong>21,986 Da</strong>, 192 aa mature protein</td>
+<td>(hunter1997cloningexpressionand pages 6-7, hunter1997cloningexpressionand pages 5-6)</td>
+</tr>
+<tr>
+<td>Oligomeric state / dimer mass</td>
+<td>Functions as an <strong>active dimer</strong>; measured mass <strong>44,961 Da</strong></td>
+<td>(hunter1997cloningexpressionand pages 6-7, hunter1997cloningexpressionand pages 5-6)</td>
+</tr>
+<tr>
+<td>Specific activity</td>
+<td><strong>2516 units/mg protein</strong> when expressed in <em>E. coli</em></td>
+<td>(hunter1997cloningexpressionand pages 6-7)</td>
+</tr>
+<tr>
+<td>Subcellular localization</td>
+<td><strong>Mitochondrial</strong>, specifically consistent with the <strong>mitochondrial matrix</strong></td>
+<td>(hunter1997cloningexpressionand pages 1-1, raamsdonk2009deletionofthe pages 2-3)</td>
+</tr>
+<tr>
+<td>N-terminal transit peptide</td>
+<td>Contains an <strong>N-terminal mitochondrial transit peptide</strong>; mature enzyme generated after targeting/processing</td>
+<td>(hunter1997cloningexpressionand pages 1-1, hunter1997cloningexpressionand pages 4-5)</td>
+</tr>
+<tr>
+<td>Physical mitochondrial association</td>
+<td>Reported as physically associated with the <strong>I:III:IV respiratory supercomplex</strong> in the inner mitochondrial membrane context</td>
+<td>(braeckman2016invivodetection pages 2-3)</td>
+</tr>
+<tr>
+<td>Isoelectric point (pI)</td>
+<td><strong>6.5</strong></td>
+<td>(hunter1997cloningexpressionand pages 6-7)</td>
+</tr>
+<tr>
+<td>Chromosome location</td>
+<td><strong>Chromosome I</strong></td>
+<td>(hunter1997cloningexpressionand pages 1-1)</td>
+</tr>
+<tr>
+<td>Key domains / family</td>
+<td>Member of the <strong>iron/manganese superoxide dismutase family</strong>; Mn/Fe SOD-type enzyme</td>
+<td>(hunter1997cloningexpressionand pages 6-7, hunter1997cloningexpressionand pages 1-1)</td>
+</tr>
+<tr>
+<td>Inhibitor sensitivity</td>
+<td><strong>Not inhibited by hydrogen peroxide or potassium cyanide</strong>, consistent with MnSOD rather than Cu/ZnSOD</td>
+<td>(hunter1997cloningexpressionand pages 6-7, hunter1997cloningexpressionand pages 1-1)</td>
+</tr>
+<tr>
+<td>Functional complementation</td>
+<td>Expressed SOD-2 protects <strong>SOD-deficient <em>E. coli</em></strong> from methyl viologen-induced oxidative stress</td>
+<td>(hunter1997cloningexpressionand pages 1-1)</td>
+</tr>
+<tr>
+<td>Core biological role in worm</td>
+<td>Major mitochondrial superoxide detox enzyme; also shapes redox signaling by controlling conversion of mitochondrial superoxide into signaling-competent peroxide</td>
+<td>(raamsdonk2009deletionofthe pages 2-3, branicky2022stimulationofrasdependent pages 2-3, onukwufor2022areversiblemitochondrial pages 8-9)</td>
+</tr>
+<tr>
+<td>Lifespan phenotype of loss</td>
+<td><strong>Deletion of sod-2 extends lifespan</strong> in <em>C. elegans</em> despite increased oxidative stress sensitivity and oxidative damage</td>
+<td>(raamsdonk2009deletionofthe pages 1-2, raamsdonk2009deletionofthe pages 6-8, raamsdonk2009deletionofthe pages 3-5)</td>
+</tr>
+<tr>
+<td>Mitochondrial-function phenotype of loss</td>
+<td>sod-2 mutants show <strong>decreased oxygen consumption</strong>, slow development, low brood size, and slow defecation, resembling long-lived mitochondrial mutants</td>
+<td>(raamsdonk2009deletionofthe pages 1-2, raamsdonk2009deletionofthe pages 9-10, raamsdonk2009deletionofthe pages 5-6)</td>
+</tr>
+<tr>
+<td>Interaction with mitochondrial mutants</td>
+<td><strong>Extends lifespan in clk-1</strong>, but <strong>shortens lifespan in isp-1</strong> backgrounds; supports a mitochondrial threshold model</td>
+<td>(raamsdonk2009deletionofthe pages 8-9, raamsdonk2009deletionofthe pages 10-11, raamsdonk2009deletionofthe pages 9-10)</td>
+</tr>
+<tr>
+<td>Role in ROS signaling</td>
+<td>Loss of SOD-2 elevates mitochondrial superoxide; longevity signaling requires downstream conversion involving <strong>SOD-1</strong> and <strong>LET-60/RAS</strong> redox signaling</td>
+<td>(branicky2022stimulationofrasdependent pages 2-3, raamsdonk2009deletionofthe pages 5-6)</td>
+</tr>
+<tr>
+<td>Role in reproduction</td>
+<td>SOD-2-generated <strong>H2O2 activates sperm pseudopod extension</strong> and is required for normal sperm activation</td>
+<td>(sakamoto2017hydrogenperoxideproduced pages 10-11, sakamoto2017hydrogenperoxideproduced pages 1-2)</td>
+</tr>
+<tr>
+<td>Comparison with SOD-3: localization/class</td>
+<td>Both <strong>SOD-2 and SOD-3 are mitochondrial MnSODs</strong> with transit peptides and comparable specific activities</td>
+<td>(hunter1997cloningexpressionand pages 1-1, hunter1997cloningexpressionand pages 4-5)</td>
+</tr>
+<tr>
+<td>Comparison with SOD-3: biochemical differences</td>
+<td>Both are dimers and active MnSODs, but show <strong>different electrophoretic mobilities and isoelectric points</strong></td>
+<td>(hunter1997cloningexpressionand pages 1-1)</td>
+</tr>
+<tr>
+<td>Comparison with SOD-3: expression/regulation</td>
+<td><strong>sod-2</strong> is relatively constitutive and similar in adult/dauer, whereas <strong>sod-3</strong> is more <strong>dauer-associated</strong> and strongly induced in <strong>daf-2</strong> mutants; sod-2 is more linked to <strong>SKN-1/p38 MAPK</strong> regulation, sod-3 to <strong>DAF-16/IIS</strong></td>
+<td>(honda1999thedaf‐2gene pages 6-7, yanase2020interactionbetweenthe pages 4-5, honda1999thedaf‐2gene pages 3-5)</td>
+</tr>
+</tbody>
+</table>
+<p><em>Table: This table summarizes the main biochemical, localization, and functional properties of C. elegans SOD-2, including direct comparisons with the paralog SOD-3. It is useful as a compact reference for annotation of sod-2/MnSOD in mitochondrial redox biology and lifespan signaling.</em></p>
+<h2 id="2-enzymatic-function-and-reaction">2. Enzymatic Function and Reaction</h2>
+<p>SOD-2 catalyzes the dismutation of the superoxide radical anion (O₂•⁻) into hydrogen peroxide (H₂O₂) and molecular oxygen (O₂), using a manganese cofactor at its active site (hunter1997cloningexpressionand pages 1-1, hunter1997cloningexpressionand pages 1-2). The reaction is:</p>
+<p><strong>2 O₂•⁻ + 2 H⁺ → H₂O₂ + O₂</strong></p>
+<p>Recombinant SOD-2 expressed in <em>E. coli</em> deficient in endogenous SODs exhibits a specific activity of <strong>2,516 units/mg protein</strong>, comparable to that of its paralog SOD-3 (hunter1997cloningexpressionand pages 6-7). The mature SOD-2 monomer has a calculated molecular mass of <strong>21,986 Da</strong> (192 amino acids) and functions as an <strong>active homodimer</strong> with a measured dimer mass of <strong>44,961 Da</strong> (hunter1997cloningexpressionand pages 6-7, hunter1997cloningexpressionand pages 5-6). Consistent with its identity as an MnSOD, SOD-2 is <strong>not inhibited by hydrogen peroxide or potassium cyanide</strong>, distinguishing it biochemically from the Cu/Zn class of superoxide dismutases (hunter1997cloningexpressionand pages 6-7, hunter1997cloningexpressionand pages 1-1). Both recombinant SOD-2 and SOD-3 conferred comparable protection against methyl viologen (paraquat)-induced oxidative stress when expressed in SOD-deficient <em>E. coli</em> (hunter1997cloningexpressionand pages 1-1).</p>
+<p>A critical insight from recent work is that the product of the SOD-2 catalyzed reaction—H₂O₂—is not merely a detoxified by-product but serves as a <strong>biologically active signaling molecule</strong> in multiple physiological contexts (sakamoto2017hydrogenperoxideproduced pages 10-11, branicky2022stimulationofrasdependent pages 2-3).</p>
+<h2 id="3-subcellular-localization">3. Subcellular Localization</h2>
+<p>SOD-2 contains an <strong>N-terminal mitochondrial transit peptide</strong> that targets the protein to the <strong>mitochondrial matrix</strong>, where the transit peptide is cleaved to generate the mature enzyme (hunter1997cloningexpressionand pages 1-1, hunter1997cloningexpressionand pages 4-5). The positively charged residues in the transit peptide and at the beginning of the mature peptide are characteristic of mitochondrially targeted MnSODs across species (hunter1997cloningexpressionand pages 4-5). Within the mitochondria, SOD-2 has been reported to be <strong>physically associated with the I:III:IV respiratory supercomplex</strong> of the inner mitochondrial membrane (braeckman2016invivodetection pages 2-3), placing it in close proximity to the major sites of superoxide generation—particularly Complex I and Complex III of the electron transport chain (raamsdonk2009deletionofthe pages 2-3). This localization is functionally significant, as the mitochondrial matrix is the primary intracellular compartment where superoxide is actively produced during oxidative phosphorylation (raamsdonk2009deletionofthe pages 2-3, honda1999thedaf‐2gene pages 2-3).</p>
+<h2 id="4-transcriptional-regulation-and-expression-pattern">4. Transcriptional Regulation and Expression Pattern</h2>
+<p>SOD-2 is expressed under <strong>normal growth conditions</strong> in <em>C. elegans</em>, and its transcripts are trans-spliced to the SL-1 leader sequence, indicating mono-cistronic transcription (hunter1997cloningexpressionand pages 1-1, hunter1997cloningexpressionand pages 5-6). Northern blot analysis confirms a single transcript of approximately 800 nucleotides (hunter1997cloningexpressionand pages 5-6).</p>
+<p>A key distinction between the two mitochondrial MnSODs involves their transcriptional regulation. <strong>sod-2</strong> is expressed at relatively <strong>constitutive levels</strong> across developmental stages, including both adult and dauer stages, whereas <strong>sod-3</strong> is more specifically induced during the dauer stage and in <strong>daf-2</strong> (insulin receptor) mutants (honda1999thedaf‐2gene pages 6-7, honda1999thedaf‐2gene pages 3-5). Importantly, sod-2 mRNA levels in <em>daf-2</em> mutants are comparable to wild-type, while sod-3 mRNA is markedly elevated (honda1999thedaf‐2gene pages 3-5). This indicates that sod-2 and sod-3 are regulated through <strong>distinct transcriptional programs</strong>: sod-2 is predominantly regulated by the <strong>SKN-1/Nrf2</strong> transcription factor acting downstream of the <strong>p38 MAPK signaling pathway</strong>, whereas sod-3 is primarily a target of <strong>DAF-16/FOXO</strong> within the insulin/IGF-1 signaling (IIS) pathway (yanase2020interactionbetweenthe pages 4-5). Although putative DAF-16 binding elements (DBEs) exist in the sod-2 promoter, functional studies in <em>daf-16</em> null mutants suggest these sites are non-functional for sod-2 regulation (yanase2020interactionbetweenthe pages 4-5).</p>
+<h2 id="5-role-in-aging-lifespan-and-mitochondrial-function">5. Role in Aging, Lifespan, and Mitochondrial Function</h2>
+<p>One of the most striking and paradigm-challenging findings regarding sod-2 is that its <strong>deletion extends lifespan</strong> in <em>C. elegans</em>, in stark contrast to yeast, flies, and mice where SOD2 loss shortens lifespan (raamsdonk2009deletionofthe pages 1-2, raamsdonk2009deletionofthe pages 2-3). Van Raamsdonk and Hekimi (2009) demonstrated that <em>sod-2</em> deletion mutants live significantly longer than wild-type worms, despite exhibiting <strong>increased oxidative damage</strong> (measured as oxidatively modified proteins) and <strong>increased sensitivity</strong> to paraquat- and juglone-induced oxidative stress (raamsdonk2009deletionofthe pages 1-2, raamsdonk2009deletionofthe pages 3-5). This paradox fundamentally challenged the oxidative stress theory of aging.</p>
+<p>The mechanism underlying this lifespan extension appears to involve <strong>altered mitochondrial function</strong> rather than changes in oxidative stress per se. <em>sod-2</em> mutant worms display a suite of phenotypes characteristic of long-lived mitochondrial mutants: <strong>slow post-embryonic development</strong>, <strong>reduced brood size</strong>, <strong>slow defecation cycle rate</strong>, and critically, <strong>decreased whole-worm oxygen consumption</strong> (raamsdonk2009deletionofthe pages 1-2, raamsdonk2009deletionofthe pages 5-6, raamsdonk2009deletionofthe pages 6-8). Genetic interaction studies revealed that sod-2 deletion <strong>markedly extends lifespan</strong> (by ~15 days) in <em>clk-1</em> mutant backgrounds (which have mildly impaired mitochondrial function), but <strong>decreases lifespan</strong> (by ~25 days) in <em>isp-1</em> mutant backgrounds (which already have &gt;50% reduced respiration) (raamsdonk2009deletionofthe pages 8-9, raamsdonk2009deletionofthe pages 9-10, raamsdonk2009deletionofthe pages 6-8). This led to a <strong>mitochondrial threshold model</strong>: moderate reductions in mitochondrial function can activate compensatory longevity-promoting programs, but when dysfunction exceeds a critical threshold, the organism can no longer compensate and lifespan shortens (raamsdonk2009deletionofthe pages 10-11, raamsdonk2009deletionofthe pages 9-10).</p>
+<h2 id="6-role-in-ros-signaling-pathways">6. Role in ROS Signaling Pathways</h2>
+<h3 id="61-ras-dependent-ros-signaling-rdrs">6.1 RAS-Dependent ROS Signaling (RDRS)</h3>
+<p>Recent work by Branicky et al. (2022) has elucidated a mechanistic pathway explaining how loss of SOD-2 extends lifespan through a <strong>RAS-dependent ROS signaling (RDRS)</strong> pathway. Loss of SOD-2 elevates mitochondrial superoxide levels. This superoxide exits the mitochondria and is converted to <strong>hydrogen peroxide</strong> by cytoplasmic <strong>SOD-1</strong> (Cu/ZnSOD). The H₂O₂ then acts on a <strong>redox-sensitive cysteine residue (C118)</strong> of <strong>LET-60/RAS</strong>, modulating its activity and triggering a global program of gene expression that affects approximately half of the genome (branicky2022stimulationofrasdependent pages 2-3). Critically, the longevity benefit of sod-2 loss <strong>requires SOD-1</strong>: when SOD-1 is also deleted, the lifespan extension of sod-2 mutants is completely suppressed, demonstrating that the longevity signal is not from superoxide itself but from the SOD-1-generated H₂O₂ acting through cytoplasmic RAS signaling (branicky2022stimulationofrasdependent pages 2-3).</p>
+<h3 id="62-complex-i-ros-and-behavioral-signaling">6.2 Complex I ROS and Behavioral Signaling</h3>
+<p>Onukwufor et al. (2022) demonstrated that SOD-2 is required for <strong>Complex I-derived ROS to drive behavioral responses</strong> in <em>C. elegans</em>. Using optogenetic tools to generate site-specific mitochondrial ROS, they showed that SOD-2/SOD-3-dependent conversion of superoxide to H₂O₂ is necessary for ROS-induced locomotory remodeling, specifically hypoxic avoidance behavior. In the absence of SOD-2, the behavioral response to Complex I ROS is abolished, though it can be rescued by a SOD mimetic compound (MnPyP) (onukwufor2022areversiblemitochondrial pages 8-9, onukwufor2022areversiblemitochondrial pages 6-8). This establishes SOD-2 as a critical mediator linking mitochondrial ROS production to acute behavioral outputs.</p>
+<h3 id="63-daf-16foxo-activation">6.3 DAF-16/FOXO Activation</h3>
+<p>Senchuk et al. (2018) showed that elevated ROS in <em>sod-2</em> mutants contributes to <strong>DAF-16/FOXO activation</strong>, which is required for the full longevity of long-lived mitochondrial mutants. The transcriptional changes in mitochondrial mutants overlap significantly with those in long-lived <em>daf-2</em> (insulin/IGF-1 receptor) mutants, and DAF-16 along with multiple DAF-16-interacting proteins are required for full lifespan extension (prasad2013evaluationofrole pages 3-4). Overexpression of SOD-2 has also been shown to extend lifespan in a <strong>daf-16-dependent</strong> manner, indicating that both gain and loss of SOD-2 function can modulate longevity signaling through DAF-16, albeit through distinct mechanisms (prasad2013evaluationofrole pages 3-4).</p>
+<h2 id="7-role-in-sperm-activation">7. Role in Sperm Activation</h2>
+<p>Sakamoto and Imai (2017) discovered a surprising role for SOD-2 in <strong>sperm activation</strong> in <em>C. elegans</em>. The H₂O₂ produced by SOD-2's catalytic activity acts as a <strong>positive signaling molecule</strong> required for <strong>pseudopod extension</strong> during sperm activation. In <em>sod-1;sod-2</em> double mutant sperm, pseudopod extension is defective, leading to significantly reduced brood size (sakamoto2017hydrogenperoxideproduced pages 10-11, sakamoto2017hydrogenperoxideproduced pages 1-2). Exogenous application of H₂O₂ rescues the activation defects of double mutant sperm, while the H₂O₂ scavenger ebselen completely inhibits pseudopod extension in wild-type sperm (sakamoto2017hydrogenperoxideproduced pages 10-11). Analysis of single mutants demonstrated that <strong>sod-2, rather than sod-1, is the specific SOD gene required</strong> for proper pseudopod extension during sperm activation (sakamoto2017hydrogenperoxideproduced pages 10-11, sakamoto2017hydrogenperoxideproduced pages 1-2).</p>
+<h2 id="8-role-in-mitochondrial-integrity-and-stress-responses">8. Role in Mitochondrial Integrity and Stress Responses</h2>
+<p>SOD-2 plays a critical protective role in contexts of compromised mitochondrial morphology. Kanazawa et al. (2008) demonstrated that <em>eat-3</em> mutants (defective in mitochondrial inner membrane fusion, homologous to human OPA1) are <strong>highly sensitive to loss of sod-2</strong>. The <em>eat-3</em> mutants upregulate SOD-2 protein levels more than two-fold as a compensatory response, and depletion of sod-2 by RNAi or genetic mutation causes a strong negative effect on survival and growth in the <em>eat-3</em> background (kanazawa2008thec.elegans pages 8-9, kanazawa2008thec.elegans pages 1-2). This effect is specific to sod-2, as loss of other SOD genes (sod-1, sod-3, sod-5) has only modest effects in <em>eat-3</em> animals (kanazawa2008thec.elegans pages 9-10). The selective dependency on SOD-2 is consistent with its mitochondrial matrix localization, where disrupted cristae morphology in <em>eat-3</em> mutants leads to increased free radical production that must be managed locally (kanazawa2008thec.elegans pages 9-10).</p>
+<h2 id="9-summary-of-signaling-and-biochemical-pathways">9. Summary of Signaling and Biochemical Pathways</h2>
+<p>The following table summarizes the key pathways in which SOD-2 participates:</p>
+<table>
+<thead>
+<tr>
+<th>Pathway</th>
+<th>Key components</th>
+<th>Role of SOD-2</th>
+<th>Biological outcome</th>
+<th>Evidence</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Mitochondrial superoxide detoxification</td>
+<td>Mitochondrial electron transport chain; superoxide (O2•−); Mn cofactor; SOD-2 in mitochondrial matrix; H2O2/O2 products</td>
+<td>Primary mitochondrial Mn-superoxide dismutase that converts superoxide to hydrogen peroxide and oxygen; active dimeric enzyme with mitochondrial transit peptide and matrix localization</td>
+<td>Limits mitochondrial superoxide burden and contributes to basal antioxidant defense; loss increases oxidative stress sensitivity and oxidative damage even when lifespan is not shortened</td>
+<td>(hunter1997cloningexpressionand pages 6-7, hunter1997cloningexpressionand pages 1-1, raamsdonk2009deletionofthe pages 2-3, raamsdonk2009deletionofthe pages 3-5)</td>
+</tr>
+<tr>
+<td>RAS-dependent ROS signaling (RDRS)</td>
+<td>Mitochondrial superoxide; SOD-2; cytosolic SOD-1; H2O2; LET-60/RAS C118 redox switch</td>
+<td>Loss of SOD-2 raises mitochondrial superoxide; longevity signal requires downstream conversion by SOD-1 to H2O2, which oxidizes LET-60/RAS and activates RDRS</td>
+<td>Global transcriptional remodeling and lifespan extension from mitochondrial ROS signaling rather than simple detoxification</td>
+<td>(branicky2022stimulationofrasdependent pages 2-3, raamsdonk2009deletionofthe pages 5-6)</td>
+</tr>
+<tr>
+<td>p38 MAPK/SKN-1/Nrf2 regulation of sod-2</td>
+<td>p38 MAPK pathway; SKN-1/Nrf2; sod-2 promoter</td>
+<td>sod-2 is regulated predominantly by SKN-1 rather than DAF-16 under stress-responsive conditions, especially in molecular compensation among sod mutants</td>
+<td>Supports stress adaptation and longevity-associated redox homeostasis under intracellular oxidative stress</td>
+<td>(yanase2020interactionbetweenthe pages 4-5)</td>
+</tr>
+<tr>
+<td>Insulin/IGF-1 signaling (IIS) via DAF-2/DAF-16</td>
+<td>DAF-2 insulin/IGF-1 receptor; DAF-16/FoxO; MnSOD genes sod-2 and sod-3</td>
+<td>sod-2 is part of the MnSOD antioxidant network linked to longevity signaling, but unlike sod-3 it is not strongly induced in daf-2 mutants and appears less directly controlled by DAF-16</td>
+<td>Contributes to oxidative stress resistance framework of IIS, while sod-3 is the more prominent dauer/DAF-16-responsive MnSOD output</td>
+<td>(honda1999thedaf‐2gene pages 2-3, honda1999thedaf‐2gene pages 6-7, honda1999thedaf‐2gene pages 3-5)</td>
+</tr>
+<tr>
+<td>Mitochondrial unfolded protein response (UPRmt) / mitochondrial dysfunction programs</td>
+<td>Mitochondrial stress; mitochondrial proteostasis pathways; respiratory dysfunction; stress-response genes including SOD enzymes</td>
+<td>SOD-2 is repeatedly discussed as part of mitochondrial stress-response programs and as a mitochondrial redox effector whose loss phenocopies long-lived mitochondrial mutants with reduced respiration</td>
+<td>Links mitochondrial dysfunction to compensatory stress programs and altered lifespan trajectories</td>
+<td>(raamsdonk2009deletionofthe pages 1-2, raamsdonk2009deletionofthe pages 5-6)</td>
+</tr>
+<tr>
+<td>Complex I ROS signaling and hypoxic avoidance behavior</td>
+<td>Complex I-derived ROS; SOD-2/SOD-3; H2O2; redox-sensitive thiol switch on NDUF-2.1-related pathway; locomotory/hypoxia avoidance circuitry</td>
+<td>SOD-2 is required to convert complex I-derived superoxide into H2O2 that mediates behavioral signaling; loss of sod-2 abolishes ROS-triggered avoidance/photolocomotory responses</td>
+<td>Enables mitochondrial ROS to function as a signal for hypoxic avoidance and acute behavioral adaptation</td>
+<td>(onukwufor2022areversiblemitochondrial pages 8-9, onukwufor2022areversiblemitochondrial pages 6-8)</td>
+</tr>
+<tr>
+<td>Sperm activation via H2O2 signaling</td>
+<td>SOD-2; SOD-1; H2O2; Pronase-responsive sperm activation; pseudopod extension machinery</td>
+<td>SOD-2-generated H2O2 acts as a positive signaling molecule required for sperm activation and pseudopod extension; exogenous H2O2 rescues activation defects in sod-1;sod-2 mutants</td>
+<td>Promotes normal sperm motility/activation and supports fertility/brood size</td>
+<td>(sakamoto2017hydrogenperoxideproduced pages 10-11, sakamoto2017hydrogenperoxideproduced pages 1-2, sakamoto2017hydrogenperoxideproduced pages 8-10)</td>
+</tr>
+</tbody>
+</table>
+<p><em>Table: This table summarizes the main signaling and biochemical pathways involving C. elegans SOD-2, emphasizing where it acts as a detoxifying enzyme versus a redox-signaling mediator. It is useful for functional annotation because it connects SOD-2 to localization, pathway context, and experimentally observed organismal outcomes.</em></p>
+<h2 id="10-conclusions">10. Conclusions</h2>
+<p><em>C. elegans</em> SOD-2 is a mitochondrial matrix-localized manganese superoxide dismutase that catalyzes the dismutation of superoxide radicals to hydrogen peroxide and oxygen. Beyond its canonical antioxidant function, SOD-2 has emerged as a <strong>critical node in mitochondrial redox signaling</strong>. Its enzymatic product, H₂O₂, serves as a signaling molecule in at least three distinct biological contexts: (1) RAS-dependent longevity signaling, where mitochondrial superoxide escaping from the matrix is converted to cytoplasmic H₂O₂ by SOD-1 to activate LET-60/RAS (branicky2022stimulationofrasdependent pages 2-3); (2) sperm activation, where SOD-2-derived H₂O₂ directly drives pseudopod extension (sakamoto2017hydrogenperoxideproduced pages 10-11, sakamoto2017hydrogenperoxideproduced pages 1-2); and (3) behavioral responses, where SOD-2-dependent H₂O₂ production mediates Complex I ROS-triggered locomotory adaptation (onukwufor2022areversiblemitochondrial pages 8-9, onukwufor2022areversiblemitochondrial pages 6-8). The paradoxical lifespan extension upon <em>sod-2</em> deletion reflects altered mitochondrial function and activation of compensatory longevity programs, rather than a simple reduction in oxidative damage (raamsdonk2009deletionofthe pages 1-2, raamsdonk2009deletionofthe pages 5-6). Transcriptionally, sod-2 is regulated predominantly by the SKN-1/Nrf2 pathway through p38 MAPK signaling, distinguishing it from its paralog sod-3, which is a primary target of DAF-16/FOXO in the insulin/IGF-1 signaling pathway (yanase2020interactionbetweenthe pages 4-5). Together, these findings position SOD-2 as both a protective antioxidant enzyme and a redox-signaling mediator at the interface of mitochondrial function, aging, reproduction, and behavior.</p>
+<p>References</p>
+<ol>
+<li>
+<p>(hunter1997cloningexpressionand pages 1-1): Thérèse Hunter, William H. Bannister, and Gary J. Hunter. Cloning, expression, and characterization of two manganese superoxide dismutases from caenorhabditis elegans *. The Journal of Biological Chemistry, 272:28652-28659, Nov 1997. URL: https://doi.org/10.1074/jbc.272.45.28652, doi:10.1074/jbc.272.45.28652. This article has 183 citations.</p>
+</li>
+<li>
+<p>(braeckman2016invivodetection pages 2-3): Bart P. Braeckman, Arne Smolders, Patricia Back, and Sasha De Henau. In vivo detection of reactive oxygen species and redox status in caenorhabditis elegans. Antioxidants &amp; redox signaling, 25 10:577-92, Oct 2016. URL: https://doi.org/10.1089/ars.2016.6751, doi:10.1089/ars.2016.6751. This article has 64 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(hunter1997cloningexpressionand pages 4-5): Thérèse Hunter, William H. Bannister, and Gary J. Hunter. Cloning, expression, and characterization of two manganese superoxide dismutases from caenorhabditis elegans *. The Journal of Biological Chemistry, 272:28652-28659, Nov 1997. URL: https://doi.org/10.1074/jbc.272.45.28652, doi:10.1074/jbc.272.45.28652. This article has 183 citations.</p>
+</li>
+<li>
+<p>(hunter1997cloningexpressionand pages 6-7): Thérèse Hunter, William H. Bannister, and Gary J. Hunter. Cloning, expression, and characterization of two manganese superoxide dismutases from caenorhabditis elegans *. The Journal of Biological Chemistry, 272:28652-28659, Nov 1997. URL: https://doi.org/10.1074/jbc.272.45.28652, doi:10.1074/jbc.272.45.28652. This article has 183 citations.</p>
+</li>
+<li>
+<p>(hunter1997cloningexpressionand pages 1-2): Thérèse Hunter, William H. Bannister, and Gary J. Hunter. Cloning, expression, and characterization of two manganese superoxide dismutases from caenorhabditis elegans *. The Journal of Biological Chemistry, 272:28652-28659, Nov 1997. URL: https://doi.org/10.1074/jbc.272.45.28652, doi:10.1074/jbc.272.45.28652. This article has 183 citations.</p>
+</li>
+<li>
+<p>(sakamoto2017hydrogenperoxideproduced pages 1-2): Taro Sakamoto and Hirotaka Imai. Hydrogen peroxide produced by superoxide dismutase sod-2 activates sperm in caenorhabditis elegans. Journal of Biological Chemistry, 292:14804-14813, Sep 2017. URL: https://doi.org/10.1074/jbc.m117.788901, doi:10.1074/jbc.m117.788901. This article has 105 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(raamsdonk2009deletionofthe pages 2-3): Jeremy M. Van Raamsdonk and Siegfried Hekimi. Deletion of the mitochondrial superoxide dismutase sod-2 extends lifespan in caenorhabditis elegans. PLoS Genetics, 5:e1000361, Feb 2009. URL: https://doi.org/10.1371/journal.pgen.1000361, doi:10.1371/journal.pgen.1000361. This article has 699 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(sakamoto2017hydrogenperoxideproduced pages 10-11): Taro Sakamoto and Hirotaka Imai. Hydrogen peroxide produced by superoxide dismutase sod-2 activates sperm in caenorhabditis elegans. Journal of Biological Chemistry, 292:14804-14813, Sep 2017. URL: https://doi.org/10.1074/jbc.m117.788901, doi:10.1074/jbc.m117.788901. This article has 105 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(branicky2022stimulationofrasdependent pages 2-3): Robyn Branicky, Ying Wang, Arman Khaki, Ju-Ling Liu, Maximilian Kramer-Drauberg, and Siegfried Hekimi. Stimulation of ras-dependent ros signaling extends longevity by modulating a developmental program of global gene expression. Dec 2022. URL: https://doi.org/10.1126/sciadv.adc9851, doi:10.1126/sciadv.adc9851. This article has 17 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(hunter1997cloningexpressionand pages 5-6): Thérèse Hunter, William H. Bannister, and Gary J. Hunter. Cloning, expression, and characterization of two manganese superoxide dismutases from caenorhabditis elegans *. The Journal of Biological Chemistry, 272:28652-28659, Nov 1997. URL: https://doi.org/10.1074/jbc.272.45.28652, doi:10.1074/jbc.272.45.28652. This article has 183 citations.</p>
+</li>
+<li>
+<p>(onukwufor2022areversiblemitochondrial pages 8-9): John O. Onukwufor, M. Arsalan Farooqi, Anežka Vodičková, Shon A. Koren, Aksana Baldzizhar, Brandon J. Berry, Gisela Beutner, George A. Porter, Vsevolod Belousov, Alan Grossfield, and Andrew P. Wojtovich. A reversible mitochondrial complex i thiol switch mediates hypoxic avoidance behavior in c. elegans. Nature Communications, May 2022. URL: https://doi.org/10.1038/s41467-022-30169-y, doi:10.1038/s41467-022-30169-y. This article has 44 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(raamsdonk2009deletionofthe pages 1-2): Jeremy M. Van Raamsdonk and Siegfried Hekimi. Deletion of the mitochondrial superoxide dismutase sod-2 extends lifespan in caenorhabditis elegans. PLoS Genetics, 5:e1000361, Feb 2009. URL: https://doi.org/10.1371/journal.pgen.1000361, doi:10.1371/journal.pgen.1000361. This article has 699 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(raamsdonk2009deletionofthe pages 6-8): Jeremy M. Van Raamsdonk and Siegfried Hekimi. Deletion of the mitochondrial superoxide dismutase sod-2 extends lifespan in caenorhabditis elegans. PLoS Genetics, 5:e1000361, Feb 2009. URL: https://doi.org/10.1371/journal.pgen.1000361, doi:10.1371/journal.pgen.1000361. This article has 699 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(raamsdonk2009deletionofthe pages 3-5): Jeremy M. Van Raamsdonk and Siegfried Hekimi. Deletion of the mitochondrial superoxide dismutase sod-2 extends lifespan in caenorhabditis elegans. PLoS Genetics, 5:e1000361, Feb 2009. URL: https://doi.org/10.1371/journal.pgen.1000361, doi:10.1371/journal.pgen.1000361. This article has 699 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(raamsdonk2009deletionofthe pages 9-10): Jeremy M. Van Raamsdonk and Siegfried Hekimi. Deletion of the mitochondrial superoxide dismutase sod-2 extends lifespan in caenorhabditis elegans. PLoS Genetics, 5:e1000361, Feb 2009. URL: https://doi.org/10.1371/journal.pgen.1000361, doi:10.1371/journal.pgen.1000361. This article has 699 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(raamsdonk2009deletionofthe pages 5-6): Jeremy M. Van Raamsdonk and Siegfried Hekimi. Deletion of the mitochondrial superoxide dismutase sod-2 extends lifespan in caenorhabditis elegans. PLoS Genetics, 5:e1000361, Feb 2009. URL: https://doi.org/10.1371/journal.pgen.1000361, doi:10.1371/journal.pgen.1000361. This article has 699 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(raamsdonk2009deletionofthe pages 8-9): Jeremy M. Van Raamsdonk and Siegfried Hekimi. Deletion of the mitochondrial superoxide dismutase sod-2 extends lifespan in caenorhabditis elegans. PLoS Genetics, 5:e1000361, Feb 2009. URL: https://doi.org/10.1371/journal.pgen.1000361, doi:10.1371/journal.pgen.1000361. This article has 699 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(raamsdonk2009deletionofthe pages 10-11): Jeremy M. Van Raamsdonk and Siegfried Hekimi. Deletion of the mitochondrial superoxide dismutase sod-2 extends lifespan in caenorhabditis elegans. PLoS Genetics, 5:e1000361, Feb 2009. URL: https://doi.org/10.1371/journal.pgen.1000361, doi:10.1371/journal.pgen.1000361. This article has 699 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(honda1999thedaf‐2gene pages 6-7): Yoko Honda and Shuji Honda. The daf‐2 gene network for longevity regulates oxidative stress resistance and mn‐superoxide dismutase gene expression in caenorhabditis elegans. The FASEB Journal, 13:1385-1393, Aug 1999. URL: https://doi.org/10.1096/fasebj.13.11.1385, doi:10.1096/fasebj.13.11.1385. This article has 968 citations.</p>
+</li>
+<li>
+<p>(yanase2020interactionbetweenthe pages 4-5): Sumino Yanase, Kayo Yasuda, and Naoaki Ishii. Interaction between the ins/igf-1 and p38 mapk signaling pathways in molecular compensation of sod genes and modulation related to intracellular ros levels in c. elegans. Sep 2020. URL: https://doi.org/10.1016/j.bbrep.2020.100796, doi:10.1016/j.bbrep.2020.100796. This article has 37 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(honda1999thedaf‐2gene pages 3-5): Yoko Honda and Shuji Honda. The daf‐2 gene network for longevity regulates oxidative stress resistance and mn‐superoxide dismutase gene expression in caenorhabditis elegans. The FASEB Journal, 13:1385-1393, Aug 1999. URL: https://doi.org/10.1096/fasebj.13.11.1385, doi:10.1096/fasebj.13.11.1385. This article has 968 citations.</p>
+</li>
+<li>
+<p>(honda1999thedaf‐2gene pages 2-3): Yoko Honda and Shuji Honda. The daf‐2 gene network for longevity regulates oxidative stress resistance and mn‐superoxide dismutase gene expression in caenorhabditis elegans. The FASEB Journal, 13:1385-1393, Aug 1999. URL: https://doi.org/10.1096/fasebj.13.11.1385, doi:10.1096/fasebj.13.11.1385. This article has 968 citations.</p>
+</li>
+<li>
+<p>(onukwufor2022areversiblemitochondrial pages 6-8): John O. Onukwufor, M. Arsalan Farooqi, Anežka Vodičková, Shon A. Koren, Aksana Baldzizhar, Brandon J. Berry, Gisela Beutner, George A. Porter, Vsevolod Belousov, Alan Grossfield, and Andrew P. Wojtovich. A reversible mitochondrial complex i thiol switch mediates hypoxic avoidance behavior in c. elegans. Nature Communications, May 2022. URL: https://doi.org/10.1038/s41467-022-30169-y, doi:10.1038/s41467-022-30169-y. This article has 44 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(prasad2013evaluationofrole pages 3-4): Kedar Prasad and Stephen Bondy. Evaluation of role of oxidative stress on aging in caenorhabditis elegans: a brief review. Current Aging Science, 6:215-219, Dec 2013. URL: https://doi.org/10.2174/18746098112059990031, doi:10.2174/18746098112059990031. This article has 13 citations.</p>
+</li>
+<li>
+<p>(kanazawa2008thec.elegans pages 8-9): Takayuki Kanazawa, Mauro Zappaterra, Ayako Hasegawa, Ashley P Wright, Erin D Newman-Smith, Karolyn F Buttle, Kent L McDonald, Carmen Mannella, and Alex van der Bliek. The c. elegans opa1 homologue eat-3 is essential for resistance to free radicals. PLoS Genetics, 4:e39, Feb 2008. URL: https://doi.org/10.1371/journal.pgen.1000022, doi:10.1371/journal.pgen.1000022. This article has 198 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(kanazawa2008thec.elegans pages 1-2): Takayuki Kanazawa, Mauro Zappaterra, Ayako Hasegawa, Ashley P Wright, Erin D Newman-Smith, Karolyn F Buttle, Kent L McDonald, Carmen Mannella, and Alex van der Bliek. The c. elegans opa1 homologue eat-3 is essential for resistance to free radicals. PLoS Genetics, 4:e39, Feb 2008. URL: https://doi.org/10.1371/journal.pgen.1000022, doi:10.1371/journal.pgen.1000022. This article has 198 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(kanazawa2008thec.elegans pages 9-10): Takayuki Kanazawa, Mauro Zappaterra, Ayako Hasegawa, Ashley P Wright, Erin D Newman-Smith, Karolyn F Buttle, Kent L McDonald, Carmen Mannella, and Alex van der Bliek. The c. elegans opa1 homologue eat-3 is essential for resistance to free radicals. PLoS Genetics, 4:e39, Feb 2008. URL: https://doi.org/10.1371/journal.pgen.1000022, doi:10.1371/journal.pgen.1000022. This article has 198 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(sakamoto2017hydrogenperoxideproduced pages 8-10): Taro Sakamoto and Hirotaka Imai. Hydrogen peroxide produced by superoxide dismutase sod-2 activates sperm in caenorhabditis elegans. Journal of Biological Chemistry, 292:14804-14813, Sep 2017. URL: https://doi.org/10.1074/jbc.m117.788901, doi:10.1074/jbc.m117.788901. This article has 105 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+</ol>
+<h2 id="artifacts">Artifacts</h2>
+<ul>
+<li><a href="sod-2-deep-research-falcon_artifacts/artifact-00.md">Edison artifact artifact-00</a></li>
+<li><a href="sod-2-deep-research-falcon_artifacts/artifact-01.md">Edison artifact artifact-01</a></li>
+</ul>
+<h2 id="citations">Citations</h2>
+<ol>
+<li>hunter1997cloningexpressionand pages 1-1</li>
+<li>braeckman2016invivodetection pages 2-3</li>
+<li>hunter1997cloningexpressionand pages 6-7</li>
+<li>hunter1997cloningexpressionand pages 4-5</li>
+<li>raamsdonk2009deletionofthe pages 2-3</li>
+<li>hunter1997cloningexpressionand pages 5-6</li>
+<li>yanase2020interactionbetweenthe pages 4-5</li>
+<li>branicky2022stimulationofrasdependent pages 2-3</li>
+<li>prasad2013evaluationofrole pages 3-4</li>
+<li>sakamoto2017hydrogenperoxideproduced pages 10-11</li>
+<li>hunter1997cloningexpressionand pages 1-2</li>
+<li>sakamoto2017hydrogenperoxideproduced pages 1-2</li>
+<li>onukwufor2022areversiblemitochondrial pages 8-9</li>
+<li>raamsdonk2009deletionofthe pages 1-2</li>
+<li>raamsdonk2009deletionofthe pages 6-8</li>
+<li>raamsdonk2009deletionofthe pages 3-5</li>
+<li>raamsdonk2009deletionofthe pages 9-10</li>
+<li>raamsdonk2009deletionofthe pages 5-6</li>
+<li>raamsdonk2009deletionofthe pages 8-9</li>
+<li>raamsdonk2009deletionofthe pages 10-11</li>
+<li>onukwufor2022areversiblemitochondrial pages 6-8</li>
+<li>sakamoto2017hydrogenperoxideproduced pages 8-10</li>
+<li>Mn</li>
+<li>https://doi.org/10.1074/jbc.272.45.28652,</li>
+<li>https://doi.org/10.1089/ars.2016.6751,</li>
+<li>https://doi.org/10.1074/jbc.m117.788901,</li>
+<li>https://doi.org/10.1371/journal.pgen.1000361,</li>
+<li>https://doi.org/10.1126/sciadv.adc9851,</li>
+<li>https://doi.org/10.1038/s41467-022-30169-y,</li>
+<li>https://doi.org/10.1096/fasebj.13.11.1385,</li>
+<li>https://doi.org/10.1016/j.bbrep.2020.100796,</li>
+<li>https://doi.org/10.2174/18746098112059990031,</li>
+<li>https://doi.org/10.1371/journal.pgen.1000022,</li>
+</ol>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(sod-2-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="P31161" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="sod-2-c-elegans-research-notes">sod-2 (C. elegans) — research notes</h1>
+<p>UniProt: P31161 (SODM1_CAEEL). Gene: sod-2; synonym sdm-1; ORF F10D11.1;<br />
+WormBase WBGene00004931. Chromosome I. 221 aa precursor (24-aa mitochondrial<br />
+transit peptide, mature chain 25-221). EC 1.15.1.1. PDB: 3DC6 (1.80 Å).</p>
+<p>This is the primary/constitutive mitochondrial manganese superoxide dismutase<br />
+(MnSOD) of C. elegans. It is one of two mitochondrial MnSODs — the paralog<br />
+<strong>sod-3</strong> is on chromosome X and is the DAF-16/insulin-signalling-INDUCIBLE<br />
+mtSOD normally expressed at very low basal levels. The two proteins are ~86%<br />
+identical, so evidence must be attributed carefully (see paralog section below).<br />
+C. elegans has five SOD genes total: sod-1 (major cytosolic Cu/Zn), sod-2 and<br />
+sod-3 (mitochondrial MnSOD), sod-4 (extracellular Cu/Zn), sod-5 (cytosolic<br />
+Cu/Zn).</p>
+<h2 id="known-sod-2-specific">KNOWN — sod-2 specific</h2>
+<h3 id="molecular-function-mn-dependent-superoxide-dismutase">Molecular function: Mn-dependent superoxide dismutase</h3>
+<ul>
+<li>Catalyzes 2 superoxide + 2 H+ = H2O2 + O2 (EC 1.15.1.1; RHEA:20696). Binds<br />
+  1 Mn(2+) per subunit (UniProt COFACTOR; metal-ligand residues His50, His98,<br />
+  Asp182, His186 by similarity). Belongs to the Fe/Mn SOD family.</li>
+<li>Hunter et al. 1997 cloned sod-2 and sod-3, expressed the mature proteins in<br />
+  E. coli deficient in cytosolic SODs, and directly measured SOD activity: the<br />
+  enzymes are Mn-type (not inhibited by H2O2 or cyanide, which distinguishes<br />
+  Mn-SOD from Fe-SOD and Cu/Zn-SOD), dimeric, and have comparable specific<br />
+  activities <a href="https://pubmed.ncbi.nlm.nih.gov/9353332" title="The expressed enzymes, which were not inhibited by   hydrogen peroxide or cyanide, are dimeric, show quite different electrophoretic   mobilities and isoelectric points, but exhibit comparable specific activities.">PMID:9353332</a>.<br />
+  This is the basis of the WormBase IDA annotation to GO:0004784 (superoxide<br />
+  dismutase activity).</li>
+<li>Functional (heterologous) evidence for superoxide removal: the worm enzymes<br />
+  protected SOD-deficient E. coli against methyl-viologen (paraquat) oxidative<br />
+  stress <a href="https://pubmed.ncbi.nlm.nih.gov/9353332" title="Both proteins were shown to be active in E. coli,   providing similar protection against methyl viologen-induced oxidative stress.">PMID:9353332</a>.<br />
+  Basis of the WormBase IMP annotation to GO:0019430 (removal of superoxide<br />
+  radicals). NOTE: this is a heterologous E. coli complementation assay, not a<br />
+  worm mutant phenotype; the annotation is nonetheless functionally sound.</li>
+</ul>
+<h3 id="localization-mitochondrion-mitochondrial-matrix-and-etc-supercomplex">Localization: mitochondrion / mitochondrial matrix, and ETC supercomplex</h3>
+<ul>
+<li>N-terminal mitochondrial transit peptide (residues 1-24); UniProt subcellular<br />
+  location = mitochondrion matrix <a href="https://pubmed.ncbi.nlm.nih.gov/9353332" title="Both deduced protein sequences   contain the expected N-terminal mitochondrial transit peptides.">PMID:9353332</a>.</li>
+<li>SOD-2 is the primary mitochondrial SOD: "sod-2 encodes the primary SOD found<br />
+  in the mitochondrion" <a href="https://pubmed.ncbi.nlm.nih.gov/23895727">PMID:23895727</a>.</li>
+<li>SOD-2 physically co-localizes with the mitochondrial respiratory<br />
+  supercomplex I:III:IV by blue-native gel Western blotting (Fig 4D)<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/23895727" title="Western blots of BNGs indicated that SOD-2 co-localized with   the I:III:IV supercomplex (Figure 4D).">PMID:23895727</a>. Basis of the WormBase IDA<br />
+  annotation to GO:0098803 (respiratory chain complex, located_in). SOD-3 also<br />
+  localizes there. This is an association/embedding, not classical structural<br />
+  subunit membership; the authors conclude "mtSODs are embedded within the<br />
+  supercomplex I:III:IV and stabilize or locally protect it from reactive<br />
+  oxygen species (ROS) damage" <a href="https://pubmed.ncbi.nlm.nih.gov/23895727">PMID:23895727</a>.</li>
+<li>HDA mitochondrial-proteome localization (GO:0005739) is attributed to<br />
+  PMID:20188671 (Haynes et al. 2010). That paper's abstract is about HAF-1/ClpP<br />
+  and the mitochondrial UPR (mtUPR) and does not mention sod-2; the annotation<br />
+  is a high-throughput direct-assay (mass-spec) mitochondrial localization.<br />
+  Localization of a MnSOD to the mitochondrion is biologically unambiguous, so<br />
+  this is accepted (as a general, less-specific companion to matrix).</li>
+</ul>
+<h3 id="effect-of-loss-of-sod-2-on-the-etc-sod-2-specific-from-pmid23895727">Effect of loss of SOD-2 on the ETC (sod-2-specific, from PMID:23895727)</h3>
+<ul>
+<li>Loss of SOD-2 specifically decreases complex I and complex II activities;<br />
+  complexes III and IV remain normal <a href="https://pubmed.ncbi.nlm.nih.gov/23895727" title="Loss of SOD-2 specifically   (i) decreases the activities of complexes I and II, complexes III and IV   remain normal">PMID:23895727</a>.</li>
+<li>sod-2(0) reduces formation of I:III and I:III:IV supercomplexes (~28%),<br />
+  implying SOD-2 stabilizes or protects the supercomplex.</li>
+<li>Complex I function decreases out of proportion to ROS damage, suggesting a<br />
+  possible direct structural/stabilizing role in addition to local scavenging.</li>
+</ul>
+<h2 id="known-paralog-sod-3-attribution-notes">KNOWN — paralog (sod-3) attribution notes</h2>
+<ul>
+<li>sod-2 and sod-3 are 86.3% identical MnSODs, both mitochondrial, both with<br />
+  transit peptides, both trans-spliced to SL-1, both catalytically active<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/9353332">PMID:9353332</a>. sod-3 is on chromosome X; sod-2 on chromosome I.</li>
+<li>sod-3 is the DAF-16 (FOXO)/insulin-IGF-inducible mtSOD, "normally expressed in<br />
+  very low levels in wild type worms" <a href="https://pubmed.ncbi.nlm.nih.gov/23895727">PMID:23895727</a>; sod-2 is constitutive and<br />
+  quantitatively dominant. daf-2 longevity increases sod-3, but eliminating both<br />
+  sod-2 and sod-3 does not suppress daf-2 long life.</li>
+<li>Antibody cross-reactivity: the anti-SOD-2 antibody used in PMID:23895727 also<br />
+  detected SOD-3 (residual signal in sod-2 single mutant was lost in the<br />
+  sod-2;sod-3 double), so the supercomplex-localization result reports both<br />
+  mtSODs; the sod-2-specific signal is real (dominant band lost in sod-2 mutant).</li>
+<li>Phenotypic divergence: loss of sod-2 vs sod-3 have DIFFERENT genetic<br />
+  interactions with ETC mutants (gas-1/complex I, mev-1/complex II,<br />
+  isp-1/complex III). E.g. sod-2;gas-1 lives longer than gas-1; sod-3 does not<br />
+  change gas-1 lifespan <a href="https://pubmed.ncbi.nlm.nih.gov/23895727">PMID:23895727</a>. So they are NOT functionally redundant.</li>
+</ul>
+<h2 id="not-known-knowledge-gaps">NOT known / knowledge gaps</h2>
+<ol>
+<li><strong>Counterintuitive longevity of sod-2 loss.</strong> Deleting the <em>primary</em><br />
+   mitochondrial antioxidant does not shorten, and can EXTEND, lifespan —<br />
+   contrary to the oxidative-damage theory of aging. Suthammarak et al. quote<br />
+   the prior finding directly: "Hekimi reported that a deletion of sod-2<br />
+   lengthened lifespan, and that clk-1;sod-2 lived longer than the long-lived<br />
+   clk-1, despite increased oxidative damage in mitochondrial protein"<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/23895727">PMID:23895727</a>; and note that all five SODs could be eliminated without<br />
+   shortening lifespan <a href="https://pubmed.ncbi.nlm.nih.gov/23895727" title="Van Raamsdonk eliminated all of the    superoxide dismutases in C. elegans without shortening lifespan">PMID:23895727</a>. Yet<br />
+   sod-2(gk257) on its own has a normal lifespan <a href="https://pubmed.ncbi.nlm.nih.gov/23895727" title="sod-2(gk257)    had a normal lifespan in agreement with Gems and colleagues">PMID:23895727</a>. The mechanism<br />
+   (mitohormesis / superoxide as a pro-longevity signal vs. metabolic slowing)<br />
+   is unresolved: "no single component of mitochondrial physiology that we<br />
+   studied correlates simply with lifespan" <a href="https://pubmed.ncbi.nlm.nih.gov/23895727">PMID:23895727</a>.</li>
+<li><strong>Functional division of labour between sod-2 and sod-3.</strong> Why two nearly<br />
+   identical mitochondrial MnSODs? Their non-redundant, opposite genetic<br />
+   interactions with ETC mutants are unexplained, and the interaction of sod-3<br />
+   with the supercomplex was, at time of writing, still being investigated:<br />
+   "Studies are now being undertaken to characterize the interaction of sod3<br />
+   with supercomplex I:III:IV formation" <a href="https://pubmed.ncbi.nlm.nih.gov/23895727">PMID:23895727</a>.</li>
+<li><strong>Scavenger vs. structural role in the supercomplex.</strong> Whether SOD-2 acts<br />
+   only as a local superoxide scavenger at the site of ROS production or also<br />
+   as a direct structural stabilizer of supercomplex I:III:IV is undetermined:<br />
+   complex I function falls "out of proportion to the amount of ROS damage",<br />
+   so "it is also possible that the mtSODs may directly serve as stabilizing<br />
+   factors in the I:III:IV supercomplex" <a href="https://pubmed.ncbi.nlm.nih.gov/23895727">PMID:23895727</a>.</li>
+</ol>
+<h2 id="annotation-review-plan-goa-has-12-rows">Annotation review plan (GOA has 12 rows)</h2>
+<ul>
+<li>GO:0004784 superoxide dismutase activity — IDA (PMID:9353332) → ACCEPT, CORE.<br />
+  Same term IBA (GO_REF:0000033) and IEA (GO_REF:0000120) → ACCEPT (redundant<br />
+  support, non-core duplicates).</li>
+<li>GO:0030145 manganese ion binding — IBA (GO_REF:0000033) → ACCEPT, CORE<br />
+  (matches UniProt Mn cofactor; the correct specific metal term).</li>
+<li>GO:0046872 metal ion binding — IEA (InterPro) → generalization of manganese<br />
+  ion binding; KEEP_AS_NON_CORE (less informative parent).</li>
+<li>GO:0005759 mitochondrial matrix — IEA (SubCell) → ACCEPT, CORE location.</li>
+<li>GO:0005739 mitochondrion — IBA (is_active_in) and HDA (PMID:20188671) →<br />
+  ACCEPT as non-core (less specific than matrix).</li>
+<li>GO:0098803 respiratory chain complex — IDA (PMID:23895727) and IEA (ARBA) →<br />
+  the IDA reflects real BNG co-localization; KEEP_AS_NON_CORE (association, not<br />
+  a core catalytic/structural identity). The IEA(ARBA) part_of duplicate: keep<br />
+  non-core.</li>
+<li>GO:0019430 removal of superoxide radicals — IMP (PMID:9353332) → ACCEPT, CORE<br />
+  process (heterologous complementation; functionally correct).</li>
+<li>GO:0006801 superoxide metabolic process — IEA (InterPro) → parent BP; ACCEPT<br />
+  as non-core (removal of superoxide radicals is more specific).</li>
+<li>GO:0042803 protein homodimerization activity (in UniProt DR as ARBA IEA) — not<br />
+  present in GOA TSV rows; the mature enzyme is dimeric <a href="https://pubmed.ncbi.nlm.nih.gov/9353332">PMID:9353332</a>, but this<br />
+  is a structural property, not a core informative function; not added.</li>
+</ul>
+<h2 id="update-from-falcon-deep-research-sod-2-deep-research-falconmd-edison-33-cites">Update from falcon deep research (sod-2-deep-research-falcon.md, Edison, 33 cites)</h2>
+<p>Additional sod-2-specific literature retrieved (PMIDs then cached and cited in the<br />
+review):<br />
+- <strong>Lifespan extension (seminal).</strong> Van Raamsdonk &amp; Hekimi 2009 deleted each of the<br />
+  five worm sod genes; none shortens lifespan and sod-2 loss extends it<br />
+  [PMID:19197346 "we find that sod-2 mutants are long-lived despite a significant<br />
+  increase in oxidatively damaged proteins"; "deletion of sod-2 extends worm lifespan<br />
+  by altering mitochondrial function"]. Threshold model: sod-2 deletion increases<br />
+  lifespan in clk-1 (mild mito dysfunction) but decreases it in isp-1 (severe)<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/19197346" title="sod-2 deletion markedly increases lifespan in clk-1 worms while   clearly decreasing the lifespan of isp-1 worms">PMID:19197346</a>.<br />
+- <strong>Mechanism (RDRS).</strong> Branicky et al. 2022 Sci Adv: loss of SOD-2 raises<br />
+  mitochondrial superoxide; cytosolic SOD-1 converts it to H2O2 that oxidizes<br />
+  LET-60/RAS Cys118, driving a genome-wide developmental program; requires SOD-1<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/36449615" title="RDRS is regulated by negative feedback from the superoxide   dismutase 1 (SOD-1)-dependent conversion of superoxide into cytoplasmic hydrogen   peroxide, which, in turn, acts on a redox-sensitive cysteine (C118) of RAS">PMID:36449615</a>. This<br />
+  substantially NARROWS knowledge gap 1 (mechanism of longevity).<br />
+- <strong>Sperm activation (sod-2-specific).</strong> Sakamoto &amp; Imai 2017: SOD-2-produced H2O2 is<br />
+  a positive signal for sperm pseudopod extension; sod-2, not sod-1, is the required<br />
+  SOD [PMID:28724632 "sod-2 is required for pseudopod extension"; "SOD-2 plays an<br />
+  important role in the sperm activation of C. elegans by producing H2O2 as an<br />
+  activator of pseudopod extension"]. Reinforces sod-2/sod-3 non-redundancy and the<br />
+  signalling (not merely detoxifying) role of the H2O2 product.<br />
+- <strong>Transcriptional regulation split (from falcon; sources not cached).</strong> falcon<br />
+  reports sod-2 is regulated mainly by SKN-1/Nrf2 via p38 MAPK, whereas sod-3 is a<br />
+  DAF-16/FOXO (insulin/IGF-1) target (Yanase 2020; Honda 1999). Not independently<br />
+  quote-verified here (papers not in cache); recorded as context only.</p>
+<h2 id="sources">Sources</h2>
+<ul>
+<li>PMID:9353332 Hunter et al. 1997 J Biol Chem (abstract only in cache) — cloning</li>
+<li>heterologous expression + biochemical characterization of sod-2 and sod-3.</li>
+<li>PMID:23895727 Suthammarak et al. 2013 Aging Cell (full text cached) — mtSOD /<br />
+  ETC supercomplex interactions and lifespan; richest sod-2-specific source.</li>
+<li>PMID:19197346 Van Raamsdonk &amp; Hekimi 2009 PLoS Genet (full text cached) —<br />
+  sod-2 deletion extends lifespan; oxidative-stress-theory challenge.</li>
+<li>PMID:36449615 Branicky et al. 2022 Sci Adv (full text cached) — RAS-dependent<br />
+  ROS signalling (RDRS) mechanism of sod-2 longevity.</li>
+<li>PMID:28724632 Sakamoto &amp; Imai 2017 J Biol Chem (abstract only) — SOD-2 H2O2 in<br />
+  sperm activation; sod-2-specific.</li>
+<li>PMID:20188671 Haynes et al. 2010 Mol Cell (abstract only) — source of HDA<br />
+  mitochondrial-proteome localization annotation.</li>
+<li>genes/worm/sod-2/sod-2-deep-research-falcon.md — Edison deep research (33 cites).</li>
+</ul>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: P31161
+gene_symbol: sod-2
+product_type: PROTEIN
+status: COMPLETE
+taxon:
+  id: NCBITaxon:6239
+  label: Caenorhabditis elegans
+description: &gt;-
+  sod-2 encodes the principal manganese-dependent superoxide dismutase (MnSOD) of
+  the Caenorhabditis elegans mitochondrion. The nuclear-encoded precursor carries
+  an N-terminal mitochondrial transit peptide that directs import into the
+  mitochondrial matrix, where the mature chain assembles into the characteristic
+  iron/manganese superoxide dismutase fold and binds one catalytic Mn(2+) ion per
+  subunit. The enzyme dismutates the superoxide anion radical, a by-product of the
+  respiratory electron transport chain, into hydrogen peroxide and molecular oxygen
+  (2 superoxide + 2 H+ -&gt; H2O2 + O2; EC 1.15.1.1), providing a first line of
+  antioxidant defense within the organelle. C. elegans has a second, closely
+  related mitochondrial MnSOD, sod-3 (~86% identical), which is expressed at low
+  basal levels and is strongly induced by the DAF-16/FOXO branch of insulin/IGF-1
+  signalling; sod-2 is the constitutively expressed and quantitatively dominant
+  mitochondrial isoform. Beyond bulk matrix scavenging, SOD-2 physically associates
+  with the respiratory-chain supercomplex I:III:IV, positioning it to detoxify
+  superoxide at its site of production and potentially to influence supercomplex
+  stability and complex I/II activity. Counterintuitively for a core antioxidant
+  enzyme, loss of sod-2 does not shorten and in several mitochondrial-mutant
+  backgrounds can extend C. elegans lifespan, a finding central to debates over the
+  role of reactive oxygen species in aging. The enzyme&#39;s hydrogen peroxide product
+  also serves as a signalling molecule: it contributes to a RAS-dependent
+  ROS-signalling program linked to longevity and is required for sperm pseudopod
+  extension during sperm activation.
+references:
+- id: GO_REF:0000002
+  title: Gene Ontology annotation through association of InterPro records with GO
+    terms
+  findings: []
+- id: GO_REF:0000033
+  title: Annotation inferences using phylogenetic trees
+  findings: []
+- id: GO_REF:0000044
+  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location
+    vocabulary mapping, accompanied by conservative changes to GO terms applied by
+    UniProt
+  findings: []
+- id: GO_REF:0000117
+  title: Electronic Gene Ontology annotations created by ARBA machine learning models
+  findings: []
+- id: GO_REF:0000120
+  title: Combined Automated Annotation using Multiple IEA Methods
+  findings: []
+- id: PMID:19197346
+  title: Deletion of the mitochondrial superoxide dismutase sod-2 extends lifespan
+    in Caenorhabditis elegans.
+  findings:
+  - statement: &gt;-
+      Seminal demonstration that deleting the primary mitochondrial MnSOD sod-2
+      extends C. elegans lifespan despite increased protein oxidative damage and
+      heightened sensitivity to oxidative stress, directly challenging the
+      oxidative-damage theory of aging. sod-2 mutants phenocopy long-lived
+      mitochondrial mutants (slow development, small brood, reduced respiration).
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PubMed-verified (PMID 19197346, PMC2628729) via DOI 10.1371/journal.pgen.1000361.
+      The defining reference for the counterintuitive longevity phenotype of sod-2
+      loss.
+- id: PMID:28724632
+  title: Hydrogen peroxide produced by superoxide dismutase SOD-2 activates sperm
+    in Caenorhabditis elegans.
+  findings:
+  - statement: &gt;-
+      SOD-2-generated hydrogen peroxide acts as a positive signaling molecule
+      required for sperm pseudopod extension during activation; sod-2 (not sod-1)
+      is the specific SOD required, linking SOD-2 enzymatic output to fertility.
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PubMed-verified (PMID 28724632, PMC5592662) via DOI 10.1074/jbc.M117.788901.
+      Establishes a signalling (H2O2-mediated) role for SOD-2 output distinct from
+      bulk detoxification.
+- id: PMID:36449615
+  title: Stimulation of RAS-dependent ROS signaling extends longevity by modulating
+    a developmental program of global gene expression.
+  findings:
+  - statement: &gt;-
+      Proposes the RAS-dependent ROS signaling (RDRS) mechanism for sod-2 longevity:
+      loss of SOD-2 raises mitochondrial superoxide, which is converted by cytosolic
+      SOD-1 to hydrogen peroxide that oxidizes a redox-sensitive cysteine of
+      LET-60/RAS, driving a global developmental gene-expression program; the
+      lifespan extension requires SOD-1.
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PubMed-verified (PMID 36449615, PMC9710873) via DOI 10.1126/sciadv.adc9851.
+      Provides a mechanistic account that narrows the long-standing gap in how sod-2
+      loss extends lifespan.
+- id: PMID:20188671
+  title: The matrix peptide exporter HAF-1 signals a mitochondrial UPR by activating
+    the transcription factor ZC376.7 in C. elegans.
+  findings:
+  - statement: &gt;-
+      High-throughput direct-assay (mass-spectrometry) source underlying the GOA
+      mitochondrion localization annotation for SOD-2. The cached abstract concerns
+      HAF-1/ClpP-mediated mitochondrial unfolded protein response signalling and
+      does not itself discuss sod-2; the annotation reflects detection of SOD-2 in
+      a mitochondrial proteome dataset.
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PMID resolves to the correct Haynes et al. 2010 Mol Cell paper on the
+      mitochondrial UPR. It is the assigned source of an HDA mitochondrial
+      localization for SOD-2; the abstract does not mention sod-2 (full text /
+      proteomics supplement not in cache), so no sod-2-specific verbatim quote is
+      available. Mitochondrial localization of a MnSOD is biologically unambiguous.
+- id: PMID:23895727
+  title: Novel interactions between mitochondrial superoxide dismutases and the electron
+    transport chain.
+  findings:
+  - statement: &gt;-
+      SOD-2 is the primary mitochondrial superoxide dismutase and co-localizes by
+      blue-native gel with the respiratory supercomplex I:III:IV; loss of SOD-2
+      specifically lowers complex I and II activity and destabilizes supercomplex
+      formation. sod-2 single mutants have a normal lifespan, but loss of sod-2 can
+      extend the lifespan of some electron-transport-chain mutants.
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Full text cached (PMC3838459). The richest sod-2-specific source: directly
+      supports the supercomplex association (Fig 4D), the primary-mtSOD identity,
+      and the counterintuitive lifespan phenotypes. An anti-SOD-2 antibody with
+      partial cross-reactivity to SOD-3 is noted by the authors, but the
+      sod-2-specific band is lost in the sod-2 mutant, so the SOD-2 localization is
+      real.
+- id: PMID:9353332
+  title: Cloning, expression, and characterization of two manganese superoxide dismutases
+    from Caenorhabditis elegans.
+  findings:
+  - statement: &gt;-
+      Cloned sod-2 and sod-3, showed both encode mitochondrial (transit-peptide
+      bearing) manganese-type superoxide dismutases, and directly measured their
+      enzymatic activity after heterologous expression in SOD-deficient E. coli
+      (Mn-type: insensitive to hydrogen peroxide and cyanide; dimeric; protective
+      against paraquat/methyl-viologen oxidative stress).
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Abstract-only in cache (full_text_available: false), but the abstract
+      explicitly reports the direct biochemical characterization that underlies the
+      WormBase IDA (superoxide dismutase activity) and IMP (removal of superoxide
+      radicals) annotations. Note the IMP is based on heterologous E. coli
+      complementation, not a worm-mutant phenotype.
+existing_annotations:
+- term:
+    id: GO:0005739
+    label: mitochondrion
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: is_active_in
+  review:
+    summary: &gt;-
+      Phylogenetic (IBA) inference that SOD-2 is active in the mitochondrion.
+      Correct but less specific than the mitochondrial matrix, which is where this
+      MnSOD acts.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Consistent with the mitochondrial transit peptide and with experimental
+      localization, but generic relative to mitochondrial matrix (GO:0005759),
+      which is retained as the core location. Kept as a correct, less-specific
+      companion term.
+- term:
+    id: GO:0004784
+    label: superoxide dismutase activity
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Phylogenetic (IBA) inference of superoxide dismutase activity. This is the
+      core molecular function of SOD-2 and is directly confirmed experimentally.
+    action: ACCEPT
+    reason: &gt;-
+      SOD-2 is an experimentally validated manganese superoxide dismutase; the IBA
+      call is fully concordant with the IDA evidence (PMID:9353332) and with the
+      Fe/Mn-SOD family assignment. Core function.
+    supported_by:
+    - reference_id: PMID:9353332
+      supporting_text: &gt;-
+        The expressed enzymes, which were not inhibited by hydrogen peroxide or
+        cyanide, are dimeric, show quite different electrophoretic mobilities and
+        isoelectric points, but exhibit comparable specific activities.
+- term:
+    id: GO:0030145
+    label: manganese ion binding
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Phylogenetic (IBA) inference of manganese ion binding, the catalytic cofactor
+      of this MnSOD. Concordant with the UniProt Mn(2+) cofactor and Mn-ligand
+      residues, and with the enzyme&#39;s Mn-type biochemistry.
+    action: ACCEPT
+    reason: &gt;-
+      Correct and specific metal-binding function: this is a Mn-type (not Fe- or
+      Cu/Zn-type) SOD, insensitive to hydrogen peroxide and cyanide, binding one
+      Mn(2+) per subunit. Core cofactor-binding function.
+    supported_by:
+    - reference_id: PMID:9353332
+      supporting_text: &gt;-
+        The expressed enzymes, which were not inhibited by hydrogen peroxide or
+        cyanide, are dimeric, show quite different electrophoretic mobilities and
+        isoelectric points, but exhibit comparable specific activities.
+- term:
+    id: GO:0004784
+    label: superoxide dismutase activity
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000120
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Electronic (IEA) assignment of superoxide dismutase activity from combined
+      automated methods (ARBA/InterPro/EC/RHEA mapping). Redundant with the
+      experimental IDA and phylogenetic IBA calls for the same core function.
+    action: ACCEPT
+    reason: &gt;-
+      Same core molecular function as the IDA/IBA annotations; the EC 1.15.1.1 /
+      RHEA:20696 mapping is correct for this enzyme. Retained as concordant
+      supporting evidence.
+- term:
+    id: GO:0005759
+    label: mitochondrial matrix
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000044
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Electronic (SubCell) localization to the mitochondrial matrix, matching the
+      UniProt subcellular location and the N-terminal mitochondrial transit
+      peptide. This is the core site of SOD-2 action.
+    action: ACCEPT
+    reason: &gt;-
+      Correct and appropriately specific localization for a matrix MnSOD; supported
+      by the transit peptide and by the primary-mtSOD role. Core location.
+    supported_by:
+    - reference_id: PMID:9353332
+      supporting_text: &gt;-
+        Both deduced protein sequences contain the expected N-terminal
+        mitochondrial transit peptides.
+- term:
+    id: GO:0006801
+    label: superoxide metabolic process
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Electronic (InterPro2GO) assignment to the general superoxide metabolic
+      process. Correct but less specific than removal of superoxide radicals
+      (GO:0019430), which is the experimentally supported process.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Accurate parent process, but subsumed by the more specific removal of
+      superoxide radicals term retained as core. Kept as a correct, less-informative
+      companion.
+- term:
+    id: GO:0046872
+    label: metal ion binding
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Electronic (InterPro2GO) generic metal-ion-binding annotation. Subsumed by
+      the specific manganese ion binding (GO:0030145) term.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Correct but uninformative parent of manganese ion binding; the specific Mn(2+)
+      term is retained as core. Kept as a non-core, less-specific companion.
+- term:
+    id: GO:0098803
+    label: respiratory chain complex
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000117
+  qualifier: part_of
+  review:
+    summary: &gt;-
+      Electronic (ARBA) assertion that SOD-2 is part_of the respiratory chain
+      complex. SOD-2 is a soluble matrix MnSOD that physically associates with
+      supercomplex I:III:IV (see the experimental located_in annotation), but it is
+      not a canonical structural subunit of an electron-transport complex, so the
+      part_of qualifier overstates the relationship.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      The experimentally supported relationship is association/co-localization with
+      the I:III:IV supercomplex (PMID:23895727, located_in), consistent with local
+      superoxide scavenging and possible supercomplex stabilization; SOD-2 does not
+      carry out or structurally constitute electron transport. The automated part_of
+      qualifier is an over-generalization, so this is retained only as a non-core
+      companion to the experimental located_in annotation rather than as evidence of
+      structural subunit membership.
+    supported_by:
+    - reference_id: PMID:23895727
+      supporting_text: &gt;-
+        Western blots of BNGs indicated that SOD-2 co-localized with the I:III:IV
+        supercomplex (Figure 4D).
+- term:
+    id: GO:0004784
+    label: superoxide dismutase activity
+  evidence_type: IDA
+  original_reference_id: PMID:9353332
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Direct assay (IDA) of superoxide dismutase activity: the mature SOD-2 protein
+      was expressed in SOD-deficient E. coli and shown to be an active, Mn-type
+      dismutase. This is the primary experimental evidence for the core function.
+    action: ACCEPT
+    reason: &gt;-
+      Gold-standard experimental support for the defining molecular function.
+      Insensitivity to hydrogen peroxide and cyanide confirms the Mn-type (not Fe-
+      or Cu/Zn-type) mechanism. Core function.
+    supported_by:
+    - reference_id: PMID:9353332
+      supporting_text: &gt;-
+        The expressed enzymes, which were not inhibited by hydrogen peroxide or
+        cyanide, are dimeric, show quite different electrophoretic mobilities and
+        isoelectric points, but exhibit comparable specific activities.
+    - reference_id: file:worm/sod-2/sod-2-deep-research-falcon.md
+      supporting_text: &gt;-
+        Primary mitochondrial Mn-superoxide dismutase that converts superoxide to
+        hydrogen peroxide and oxygen
+- term:
+    id: GO:0019430
+    label: removal of superoxide radicals
+  evidence_type: IMP
+  original_reference_id: PMID:9353332
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      SOD-2 removes superoxide radicals: heterologous expression of the worm enzyme
+      rescued SOD-deficient E. coli from methyl-viologen (paraquat) oxidative
+      stress. This is the core biological process the enzyme serves.
+    action: ACCEPT
+    reason: &gt;-
+      Functionally correct core process. The evidence is heterologous complementation
+      (protection of SOD-null E. coli against a superoxide generator) rather than a
+      worm loss-of-function phenotype, but it directly demonstrates superoxide-radical
+      removal by the SOD-2 protein. Core process.
+    supported_by:
+    - reference_id: PMID:9353332
+      supporting_text: &gt;-
+        Both proteins were shown to be active in E. coli, providing similar
+        protection against methyl viologen-induced oxidative stress.
+- term:
+    id: GO:0098803
+    label: respiratory chain complex
+  evidence_type: IDA
+  original_reference_id: PMID:23895727
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Direct assay (IDA) showing SOD-2 co-localizes with mitochondrial supercomplex
+      I:III:IV by blue-native gel Western blotting. A genuine, sod-2-specific
+      localization finding, but a peripheral association rather than the enzyme&#39;s
+      core identity.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Experimentally supported association of SOD-2 with the I:III:IV supercomplex,
+      consistent with local scavenging of superoxide at its site of production and a
+      possible supercomplex-stabilizing role. Retained with the located_in qualifier
+      as a real but non-core localization (SOD-2&#39;s core identity is a matrix MnSOD,
+      not a structural ETC subunit).
+    supported_by:
+    - reference_id: PMID:23895727
+      supporting_text: &gt;-
+        Western blots of BNGs indicated that SOD-2 co-localized with the I:III:IV
+        supercomplex (Figure 4D).
+- term:
+    id: GO:0005739
+    label: mitochondrion
+  evidence_type: HDA
+  original_reference_id: PMID:20188671
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      High-throughput direct-assay (HDA) mitochondrial-proteome localization of
+      SOD-2. Correct but generic relative to the mitochondrial matrix term.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Mitochondrial localization of this MnSOD is biologically unambiguous and
+      concordant with the transit peptide and matrix localization; retained as a
+      correct, less-specific companion to mitochondrial matrix (GO:0005759). The
+      cited abstract concerns the mtUPR and does not mention sod-2, so no
+      sod-2-specific verbatim quote is available for the HDA dataset.
+core_functions:
+- description: &gt;-
+    SOD-2 is a mitochondrial matrix manganese superoxide dismutase that catalyzes
+    the dismutation of the superoxide anion radical to hydrogen peroxide and
+    molecular oxygen (2 superoxide + 2 H+ -&gt; H2O2 + O2; EC 1.15.1.1), the core
+    antioxidant defense of the mitochondrial matrix and the primary constitutively
+    expressed mtSOD of C. elegans.
+  molecular_function:
+    id: GO:0004784
+    label: superoxide dismutase activity
+  directly_involved_in:
+  - id: GO:0019430
+    label: removal of superoxide radicals
+  locations:
+  - id: GO:0005759
+    label: mitochondrial matrix
+  supported_by:
+  - reference_id: PMID:9353332
+    supporting_text: &gt;-
+      The expressed enzymes, which were not inhibited by hydrogen peroxide or
+      cyanide, are dimeric, show quite different electrophoretic mobilities and
+      isoelectric points, but exhibit comparable specific activities.
+  - reference_id: PMID:9353332
+    supporting_text: &gt;-
+      Both proteins were shown to be active in E. coli, providing similar
+      protection against methyl viologen-induced oxidative stress.
+- description: &gt;-
+    SOD-2 binds one catalytic manganese (Mn2+) ion per subunit, the redox-active
+    cofactor required for the dismutase mechanism. Its Mn-type identity is
+    established by insensitivity to hydrogen peroxide and cyanide, which inhibit
+    Fe-type and Cu/Zn-type SODs respectively.
+  molecular_function:
+    id: GO:0030145
+    label: manganese ion binding
+  locations:
+  - id: GO:0005759
+    label: mitochondrial matrix
+  supported_by:
+  - reference_id: PMID:9353332
+    supporting_text: &gt;-
+      The expressed enzymes, which were not inhibited by hydrogen peroxide or
+      cyanide, are dimeric, show quite different electrophoretic mobilities and
+      isoelectric points, but exhibit comparable specific activities.
+proposed_new_terms: []
+suggested_questions:
+- question: &gt;-
+    By what mechanism does loss of the primary mitochondrial antioxidant SOD-2 fail
+    to shorten, and in some backgrounds extend, C. elegans lifespan — is superoxide
+    acting as a pro-longevity signal (mitohormesis), or is the effect mediated by
+    metabolic slowing and supercomplex remodeling?
+- question: &gt;-
+    What is the functional division of labour between the two nearly identical
+    mitochondrial MnSODs, SOD-2 (constitutive, dominant) and SOD-3 (DAF-16-inducible,
+    low basal), given their non-redundant and sometimes opposite genetic
+    interactions with electron-transport-chain mutants?
+- question: &gt;-
+    Is SOD-2&#39;s association with respiratory supercomplex I:III:IV purely a
+    positioning device for local superoxide scavenging, or does SOD-2 also act as a
+    structural stabilizer of the supercomplex independent of its catalytic activity?
+suggested_experiments:
+- description: &gt;-
+    Catalytically-dead (metal-ligand mutant) versus wild-type sod-2 rescue in a
+    sod-2 null, scoring lifespan, complex I/II activity, and supercomplex formation,
+    to separate the scavenging function from a possible structural role.
+- description: &gt;-
+    Quantitative, isoform-resolved proteomics and tagged-allele localization of
+    SOD-2 versus SOD-3 across tissues and stress conditions to define their
+    non-redundant contributions and supercomplex occupancy.
+- description: &gt;-
+    Genetic-epistasis and redox-biosensor (e.g. mitochondrial roGFP/HyPer) analysis
+    of sod-2 loss in long-lived ETC mutants to test whether a superoxide/ROS signal,
+    rather than bulk oxidative damage, mediates the lifespan extension.
+knowledge_gaps:
+- gap_statement: &gt;-
+    How loss of the primary mitochondrial superoxide dismutase SOD-2 extends
+    C. elegans lifespan is only partly resolved. A specific mechanism has been
+    proposed — a RAS-dependent ROS-signalling (RDRS) pathway in which elevated
+    mitochondrial superoxide is converted by cytosolic SOD-1 to hydrogen peroxide
+    that oxidizes a redox-sensitive cysteine of LET-60/RAS — but how much of the
+    longevity effect is attributable to this ROS signal versus to the concurrent
+    reduction in respiration, altered mitochondrial supercomplex stability, and
+    developmental/metabolic slowing remains undetermined, as does why the same loss
+    shortens lifespan once mitochondrial dysfunction exceeds a threshold.
+  boundary: &gt;-
+    It is firmly established that SOD-2 is an active mitochondrial MnSOD and the
+    primary mitochondrial superoxide scavenger, that sod-2 single mutants are not
+    short-lived and are in fact long-lived despite increased protein oxidative
+    damage, that deletion of sod-2 markedly increases lifespan in clk-1 but
+    decreases it in isp-1 backgrounds, that loss of sod-2 lowers complex I/II
+    activity and supercomplex formation, and that a RDRS mechanism requiring SOD-1
+    can account for part of the extension. What is not established is the causal
+    weighting of the signalling versus metabolic contributions.
+  gap_kind:
+  - BIOLOGY
+  dark_aspect: BP_DARK
+  status: NARROWING
+  significance: &gt;-
+    This is a central, counterintuitive case in the debate over the free-radical /
+    oxidative-damage theory of aging: a core antioxidant enzyme whose removal does
+    not shorten and can extend life. Resolving the causal weighting would clarify
+    when mitochondrial superoxide acts as a damaging agent versus a pro-longevity
+    signal.
+  provenance:
+  - reference_id: PMID:19197346
+    supporting_text: &gt;-
+      we find that sod-2 mutants are long-lived despite a significant increase in
+      oxidatively damaged proteins
+  - reference_id: PMID:19197346
+    supporting_text: &gt;-
+      deletion of sod-2 extends worm lifespan by altering mitochondrial function
+  - reference_id: PMID:36449615
+    supporting_text: &gt;-
+      RDRS is regulated by negative feedback from the superoxide dismutase 1
+      (SOD-1)-dependent conversion of superoxide into cytoplasmic hydrogen peroxide,
+      which, in turn, acts on a redox-sensitive cysteine (C118) of RAS
+  - reference_id: PMID:23895727
+    supporting_text: &gt;-
+      no single component of mitochondrial physiology that we studied correlates
+      simply with lifespan
+- gap_statement: &gt;-
+    The functional division of labour between the two nearly identical mitochondrial
+    manganese superoxide dismutases, SOD-2 and SOD-3, is undefined. It is unknown why
+    C. elegans maintains both, what distinguishes their substrates or sub-mitochondrial
+    contexts, and why loss of sod-2 versus sod-3 produces different (sometimes
+    opposite) genetic interactions with electron-transport-chain mutants.
+  boundary: &gt;-
+    It is established that sod-2 and sod-3 are ~86% identical mitochondrial MnSODs,
+    that sod-2 is constitutively expressed and dominant while sod-3 is expressed at
+    low basal levels and induced by DAF-16/insulin signalling, that both associate
+    with supercomplex I:III:IV, and that they are functionally non-redundant (loss of
+    sod-2 versus sod-3 produces different genetic interactions with ETC mutants, and
+    sod-2 but not sod-1 is specifically required for H2O2-dependent sperm activation).
+    What is not established is the mechanistic basis of the non-redundancy at the
+    level of substrate, sub-mitochondrial context, or partner; the authors of the key
+    ETC study explicitly state that the sod-3/supercomplex relationship was still
+    under investigation.
+  gap_kind:
+  - BIOLOGY
+  dark_aspect: RESIDUAL_SUBGAP
+  status: OPEN
+  significance: &gt;-
+    Two paralogous mitochondrial MnSODs with divergent, non-redundant phenotypes are
+    a clean model for how gene duplication partitions an antioxidant function; the
+    division of labour also determines which isoform is limiting under which stress.
+  provenance:
+  - reference_id: PMID:23895727
+    supporting_text: &gt;-
+      Studies are now being undertaken to characterize the interaction of sod3 with
+      supercomplex I:III:IV formation
+  - reference_id: PMID:28724632
+    supporting_text: &gt;-
+      sod-2 is required for pseudopod extension
+- gap_statement: &gt;-
+    Whether SOD-2&#39;s association with respiratory supercomplex I:III:IV reflects only
+    local superoxide scavenging at the site of ROS production, or whether SOD-2 also
+    acts as a direct structural stabilizer of the supercomplex independent of its
+    catalytic activity, is undetermined.
+  boundary: &gt;-
+    It is established that SOD-2 co-localizes with the I:III:IV supercomplex by
+    blue-native gel and that sod-2 loss reduces supercomplex formation and complex I
+    activity. The open question is causality/mechanism: complex I function falls out
+    of proportion to the measured ROS damage, so a catalysis-independent structural
+    role remains possible but unproven.
+  gap_kind:
+  - BIOLOGY
+  dark_aspect: RESIDUAL_SUBGAP
+  status: OPEN
+  significance: &gt;-
+    Distinguishing a scavenging role from a structural role would determine whether
+    MnSOD is a modular antioxidant or an integral stabilizer of the electron
+    transport chain, with implications for how supercomplex integrity is maintained.
+  provenance:
+  - reference_id: PMID:23895727
+    supporting_text: &gt;-
+      it is also possible that the mtSODs may directly serve as stabilizing factors
+      in the I:III:IV supercomplex
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/genes/worm/sod-3/sod-3-ai-review.html
+++ b/genes/worm/sod-3/sod-3-ai-review.html
@@ -1,0 +1,3280 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>sod-3 - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        .propagation-review {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f8fafc;
+            border-left: 3px solid #64748b;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .propagation-title {
+            font-weight: 600;
+            color: #334155;
+            margin-bottom: 0.25rem;
+        }
+
+        .propagation-row {
+            margin-top: 0.25rem;
+        }
+
+        .propagation-source {
+            margin-top: 0.5rem;
+            padding-top: 0.5rem;
+            border-top: 1px solid #e5e7eb;
+        }
+
+        .propagation-source-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #1d4ed8;
+        }
+
+        .propagation-comment {
+            color: #4b5563;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>sod-3</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/P41977" target="_blank" class="term-link">
+                        P41977
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Caenorhabditis elegans</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-complete">
+                    COMPLETE
+                </span>
+            </div>
+
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "sod-3";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="P41977" data-a="DESCRIPTION: sod-3 encodes a mitochondrial matrix manganese sup..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>sod-3 encodes a mitochondrial matrix manganese superoxide dismutase (MnSOD) of Caenorhabditis elegans. The nuclear-encoded 218-residue precursor carries an N-terminal mitochondrial transit peptide that directs import into the mitochondrial matrix, where the mature chain adopts the characteristic iron/manganese superoxide dismutase fold and binds one catalytic Mn(2+) ion per subunit. The enzyme dismutates the superoxide anion radical, a by-product of the respiratory electron transport chain, into hydrogen peroxide and molecular oxygen (2 superoxide + 2 H+ -&gt; H2O2 + O2; EC 1.15.1.1), providing antioxidant defense within the organelle. SOD-3 is the paralog of the constitutive, quantitatively dominant mitochondrial MnSOD SOD-2, to which it is ~86% identical; unlike sod-2, sod-3 is expressed at very low basal levels and is strongly induced by the DAF-16/FOXO branch of insulin/IGF-1 signalling, making it a canonical DAF-16 target gene and a widely used transcriptional reporter of insulin/IGF-1 pathway activity and stress. Basal expression is seen in the pharynx and rectum, expanding to vulva, body-wall muscle and hypodermis upon thermal stress. Like SOD-2, SOD-3 physically associates with the mitochondrial respiratory supercomplex I:III:IV, positioning it to scavenge superoxide near its site of production, and it may help stabilize or locally protect the supercomplex, particularly when SOD-2 is absent. Loss of sod-3 alone does not alter lifespan or the activity of the respiratory complexes, but sod-3 shows distinct, non-redundant genetic interactions with electron-transport-chain mutants compared with sod-2.</p>
+    </div>
+
+
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005739" target="_blank" class="term-link">
+                                    GO:0005739
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrion</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P41977" data-a="GO:0005739" data-r="GO_REF:0000033" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetic (IBA) inference that SOD-3 is active in the mitochondrion. Correct but less specific than the mitochondrial matrix, where this MnSOD acts.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Consistent with the N-terminal mitochondrial transit peptide and with experimental localization, but generic relative to mitochondrial matrix (GO:0005759), which is retained as the core location. Kept as a correct, less-specific companion term.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004784" target="_blank" class="term-link">
+                                    GO:0004784
+                                </a>
+                            </span>
+                            <span class="term-label">superoxide dismutase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P41977" data-a="GO:0004784" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetic (IBA) inference of superoxide dismutase activity. This is the core molecular function of SOD-3 and is directly confirmed experimentally.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> SOD-3 is an experimentally validated manganese superoxide dismutase; the IBA call is fully concordant with the IDA evidence (PMID:9353332, in which the SOD-3 protein was expressed and assayed) and with the Fe/Mn-SOD family assignment. Core function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9353332" target="_blank" class="term-link">
+                                        PMID:9353332
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The expressed enzymes, which were not inhibited by hydrogen peroxide or cyanide, are dimeric, show quite different electrophoretic mobilities and isoelectric points, but exhibit comparable specific activities.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030145" target="_blank" class="term-link">
+                                    GO:0030145
+                                </a>
+                            </span>
+                            <span class="term-label">manganese ion binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P41977" data-a="GO:0030145" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetic (IBA) inference of manganese ion binding, the catalytic cofactor of this MnSOD. Concordant with the UniProt Mn(2+) cofactor and Mn-ligand residues (His50, His98, Asp179, His183) and with the enzyme&#39;s Mn-type biochemistry.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct and specific metal-binding function: this is a Mn-type (not Fe- or Cu/Zn-type) SOD, insensitive to hydrogen peroxide and cyanide, binding one Mn(2+) per subunit. Core cofactor-binding function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9353332" target="_blank" class="term-link">
+                                        PMID:9353332
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The expressed enzymes, which were not inhibited by hydrogen peroxide or cyanide, are dimeric, show quite different electrophoretic mobilities and isoelectric points, but exhibit comparable specific activities.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004784" target="_blank" class="term-link">
+                                    GO:0004784
+                                </a>
+                            </span>
+                            <span class="term-label">superoxide dismutase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000120
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P41977" data-a="GO:0004784" data-r="GO_REF:0000120" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic (IEA) assignment of superoxide dismutase activity from combined automated methods (ARBA/InterPro/EC/RHEA mapping). Redundant with the experimental IDA and phylogenetic IBA calls for the same core function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Same core molecular function as the IDA/IBA annotations; the EC 1.15.1.1 / RHEA:20696 mapping is correct for this enzyme. Retained as concordant supporting evidence.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005739" target="_blank" class="term-link">
+                                    GO:0005739
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrion</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000044
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P41977" data-a="GO:0005739" data-r="GO_REF:0000044" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic (UniProt SubCell) mitochondrial localization, matching the UniProt subcellular location and the N-terminal mitochondrial transit peptide. Correct but generic relative to the mitochondrial matrix, the specific site of action.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct localization but less specific than mitochondrial matrix (GO:0005759), which is retained as the core location for this matrix MnSOD. Kept as a correct, less-specific companion.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9353332" target="_blank" class="term-link">
+                                        PMID:9353332
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Both deduced protein sequences contain the expected N-terminal mitochondrial transit peptides.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006801" target="_blank" class="term-link">
+                                    GO:0006801
+                                </a>
+                            </span>
+                            <span class="term-label">superoxide metabolic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P41977" data-a="GO:0006801" data-r="GO_REF:0000002" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic (InterPro2GO) assignment to the general superoxide metabolic process. Correct but less specific than removal of superoxide radicals (GO:0019430), which is the experimentally supported process.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Accurate parent process, but subsumed by the more specific removal of superoxide radicals term retained as core. Kept as a correct, less-informative companion.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0046872" target="_blank" class="term-link">
+                                    GO:0046872
+                                </a>
+                            </span>
+                            <span class="term-label">metal ion binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P41977" data-a="GO:0046872" data-r="GO_REF:0000002" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic (InterPro2GO) generic metal-ion-binding annotation. Subsumed by the specific manganese ion binding (GO:0030145) term.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct but uninformative parent of manganese ion binding; the specific Mn(2+) term is retained as core. Kept as a non-core, less-specific companion.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0098803" target="_blank" class="term-link">
+                                    GO:0098803
+                                </a>
+                            </span>
+                            <span class="term-label">respiratory chain complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000117
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P41977" data-a="GO:0098803" data-r="GO_REF:0000117" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic (ARBA) assertion that SOD-3 is part_of the respiratory chain complex. SOD-3 is a soluble matrix MnSOD that physically associates with supercomplex I:III:IV (see the experimental located_in annotation), but it is not a canonical structural subunit of an electron-transport complex, so the part_of qualifier overstates the relationship.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The experimentally supported relationship is association/co-localization with the I:III:IV supercomplex (PMID:23895727, located_in), consistent with local superoxide scavenging and possible supercomplex stabilization; SOD-3 does not carry out or structurally constitute electron transport. The automated part_of qualifier is an over-generalization, so this is retained only as a non-core companion to the experimental located_in annotation rather than as evidence of structural subunit membership.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/23895727" target="_blank" class="term-link">
+                                        PMID:23895727
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">In addition, the results show that SOD-3 is also localized to the I:III:IV supercomplex.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0098803" target="_blank" class="term-link">
+                                    GO:0098803
+                                </a>
+                            </span>
+                            <span class="term-label">respiratory chain complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/23895727" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:23895727
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Novel interactions between mitochondrial superoxide dismutas...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P41977" data-a="GO:0098803" data-r="PMID:23895727" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct assay (IDA) showing SOD-3 co-localizes with the mitochondrial supercomplex I:III:IV by blue-native gel Western blotting. A genuine, sod-3-specific localization finding, but a peripheral association rather than the enzyme&#39;s core identity; the part_of qualifier overstates it (SOD-3 is not a structural ETC subunit).
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Experimentally supported association of SOD-3 with the I:III:IV supercomplex, consistent with local scavenging of superoxide at its site of production and a possible supercomplex-stabilizing role (the authors note SOD-3 may substitute for this SOD-2 function when SOD-2 is absent). Retained as a real but non-core localization; SOD-3&#39;s core identity is a matrix MnSOD, not a structural ETC subunit.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/23895727" target="_blank" class="term-link">
+                                        PMID:23895727
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">In addition, the results show that SOD-3 is also localized to the I:III:IV supercomplex.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004784" target="_blank" class="term-link">
+                                    GO:0004784
+                                </a>
+                            </span>
+                            <span class="term-label">superoxide dismutase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/9353332" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:9353332
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Cloning, expression, and characterization of two manganese s...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P41977" data-a="GO:0004784" data-r="PMID:9353332" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct assay (IDA) of superoxide dismutase activity: the mature SOD-3 protein was expressed in SOD-deficient E. coli and shown to be an active, Mn-type dismutase. This is the primary experimental evidence for the core function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Gold-standard experimental support for the defining molecular function. Insensitivity to hydrogen peroxide and cyanide confirms the Mn-type (not Fe- or Cu/Zn-type) mechanism. Both worm MnSODs were expressed and assayed in this study. Core function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9353332" target="_blank" class="term-link">
+                                        PMID:9353332
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The expressed enzymes, which were not inhibited by hydrogen peroxide or cyanide, are dimeric, show quite different electrophoretic mobilities and isoelectric points, but exhibit comparable specific activities.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0019430" target="_blank" class="term-link">
+                                    GO:0019430
+                                </a>
+                            </span>
+                            <span class="term-label">removal of superoxide radicals</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/9353332" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:9353332
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Cloning, expression, and characterization of two manganese s...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P41977" data-a="GO:0019430" data-r="PMID:9353332" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> SOD-3 removes superoxide radicals: heterologous expression of the worm enzyme rescued SOD-deficient E. coli from methyl-viologen (paraquat) oxidative stress. This is the core biological process the enzyme serves.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Functionally correct core process. The evidence is heterologous complementation (protection of SOD-null E. coli against a superoxide generator) rather than a worm sod-3 loss-of-function phenotype, but it directly demonstrates superoxide-radical removal by the SOD-3 protein. Core process.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9353332" target="_blank" class="term-link">
+                                        PMID:9353332
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Both proteins were shown to be active in E. coli, providing similar protection against methyl viologen-induced oxidative stress.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005739" target="_blank" class="term-link">
+                                    GO:0005739
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrion</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/17894411" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:17894411
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The MAP kinase JNK-1 of Caenorhabditis elegans: location, ac...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P41977" data-a="GO:0005739" data-r="PMID:17894411" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct-assay (IDA) mitochondrial localization of SOD-3 (WormBase, from the full text of Wolf et al. 2008, the paper UniProt cites for the SUBCELLULAR LOCATION). Correct but generic relative to the mitochondrial matrix term.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Mitochondrial localization of this MnSOD is biologically unambiguous and concordant with the transit peptide and matrix localization; retained as a correct, less-specific companion to mitochondrial matrix (GO:0005759). The cached abstract of PMID:17894411 concerns JNK-1/DAF-16 signalling and does not itself state the mitochondrial localization (it is in the full text), so no sod-3-specific verbatim localization quote is available.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005759" target="_blank" class="term-link">
+                                    GO:0005759
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial matrix</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ISS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/9353332" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:9353332
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Cloning, expression, and characterization of two manganese s...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-new">
+                            NEW
+                        </span>
+                        <span class="vote-buttons" data-g="P41977" data-a="GO:0005759" data-r="PMID:9353332" data-act="NEW">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Proposed more-specific localization: as a nuclear-encoded manganese superoxide dismutase bearing an N-terminal mitochondrial transit peptide, SOD-3 is imported into and acts within the mitochondrial matrix, the compartment where Fe/Mn-SOD family MnSODs reside. This refines the generic mitochondrion annotations.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The existing localization annotations (IBA, SubCell IEA, IDA) all use the generic GO:0005739 mitochondrion. The transit peptide and Mn-SOD family assignment place SOD-3 specifically in the mitochondrial matrix, which is retained as the core location. Added as a NEW, more-specific companion inferred from sequence features (ISS) rather than by rewriting the trusted GOA ids.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9353332" target="_blank" class="term-link">
+                                        PMID:9353332
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Both deduced protein sequences contain the expected N-terminal mitochondrial transit peptides.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>SOD-3 is a mitochondrial matrix manganese superoxide dismutase that catalyzes the dismutation of the superoxide anion radical to hydrogen peroxide and molecular oxygen (2 superoxide + 2 H+ -&gt; H2O2 + O2; EC 1.15.1.1), a DAF-16/FOXO-inducible antioxidant defense of the mitochondrial matrix that complements the constitutive SOD-2.</h3>
+                <span class="vote-buttons" data-g="P41977" data-a="FUNCTION: SOD-3 is a mitochondrial matrix manganese superoxi..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004784" target="_blank" class="term-link">
+                            superoxide dismutase activity
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0019430" target="_blank" class="term-link">
+                                removal of superoxide radicals
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005759" target="_blank" class="term-link">
+                                mitochondrial matrix
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/9353332" target="_blank" class="term-link">
+                                PMID:9353332
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">The expressed enzymes, which were not inhibited by hydrogen peroxide or cyanide, are dimeric, show quite different electrophoretic mobilities and isoelectric points, but exhibit comparable specific activities.</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/9353332" target="_blank" class="term-link">
+                                PMID:9353332
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">Both proteins were shown to be active in E. coli, providing similar protection against methyl viologen-induced oxidative stress.</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>SOD-3 binds one catalytic manganese (Mn2+) ion per subunit, the redox-active cofactor required for the dismutase mechanism. Its Mn-type identity is established by insensitivity to hydrogen peroxide and cyanide, which inhibit Fe-type and Cu/Zn-type SODs respectively.</h3>
+                <span class="vote-buttons" data-g="P41977" data-a="FUNCTION: SOD-3 binds one catalytic manganese (Mn2+) ion per..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030145" target="_blank" class="term-link">
+                            manganese ion binding
+                        </a>
+                    </span>
+                </div>
+
+
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005759" target="_blank" class="term-link">
+                                mitochondrial matrix
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/9353332" target="_blank" class="term-link">
+                                PMID:9353332
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">The expressed enzymes, which were not inhibited by hydrogen peroxide or cyanide, are dimeric, show quite different electrophoretic mobilities and isoelectric points, but exhibit comparable specific activities.</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000002.md" target="_blank" class="term-link">
+                            GO_REF:0000002
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation through association of InterPro records with GO terms</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
+                            GO_REF:0000033
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Annotation inferences using phylogenetic trees</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
+                            GO_REF:0000044
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000117.md" target="_blank" class="term-link">
+                            GO_REF:0000117
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Electronic Gene Ontology annotations created by ARBA machine learning models</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000120.md" target="_blank" class="term-link">
+                            GO_REF:0000120
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Combined Automated Annotation using Multiple IEA Methods</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/9353332" target="_blank" class="term-link">
+                            PMID:9353332
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Cloning, expression, and characterization of two manganese superoxide dismutases from Caenorhabditis elegans.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Cloned sod-2 and sod-3, showed both encode mitochondrial (transit-peptide bearing) manganese-type superoxide dismutases (~86% identical proteins), and directly measured their enzymatic activity after heterologous expression of the mature chains in SOD-deficient E. coli (Mn-type: insensitive to hydrogen peroxide and cyanide; dimeric; protective against methyl-viologen/paraquat oxidative stress). Both proteins were assayed, so the biochemical evidence is sod-3-specific as well as sod-2-specific.</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/23895727" target="_blank" class="term-link">
+                            PMID:23895727
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Novel interactions between mitochondrial superoxide dismutases and the electron transport chain.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">SOD-3 (like SOD-2) localizes to the mitochondrial respiratory supercomplex I:III:IV by blue-native gel Western. In contrast to sod-2, loss of sod-3 does not decrease complex I-dependent respiration and sod-3 BNGs are normal; sod-3 single-mutant lifespan equals wild type, but sod-3 has distinct, non-redundant genetic interactions with the ETC mutants gas-1, mev-1 and isp-1. sod-3 is an mtSOD normally expressed at very low levels and induced by DAF-16.</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/17894411" target="_blank" class="term-link">
+                            PMID:17894411
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">The MAP kinase JNK-1 of Caenorhabditis elegans: location, activation, and influences over temperature-dependent insulin-like signaling, stress responses, and fitness.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Establishes sod-3 as a DAF-16 target gene whose peripheral, non-neuronal expression is promoted by JNK-1-driven nuclear translocation of DAF-16. UniProt cites this paper for the SUBCELLULAR LOCATION (mitochondrion), TISSUE SPECIFICITY (pharynx/rectum basally; vulva, body-wall muscle, hypodermis on thermal stress), and heat INDUCTION of SOD-3.</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Questions for Experts</h2>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Does the very low basal level of SOD-3 make a material contribution to superoxide scavenging in the wild-type mitochondrial matrix, or is SOD-3 essentially a stress- and DAF-16-inducible reserve isoform that matters mainly when SOD-2 is limiting?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P41977" data-a="Q: Does the very low basal level of SOD-3 make a mate..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> What is the mechanistic basis of the division of labour between the two nearly identical mitochondrial MnSODs, SOD-2 (constitutive, dominant) and SOD-3 (DAF-16-inducible, low basal), given their distinct and sometimes opposite genetic interactions with electron-transport-chain mutants?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P41977" data-a="Q: What is the mechanistic basis of the division of l..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Is the DAF-16-driven induction of sod-3 causally protective (extending lifespan or raising stress resistance), or is it primarily a transcriptional marker of DAF-16 activity, given that eliminating both mitochondrial SODs does not suppress daf-2 longevity?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P41977" data-a="Q: Is the DAF-16-driven induction of sod-3 causally p..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Experiments</h2>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Isoform-resolved, tagged-allele quantification and localization of SOD-3 versus SOD-2 across tissues, developmental stages and stress/DAF-16-active conditions, to define SOD-3&#39;s basal contribution and its supercomplex occupancy relative to SOD-2.</p>
+
+
+
+                </div>
+                <span class="vote-buttons" data-g="P41977" data-a="EXPERIMENT: Isoform-resolved, tagged-allele quantification and..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Catalytically-dead (Mn-ligand mutant) versus wild-type sod-3 rescue in sod-3 and sod-2;sod-3 backgrounds, scoring supercomplex I:III:IV formation, complex I/II activity and ROS damage, to test whether SOD-3 acts by scavenging or as a catalysis-independent supercomplex stabilizer.</p>
+
+
+
+                </div>
+                <span class="vote-buttons" data-g="P41977" data-a="EXPERIMENT: Catalytically-dead (Mn-ligand mutant) versus wild-..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Redox-biosensor (mitochondrial roGFP/HyPer) measurement of matrix superoxide/H2O2 in wild type, sod-2, sod-3 and sod-2;sod-3 under DAF-16-activating conditions to resolve whether sod-3 induction lowers matrix superoxide and whether that change is required for the associated stress-resistance/longevity phenotypes.</p>
+
+
+
+                </div>
+                <span class="vote-buttons" data-g="P41977" data-a="EXPERIMENT: Redox-biosensor (mitochondrial roGFP/HyPer) measur..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Knowledge Gaps</h2>
+        <p style="color: #555; font-size: 0.92rem; margin-top: -0.3rem;">
+            What is <em>not</em> known — curated, literature-grounded statements of the open
+            unknowns (the inverse of core functions).
+        </p>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The functional division of labour between the two nearly identical mitochondrial manganese superoxide dismutases, SOD-3 and SOD-2, is undefined. It is unknown why C. elegans maintains a low-basal, DAF-16-inducible MnSOD (sod-3) alongside a constitutive, dominant one (sod-2), what distinguishes their substrates or sub-mitochondrial contexts, and why loss of sod-3 versus sod-2 produces different (sometimes opposite) genetic interactions with electron-transport-chain mutants.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">BP_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> It is established that sod-2 and sod-3 are ~86% identical mitochondrial MnSODs, that sod-3 is normally expressed at very low levels and induced by DAF-16/insulin signalling whereas sod-2 is constitutive and dominant, that both localize to supercomplex I:III:IV, that loss of sod-3 (unlike sod-2) does not decrease complex I respiration and leaves blue-native supercomplex profiles normal, and that sod-3 has distinct genetic interactions with gas-1, mev-1 and isp-1. What is not established is the mechanistic basis of the non-redundancy at the level of substrate, sub-mitochondrial context, or partner; the authors of the key ETC study explicitly state that the sod-3/supercomplex interaction was still under investigation.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Two paralogous mitochondrial MnSODs with divergent, non-redundant phenotypes are a clean model for how gene duplication partitions an antioxidant function, and the division of labour determines which isoform is limiting under which stress or signalling state.</p>
+
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"However, the mutation sod-3 differed from sod-2 in its interactions with gas-1, mev-1 and isp-1."</em> — PMID:23895727</li>
+
+                <li><em>"Studies are now being undertaken to characterize the interaction of sod3 with supercomplex I:III:IV formation."</em> — PMID:23895727</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> Whether the DAF-16-driven induction of sod-3 is causally protective (increasing oxidative-stress resistance or extending lifespan) or is primarily a transcriptional readout of DAF-16 activity is unresolved. It is also unknown whether the very low basal SOD-3 level makes a material contribution to matrix superoxide scavenging in otherwise wild-type animals.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">BP_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> It is established that sod-3 is a canonical DAF-16 target gene, expressed at very low basal levels and strongly induced upon DAF-16 nuclear translocation (including JNK-1-promoted translocation under thermal stress), and that its induction correlates with stress-resistant, long-lived states. However, simultaneous elimination of both mitochondrial SODs (sod-2 and sod-3) does not suppress the long lifespan of daf-2, arguing that sod-3 induction is not required for insulin/IGF-1-pathway longevity. What is not established is whether sod-3 induction confers a measurable protective benefit on its own, or whether it is chiefly a marker of the DAF-16 program.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> sod-3 is one of the most widely used transcriptional reporters of DAF-16/FOXO activity in aging and stress research; establishing whether its induction is protective or merely a marker directly affects how thousands of studies interpret sod-3 reporter readouts.</p>
+
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"The activation of daf-16 increased expression of sod-3, an mtSOD normally expressed in very low levels in wild type worms"</em> — PMID:23895727</li>
+
+                <li><em>"elimination of both mitochondrial sod-2 and sod-3 failed to suppress the long life span of daf-2"</em> — PMID:23895727</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> Whether SOD-3&#39;s association with the respiratory supercomplex I:III:IV reflects only local superoxide scavenging at the site of ROS production, or whether SOD-3 can also act as a catalysis-independent structural stabilizer of the supercomplex (a role proposed for the mitochondrial SODs, and one SOD-3 may assume when SOD-2 is absent), is undetermined.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">RESIDUAL_SUBGAP</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> It is established that SOD-3 co-localizes with the I:III:IV supercomplex by blue-native gel and that, unlike sod-2 loss, sod-3 loss does not by itself decrease complex I respiration or perturb the supercomplex profile. The open question is causality/mechanism: the mtSODs are proposed to stabilize the supercomplex, and the limited rise in supercomplex ROS damage in sod-2 animals suggests SOD-3 may perform this function when supercomplex levels fall, but a catalysis-independent structural role for SOD-3 remains unproven.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Distinguishing a scavenging role from a structural role would determine whether SOD-3 is a modular antioxidant or an integral stabilizer of the electron transport chain, with implications for how supercomplex integrity is maintained when the dominant SOD-2 is lost.</p>
+
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"it is also possible that the mtSODs may directly serve as stabilizing factors in the I:III:IV supercomplex"</em> — PMID:23895727</li>
+
+                <li><em>"the lack of a large increase in ROS damage to supercomplexes in a sod-2 animal may indicate that SOD-3 is also capable of performing this function, especially when the amount of supercomplex I:III:IV is reduced."</em> — PMID:23895727</li>
+
+            </ul>
+
+
+        </div>
+
+    </div>
+
+
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Deep Research Sections -->
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(sod-3-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="P41977" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="sod-3-c-elegans-curation-notes">sod-3 (C. elegans) — curation notes</h1>
+<p>UniProt: <strong>P41977</strong> (SODM2_CAEEL). WormBase: WBGene00004932 / C08A9.1. Chromosome X.<br />
+EC 1.15.1.1. 218 aa precursor with N-terminal mitochondrial transit peptide (1–24),<br />
+mature chain 25–218. Mn(2+) ligand residues 50, 98, 179, 183 (UniProt, by similarity).<br />
+7 PDB structures (e.g. 6S0D at 1.52 Å). PANTHER PTHR11404:SF6.</p>
+<h2 id="one-line-identity">One-line identity</h2>
+<p>sod-3 encodes the <strong>DAF-16/FOXO-inducible, low-basal mitochondrial matrix manganese<br />
+superoxide dismutase (MnSOD)</strong> of C. elegans; paralog of the constitutive, dominant<br />
+sod-2 (~86% identical protein). Classic DAF-16/insulin-signalling target gene and<br />
+widely used longevity reporter.</p>
+<h2 id="known-well-supported">KNOWN (well supported)</h2>
+<ul>
+<li><strong>Mn-type superoxide dismutase activity</strong> (EC 1.15.1.1). Mature SOD-3 protein<br />
+  expressed in SOD-deficient E. coli is an active dismutase; Mn-type identity shown<br />
+  by insensitivity to H2O2 and cyanide; dimeric. <a href="https://pubmed.ncbi.nlm.nih.gov/9353332" title="The expressed enzymes,   which were not inhibited by hydrogen peroxide or cyanide, are dimeric, show quite   different electrophoretic mobilities and isoelectric points, but exhibit comparable   specific activities.">PMID:9353332</a> — NOTE: this paper cloned and assayed BOTH sod-2 and sod-3;<br />
+  the quote refers to both expressed enzymes, so it is genuinely sod-3-specific.</li>
+<li><strong>Removal of superoxide radicals</strong> (protective against superoxide stress). Both<br />
+  MnSODs rescued paraquat/methyl-viologen sensitivity of SOD-null E. coli.<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/9353332" title="Both proteins were shown to be active in E. coli, providing similar   protection against methyl viologen-induced oxidative stress.">PMID:9353332</a> — evidence is<br />
+  heterologous complementation, not a worm sod-3 loss-of-function phenotype.</li>
+<li><strong>Mitochondrial localization.</strong> UniProt subcellular location = Mitochondrion,<br />
+  ECO:0000269|PubMed:17894411 (Wolf et al. 2008); N-terminal mitochondrial transit<br />
+  peptide present in the deduced sequence. <a href="https://pubmed.ncbi.nlm.nih.gov/9353332" title="Both deduced protein   sequences contain the expected N-terminal mitochondrial transit peptides.">PMID:9353332</a> The<br />
+  17894411 abstract itself does not state the mitochondrial localization (it is in the<br />
+  full text; abstract-only in cache), but UniProt cites it for SUBCELLULAR LOCATION.</li>
+<li><strong>Localizes to respiratory supercomplex I:III:IV.</strong> By blue-native gel Western,<br />
+  SOD-3 co-migrates with the I:III:IV supercomplex. <a href="https://pubmed.ncbi.nlm.nih.gov/23895727" title="In addition, the   results show that SOD-3 is also localized to the I:III:IV supercomplex.">PMID:23895727</a> This is the<br />
+  source of the WormBase IDA GO:0098803 (respiratory chain complex) annotation.<br />
+  Caveat: the anti-SOD-2 antibody cross-reacts with SOD-3 (Figure S2); the authors<br />
+  nonetheless conclude SOD-3 localizes to the supercomplex.</li>
+<li><strong>DAF-16/FOXO-inducible, low basal expression.</strong> sod-3 is normally expressed at very<br />
+  low levels and is induced by DAF-16 (insulin/IGF-1 signalling). <a href="https://pubmed.ncbi.nlm.nih.gov/23895727" title="The   activation of daf-16 increased expression of sod-3, an mtSOD normally expressed in   very low levels in wild type worms">PMID:23895727</a>. JNK-1 promotes DAF-16 nuclear translocation and<br />
+  sod-3 target-gene expression in peripheral tissue. <a href="https://pubmed.ncbi.nlm.nih.gov/17894411" title="a promoting   influence of JNK-1 on both nuclear DAF-16 translocations and DAF-16 target gene   (superoxide dismutase 3, sod-3) expressions within peripheral, non-neuronal tissue">PMID:17894411</a>.</li>
+<li><strong>Tissue expression (UniProt, from PMID:17894411 full text):</strong> pharynx and rectum<br />
+  basally; on thermal stress also vulva, body-wall muscle, hypodermis. Induced by heat.</li>
+<li><strong>sod-3 single mutant lifespan = wild type.</strong> <a href="https://pubmed.ncbi.nlm.nih.gov/23895727" title="the lifespan of sod-3   was not different from N2 (Figure S1)">PMID:23895727</a>.</li>
+<li><strong>Non-redundant with sod-2 in ETC-mutant interactions.</strong> <a href="https://pubmed.ncbi.nlm.nih.gov/23895727" title="the mutation   sod-3 differed from sod-2 in its interactions with gas-1, mev-1 and isp-1.">PMID:23895727</a><br />
+  Specifically: gas-1;sod-3 ≈ gas-1; mev-1;sod-3 shorter than mev-1; isp-1;sod-3 longer<br />
+  than isp-1. Complex I-dependent respiration decreased in sod-2 but NOT sod-3; sod-3<br />
+  BNGs normal. <a href="https://pubmed.ncbi.nlm.nih.gov/23895727" title="sod-3 BNGs were normal (Figure 5E).">PMID:23895727</a></li>
+</ul>
+<h2 id="sod-3-vs-sod-2-attribution-important">sod-3 vs sod-2 attribution (important)</h2>
+<ul>
+<li>sod-2 (P31161): constitutive, quantitatively dominant mitochondrial MnSOD; loss lowers<br />
+  complex I/II activity, destabilizes supercomplex, and (counterintuitively) does not<br />
+  shorten / can extend lifespan.</li>
+<li>sod-3 (P41977): low-basal, DAF-16-inducible paralog; single-mutant lifespan normal;<br />
+  does not by itself decrease complex I respiration; also localizes to supercomplex and<br />
+  may be able to substitute for SOD-2's supercomplex-protective function when SOD-2 is<br />
+  absent. <a href="https://pubmed.ncbi.nlm.nih.gov/23895727" title="the lack of a large increase in ROS damage to supercomplexes   in a sod-2 animal may indicate that SOD-3 is also capable of performing this function,   especially when the amount of supercomplex I:III:IV is reduced.">PMID:23895727</a></li>
+<li>PMID:9353332 assayed BOTH proteins → its enzymatic/complementation quotes apply to<br />
+  sod-3 as well as sod-2. PMID:23895727 has explicit sod-3-specific statements.</li>
+</ul>
+<h2 id="not-known-open">NOT known / open</h2>
+<ul>
+<li>Whether basal sod-3 (very low) contributes materially to matrix superoxide scavenging<br />
+  in the wild type, or whether it is essentially a stress-inducible reserve isoform.</li>
+<li>The mechanistic basis of the sod-2/sod-3 division of labour (substrate, sub-mito<br />
+  context, partner). Authors explicitly state this is under investigation.<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/23895727" title="Studies are now being undertaken to characterize the interaction of   sod3 with supercomplex I:III:IV formation.">PMID:23895727</a></li>
+<li>Whether DAF-16-driven sod-3 induction is causally protective (extends life / raises<br />
+  stress resistance) or is chiefly a transcriptional MARKER of DAF-16 activity. In daf-2<br />
+  longevity, eliminating both mtSODs did not suppress the long lifespan, arguing sod-3<br />
+  induction is not required for daf-2 longevity <a href="https://pubmed.ncbi.nlm.nih.gov/23895727" title="elimination of both   mitochondrial sod-2 and sod-3 failed to suppress the long life span of daf-2">PMID:23895727</a>.</li>
+<li>Whether SOD-3 is a catalytic scavenger or also a structural stabilizer of the<br />
+  supercomplex (catalysis-independent role), as proposed for the mtSODs generally<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/23895727" title="it is also possible that the mtSODs may directly serve as stabilizing   factors in the I:III:IV supercomplex">PMID:23895727</a>.</li>
+</ul>
+<h2 id="goa-annotation-inventory-12">GOA annotation inventory (12)</h2>
+<ol>
+<li>GO:0005739 mitochondrion — IBA — GO_REF:0000033 — is_active_in</li>
+<li>GO:0004784 superoxide dismutase activity — IBA — GO_REF:0000033 — enables</li>
+<li>GO:0030145 manganese ion binding — IBA — GO_REF:0000033 — enables</li>
+<li>GO:0004784 superoxide dismutase activity — IEA — GO_REF:0000120 — enables</li>
+<li>GO:0005739 mitochondrion — IEA — GO_REF:0000044 (SubCell) — located_in</li>
+<li>GO:0006801 superoxide metabolic process — IEA — GO_REF:0000002 (InterPro2GO) — involved_in</li>
+<li>GO:0046872 metal ion binding — IEA — GO_REF:0000002 (InterPro2GO) — enables</li>
+<li>GO:0098803 respiratory chain complex — IEA — GO_REF:0000117 (ARBA) — part_of</li>
+<li>GO:0098803 respiratory chain complex — IDA — PMID:23895727 — part_of</li>
+<li>GO:0004784 superoxide dismutase activity — IDA — PMID:9353332 — enables</li>
+<li>GO:0019430 removal of superoxide radicals — IMP — PMID:9353332 — involved_in</li>
+<li>GO:0005739 mitochondrion — IDA — PMID:17894411 — located_in</li>
+</ol>
+<h2 id="planned-actions-mirrors-sod-2-modeling-pr-1711">Planned actions (mirrors sod-2 modeling; PR #1711)</h2>
+<ul>
+<li>SOD activity (IBA/IEA/IDA), manganese ion binding (IBA), mitochondrial matrix,<br />
+  removal of superoxide radicals = CORE. ACCEPT the experimental/phylogenetic calls.</li>
+<li>mitochondrion (generic) IBA/IEA/IDA → KEEP_AS_NON_CORE (matrix is the specific core CC).</li>
+<li>superoxide metabolic process (IEA) → KEEP_AS_NON_CORE (parent of removal of superoxide).</li>
+<li>metal ion binding (IEA) → KEEP_AS_NON_CORE (parent of manganese ion binding).</li>
+<li>respiratory chain complex part_of IEA (ARBA) → KEEP_AS_NON_CORE (over-generalized;<br />
+  SOD-3 associates with, not structural subunit of, the supercomplex).</li>
+<li>respiratory chain complex located_in IDA (PMID:23895727) → KEEP_AS_NON_CORE<br />
+  (real sod-3-specific supercomplex co-localization; peripheral association not core identity).</li>
+</ul>
+<h2 id="project-note-not-for-the-review-file">Project note (not for the review file)</h2>
+<p>projects/CAEEL_MITOPHAGY.md line 76 mislabels sod-3 as "Fe-SOD"; it is a Mn-SOD<br />
+(UniProt "Superoxide dismutase [Mn] 2"; PMID:9353332). Out of scope for this PR.</p>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: P41977
+gene_symbol: sod-3
+product_type: PROTEIN
+status: COMPLETE
+taxon:
+  id: NCBITaxon:6239
+  label: Caenorhabditis elegans
+description: &gt;-
+  sod-3 encodes a mitochondrial matrix manganese superoxide dismutase (MnSOD) of
+  Caenorhabditis elegans. The nuclear-encoded 218-residue precursor carries an
+  N-terminal mitochondrial transit peptide that directs import into the
+  mitochondrial matrix, where the mature chain adopts the characteristic
+  iron/manganese superoxide dismutase fold and binds one catalytic Mn(2+) ion per
+  subunit. The enzyme dismutates the superoxide anion radical, a by-product of the
+  respiratory electron transport chain, into hydrogen peroxide and molecular oxygen
+  (2 superoxide + 2 H+ -&gt; H2O2 + O2; EC 1.15.1.1), providing antioxidant defense
+  within the organelle. SOD-3 is the paralog of the constitutive, quantitatively
+  dominant mitochondrial MnSOD SOD-2, to which it is ~86% identical; unlike sod-2,
+  sod-3 is expressed at very low basal levels and is strongly induced by the
+  DAF-16/FOXO branch of insulin/IGF-1 signalling, making it a canonical DAF-16 target
+  gene and a widely used transcriptional reporter of insulin/IGF-1 pathway activity
+  and stress. Basal expression is seen in the pharynx and rectum, expanding to vulva,
+  body-wall muscle and hypodermis upon thermal stress. Like SOD-2, SOD-3 physically
+  associates with the mitochondrial respiratory supercomplex I:III:IV, positioning it
+  to scavenge superoxide near its site of production, and it may help stabilize or
+  locally protect the supercomplex, particularly when SOD-2 is absent. Loss of sod-3
+  alone does not alter lifespan or the activity of the respiratory complexes, but
+  sod-3 shows distinct, non-redundant genetic interactions with electron-transport-chain
+  mutants compared with sod-2.
+references:
+- id: GO_REF:0000002
+  title: Gene Ontology annotation through association of InterPro records with GO
+    terms
+  findings: []
+- id: GO_REF:0000033
+  title: Annotation inferences using phylogenetic trees
+  findings: []
+- id: GO_REF:0000044
+  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location
+    vocabulary mapping, accompanied by conservative changes to GO terms applied by
+    UniProt
+  findings: []
+- id: GO_REF:0000117
+  title: Electronic Gene Ontology annotations created by ARBA machine learning models
+  findings: []
+- id: GO_REF:0000120
+  title: Combined Automated Annotation using Multiple IEA Methods
+  findings: []
+- id: PMID:9353332
+  title: Cloning, expression, and characterization of two manganese superoxide dismutases
+    from Caenorhabditis elegans.
+  findings:
+  - statement: &gt;-
+      Cloned sod-2 and sod-3, showed both encode mitochondrial (transit-peptide
+      bearing) manganese-type superoxide dismutases (~86% identical proteins), and
+      directly measured their enzymatic activity after heterologous expression of the
+      mature chains in SOD-deficient E. coli (Mn-type: insensitive to hydrogen
+      peroxide and cyanide; dimeric; protective against methyl-viologen/paraquat
+      oxidative stress). Both proteins were assayed, so the biochemical evidence is
+      sod-3-specific as well as sod-2-specific.
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Abstract-only in cache (full_text_available: false), but the abstract explicitly
+      reports the direct biochemical characterization of BOTH MnSODs, underlying the
+      WormBase IDA (superoxide dismutase activity) and IMP (removal of superoxide
+      radicals) annotations for sod-3. The IMP is heterologous E. coli complementation,
+      not a worm sod-3 mutant phenotype.
+- id: PMID:23895727
+  title: Novel interactions between mitochondrial superoxide dismutases and the electron
+    transport chain.
+  findings:
+  - statement: &gt;-
+      SOD-3 (like SOD-2) localizes to the mitochondrial respiratory supercomplex
+      I:III:IV by blue-native gel Western. In contrast to sod-2, loss of sod-3 does
+      not decrease complex I-dependent respiration and sod-3 BNGs are normal; sod-3
+      single-mutant lifespan equals wild type, but sod-3 has distinct, non-redundant
+      genetic interactions with the ETC mutants gas-1, mev-1 and isp-1. sod-3 is an
+      mtSOD normally expressed at very low levels and induced by DAF-16.
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Full text cached (PMC3838459). The richest sod-3-specific source: directly
+      supports the IDA supercomplex localization, the low-basal/DAF-16-inducible
+      expression framing, the normal single-mutant lifespan, and the sod-2/sod-3
+      non-redundancy. The anti-SOD-2 antibody cross-reacts with SOD-3 (Figure S2), but
+      the authors explicitly conclude SOD-3 is localized to the supercomplex.
+- id: PMID:17894411
+  title: &#39;The MAP kinase JNK-1 of Caenorhabditis elegans: location, activation, and
+    influences over temperature-dependent insulin-like signaling, stress responses,
+    and fitness.&#39;
+  findings:
+  - statement: &gt;-
+      Establishes sod-3 as a DAF-16 target gene whose peripheral, non-neuronal
+      expression is promoted by JNK-1-driven nuclear translocation of DAF-16. UniProt
+      cites this paper for the SUBCELLULAR LOCATION (mitochondrion), TISSUE
+      SPECIFICITY (pharynx/rectum basally; vulva, body-wall muscle, hypodermis on
+      thermal stress), and heat INDUCTION of SOD-3.
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Abstract-only in cache; the abstract supports the DAF-16-target/sod-3-reporter
+      role verbatim. The mitochondrial localization it is cited for by UniProt is in
+      the full text (not the abstract), so no verbatim mitochondrial-localization quote
+      is available here; mitochondrial localization of this MnSOD is biologically
+      unambiguous and concordant with the transit peptide.
+existing_annotations:
+- term:
+    id: GO:0005739
+    label: mitochondrion
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: is_active_in
+  review:
+    summary: &gt;-
+      Phylogenetic (IBA) inference that SOD-3 is active in the mitochondrion. Correct
+      but less specific than the mitochondrial matrix, where this MnSOD acts.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Consistent with the N-terminal mitochondrial transit peptide and with
+      experimental localization, but generic relative to mitochondrial matrix
+      (GO:0005759), which is retained as the core location. Kept as a correct,
+      less-specific companion term.
+- term:
+    id: GO:0004784
+    label: superoxide dismutase activity
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Phylogenetic (IBA) inference of superoxide dismutase activity. This is the core
+      molecular function of SOD-3 and is directly confirmed experimentally.
+    action: ACCEPT
+    reason: &gt;-
+      SOD-3 is an experimentally validated manganese superoxide dismutase; the IBA
+      call is fully concordant with the IDA evidence (PMID:9353332, in which the SOD-3
+      protein was expressed and assayed) and with the Fe/Mn-SOD family assignment.
+      Core function.
+    supported_by:
+    - reference_id: PMID:9353332
+      supporting_text: &gt;-
+        The expressed enzymes, which were not inhibited by hydrogen peroxide or
+        cyanide, are dimeric, show quite different electrophoretic mobilities and
+        isoelectric points, but exhibit comparable specific activities.
+- term:
+    id: GO:0030145
+    label: manganese ion binding
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Phylogenetic (IBA) inference of manganese ion binding, the catalytic cofactor of
+      this MnSOD. Concordant with the UniProt Mn(2+) cofactor and Mn-ligand residues
+      (His50, His98, Asp179, His183) and with the enzyme&#39;s Mn-type biochemistry.
+    action: ACCEPT
+    reason: &gt;-
+      Correct and specific metal-binding function: this is a Mn-type (not Fe- or
+      Cu/Zn-type) SOD, insensitive to hydrogen peroxide and cyanide, binding one Mn(2+)
+      per subunit. Core cofactor-binding function.
+    supported_by:
+    - reference_id: PMID:9353332
+      supporting_text: &gt;-
+        The expressed enzymes, which were not inhibited by hydrogen peroxide or
+        cyanide, are dimeric, show quite different electrophoretic mobilities and
+        isoelectric points, but exhibit comparable specific activities.
+- term:
+    id: GO:0004784
+    label: superoxide dismutase activity
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000120
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Electronic (IEA) assignment of superoxide dismutase activity from combined
+      automated methods (ARBA/InterPro/EC/RHEA mapping). Redundant with the
+      experimental IDA and phylogenetic IBA calls for the same core function.
+    action: ACCEPT
+    reason: &gt;-
+      Same core molecular function as the IDA/IBA annotations; the EC 1.15.1.1 /
+      RHEA:20696 mapping is correct for this enzyme. Retained as concordant supporting
+      evidence.
+- term:
+    id: GO:0005739
+    label: mitochondrion
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000044
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Electronic (UniProt SubCell) mitochondrial localization, matching the UniProt
+      subcellular location and the N-terminal mitochondrial transit peptide. Correct
+      but generic relative to the mitochondrial matrix, the specific site of action.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Correct localization but less specific than mitochondrial matrix (GO:0005759),
+      which is retained as the core location for this matrix MnSOD. Kept as a correct,
+      less-specific companion.
+    supported_by:
+    - reference_id: PMID:9353332
+      supporting_text: &gt;-
+        Both deduced protein sequences contain the expected N-terminal mitochondrial
+        transit peptides.
+- term:
+    id: GO:0006801
+    label: superoxide metabolic process
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Electronic (InterPro2GO) assignment to the general superoxide metabolic process.
+      Correct but less specific than removal of superoxide radicals (GO:0019430), which
+      is the experimentally supported process.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Accurate parent process, but subsumed by the more specific removal of superoxide
+      radicals term retained as core. Kept as a correct, less-informative companion.
+- term:
+    id: GO:0046872
+    label: metal ion binding
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Electronic (InterPro2GO) generic metal-ion-binding annotation. Subsumed by the
+      specific manganese ion binding (GO:0030145) term.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Correct but uninformative parent of manganese ion binding; the specific Mn(2+)
+      term is retained as core. Kept as a non-core, less-specific companion.
+- term:
+    id: GO:0098803
+    label: respiratory chain complex
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000117
+  qualifier: part_of
+  review:
+    summary: &gt;-
+      Electronic (ARBA) assertion that SOD-3 is part_of the respiratory chain complex.
+      SOD-3 is a soluble matrix MnSOD that physically associates with supercomplex
+      I:III:IV (see the experimental located_in annotation), but it is not a canonical
+      structural subunit of an electron-transport complex, so the part_of qualifier
+      overstates the relationship.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      The experimentally supported relationship is association/co-localization with the
+      I:III:IV supercomplex (PMID:23895727, located_in), consistent with local
+      superoxide scavenging and possible supercomplex stabilization; SOD-3 does not
+      carry out or structurally constitute electron transport. The automated part_of
+      qualifier is an over-generalization, so this is retained only as a non-core
+      companion to the experimental located_in annotation rather than as evidence of
+      structural subunit membership.
+    supported_by:
+    - reference_id: PMID:23895727
+      supporting_text: &gt;-
+        In addition, the results show that SOD-3 is also localized to the I:III:IV
+        supercomplex.
+- term:
+    id: GO:0098803
+    label: respiratory chain complex
+  evidence_type: IDA
+  original_reference_id: PMID:23895727
+  qualifier: part_of
+  review:
+    summary: &gt;-
+      Direct assay (IDA) showing SOD-3 co-localizes with the mitochondrial supercomplex
+      I:III:IV by blue-native gel Western blotting. A genuine, sod-3-specific
+      localization finding, but a peripheral association rather than the enzyme&#39;s core
+      identity; the part_of qualifier overstates it (SOD-3 is not a structural ETC
+      subunit).
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Experimentally supported association of SOD-3 with the I:III:IV supercomplex,
+      consistent with local scavenging of superoxide at its site of production and a
+      possible supercomplex-stabilizing role (the authors note SOD-3 may substitute for
+      this SOD-2 function when SOD-2 is absent). Retained as a real but non-core
+      localization; SOD-3&#39;s core identity is a matrix MnSOD, not a structural ETC
+      subunit.
+    supported_by:
+    - reference_id: PMID:23895727
+      supporting_text: &gt;-
+        In addition, the results show that SOD-3 is also localized to the I:III:IV
+        supercomplex.
+- term:
+    id: GO:0004784
+    label: superoxide dismutase activity
+  evidence_type: IDA
+  original_reference_id: PMID:9353332
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Direct assay (IDA) of superoxide dismutase activity: the mature SOD-3 protein was
+      expressed in SOD-deficient E. coli and shown to be an active, Mn-type dismutase.
+      This is the primary experimental evidence for the core function.
+    action: ACCEPT
+    reason: &gt;-
+      Gold-standard experimental support for the defining molecular function.
+      Insensitivity to hydrogen peroxide and cyanide confirms the Mn-type (not Fe- or
+      Cu/Zn-type) mechanism. Both worm MnSODs were expressed and assayed in this study.
+      Core function.
+    supported_by:
+    - reference_id: PMID:9353332
+      supporting_text: &gt;-
+        The expressed enzymes, which were not inhibited by hydrogen peroxide or
+        cyanide, are dimeric, show quite different electrophoretic mobilities and
+        isoelectric points, but exhibit comparable specific activities.
+- term:
+    id: GO:0019430
+    label: removal of superoxide radicals
+  evidence_type: IMP
+  original_reference_id: PMID:9353332
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      SOD-3 removes superoxide radicals: heterologous expression of the worm enzyme
+      rescued SOD-deficient E. coli from methyl-viologen (paraquat) oxidative stress.
+      This is the core biological process the enzyme serves.
+    action: ACCEPT
+    reason: &gt;-
+      Functionally correct core process. The evidence is heterologous complementation
+      (protection of SOD-null E. coli against a superoxide generator) rather than a worm
+      sod-3 loss-of-function phenotype, but it directly demonstrates superoxide-radical
+      removal by the SOD-3 protein. Core process.
+    supported_by:
+    - reference_id: PMID:9353332
+      supporting_text: &gt;-
+        Both proteins were shown to be active in E. coli, providing similar protection
+        against methyl viologen-induced oxidative stress.
+- term:
+    id: GO:0005739
+    label: mitochondrion
+  evidence_type: IDA
+  original_reference_id: PMID:17894411
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Direct-assay (IDA) mitochondrial localization of SOD-3 (WormBase, from the full
+      text of Wolf et al. 2008, the paper UniProt cites for the SUBCELLULAR LOCATION).
+      Correct but generic relative to the mitochondrial matrix term.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Mitochondrial localization of this MnSOD is biologically unambiguous and
+      concordant with the transit peptide and matrix localization; retained as a
+      correct, less-specific companion to mitochondrial matrix (GO:0005759). The cached
+      abstract of PMID:17894411 concerns JNK-1/DAF-16 signalling and does not itself
+      state the mitochondrial localization (it is in the full text), so no
+      sod-3-specific verbatim localization quote is available.
+- term:
+    id: GO:0005759
+    label: mitochondrial matrix
+  evidence_type: ISS
+  original_reference_id: PMID:9353332
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Proposed more-specific localization: as a nuclear-encoded manganese superoxide
+      dismutase bearing an N-terminal mitochondrial transit peptide, SOD-3 is imported
+      into and acts within the mitochondrial matrix, the compartment where Fe/Mn-SOD
+      family MnSODs reside. This refines the generic mitochondrion annotations.
+    action: NEW
+    reason: &gt;-
+      The existing localization annotations (IBA, SubCell IEA, IDA) all use the generic
+      GO:0005739 mitochondrion. The transit peptide and Mn-SOD family assignment place
+      SOD-3 specifically in the mitochondrial matrix, which is retained as the core
+      location. Added as a NEW, more-specific companion inferred from sequence features
+      (ISS) rather than by rewriting the trusted GOA ids.
+    supported_by:
+    - reference_id: PMID:9353332
+      supporting_text: &gt;-
+        Both deduced protein sequences contain the expected N-terminal mitochondrial
+        transit peptides.
+core_functions:
+- description: &gt;-
+    SOD-3 is a mitochondrial matrix manganese superoxide dismutase that catalyzes the
+    dismutation of the superoxide anion radical to hydrogen peroxide and molecular
+    oxygen (2 superoxide + 2 H+ -&gt; H2O2 + O2; EC 1.15.1.1), a DAF-16/FOXO-inducible
+    antioxidant defense of the mitochondrial matrix that complements the constitutive
+    SOD-2.
+  molecular_function:
+    id: GO:0004784
+    label: superoxide dismutase activity
+  directly_involved_in:
+  - id: GO:0019430
+    label: removal of superoxide radicals
+  locations:
+  - id: GO:0005759
+    label: mitochondrial matrix
+  supported_by:
+  - reference_id: PMID:9353332
+    supporting_text: &gt;-
+      The expressed enzymes, which were not inhibited by hydrogen peroxide or cyanide,
+      are dimeric, show quite different electrophoretic mobilities and isoelectric
+      points, but exhibit comparable specific activities.
+  - reference_id: PMID:9353332
+    supporting_text: &gt;-
+      Both proteins were shown to be active in E. coli, providing similar protection
+      against methyl viologen-induced oxidative stress.
+- description: &gt;-
+    SOD-3 binds one catalytic manganese (Mn2+) ion per subunit, the redox-active
+    cofactor required for the dismutase mechanism. Its Mn-type identity is established
+    by insensitivity to hydrogen peroxide and cyanide, which inhibit Fe-type and
+    Cu/Zn-type SODs respectively.
+  molecular_function:
+    id: GO:0030145
+    label: manganese ion binding
+  locations:
+  - id: GO:0005759
+    label: mitochondrial matrix
+  supported_by:
+  - reference_id: PMID:9353332
+    supporting_text: &gt;-
+      The expressed enzymes, which were not inhibited by hydrogen peroxide or cyanide,
+      are dimeric, show quite different electrophoretic mobilities and isoelectric
+      points, but exhibit comparable specific activities.
+proposed_new_terms: []
+suggested_questions:
+- question: &gt;-
+    Does the very low basal level of SOD-3 make a material contribution to superoxide
+    scavenging in the wild-type mitochondrial matrix, or is SOD-3 essentially a
+    stress- and DAF-16-inducible reserve isoform that matters mainly when SOD-2 is
+    limiting?
+- question: &gt;-
+    What is the mechanistic basis of the division of labour between the two nearly
+    identical mitochondrial MnSODs, SOD-2 (constitutive, dominant) and SOD-3
+    (DAF-16-inducible, low basal), given their distinct and sometimes opposite genetic
+    interactions with electron-transport-chain mutants?
+- question: &gt;-
+    Is the DAF-16-driven induction of sod-3 causally protective (extending lifespan or
+    raising stress resistance), or is it primarily a transcriptional marker of DAF-16
+    activity, given that eliminating both mitochondrial SODs does not suppress daf-2
+    longevity?
+suggested_experiments:
+- description: &gt;-
+    Isoform-resolved, tagged-allele quantification and localization of SOD-3 versus
+    SOD-2 across tissues, developmental stages and stress/DAF-16-active conditions, to
+    define SOD-3&#39;s basal contribution and its supercomplex occupancy relative to SOD-2.
+- description: &gt;-
+    Catalytically-dead (Mn-ligand mutant) versus wild-type sod-3 rescue in sod-3 and
+    sod-2;sod-3 backgrounds, scoring supercomplex I:III:IV formation, complex I/II
+    activity and ROS damage, to test whether SOD-3 acts by scavenging or as a
+    catalysis-independent supercomplex stabilizer.
+- description: &gt;-
+    Redox-biosensor (mitochondrial roGFP/HyPer) measurement of matrix superoxide/H2O2
+    in wild type, sod-2, sod-3 and sod-2;sod-3 under DAF-16-activating conditions to
+    resolve whether sod-3 induction lowers matrix superoxide and whether that change is
+    required for the associated stress-resistance/longevity phenotypes.
+knowledge_gaps:
+- gap_statement: &gt;-
+    The functional division of labour between the two nearly identical mitochondrial
+    manganese superoxide dismutases, SOD-3 and SOD-2, is undefined. It is unknown why
+    C. elegans maintains a low-basal, DAF-16-inducible MnSOD (sod-3) alongside a
+    constitutive, dominant one (sod-2), what distinguishes their substrates or
+    sub-mitochondrial contexts, and why loss of sod-3 versus sod-2 produces different
+    (sometimes opposite) genetic interactions with electron-transport-chain mutants.
+  boundary: &gt;-
+    It is established that sod-2 and sod-3 are ~86% identical mitochondrial MnSODs, that
+    sod-3 is normally expressed at very low levels and induced by DAF-16/insulin
+    signalling whereas sod-2 is constitutive and dominant, that both localize to
+    supercomplex I:III:IV, that loss of sod-3 (unlike sod-2) does not decrease complex I
+    respiration and leaves blue-native supercomplex profiles normal, and that sod-3 has
+    distinct genetic interactions with gas-1, mev-1 and isp-1. What is not established is
+    the mechanistic basis of the non-redundancy at the level of substrate,
+    sub-mitochondrial context, or partner; the authors of the key ETC study explicitly
+    state that the sod-3/supercomplex interaction was still under investigation.
+  gap_kind:
+  - BIOLOGY
+  dark_aspect: BP_DARK
+  status: OPEN
+  significance: &gt;-
+    Two paralogous mitochondrial MnSODs with divergent, non-redundant phenotypes are a
+    clean model for how gene duplication partitions an antioxidant function, and the
+    division of labour determines which isoform is limiting under which stress or
+    signalling state.
+  provenance:
+  - reference_id: PMID:23895727
+    supporting_text: &gt;-
+      However, the mutation sod-3 differed from sod-2 in its interactions with gas-1,
+      mev-1 and isp-1.
+  - reference_id: PMID:23895727
+    supporting_text: &gt;-
+      Studies are now being undertaken to characterize the interaction of sod3 with
+      supercomplex I:III:IV formation.
+- gap_statement: &gt;-
+    Whether the DAF-16-driven induction of sod-3 is causally protective (increasing
+    oxidative-stress resistance or extending lifespan) or is primarily a transcriptional
+    readout of DAF-16 activity is unresolved. It is also unknown whether the very low
+    basal SOD-3 level makes a material contribution to matrix superoxide scavenging in
+    otherwise wild-type animals.
+  boundary: &gt;-
+    It is established that sod-3 is a canonical DAF-16 target gene, expressed at very low
+    basal levels and strongly induced upon DAF-16 nuclear translocation (including
+    JNK-1-promoted translocation under thermal stress), and that its induction correlates
+    with stress-resistant, long-lived states. However, simultaneous elimination of both
+    mitochondrial SODs (sod-2 and sod-3) does not suppress the long lifespan of daf-2,
+    arguing that sod-3 induction is not required for insulin/IGF-1-pathway longevity.
+    What is not established is whether sod-3 induction confers a measurable protective
+    benefit on its own, or whether it is chiefly a marker of the DAF-16 program.
+  gap_kind:
+  - BIOLOGY
+  dark_aspect: BP_DARK
+  status: OPEN
+  significance: &gt;-
+    sod-3 is one of the most widely used transcriptional reporters of DAF-16/FOXO
+    activity in aging and stress research; establishing whether its induction is
+    protective or merely a marker directly affects how thousands of studies interpret
+    sod-3 reporter readouts.
+  provenance:
+  - reference_id: PMID:23895727
+    supporting_text: &gt;-
+      The activation of daf-16 increased expression of sod-3, an mtSOD normally
+      expressed in very low levels in wild type worms
+  - reference_id: PMID:23895727
+    supporting_text: &gt;-
+      elimination of both mitochondrial sod-2 and sod-3 failed to suppress the long life
+      span of daf-2
+- gap_statement: &gt;-
+    Whether SOD-3&#39;s association with the respiratory supercomplex I:III:IV reflects only
+    local superoxide scavenging at the site of ROS production, or whether SOD-3 can also
+    act as a catalysis-independent structural stabilizer of the supercomplex (a role
+    proposed for the mitochondrial SODs, and one SOD-3 may assume when SOD-2 is absent),
+    is undetermined.
+  boundary: &gt;-
+    It is established that SOD-3 co-localizes with the I:III:IV supercomplex by
+    blue-native gel and that, unlike sod-2 loss, sod-3 loss does not by itself decrease
+    complex I respiration or perturb the supercomplex profile. The open question is
+    causality/mechanism: the mtSODs are proposed to stabilize the supercomplex, and the
+    limited rise in supercomplex ROS damage in sod-2 animals suggests SOD-3 may perform
+    this function when supercomplex levels fall, but a catalysis-independent structural
+    role for SOD-3 remains unproven.
+  gap_kind:
+  - BIOLOGY
+  dark_aspect: RESIDUAL_SUBGAP
+  status: OPEN
+  significance: &gt;-
+    Distinguishing a scavenging role from a structural role would determine whether SOD-3
+    is a modular antioxidant or an integral stabilizer of the electron transport chain,
+    with implications for how supercomplex integrity is maintained when the dominant
+    SOD-2 is lost.
+  provenance:
+  - reference_id: PMID:23895727
+    supporting_text: &gt;-
+      it is also possible that the mtSODs may directly serve as stabilizing factors in
+      the I:III:IV supercomplex
+  - reference_id: PMID:23895727
+    supporting_text: &gt;-
+      the lack of a large increase in ROS damage to supercomplexes in a sod-2 animal may
+      indicate that SOD-3 is also capable of performing this function, especially when
+      the amount of supercomplex I:III:IV is reduced.
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/genes/worm/tax-4/tax-4-ai-review.html
+++ b/genes/worm/tax-4/tax-4-ai-review.html
@@ -1,0 +1,7501 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>tax-4 - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        .propagation-review {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f8fafc;
+            border-left: 3px solid #64748b;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .propagation-title {
+            font-weight: 600;
+            color: #334155;
+            margin-bottom: 0.25rem;
+        }
+
+        .propagation-row {
+            margin-top: 0.25rem;
+        }
+
+        .propagation-source {
+            margin-top: 0.5rem;
+            padding-top: 0.5rem;
+            border-top: 1px solid #e5e7eb;
+        }
+
+        .propagation-source-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #1d4ed8;
+        }
+
+        .propagation-comment {
+            color: #4b5563;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>tax-4</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/Q03611" target="_blank" class="term-link">
+                        Q03611
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Caenorhabditis elegans</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-complete">
+                    COMPLETE
+                </span>
+            </div>
+
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "tax-4";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="Q03611" data-a="DESCRIPTION: tax-4 encodes the alpha (principal, pore-forming) ..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>tax-4 encodes the alpha (principal, pore-forming) subunit of a cyclic nucleotide-gated (CNG) cation channel, the C. elegans ortholog of vertebrate CNGA subunits. The channel is opened directly by intracellular cGMP (and, with lower sensitivity, cAMP) rather than by membrane voltage, and conducts Ca2+, Na+ and K+ across the membrane; a functionally important pore glutamate forms the selectivity filter and a C-linker gating ring couples cyclic-nucleotide binding in the cytoplasmic cyclic-nucleotide-binding domain to opening of the central gate. TAX-4 assembles as a homotetramer and can form a functional homomeric channel on its own, but in vivo it partners with the modulatory beta subunit TAX-2 (which cannot form a channel alone) to build the native sensory channel; the TAX-4/TAX-2 heteromer is markedly less cGMP-sensitive than the TAX-4 homomer. TAX-4 is expressed in many ciliated sensory neurons and is concentrated at their sensory endings, in the non-motile sensory cilium (including an inversin/NPHP-2-anchored proximal ciliary compartment in the AFD thermosensory neuron) and in dendrites. As the effector channel of cGMP-mediated signal transduction, TAX-4 is required for a broad range of sensory modalities, including thermosensation and thermotaxis, chemosensation and chemotaxis (including detection of CO2), oxygen sensing and aerotaxis, and light responses (phototransduction) in specific neurons; channel activity also feeds into downstream outputs such as sensory-neuron gene expression and the maintenance of sensory axon structure.</p>
+    </div>
+
+
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005886" target="_blank" class="term-link">
+                                    GO:0005886
+                                </a>
+                            </span>
+                            <span class="term-label">plasma membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q03611" data-a="GO:0005886" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> TAX-4 is a plasma-membrane cyclic nucleotide-gated cation channel; gating cation flux across the plasma membrane at sensory endings is its site of action. Correct and core.
+                        </div>
+
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0007606" target="_blank" class="term-link">
+                                    GO:0007606
+                                </a>
+                            </span>
+                            <span class="term-label">sensory perception of chemical stimulus</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q03611" data-a="GO:0007606" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Chemosensation is a defining role of TAX-4: tax-4 mutants fail responses to water-soluble and volatile chemical attractants. Core process.
+                        </div>
+
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/8893027" target="_blank" class="term-link">
+                                        PMID:8893027
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The C. elegans tax-4 mutants are abnormal in multiple sensory behaviors: they fail to respond to temperature or to water-soluble or volatile chemical attractants.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005222" target="_blank" class="term-link">
+                                    GO:0005222
+                                </a>
+                            </span>
+                            <span class="term-label">intracellularly cAMP-activated cation channel activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q03611" data-a="GO:0005222" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> TAX-4 is a cyclic-nucleotide-gated channel that can also be activated by cAMP, though cGMP is the physiologically relevant ligand and the channel is cGMP-selective. Retained as a genuine (if secondary) channel activity.
+                        </div>
+
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005223" target="_blank" class="term-link">
+                                    GO:0005223
+                                </a>
+                            </span>
+                            <span class="term-label">intracellularly cGMP-activated cation channel activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q03611" data-a="GO:0005223" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> This is the core molecular function of TAX-4: a directly cGMP-gated cation channel that is the effector of cGMP sensory signal transduction.
+                        </div>
+
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030553" target="_blank" class="term-link">
+                                    GO:0030553
+                                </a>
+                            </span>
+                            <span class="term-label">cGMP binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q03611" data-a="GO:0030553" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> TAX-4 has a cyclic-nucleotide-binding domain that binds cGMP to open the gate; cGMP binding is directly demonstrated by the cGMP-bound structures. Core.
+                        </div>
+
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0098655" target="_blank" class="term-link">
+                                    GO:0098655
+                                </a>
+                            </span>
+                            <span class="term-label">monoatomic cation transmembrane transport</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q03611" data-a="GO:0098655" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> The channel conducts Ca2+, Na+ and K+ (non-selective cation permeation); monoatomic cation transmembrane transport is the accurate transport-process term. Core.
+                        </div>
+
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0017071" target="_blank" class="term-link">
+                                    GO:0017071
+                                </a>
+                            </span>
+                            <span class="term-label">intracellular cyclic nucleotide activated cation channel complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q03611" data-a="GO:0017071" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> TAX-4 is a subunit of the cyclic-nucleotide-gated cation channel complex (homotetramer in vitro; native TAX-4/TAX-2 heteromer). Correct complex term.
+                        </div>
+
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005216" target="_blank" class="term-link">
+                                    GO:0005216
+                                </a>
+                            </span>
+                            <span class="term-label">monoatomic ion channel activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q03611" data-a="GO:0005216" data-r="GO_REF:0000002" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Accurate but generic parent of the specific cGMP-gated cation channel activity. Retained; the informative term is GO:0005223.
+                        </div>
+
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005221" target="_blank" class="term-link">
+                                    GO:0005221
+                                </a>
+                            </span>
+                            <span class="term-label">intracellularly cyclic nucleotide-activated monoatomic cation channel activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q03611" data-a="GO:0005221" data-r="GO_REF:0000002" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Accurate family-level CNG channel molecular-function term; a direct parent of the cGMP- and cAMP-activated specific terms already annotated.
+                        </div>
+
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005249" target="_blank" class="term-link">
+                                    GO:0005249
+                                </a>
+                            </span>
+                            <span class="term-label">voltage-gated potassium channel activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-remove">
+                            REMOVE
+                        </span>
+                        <span class="vote-buttons" data-g="Q03611" data-a="GO:0005249" data-r="GO_REF:0000002" data-act="REMOVE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Incorrect. TAX-4 is a non-selective cation CNG channel, NOT a voltage-gated, K+-selective channel. The cryo-EM structure shows an unusual voltage-sensor-like domain accounting for its deficient voltage dependence. This IEA term is an over-propagation from the shared EAG/ELK/ERG-family InterPro signature and should be removed.
+                        </div>
+
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/28099415" target="_blank" class="term-link">
+                                        PMID:28099415
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The channel has an unusual voltage-sensor-like domain, accounting for its deficient voltage dependence.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005886" target="_blank" class="term-link">
+                                    GO:0005886
+                                </a>
+                            </span>
+                            <span class="term-label">plasma membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000044
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q03611" data-a="GO:0005886" data-r="GO_REF:0000044" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Plasma-membrane localization (UniProt subcellular-location mapping), consistent with the cryo-EM cell-membrane assignment and ciliary/dendritic membrane localization. Correct and core.
+                        </div>
+
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005929" target="_blank" class="term-link">
+                                    GO:0005929
+                                </a>
+                            </span>
+                            <span class="term-label">cilium</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000044
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q03611" data-a="GO:0005929" data-r="GO_REF:0000044" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> TAX-4 localizes to sensory cilia; a more specific experimental term (non-motile cilium, GO:0097730) is also annotated. Correct.
+                        </div>
+
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006811" target="_blank" class="term-link">
+                                    GO:0006811
+                                </a>
+                            </span>
+                            <span class="term-label">monoatomic ion transport</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q03611" data-a="GO:0006811" data-r="GO_REF:0000002" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Accurate but generic parent of monoatomic cation transmembrane transport. Retained.
+                        </div>
+
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006813" target="_blank" class="term-link">
+                                    GO:0006813
+                                </a>
+                            </span>
+                            <span class="term-label">potassium ion transport</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q03611" data-a="GO:0006813" data-r="GO_REF:0000002" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Over-annotation. TAX-4 is a non-selective cation channel that does conduct K+, but it is not a dedicated potassium transporter; the K+-specific process term comes from the K-channel-family InterPro signature. The accurate term is monoatomic cation transmembrane transport (GO:0098655).
+                        </div>
+
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016020" target="_blank" class="term-link">
+                                    GO:0016020
+                                </a>
+                            </span>
+                            <span class="term-label">membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q03611" data-a="GO:0016020" data-r="GO_REF:0000002" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Generic membrane location; true but superseded by plasma membrane / cilium. Retained.
+                        </div>
+
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0034703" target="_blank" class="term-link">
+                                    GO:0034703
+                                </a>
+                            </span>
+                            <span class="term-label">cation channel complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000117
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q03611" data-a="GO:0034703" data-r="GO_REF:0000117" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> TAX-4 is part of a cation channel complex (the CNG channel). Correct; also supported experimentally (PMID:10064800).
+                        </div>
+
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0055085" target="_blank" class="term-link">
+                                    GO:0055085
+                                </a>
+                            </span>
+                            <span class="term-label">transmembrane transport</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q03611" data-a="GO:0055085" data-r="GO_REF:0000002" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Accurate but generic parent process. Retained.
+                        </div>
+
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0070482" target="_blank" class="term-link">
+                                    GO:0070482
+                                </a>
+                            </span>
+                            <span class="term-label">response to oxygen levels</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000117
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q03611" data-a="GO:0070482" data-r="GO_REF:0000117" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> The tax-2/tax-4 CNG channel is required for O2-evoked responses and hyperoxia avoidance; also supported experimentally. A downstream sensory output rather than the core channel function.
+                        </div>
+
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0071805" target="_blank" class="term-link">
+                                    GO:0071805
+                                </a>
+                            </span>
+                            <span class="term-label">potassium ion transmembrane transport</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000108
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q03611" data-a="GO:0071805" data-r="GO_REF:0000108" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Over-annotation, same rationale as GO:0006813: non-selective cation channel wrongly cast as a K+-specific transporter via the K-channel InterPro signature. Use monoatomic cation transmembrane transport (GO:0098655).
+                        </div>
+
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042802" target="_blank" class="term-link">
+                                    GO:0042802
+                                </a>
+                            </span>
+                            <span class="term-label">identical protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/28099415" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:28099415
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Structure of a eukaryotic cyclic-nucleotide-gated channel.
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q03611" data-a="GO:0042802" data-r="PMID:28099415" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reflects TAX-4 self-association into a homotetramer, directly seen in the cryo-EM structure (PMID:28099415), which solved the channel as a homotetramer. Accurate but low-information on its own; the tetramer is captured better by the channel-complex terms (GO:0017071, GO:0034703). Kept as reported.
+                        </div>
+
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042802" target="_blank" class="term-link">
+                                    GO:0042802
+                                </a>
+                            </span>
+                            <span class="term-label">identical protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/32483338" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:32483338
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Mechanism of ligand activation of a eukaryotic cyclic nucleo...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q03611" data-a="GO:0042802" data-r="PMID:32483338" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Duplicate self-association (homotetramer) evidence from the second cryo-EM structure. Kept as reported; non-core.
+                        </div>
+
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0097730" target="_blank" class="term-link">
+                                    GO:0097730
+                                </a>
+                            </span>
+                            <span class="term-label">non-motile cilium</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/31259686" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:31259686
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The Caenorhabditis elegans Tubby homolog dynamically modulat...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q03611" data-a="GO:0097730" data-r="PMID:31259686" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> TAX-4 is a ciliary CNG channel; UniProt records ciliary subcellular location from this study. Core cellular component.
+                        </div>
+
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0034703" target="_blank" class="term-link">
+                                    GO:0034703
+                                </a>
+                            </span>
+                            <span class="term-label">cation channel complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/10064800" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:10064800
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Functional reconstitution of a heteromeric cyclic nucleotide...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q03611" data-a="GO:0034703" data-r="PMID:10064800" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Functional reconstitution shows TAX-4 and TAX-2 form a heteromeric cation channel in cultured cells. Directly supports channel-complex membership. Core.
+                        </div>
+
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/10064800" target="_blank" class="term-link">
+                                        PMID:10064800
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Here we show that TAX-4 and TAX-2 form a heteromeric channel when expressed in HEK293 cells, but TAX-2 does not form a channel on its own.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003031" target="_blank" class="term-link">
+                                    GO:0003031
+                                </a>
+                            </span>
+                            <span class="term-label">detection of carbon dioxide</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/24240097" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:24240097
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    A chemoreceptor that detects molecular carbon dioxide.
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q03611" data-a="GO:0003031" data-r="PMID:24240097" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> CO2 detection in BAG (and other) neurons requires the tax-2/tax-4 cGMP-gated channel downstream of the receptor guanylyl cyclase GCY-9. A specific chemosensory modality; retained as a downstream consequence of the core channel function. (Cited paper is abstract-only in the cache; the tax-4 requirement for CO2 responses is independently established in PMID:21435556.)
+                        </div>
+
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0019722" target="_blank" class="term-link">
+                                    GO:0019722
+                                </a>
+                            </span>
+                            <span class="term-label">calcium-mediated signaling</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/24240097" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:24240097
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    A chemoreceptor that detects molecular carbon dioxide.
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q03611" data-a="GO:0019722" data-r="PMID:24240097" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Channel opening admits Ca2+, driving the calcium signal in chemosensory neurons. A downstream signaling consequence of cation channel activity; non-core.
+                        </div>
+
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0010628" target="_blank" class="term-link">
+                                    GO:0010628
+                                </a>
+                            </span>
+                            <span class="term-label">positive regulation of gene expression</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/25303524" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:25303524
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Chemosensation of bacterial secondary metabolites modulates ...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q03611" data-a="GO:0010628" data-r="PMID:25303524" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> In ASJ, TAX-4-dependent chemosensory signaling induces expression of the DAF-7/TGF-beta neuromodulator on exposure to P. aeruginosa metabolites. An indirect, activity-dependent transcriptional output; non-core.
+                        </div>
+
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/25303524" target="_blank" class="term-link">
+                                        PMID:25303524
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">secondary metabolites produced by Pseudomonas aeruginosa modulates a neuroendocrine signaling pathway that promotes avoidance behavior</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0050907" target="_blank" class="term-link">
+                                    GO:0050907
+                                </a>
+                            </span>
+                            <span class="term-label">detection of chemical stimulus involved in sensory perception</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/24240097" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:24240097
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    A chemoreceptor that detects molecular carbon dioxide.
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q03611" data-a="GO:0050907" data-r="PMID:24240097" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> TAX-4 is the effector channel for detection of chemical stimuli in sensory neurons; an accurate general term for its core sensory role. Core.
+                        </div>
+
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0007602" target="_blank" class="term-link">
+                                    GO:0007602
+                                </a>
+                            </span>
+                            <span class="term-label">phototransduction</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/20436480" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:20436480
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    C. elegans phototransduction requires a G protein-dependent ...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q03611" data-a="GO:0007602" data-r="PMID:20436480" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> In the ASJ photoreceptor neuron, light-evoked cGMP opens cGMP-sensitive CNG channels; TAX-4 is required for this response. A specialized downstream sensory modality; non-core.
+                        </div>
+
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/20436480" target="_blank" class="term-link">
+                                        PMID:20436480
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">opening of cGMP-sensitive CNG channels and stimulation of photoreceptor cells.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0007199" target="_blank" class="term-link">
+                                    GO:0007199
+                                </a>
+                            </span>
+                            <span class="term-label">G protein-coupled receptor signaling pathway coupled to cGMP nucleotide second messenger</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/20436480" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:20436480
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    C. elegans phototransduction requires a G protein-dependent ...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q03611" data-a="GO:0007199" data-r="PMID:20436480" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> TAX-4 acts as the cGMP-gated effector at the end of a G-protein/cGMP phototransduction cascade in ASJ. Retained as a downstream pathway role; non-core.
+                        </div>
+
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/20436480" target="_blank" class="term-link">
+                                        PMID:20436480
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">phototransduction in ASJ is a G protein-mediated process and requires membrane-associated guanylate cyclases</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0040040" target="_blank" class="term-link">
+                                    GO:0040040
+                                </a>
+                            </span>
+                            <span class="term-label">thermosensory behavior</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/21315599" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:21315599
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Regulation of response properties and operating range of the...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q03611" data-a="GO:0040040" data-r="PMID:21315599" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Mutations in the tax-4 CNG channel abolish AFD thermosensitivity and isothermal tracking (per this study&#39;s electrophysiology and behavior). Thermosensation is a flagship sensory role of TAX-4. Core.
+                        </div>
+
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/21315599" target="_blank" class="term-link">
+                                        PMID:21315599
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">These results indicate that the AFD neurons and TAX-4 CNG channel are required to both initiate and maintain isothermal tracks.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0043052" target="_blank" class="term-link">
+                                    GO:0043052
+                                </a>
+                            </span>
+                            <span class="term-label">thermotaxis</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/21315599" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:21315599
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Regulation of response properties and operating range of the...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q03611" data-a="GO:0043052" data-r="PMID:21315599" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Thermotaxis (isothermal tracking) is the behavioral output of AFD thermosensation that requires TAX-4. A downstream behavior; non-core.
+                        </div>
+
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0010754" target="_blank" class="term-link">
+                                    GO:0010754
+                                </a>
+                            </span>
+                            <span class="term-label">negative regulation of receptor guanylyl cyclase signaling pathway</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/23940325" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:23940325
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    In vivo genetic dissection of O2-evoked cGMP dynamics in a C...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q03611" data-a="GO:0010754" data-r="PMID:23940325" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> In O2-sensing neurons, cGMP-gated channel activity (Ca2+ entry) drives Ca2+-dependent negative-feedback loops that shape cGMP dynamics. A feedback role secondary to the core channel function; non-core.
+                        </div>
+
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/23940325" target="_blank" class="term-link">
+                                        PMID:23940325
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Increased cGMP leads to a sustained Ca(2+) response in the neuron that depends on cGMP-gated ion channels.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0070482" target="_blank" class="term-link">
+                                    GO:0070482
+                                </a>
+                            </span>
+                            <span class="term-label">response to oxygen levels</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/23940325" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:23940325
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    In vivo genetic dissection of O2-evoked cGMP dynamics in a C...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q03611" data-a="GO:0070482" data-r="PMID:23940325" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> TAX-4-containing cGMP-gated channels transduce O2-evoked cGMP into sustained Ca2+ responses in the gas-sensing neuron. Downstream sensory output; non-core.
+                        </div>
+
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0040010" target="_blank" class="term-link">
+                                    GO:0040010
+                                </a>
+                            </span>
+                            <span class="term-label">positive regulation of growth rate</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IGI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/15530424" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:15530424
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    A new putative cyclic nucleotide-gated channel gene, cng-3, ...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q03611" data-a="GO:0040010" data-r="PMID:15530424" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Genetic-interaction annotation from a study primarily on the cng-3 CNG channel and thermotolerance, with tax-4 as background. A pleiotropic physiological consequence; non-core. (Cited paper abstract-only in cache.)
+                        </div>
+
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0097543" target="_blank" class="term-link">
+                                    GO:0097543
+                                </a>
+                            </span>
+                            <span class="term-label">ciliary inversin compartment</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/25335890" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:25335890
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Ciliopathy proteins establish a bipartite signaling compartm...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q03611" data-a="GO:0097543" data-r="PMID:25335890" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> In AFD, NPHP-2/inversin anchors the cGMP-gated ion channel within the proximal ciliary (inversin) compartment. Directly supports this specific ciliary sub-compartment localization. Core cellular component.
+                        </div>
+
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/25335890" target="_blank" class="term-link">
+                                        PMID:25335890
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">requires NPHP-2 (known as inversin in mammals) to anchor a cGMP-gated ion channel within the proximal ciliary region.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0097730" target="_blank" class="term-link">
+                                    GO:0097730
+                                </a>
+                            </span>
+                            <span class="term-label">non-motile cilium</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/25335890" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:25335890
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Ciliopathy proteins establish a bipartite signaling compartm...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q03611" data-a="GO:0097730" data-r="PMID:25335890" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> TAX-4/TAX-2 cGMP-gated channel localizes to the AFD sensory cilium. Core cellular component.
+                        </div>
+
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005223" target="_blank" class="term-link">
+                                    GO:0005223
+                                </a>
+                            </span>
+                            <span class="term-label">intracellularly cGMP-activated cation channel activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/10064800" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:10064800
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Functional reconstitution of a heteromeric cyclic nucleotide...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q03611" data-a="GO:0005223" data-r="PMID:10064800" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct functional reconstitution in cultured cells demonstrates a cGMP-gated cation channel. Core molecular function.
+                        </div>
+
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/10064800" target="_blank" class="term-link">
+                                        PMID:10064800
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The heteromeric TAX-4/TAX-2 channel is 25-fold less sensitive to cGMP than the TAX-4 channel, but it remains highly selective for cGMP over cAMP.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0098655" target="_blank" class="term-link">
+                                    GO:0098655
+                                </a>
+                            </span>
+                            <span class="term-label">monoatomic cation transmembrane transport</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/10064800" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:10064800
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Functional reconstitution of a heteromeric cyclic nucleotide...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q03611" data-a="GO:0098655" data-r="PMID:10064800" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reconstituted channel conducts cations across the membrane. Core transport process.
+                        </div>
+
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0097730" target="_blank" class="term-link">
+                                    GO:0097730
+                                </a>
+                            </span>
+                            <span class="term-label">non-motile cilium</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/23886944" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:23886944
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Cell- and subunit-specific mechanisms of CNG channel ciliary...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q03611" data-a="GO:0097730" data-r="PMID:23886944" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Study defines sequences and trans-acting factors required for ciliary targeting/localization of the TAX-4 CNGA and TAX-2 CNGB subunits. Directly supports ciliary localization. Core cellular component.
+                        </div>
+
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/23886944" target="_blank" class="term-link">
+                                        PMID:23886944
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">sequences required for efficient ciliary targeting and localization of the TAX-2 CNGB and TAX-4 CNGA subunits.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006935" target="_blank" class="term-link">
+                                    GO:0006935
+                                </a>
+                            </span>
+                            <span class="term-label">chemotaxis</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/21435556" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:21435556
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Temperature, oxygen, and salt-sensing neurons in C. elegans ...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q03611" data-a="GO:0006935" data-r="PMID:21435556" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> CO2-evoked responses and CO2 avoidance behavior require cGMP-gated channels containing TAX-2 and TAX-4. Chemotaxis is a behavioral output of the core chemosensory channel function; retained as non-core for this study.
+                        </div>
+
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/21435556" target="_blank" class="term-link">
+                                        PMID:21435556
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">CO(2)-evoked Ca(2+) responses in AFD and BAG neurons require cGMP-gated ion channels.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0070482" target="_blank" class="term-link">
+                                    GO:0070482
+                                </a>
+                            </span>
+                            <span class="term-label">response to oxygen levels</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/19323996" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:19323996
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Neurons detect increases and decreases in oxygen levels usin...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q03611" data-a="GO:0070482" data-r="PMID:19323996" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> URX and BAG O2-sensing neurons use cGMP signaling (via sGCs) that is transduced by CNG channels; tax-4 is required for O2 responses. Downstream sensory output; non-core.
+                        </div>
+
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005222" target="_blank" class="term-link">
+                                    GO:0005222
+                                </a>
+                            </span>
+                            <span class="term-label">intracellularly cAMP-activated cation channel activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/8893027" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:8893027
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Mutations in a cyclic nucleotide-gated channel lead to abnor...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q03611" data-a="GO:0005222" data-r="PMID:8893027" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> TAX-4 expressed in cultured cells functions as a cyclic-nucleotide-gated channel (cAMP-responsive as well as cGMP-gated). Genuine channel activity, though cGMP is physiologically dominant.
+                        </div>
+
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/8893027" target="_blank" class="term-link">
+                                        PMID:8893027
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Tax-4 protein expressed in cultured cells functions as a cyclic nucleotide-gated channel.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005223" target="_blank" class="term-link">
+                                    GO:0005223
+                                </a>
+                            </span>
+                            <span class="term-label">intracellularly cGMP-activated cation channel activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/8893027" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:8893027
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Mutations in a cyclic nucleotide-gated channel lead to abnor...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q03611" data-a="GO:0005223" data-r="PMID:8893027" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Original demonstration that TAX-4 forms a cyclic-nucleotide-gated channel; cGMP is the key intracellular messenger in worm sensory transduction. Core molecular function.
+                        </div>
+
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/8893027" target="_blank" class="term-link">
+                                        PMID:8893027
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The results suggest that a cyclic nucleotide-gated channel is required for thermosensation and chemosensation</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030425" target="_blank" class="term-link">
+                                    GO:0030425
+                                </a>
+                            </span>
+                            <span class="term-label">dendrite</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/8893027" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:8893027
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Mutations in a cyclic nucleotide-gated channel lead to abnor...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q03611" data-a="GO:0030425" data-r="PMID:8893027" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> TAX-4::GFP localizes at the sensory endings of thermosensory, gustatory and olfactory neurons (dendritic sensory endings/cilia). Core cellular component.
+                        </div>
+
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/8893027" target="_blank" class="term-link">
+                                        PMID:8893027
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The Tax-4::GFP fusion is partly localized at the sensory endings of these neurons.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0097730" target="_blank" class="term-link">
+                                    GO:0097730
+                                </a>
+                            </span>
+                            <span class="term-label">non-motile cilium</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/8893027" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:8893027
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Mutations in a cyclic nucleotide-gated channel lead to abnor...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q03611" data-a="GO:0097730" data-r="PMID:8893027" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> TAX-4 localizes to the sensory endings (cilia) of ciliated sensory neurons. Core cellular component.
+                        </div>
+
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/8893027" target="_blank" class="term-link">
+                                        PMID:8893027
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">expressed in thermosensory, gustatory, and olfactory neurons mediating all the sensory behaviors affected by the tax-4 mutations</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030516" target="_blank" class="term-link">
+                                    GO:0030516
+                                </a>
+                            </span>
+                            <span class="term-label">regulation of axon extension</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/9486798" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:9486798
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    A cyclic nucleotide-gated channel inhibits sensory axon outg...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q03611" data-a="GO:0030516" data-r="PMID:9486798" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> tax-2/tax-4 are required to maintain correct sensory axon structure; mutants show inappropriate late-larval axon outgrowth. A pleiotropic developmental/maintenance role distinct from acute sensory transduction; non-core.
+                        </div>
+
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9486798" target="_blank" class="term-link">
+                                        PMID:9486798
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">tax-2 and tax-4 are required for the maintenance of correct axon structure</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0009454" target="_blank" class="term-link">
+                                    GO:0009454
+                                </a>
+                            </span>
+                            <span class="term-label">aerotaxis</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/15220933" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:15220933
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Oxygen sensation and social feeding mediated by a C. elegans...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q03611" data-a="GO:0009454" data-r="PMID:15220933" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Avoidance of high oxygen requires the sensory cGMP-gated channel tax-2/tax-4 plus the sGC gcy-35. Aerotaxis is a downstream O2-driven behavior; non-core.
+                        </div>
+
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/15220933" target="_blank" class="term-link">
+                                        PMID:15220933
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Avoidance of high oxygen levels by C. elegans requires the sensory cGMP-gated channel tax-2/tax-4 and a specific soluble guanylate cyclase homologue, gcy-35.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0055093" target="_blank" class="term-link">
+                                    GO:0055093
+                                </a>
+                            </span>
+                            <span class="term-label">response to hyperoxia</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/15220933" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:15220933
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Oxygen sensation and social feeding mediated by a C. elegans...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q03611" data-a="GO:0055093" data-r="PMID:15220933" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> TAX-4-dependent O2 sensation mediates avoidance of hyperoxic environments. Downstream sensory output; non-core.
+                        </div>
+
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0040040" target="_blank" class="term-link">
+                                    GO:0040040
+                                </a>
+                            </span>
+                            <span class="term-label">thermosensory behavior</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/11879652" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:11879652
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Negative regulation and gain control of sensory neurons by t...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q03611" data-a="GO:0040040" data-r="PMID:11879652" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Thermosensory behavior requiring TAX-4, assayed here in the context of the TAX-6 calcineurin gain-control pathway. Thermosensation is a core TAX-4 sensory role.
+                        </div>
+
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0040040" target="_blank" class="term-link">
+                                    GO:0040040
+                                </a>
+                            </span>
+                            <span class="term-label">thermosensory behavior</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IGI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/11879652" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:11879652
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Negative regulation and gain control of sensory neurons by t...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q03611" data-a="GO:0040040" data-r="PMID:11879652" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Genetic-interaction (with tax-6) evidence corroborating TAX-4&#39;s core thermosensory-behavior role.
+                        </div>
+
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042048" target="_blank" class="term-link">
+                                    GO:0042048
+                                </a>
+                            </span>
+                            <span class="term-label">olfactory behavior</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/11879652" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:11879652
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Negative regulation and gain control of sensory neurons by t...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q03611" data-a="GO:0042048" data-r="PMID:11879652" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Olfaction is one of the sensory modalities requiring TAX-4; here in the context of tax-6-mediated adaptation/gain control. A downstream behavioral output; non-core.
+                        </div>
+
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042048" target="_blank" class="term-link">
+                                    GO:0042048
+                                </a>
+                            </span>
+                            <span class="term-label">olfactory behavior</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IGI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/11879652" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:11879652
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Negative regulation and gain control of sensory neurons by t...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q03611" data-a="GO:0042048" data-r="PMID:11879652" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Genetic-interaction evidence for an olfactory-behavior role. Non-core.
+                        </div>
+
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0043052" target="_blank" class="term-link">
+                                    GO:0043052
+                                </a>
+                            </span>
+                            <span class="term-label">thermotaxis</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/11879652" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:11879652
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Negative regulation and gain control of sensory neurons by t...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q03611" data-a="GO:0043052" data-r="PMID:11879652" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Thermotaxis behavior involving TAX-4 in the tax-6 gain-control study. Downstream behavior; non-core.
+                        </div>
+
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0043052" target="_blank" class="term-link">
+                                    GO:0043052
+                                </a>
+                            </span>
+                            <span class="term-label">thermotaxis</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IGI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/11879652" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:11879652
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Negative regulation and gain control of sensory neurons by t...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q03611" data-a="GO:0043052" data-r="PMID:11879652" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Genetic-interaction evidence for a thermotaxis role. Non-core.
+                        </div>
+
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0040040" target="_blank" class="term-link">
+                                    GO:0040040
+                                </a>
+                            </span>
+                            <span class="term-label">thermosensory behavior</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/14711416" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:14711416
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The CMK-1 CaMKI and the TAX-4 Cyclic nucleotide-gated channe...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q03611" data-a="GO:0040040" data-r="PMID:14711416" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> CMK-1 and TAX-4 regulate AFD thermosensory-neuron gene expression, morphology and function. Thermosensation is a core TAX-4 role; well supported.
+                        </div>
+
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/14711416" target="_blank" class="term-link">
+                                        PMID:14711416
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">the CMK-1 Ca2+/calmodulin-dependent protein kinase I (CaMKI) and the TAX-4 cyclic nucleotide-gated channel regulate gene expression, morphology, and functions of the AFD thermosensory neurons.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0045664" target="_blank" class="term-link">
+                                    GO:0045664
+                                </a>
+                            </span>
+                            <span class="term-label">regulation of neuron differentiation</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/14711416" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:14711416
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The CMK-1 CaMKI and the TAX-4 Cyclic nucleotide-gated channe...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q03611" data-a="GO:0045664" data-r="PMID:14711416" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> TAX-4 activity is required to maintain AFD-specific gene expression and morphology; an activity-dependent effect on neuronal differentiation state rather than a direct role. Non-core.
+                        </div>
+
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0045944" target="_blank" class="term-link">
+                                    GO:0045944
+                                </a>
+                            </span>
+                            <span class="term-label">positive regulation of transcription by RNA polymerase II</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/14711416" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:14711416
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The CMK-1 CaMKI and the TAX-4 Cyclic nucleotide-gated channe...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q03611" data-a="GO:0045944" data-r="PMID:14711416" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> TAX-4 channel activity is required to maintain AFD-specific gene expression. This is an indirect, activity-dependent transcriptional consequence; TAX-4 is a channel, not a transcriptional regulator. Non-core.
+                        </div>
+
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/14711416" target="_blank" class="term-link">
+                                        PMID:14711416
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">TAX-4 functions are required during larval stages to maintain gene expression in the adult.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0048812" target="_blank" class="term-link">
+                                    GO:0048812
+                                </a>
+                            </span>
+                            <span class="term-label">neuron projection morphogenesis</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/14711416" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:14711416
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The CMK-1 CaMKI and the TAX-4 Cyclic nucleotide-gated channe...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q03611" data-a="GO:0048812" data-r="PMID:14711416" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> TAX-4 activity influences AFD sensory-ending morphology. A downstream, activity-dependent morphological effect; non-core.
+                        </div>
+
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0007635" target="_blank" class="term-link">
+                                    GO:0007635
+                                </a>
+                            </span>
+                            <span class="term-label">chemosensory behavior</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/8893027" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:8893027
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Mutations in a cyclic nucleotide-gated channel lead to abnor...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q03611" data-a="GO:0007635" data-r="PMID:8893027" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> tax-4 mutants are defective in chemosensory behaviors (gustation and olfaction). Core sensory role.
+                        </div>
+
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/8893027" target="_blank" class="term-link">
+                                        PMID:8893027
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The C. elegans tax-4 mutants are abnormal in multiple sensory behaviors: they fail to respond to temperature or to water-soluble or volatile chemical attractants.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016020" target="_blank" class="term-link">
+                                    GO:0016020
+                                </a>
+                            </span>
+                            <span class="term-label">membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">NAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/8893027" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:8893027
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Mutations in a cyclic nucleotide-gated channel lead to abnor...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q03611" data-a="GO:0016020" data-r="PMID:8893027" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Generic membrane localization (NAS). True but superseded by plasma membrane / cilium / dendrite. Retained.
+                        </div>
+
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030553" target="_blank" class="term-link">
+                                    GO:0030553
+                                </a>
+                            </span>
+                            <span class="term-label">cGMP binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">NAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/8893027" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:8893027
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Mutations in a cyclic nucleotide-gated channel lead to abnor...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q03611" data-a="GO:0030553" data-r="PMID:8893027" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> cGMP binding inferred (NAS) from the CNG-channel homology and cGMP-gated activity; later confirmed structurally. Core molecular function.
+                        </div>
+
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0040040" target="_blank" class="term-link">
+                                    GO:0040040
+                                </a>
+                            </span>
+                            <span class="term-label">thermosensory behavior</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/8893027" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:8893027
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Mutations in a cyclic nucleotide-gated channel lead to abnor...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q03611" data-a="GO:0040040" data-r="PMID:8893027" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Original genetic evidence that tax-4 is required for thermosensation (mutants fail to respond to temperature). Core sensory role.
+                        </div>
+
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/8893027" target="_blank" class="term-link">
+                                        PMID:8893027
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">they fail to respond to temperature or to water-soluble or volatile chemical attractants.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>TAX-4 is the pore-forming alpha subunit of a cyclic nucleotide-gated (CNG) cation channel that is opened directly by intracellular cGMP and conducts Ca2+/Na+/K+ across the plasma membrane at the sensory endings, cilia and dendrites of ciliated sensory neurons, serving as the effector channel of cGMP-mediated sensory signal transduction. It assembles as a homotetramer and in vivo forms the native sensory channel together with the modulatory beta subunit TAX-2.</h3>
+                <span class="vote-buttons" data-g="Q03611" data-a="FUNCTION: TAX-4 is the pore-forming alpha subunit of a cycli..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005223" target="_blank" class="term-link">
+                            intracellularly cGMP-activated cation channel activity
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0007606" target="_blank" class="term-link">
+                                sensory perception of chemical stimulus
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0050907" target="_blank" class="term-link">
+                                detection of chemical stimulus involved in sensory perception
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0098655" target="_blank" class="term-link">
+                                monoatomic cation transmembrane transport
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005886" target="_blank" class="term-link">
+                                plasma membrane
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0097730" target="_blank" class="term-link">
+                                non-motile cilium
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030425" target="_blank" class="term-link">
+                                dendrite
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">In Complex:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0017071" target="_blank" class="term-link">
+                            intracellular cyclic nucleotide activated cation channel complex
+                        </a>
+                    </span>
+                </div>
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/8893027" target="_blank" class="term-link">
+                                PMID:8893027
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">Tax-4 protein expressed in cultured cells functions as a cyclic nucleotide-gated channel.</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/10064800" target="_blank" class="term-link">
+                                PMID:10064800
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">with TAX-4 as the alpha subunit and TAX-2 acting as a modifying beta subunit.</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/28099415" target="_blank" class="term-link">
+                                PMID:28099415
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">a cyclic-nucleotide-gated channel from Caenorhabditis elegans in the cyclic guanosine monophosphate (cGMP)-bound open state.</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>TAX-4 binds cGMP through its cytoplasmic cyclic-nucleotide-binding domain; ligand binding drives the conformational change (via the C-linker gating ring) that opens the central gate, making cGMP binding the ligand-sensing step of the channel&#39;s activity.</h3>
+                <span class="vote-buttons" data-g="Q03611" data-a="FUNCTION: TAX-4 binds cGMP through its cytoplasmic cyclic-nu..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030553" target="_blank" class="term-link">
+                            cGMP binding
+                        </a>
+                    </span>
+                </div>
+
+
+
+
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/28099415" target="_blank" class="term-link">
+                                PMID:28099415
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">A carboxy-terminal linker connecting S6 and the cyclic-nucleotide-binding domain interacts directly with both the voltage-sensor-like domain and the pore domain</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/32483338" target="_blank" class="term-link">
+                                PMID:32483338
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">Mechanism of ligand activation of a eukaryotic cyclic nucleotide-gated channel.</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000002.md" target="_blank" class="term-link">
+                            GO_REF:0000002
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation through association of InterPro records with GO terms</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
+                            GO_REF:0000033
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Annotation inferences using phylogenetic trees</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
+                            GO_REF:0000044
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000108.md" target="_blank" class="term-link">
+                            GO_REF:0000108
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Automatic assignment of GO terms using logical inference, based on on inter-ontology links</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000117.md" target="_blank" class="term-link">
+                            GO_REF:0000117
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Electronic Gene Ontology annotations created by ARBA machine learning models</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/10064800" target="_blank" class="term-link">
+                            PMID:10064800
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Functional reconstitution of a heteromeric cyclic nucleotide-gated channel of Caenorhabditis elegans in cultured cells.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/11879652" target="_blank" class="term-link">
+                            PMID:11879652
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Negative regulation and gain control of sensory neurons by the C. elegans calcineurin TAX-6.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/14711416" target="_blank" class="term-link">
+                            PMID:14711416
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">The CMK-1 CaMKI and the TAX-4 Cyclic nucleotide-gated channel regulate thermosensory neuron gene expression and function in C. elegans.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/15220933" target="_blank" class="term-link">
+                            PMID:15220933
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Oxygen sensation and social feeding mediated by a C. elegans guanylate cyclase homologue.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/15530424" target="_blank" class="term-link">
+                            PMID:15530424
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">A new putative cyclic nucleotide-gated channel gene, cng-3, is critical for thermotolerance in Caenorhabditis elegans.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/19323996" target="_blank" class="term-link">
+                            PMID:19323996
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Neurons detect increases and decreases in oxygen levels using distinct guanylate cyclases.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/20436480" target="_blank" class="term-link">
+                            PMID:20436480
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">C. elegans phototransduction requires a G protein-dependent cGMP pathway and a taste receptor homolog.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/21315599" target="_blank" class="term-link">
+                            PMID:21315599
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Regulation of response properties and operating range of the AFD thermosensory neurons by cGMP signaling.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/21435556" target="_blank" class="term-link">
+                            PMID:21435556
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Temperature, oxygen, and salt-sensing neurons in C. elegans are carbon dioxide sensors that control avoidance behavior.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/23886944" target="_blank" class="term-link">
+                            PMID:23886944
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Cell- and subunit-specific mechanisms of CNG channel ciliary trafficking and localization in C. elegans.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/23940325" target="_blank" class="term-link">
+                            PMID:23940325
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">In vivo genetic dissection of O2-evoked cGMP dynamics in a Caenorhabditis elegans gas sensor.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/24240097" target="_blank" class="term-link">
+                            PMID:24240097
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">A chemoreceptor that detects molecular carbon dioxide.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/25303524" target="_blank" class="term-link">
+                            PMID:25303524
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Chemosensation of bacterial secondary metabolites modulates neuroendocrine signaling and behavior of C. elegans.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/25335890" target="_blank" class="term-link">
+                            PMID:25335890
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Ciliopathy proteins establish a bipartite signaling compartment in a C. elegans thermosensory neuron.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/28099415" target="_blank" class="term-link">
+                            PMID:28099415
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Structure of a eukaryotic cyclic-nucleotide-gated channel.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/31259686" target="_blank" class="term-link">
+                            PMID:31259686
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">The Caenorhabditis elegans Tubby homolog dynamically modulates olfactory cilia membrane morphogenesis and phospholipid composition.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/32483338" target="_blank" class="term-link">
+                            PMID:32483338
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Mechanism of ligand activation of a eukaryotic cyclic nucleotide-gated channel.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/8893027" target="_blank" class="term-link">
+                            PMID:8893027
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Mutations in a cyclic nucleotide-gated channel lead to abnormal thermosensation and chemosensation in C. elegans.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/9486798" target="_blank" class="term-link">
+                            PMID:9486798
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">A cyclic nucleotide-gated channel inhibits sensory axon outgrowth in larval and adult Caenorhabditis elegans: a distinct pathway for maintenance of sensory axon structure.</div>
+
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Questions for Experts</h2>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> What is the endogenous TAX-4:TAX-2 subunit stoichiometry of the native sensory channel, and does it differ between neuron types or between ciliary subcompartments within a single neuron?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q03611" data-a="Q: What is the endogenous TAX-4:TAX-2 subunit stoichi..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Which neurons rely on the highly cGMP-sensitive TAX-4 homomer versus the less-sensitive TAX-4/TAX-2 heteromer, and how does that choice set each cell&#39;s stimulus threshold and dynamic range?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q03611" data-a="Q: Which neurons rely on the highly cGMP-sensitive TA..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Experiments</h2>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Quantitative in vivo measurement of TAX-4 and TAX-2 subunit copy number / ratio in defined sensory cilia (e.g. calibrated fluorescence or single-molecule counting) combined with cell-specific cGMP dose-response electrophysiology in tax-2(+) versus tax-2(-) backgrounds, to map homomeric versus heteromeric channels onto neurons and quantify how TAX-2 tunes cGMP sensitivity in situ.</p>
+
+
+
+                </div>
+                <span class="vote-buttons" data-g="Q03611" data-a="EXPERIMENT: Quantitative in vivo measurement of TAX-4 and TAX-..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Deep Research Sections -->
+
+    <div class="section">
+        <h2 class="section-title">Deep Research</h2>
+
+        <details class="deep-research-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; gap: 1rem;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Falcon</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(tax-4-deep-research-falcon.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="Q03611" data-a="DEEP_RESEARCH: Falcon" data-r="" data-act="DEEP_RESEARCH" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This deep research is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This deep research needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+
+                <div class="report-meta">
+
+                    <span class="report-meta-text">Comprehensive Research Report: TAX-4 (Cyclic Nucleotide-Gated Channel) in *Caenorhabditis elegans*</span>
+
+
+                    <span class="report-badge">Falcon</span>
+
+
+                    <span class="report-badge">Edison Scientific Literature</span>
+
+
+                    <span class="report-badge">37 citations</span>
+
+
+                    <span class="report-badge">1 artifacts</span>
+
+
+                    <span class="report-meta-text">2026-07-04T16:25:35.663226</span>
+
+
+
+                </div>
+
+
+                <div class="artifact-list">
+
+
+
+                    <div class="artifact-link">
+                        <a href="tax-4-deep-research-falcon_artifacts/artifact-00.md" class="term-link">Edison artifact artifact-00</a>
+                        <span>(text/markdown)</span>
+                    </div>
+
+
+                </div>
+
+                <p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h1 id="comprehensive-research-report-tax-4-cyclic-nucleotide-gated-channel-in-caenorhabditis-elegans">Comprehensive Research Report: TAX-4 (Cyclic Nucleotide-Gated Channel) in <em>Caenorhabditis elegans</em></h1>
+<h2 id="gene-identity-verification">Gene Identity Verification</h2>
+<p>The gene <strong>tax-4</strong> (UniProt: Q03611, ORF name ZC84.2) encodes the α subunit of a cyclic nucleotide-gated (CNG) cation channel in <em>Caenorhabditis elegans</em>. The gene name derives from "abnormal chemotaxis," reflecting the chemotaxis defects observed in loss-of-function mutants. The identity is confirmed: <em>tax-4</em> encodes a CNG channel α subunit belonging to the cyclic nucleotide-gated cation channel family, with characteristic domains including a cyclic nucleotide-binding domain (CNBD, IPR000595), a C-linker/CLZ domain (IPR032406), and the CNG cation channel domain (IPR050866). These features are fully consistent with the UniProt annotation and the extensive literature described below.</p>
+<h2 id="summary-of-key-properties">Summary of Key Properties</h2>
+<table>
+<thead>
+<tr>
+<th>Property</th>
+<th>Summary</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Gene name</td>
+<td><strong>tax-4</strong> (also known historically as abnormal chemotaxis protein 4) (bargmann2006chemosensationinc. pages 10-12)</td>
+</tr>
+<tr>
+<td>Protein name</td>
+<td>Cyclic nucleotide-gated channel TAX-4 (CNG channel subunit) (inada2006identificationofguanylyl pages 1-2, li2017structureofa pages 1-2)</td>
+</tr>
+<tr>
+<td>UniProt accession</td>
+<td><strong>Q03611</strong></td>
+</tr>
+<tr>
+<td>Organism</td>
+<td><em>Caenorhabditis elegans</em> (inada2006identificationofguanylyl pages 1-2, li2017structureofa pages 1-2)</td>
+</tr>
+<tr>
+<td>Protein type</td>
+<td>Cyclic nucleotide-gated (CNG) nonselective cation channel involved in sensory transduction (inada2006identificationofguanylyl pages 1-2, bargmann2006chemosensationinc. pages 10-12, troemel1999chemosensorysignalingin pages 5-6)</td>
+</tr>
+<tr>
+<td>Channel subunit type</td>
+<td><strong>α subunit</strong> of the TAX-2/TAX-4 CNG channel; TAX-4 can also form functional homomeric channels (okahata2022molecularphysiologyregulating pages 2-4, bargmann2006chemosensationinc. pages 10-12)</td>
+</tr>
+<tr>
+<td>Partner subunit</td>
+<td><strong>TAX-2</strong> (β subunit), which enhances TAX-4 channel activity in heteromeric channels (okahata2022molecularphysiologyregulating pages 2-4, bargmann2006chemosensationinc. pages 10-12)</td>
+</tr>
+<tr>
+<td>Neurons expressing TAX-4</td>
+<td>Strong evidence supports expression/requirement in multiple head sensory neurons including <strong>ASE, AWC, AWB, AFD, ASI, ASJ, ASG, ASK</strong>; later pathway summaries also place TAX-4 in <strong>BAG</strong> and <strong>PQR</strong> sensory signaling contexts (wexler2020c.elegansmales pages 7-9, bargmann2006chemosensationinc. pages 10-12, troemel1999chemosensorysignalingin pages 5-6, galande2025rolesofcyclic pages 15-16)</td>
+</tr>
+<tr>
+<td>Subcellular localization</td>
+<td>Localized to <strong>sensory cilia / ciliary membrane</strong>; in AFD, TAX-4 colocalizes with thermosensory guanylyl cyclases at sensory endings (li2024inhibitionofa pages 8-9, li2024inhibitionofa pages 1-2, inada2006identificationofguanylyl pages 6-7)</td>
+</tr>
+<tr>
+<td>Gating ligand</td>
+<td>Activated preferentially by <strong>cGMP</strong>; channel has higher affinity for cGMP than cAMP, though cyclic nucleotides gate the channel through the CNBD (inada2006identificationofguanylyl pages 1-2, li2017structureofa pages 1-2, bargmann2006chemosensationinc. pages 10-12)</td>
+</tr>
+<tr>
+<td>Ion selectivity</td>
+<td><strong>Nonselective cation channel</strong> permeable to monovalent cations and reported as permeable to <strong>Na+</strong> and <strong>Ca2+</strong> in sensory signaling; extracellular Ca2+/Mg2+ can block permeation in structural/biophysical analyses (li2017structureofa pages 4-6, li2017structureofa pages 6-8, troemel1999chemosensorysignalingin pages 5-6)</td>
+</tr>
+<tr>
+<td>Key domains / architecture</td>
+<td>Canonical CNG architecture with <strong>S1-S6 transmembrane domain</strong>, <strong>pore loop/selectivity filter</strong>, <strong>C-linker/gating ring</strong>, and <strong>cyclic nucleotide-binding domain (CNBD)</strong>; selectivity filter includes <strong>T376-I377-G378-E379</strong> (li2017structureofa pages 27-32, li2017structureofa pages 4-6, li2017structureofa pages 2-4)</td>
+</tr>
+<tr>
+<td>Structural resolution</td>
+<td>Cryo-EM structure solved at <strong>3.5 Å</strong> in the cGMP-bound open state (li2017structureofa pages 1-2, li2017structureofa pages 2-4, li2017structureofa pages 14-20)</td>
+</tr>
+<tr>
+<td>Mutant phenotypes</td>
+<td>Loss of tax-4 causes major <strong>chemotaxis</strong> and <strong>thermotaxis</strong> defects, altered food-state sensory gene expression, enhanced <strong>cold tolerance</strong> in specific contexts, ectopic neurite initiation in ASJ, and <strong>lifespan extension</strong> with intestinal UPRER activation; one study reported mean lifespan increase from <strong>19.02 to 29.95 days</strong> in tax-4(p678) mutants, while pharmacologic CNG inhibition extended lifespan by ~<strong>18%</strong> (31 to 38 days) (okahata2022molecularphysiologyregulating pages 2-4, wexler2020c.elegansmales pages 7-9, li2024inhibitionofa pages 6-7, zallen2000neuronalcellshape pages 5-7, inada2006identificationofguanylyl pages 7-10, li2024inhibitionofa pages 7-8)</td>
+</tr>
+<tr>
+<td>Key signaling pathways</td>
+<td>Core component of <strong>cGMP-dependent sensory transduction</strong>. In <strong>AWC</strong>: GPCRs → <strong>ODR-3</strong> → <strong>ODR-1/DAF-11</strong> guanylyl cyclases or PDE regulation → cGMP → TAX-4/TAX-2 opening. In <strong>AFD</strong>: <strong>GCY-8/GCY-18/GCY-23</strong> receptor guanylyl cyclases act upstream of TAX-4/TAX-2 to drive thermosensation and adaptation (inada2006identificationofguanylyl pages 11-13, inada2006identificationofguanylyl pages 10-11, troemel1999chemosensorysignalingin pages 6-8, bargmann2006chemosensationinc. pages 10-12)</td>
+</tr>
+</tbody>
+</table>
+<p><em>Table: This table summarizes the core molecular, cellular, structural, and functional properties of the C. elegans TAX-4 cyclic nucleotide-gated channel. It is useful as a compact reference linking TAX-4 identity, localization, signaling pathways, and experimentally observed mutant phenotypes.</em></p>
+<h2 id="1-molecular-function-and-channel-properties">1. Molecular Function and Channel Properties</h2>
+<h3 id="11-primary-function-as-a-cgmp-gated-ion-channel">1.1 Primary Function as a cGMP-Gated Ion Channel</h3>
+<p>TAX-4 functions as the α (CNGA) subunit of a cyclic nucleotide-gated nonselective cation channel that mediates sensory signal transduction in <em>C. elegans</em>. The channel is gated by intracellular cyclic nucleotides, with a markedly higher affinity for cGMP than for cAMP, establishing cGMP as its physiological ligand (inada2006identificationofguanylyl pages 1-2, li2017structureofa pages 1-2). Upon binding cGMP, the channel opens and allows influx of cations—primarily Na⁺ and Ca²⁺—thereby depolarizing the sensory neuron and converting a chemical second messenger signal into an electrical response (troemel1999chemosensorysignalingin pages 5-6, bargmann2006chemosensationinc. pages 10-12). TAX-4 can form functional homomeric channels on its own, but it normally assembles with its partner TAX-2 (β subunit) to form heteromeric channels with enhanced activity (bargmann2006chemosensationinc. pages 10-12).</p>
+<h3 id="12-cryo-em-structure">1.2 Cryo-EM Structure</h3>
+<p>The three-dimensional structure of TAX-4 was resolved at 3.5 Å by cryo-electron microscopy in the cGMP-bound open state (li2017structureofa pages 1-2, li2017structureofa pages 2-4). TAX-4 assembles as a four-fold symmetric tetramer with a central ion-conducting pore spanning approximately 120 Å. Each protomer contains four structural layers: an extracellular domain, a transmembrane domain (TMD) with six membrane-spanning helices (S1–S6), a pore loop, a C-linker gating ring, and the CNBD (li2017structureofa pages 2-4, li2017structureofa pages 25-27).</p>
+<p>A distinctive architectural feature of TAX-4 is its <strong>non-domain-swapped</strong> arrangement, in which the voltage-sensor-like domain (VSLD, comprising S1–S4) interacts with the pore domain of the same subunit rather than of a neighboring subunit (li2017structureofa pages 6-8, li2017structureofa pages 2-4). Despite retaining a VSLD, TAX-4 is not voltage-gated: the S4 helix is fragmented into three sub-segments with different secondary structures and orientations, which prevents voltage-dependent gating (li2017structureofa pages 2-4).</p>
+<h3 id="13-selectivity-filter-and-ion-permeation">1.3 Selectivity Filter and Ion Permeation</h3>
+<p>The selectivity filter is formed by residues T376, I377, G378, and E379, with the narrowest constriction (4.7 Å diameter) at the E379 side chains (li2017structureofa pages 4-6). The filter is relatively wide and electronegative, permitting ions with their hydration shells to pass through, which accounts for the channel's poor selectivity among monovalent cations (li2017structureofa pages 4-6, li2017structureofa pages 6-8). E379 is critical for pH-dependent permeation and divalent cation blocking; extracellular Ca²⁺ and Mg²⁺ block the channel pore under physiological conditions (li2017structureofa pages 4-6, li2017structureofa pages 6-8).</p>
+<h3 id="14-gating-mechanism">1.4 Gating Mechanism</h3>
+<p>The gating mechanism involves conformational changes in the C-linker helices (A′B′C′D′), which form a compact gating ring upon cGMP binding (li2017structureofa pages 27-32). In the liganded state, strong interactions within the gating ring cause the S6 helices to splay outward, opening the selectivity filter gate. In the unliganded state, these interactions weaken, causing S6 to constrict and close the gate (li2017structureofa pages 27-32). The C-linker is directly coupled to S6 via a two-amino-acid linker, providing the critical mechanical link between cyclic nucleotide binding at the CNBD and channel opening at the pore (li2017structureofa pages 4-6).</p>
+<h2 id="2-cellular-and-subcellular-localization">2. Cellular and Subcellular Localization</h2>
+<h3 id="21-neuronal-expression-pattern">2.1 Neuronal Expression Pattern</h3>
+<p>TAX-4 is expressed in approximately 12 classes of amphid head sensory neurons. These include <strong>ASE</strong> (gustatory), <strong>AWC</strong> (olfactory), <strong>AWB</strong> (volatile repellent detection), <strong>AFD</strong> (thermosensory), <strong>ASI</strong>, <strong>ASJ</strong>, <strong>ASG</strong>, and <strong>ASK</strong> (wexler2020c.elegansmales pages 7-9, bargmann2006chemosensationinc. pages 10-12). TAX-4 is also functionally relevant in additional sensory neurons including BAG and PQR (galande2025rolesofcyclic pages 15-16). Notably, TAX-4 is <strong>not</strong> expressed in AWA or ASH sensory neurons, which utilize alternative transduction pathways (e.g., the TRPV channel OSM-9) (wexler2020c.elegansmales pages 7-9, bargmann2006chemosensationinc. pages 10-12).</p>
+<h3 id="22-subcellular-localization-to-sensory-cilia">2.2 Subcellular Localization to Sensory Cilia</h3>
+<p>At the subcellular level, TAX-4 localizes to the <strong>ciliary membrane</strong> of sensory neurons (li2024inhibitionofa pages 1-2, li2024inhibitionofa pages 8-9). In AFD thermosensory neurons, TAX-4 colocalizes at sensory endings with the receptor guanylyl cyclases GCY-8, GCY-18, and GCY-23 that produce its ligand cGMP (inada2006identificationofguanylyl pages 6-7). This ciliary localization is functionally significant: the channel senses and transduces environmental stimuli at the tips of cilia that are exposed (directly or indirectly) to the external environment through the amphid sensory openings. Importantly, loss of tax-4 does not disrupt ciliary structure itself—tax-4 mutants maintain normal ciliary morphology, fluorescence dye uptake, ciliary length, and intraflagellar transport (li2024inhibitionofa pages 7-8).</p>
+<h2 id="3-signaling-pathways">3. Signaling Pathways</h2>
+<h3 id="31-chemosensory-transduction-in-awc-olfactory-neurons">3.1 Chemosensory Transduction in AWC Olfactory Neurons</h3>
+<p>In AWC olfactory neurons, the canonical signaling cascade proceeds as follows: volatile odorants (e.g., benzaldehyde, butanone) are detected by G protein-coupled receptors (GPCRs) that activate the Gi-like G protein α subunit ODR-3, along with modulatory G proteins GPA-2 and GPA-3 (troemel1999chemosensorysignalingin pages 6-8, bargmann2006chemosensationinc. pages 1-3). ODR-3 regulates intracellular cGMP levels by modulating receptor guanylyl cyclases ODR-1 and DAF-11 (which likely function as heterodimers) or cGMP phosphodiesterases (bargmann2006chemosensationinc. pages 10-12). Elevated cGMP opens the TAX-4/TAX-2 channel, depolarizing the cell and generating the sensory signal (bargmann2006chemosensationinc. pages 10-12). Additional regulatory components include GRK-2 (a G protein-regulated receptor kinase required for AWC chemosensation), ARR-1 (β-arrestin mediating rapid adaptation through receptor internalization), and EGL-4 (a cGMP-dependent protein kinase mediating both short- and long-term odor adaptation) (bargmann2006chemosensationinc. pages 14-15, bargmann2006chemosensationinc. pages 1-3).</p>
+<h3 id="32-thermosensory-transduction-in-afd-neurons">3.2 Thermosensory Transduction in AFD Neurons</h3>
+<p>In AFD thermosensory neurons, the signaling pathway is more direct. Three receptor-type guanylyl cyclases—<strong>GCY-8, GCY-18, and GCY-23</strong>—function as thermoreceptors. These transmembrane enzymes, containing extracellular, transmembrane, and intracellular guanylyl cyclase domains, directly convert temperature stimuli into changes in intracellular cGMP concentration (inada2006identificationofguanylyl pages 6-7, inada2006identificationofguanylyl pages 1-2). The cGMP then gates the TAX-4/TAX-2 channel, mediating Ca²⁺ influx that drives thermotactic behavior. All three guanylyl cyclases are expressed exclusively in AFD neurons and function redundantly; triple mutants lacking all three exhibit severe thermotaxis defects comparable to AFD-ablated animals, while chemotaxis remains normal (inada2006identificationofguanylyl pages 6-7, inada2006identificationofguanylyl pages 10-11). Recent work has demonstrated that GCY-18 and GCY-23 drive thermosensory adaptation at distinct temporal rates, with differential phosphorylation/dephosphorylation cycles affecting response thresholds of the TAX-4 channel (hill2024feedforwardandfeedback pages 4-5). Calcium-dependent feedback through guanylyl cyclase-activating proteins (GCAPs) modulates cGMP synthesis, ensuring transient calcium responses (hill2024molecularandneuronal pages 60-64).</p>
+<h3 id="33-cgmp-homeostasis-and-phosphodiesterase-regulation">3.3 cGMP Homeostasis and Phosphodiesterase Regulation</h3>
+<p>Cyclic nucleotide phosphodiesterases (PDEs) are critical regulators of cGMP levels and thereby modulate TAX-4 channel activity. PDEs hydrolyze cGMP to attenuate sensory signals and accelerate recovery to pre-stimulated levels (galande2025rolesofcyclic pages 15-16). The tight regulation of cGMP concentration is essential: both deficient and excessive cGMP levels produce abnormal thermotaxis phenotypes (cryophilic or thermophilic behavior, respectively) (inada2006identificationofguanylyl pages 10-11).</p>
+<h2 id="4-biological-processes-and-mutant-phenotypes">4. Biological Processes and Mutant Phenotypes</h2>
+<h3 id="41-chemotaxis">4.1 Chemotaxis</h3>
+<p>Loss of tax-4 function causes severe defects in chemotaxis to water-soluble attractants (detected by ASE neurons) and volatile odorants (detected by AWC neurons), as well as responses to volatile repellents (detected by AWB neurons) (bargmann2006chemosensationinc. pages 10-12, inada2006identificationofguanylyl pages 10-11).</p>
+<h3 id="42-thermotaxis">4.2 Thermotaxis</h3>
+<p>tax-4 mutants display severely defective thermotaxis, migrating preferentially to cold temperatures regardless of cultivation temperature. When cultivated at 20°C, nearly all tax-4 mutants migrated to the cold region rather than tracking to the cultivation temperature (inada2006identificationofguanylyl pages 7-10, inada2006identificationofguanylyl pages 11-13). Recent work shows that TAX-4 is essential for temperature-evoked calcium dynamics in AFD—mutations in tax-4 largely eliminate temperature-evoked calcium responses in this neuron (hill2024molecularandneuronal pages 60-64).</p>
+<h3 id="43-cold-tolerance">4.3 Cold Tolerance</h3>
+<p>TAX-4 negatively regulates cold tolerance through its expression in ASJ neurons. Loss-of-function tax-4 mutants exhibit abnormally enhanced cold tolerance, and this phenotype can be rescued specifically by re-expressing wild-type tax-4 in ASJ neurons but not in ASI or AWC neurons (okahata2022molecularphysiologyregulating pages 2-4).</p>
+<h3 id="44-longevity-and-unfolded-protein-response">4.4 Longevity and Unfolded Protein Response</h3>
+<p>A landmark recent finding (Li et al., 2024) demonstrated that inhibition of the TAX-4 CNG channel on sensory neuron cilia activates the unfolded protein response of the endoplasmic reticulum (UPR^ER) in intestinal cells through the IRE-1/XBP-1 signaling pathway, promoting longevity in a cell nonautonomous manner (li2024inhibitionofa pages 10-11, li2024inhibitionofa pages 8-9, li2024inhibitionofa pages 1-2). The tax-4(p678) mutation extended mean lifespan from 19.02 to 29.95 days, and pharmacological inhibition of CNG channels using ZD7288 extended lifespan by approximately 18% (li2024inhibitionofa pages 6-7, li2024inhibitionofa pages 7-8). TAX-4 mutants also show reduced aggregation of polyglutamine (polyQ) proteins, indicating improved protein quality control (li2024inhibitionofa pages 6-7). This work establishes TAX-4 as a molecular link between ciliary sensory perception and systemic stress response pathways that regulate aging.</p>
+<h3 id="45-sensory-gene-expression-and-neuronal-morphology">4.5 Sensory Gene Expression and Neuronal Morphology</h3>
+<p>tax-4 mutants display altered sensory gene expression programs. In males, loss of tax-4 leads to elevated odr-10 expression and dramatically reduced daf-7 expression in ASI and ASJ neurons, disrupting state-dependent behavioral responses to food (wexler2020c.elegansmales pages 7-9). Additionally, tax-4 mutants exhibit ectopic neurite initiation in ASJ neurons, indicating that the channel participates in activity-dependent pathways that suppress aberrant neurite outgrowth during development (zallen2000neuronalcellshape pages 5-7).</p>
+<h3 id="46-functional-specialization-distinct-roles-in-different-modalities">4.6 Functional Specialization: Distinct Roles in Different Modalities</h3>
+<p>A recent study (Rosero and Bai, 2026) revealed that TAX-4 is essential for AFD-mediated thermosensation but is <strong>dispensable</strong> for a newly discovered role of AFD in tactile-dependent locomotion modulation, where another CNG channel α subunit, CNG-3, acts instead (rosero2026afdthermosensoryneurons pages 13-14). This functional specialization indicates that different CNG α subunits are recruited for distinct sensory modalities even within the same neuron.</p>
+<h2 id="5-evolutionary-and-structural-context">5. Evolutionary and Structural Context</h2>
+<p>TAX-4 belongs to the CNGA subfamily of cyclic nucleotide-gated channels, which are ancient sensory transduction molecules conserved across metazoans. The cryo-EM structure of TAX-4 was the first high-resolution structure of any eukaryotic CNG channel, providing foundational insights into CNG channel architecture, gating, and ion selectivity that are relevant to understanding mammalian visual and olfactory CNG channels (li2017structureofa pages 1-2, li2017structureofa pages 14-20). Structural comparisons with bovine rod CNGA1/CNGB1 channels and human HCN2 channels have illuminated shared and divergent architectural features, including the non-domain-swapped arrangement and the fragmented S4 segment unique to CNG channels (li2017structureofa pages 2-4). Functionally, the <em>Brugia malayi</em> ortholog of TAX-4 partially rescues sensory defects in <em>C. elegans</em> tax-4 knockout strains, indicating conservation of CNG channel function across nematode species, including parasitic nematodes.</p>
+<h2 id="6-summary">6. Summary</h2>
+<p>TAX-4 is the α subunit of a cGMP-gated nonselective cation channel localized to the ciliary membrane of sensory neurons in <em>C. elegans</em>. It functions as a critical downstream effector in cGMP-dependent sensory transduction pathways, converting intracellular cGMP fluctuations—generated by upstream guanylyl cyclases and modulated by phosphodiesterases—into cation influx (primarily Na⁺ and Ca²⁺) and neuronal depolarization. Through its expression in distinct subsets of amphid sensory neurons, TAX-4 mediates chemotaxis, olfaction, thermotaxis, and cold tolerance. Beyond sensory transduction, TAX-4 channel activity regulates gene expression programs, neuronal morphology, dauer formation, and organismal lifespan through cell nonautonomous signaling to peripheral tissues. Its high-resolution cryo-EM structure has provided paradigm-defining insights into eukaryotic CNG channel architecture and gating mechanisms.</p>
+<p>References</p>
+<ol>
+<li>
+<p>(bargmann2006chemosensationinc. pages 10-12): Cornelia Bargmann. Chemosensation in c. elegans. WormBook : the online review of C. elegans biology, pages 1-29, Oct 2006. URL: https://doi.org/10.1895/wormbook.1.123.1, doi:10.1895/wormbook.1.123.1. This article has 1160 citations.</p>
+</li>
+<li>
+<p>(inada2006identificationofguanylyl pages 1-2): Hitoshi Inada, Hiroko Ito, John Satterlee, Piali Sengupta, Kunihiro Matsumoto, and Ikue Mori. Identification of guanylyl cyclases that function in thermosensory neurons of caenorhabditis elegans. Genetics, 172:2239-2252, Apr 2006. URL: https://doi.org/10.1534/genetics.105.050013, doi:10.1534/genetics.105.050013. This article has 218 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(li2017structureofa pages 1-2): Minghui Li, Xiaoyuan Zhou, Shu Wang, Ioannis Michailidis, Ye Gong, Deyuan Su, Huan Li, Xueming Li, and Jian Yang. Structure of a eukaryotic cyclic-nucleotide-gated channel. Nature, 542:60-65, Jan 2017. URL: https://doi.org/10.1038/nature20819, doi:10.1038/nature20819. This article has 185 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(troemel1999chemosensorysignalingin pages 5-6): Emily R. Troemel. Chemosensory signaling in c. elegans. BioEssays, 21:1011-1020, Dec 1999. URL: https://doi.org/10.1002/(sici)1521-1878(199912)22:1&lt;1011::aid-bies5&gt;3.0.co;2-v, doi:10.1002/(sici)1521-1878(199912)22:1&lt;1011::aid-bies5&gt;3.0.co;2-v. This article has 135 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(okahata2022molecularphysiologyregulating pages 2-4): Misaki OKAHATA, Haruka MOTOMURA, Akane OHTA, and Atsushi KUHARA. Molecular physiology regulating cold tolerance and acclimation of caenorhabditis elegans. Proceedings of the Japan Academy. Series B, Physical and Biological Sciences, 98:126-139, Mar 2022. URL: https://doi.org/10.2183/pjab.98.009, doi:10.2183/pjab.98.009. This article has 15 citations.</p>
+</li>
+<li>
+<p>(wexler2020c.elegansmales pages 7-9): Leigh R. Wexler, Renee M. Miller, and Douglas S. Portman. C. elegans males integrate food signals and biological sex to modulate state-dependent chemosensation and behavioral prioritization. Current Biology, 30:2695-2706.e4, Jul 2020. URL: https://doi.org/10.1016/j.cub.2020.05.006, doi:10.1016/j.cub.2020.05.006. This article has 50 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(galande2025rolesofcyclic pages 15-16): Kranti K. Galande and Rick H. Cote. Roles of cyclic nucleotide phosphodiesterases in signal transduction pathways in the nematode caenorhabditis elegans. Cells, 14:1174, Jul 2025. URL: https://doi.org/10.3390/cells14151174, doi:10.3390/cells14151174. This article has 4 citations.</p>
+</li>
+<li>
+<p>(li2024inhibitionofa pages 8-9): Dongdong Li, Di Chen, Wei Li, and Guangshuo Ou. Inhibition of a cyclic nucleotide-gated channel on neuronal cilia activates unfolded protein response in intestinal cells to promote longevity. Proceedings of the National Academy of Sciences of the United States of America, Jun 2024. URL: https://doi.org/10.1073/pnas.2321228121, doi:10.1073/pnas.2321228121. This article has 3 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(li2024inhibitionofa pages 1-2): Dongdong Li, Di Chen, Wei Li, and Guangshuo Ou. Inhibition of a cyclic nucleotide-gated channel on neuronal cilia activates unfolded protein response in intestinal cells to promote longevity. Proceedings of the National Academy of Sciences of the United States of America, Jun 2024. URL: https://doi.org/10.1073/pnas.2321228121, doi:10.1073/pnas.2321228121. This article has 3 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(inada2006identificationofguanylyl pages 6-7): Hitoshi Inada, Hiroko Ito, John Satterlee, Piali Sengupta, Kunihiro Matsumoto, and Ikue Mori. Identification of guanylyl cyclases that function in thermosensory neurons of caenorhabditis elegans. Genetics, 172:2239-2252, Apr 2006. URL: https://doi.org/10.1534/genetics.105.050013, doi:10.1534/genetics.105.050013. This article has 218 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(li2017structureofa pages 4-6): Minghui Li, Xiaoyuan Zhou, Shu Wang, Ioannis Michailidis, Ye Gong, Deyuan Su, Huan Li, Xueming Li, and Jian Yang. Structure of a eukaryotic cyclic-nucleotide-gated channel. Nature, 542:60-65, Jan 2017. URL: https://doi.org/10.1038/nature20819, doi:10.1038/nature20819. This article has 185 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(li2017structureofa pages 6-8): Minghui Li, Xiaoyuan Zhou, Shu Wang, Ioannis Michailidis, Ye Gong, Deyuan Su, Huan Li, Xueming Li, and Jian Yang. Structure of a eukaryotic cyclic-nucleotide-gated channel. Nature, 542:60-65, Jan 2017. URL: https://doi.org/10.1038/nature20819, doi:10.1038/nature20819. This article has 185 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(li2017structureofa pages 27-32): Minghui Li, Xiaoyuan Zhou, Shu Wang, Ioannis Michailidis, Ye Gong, Deyuan Su, Huan Li, Xueming Li, and Jian Yang. Structure of a eukaryotic cyclic-nucleotide-gated channel. Nature, 542:60-65, Jan 2017. URL: https://doi.org/10.1038/nature20819, doi:10.1038/nature20819. This article has 185 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(li2017structureofa pages 2-4): Minghui Li, Xiaoyuan Zhou, Shu Wang, Ioannis Michailidis, Ye Gong, Deyuan Su, Huan Li, Xueming Li, and Jian Yang. Structure of a eukaryotic cyclic-nucleotide-gated channel. Nature, 542:60-65, Jan 2017. URL: https://doi.org/10.1038/nature20819, doi:10.1038/nature20819. This article has 185 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(li2017structureofa pages 14-20): Minghui Li, Xiaoyuan Zhou, Shu Wang, Ioannis Michailidis, Ye Gong, Deyuan Su, Huan Li, Xueming Li, and Jian Yang. Structure of a eukaryotic cyclic-nucleotide-gated channel. Nature, 542:60-65, Jan 2017. URL: https://doi.org/10.1038/nature20819, doi:10.1038/nature20819. This article has 185 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(li2024inhibitionofa pages 6-7): Dongdong Li, Di Chen, Wei Li, and Guangshuo Ou. Inhibition of a cyclic nucleotide-gated channel on neuronal cilia activates unfolded protein response in intestinal cells to promote longevity. Proceedings of the National Academy of Sciences of the United States of America, Jun 2024. URL: https://doi.org/10.1073/pnas.2321228121, doi:10.1073/pnas.2321228121. This article has 3 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(zallen2000neuronalcellshape pages 5-7): Jennifer A. Zallen, Erin L. Peckol, David M. Tobin, and Cornelia I. Bargmann. Neuronal cell shape and neurite initiation are regulated by the ndr kinase sax-1, a member of the orb6/cot-1/warts serine/threonine kinase family. Molecular biology of the cell, 11 9:3177-90, Sep 2000. URL: https://doi.org/10.1091/mbc.11.9.3177, doi:10.1091/mbc.11.9.3177. This article has 131 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(inada2006identificationofguanylyl pages 7-10): Hitoshi Inada, Hiroko Ito, John Satterlee, Piali Sengupta, Kunihiro Matsumoto, and Ikue Mori. Identification of guanylyl cyclases that function in thermosensory neurons of caenorhabditis elegans. Genetics, 172:2239-2252, Apr 2006. URL: https://doi.org/10.1534/genetics.105.050013, doi:10.1534/genetics.105.050013. This article has 218 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(li2024inhibitionofa pages 7-8): Dongdong Li, Di Chen, Wei Li, and Guangshuo Ou. Inhibition of a cyclic nucleotide-gated channel on neuronal cilia activates unfolded protein response in intestinal cells to promote longevity. Proceedings of the National Academy of Sciences of the United States of America, Jun 2024. URL: https://doi.org/10.1073/pnas.2321228121, doi:10.1073/pnas.2321228121. This article has 3 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(inada2006identificationofguanylyl pages 11-13): Hitoshi Inada, Hiroko Ito, John Satterlee, Piali Sengupta, Kunihiro Matsumoto, and Ikue Mori. Identification of guanylyl cyclases that function in thermosensory neurons of caenorhabditis elegans. Genetics, 172:2239-2252, Apr 2006. URL: https://doi.org/10.1534/genetics.105.050013, doi:10.1534/genetics.105.050013. This article has 218 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(inada2006identificationofguanylyl pages 10-11): Hitoshi Inada, Hiroko Ito, John Satterlee, Piali Sengupta, Kunihiro Matsumoto, and Ikue Mori. Identification of guanylyl cyclases that function in thermosensory neurons of caenorhabditis elegans. Genetics, 172:2239-2252, Apr 2006. URL: https://doi.org/10.1534/genetics.105.050013, doi:10.1534/genetics.105.050013. This article has 218 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(troemel1999chemosensorysignalingin pages 6-8): Emily R. Troemel. Chemosensory signaling in c. elegans. BioEssays, 21:1011-1020, Dec 1999. URL: https://doi.org/10.1002/(sici)1521-1878(199912)22:1&lt;1011::aid-bies5&gt;3.0.co;2-v, doi:10.1002/(sici)1521-1878(199912)22:1&lt;1011::aid-bies5&gt;3.0.co;2-v. This article has 135 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(li2017structureofa pages 25-27): Minghui Li, Xiaoyuan Zhou, Shu Wang, Ioannis Michailidis, Ye Gong, Deyuan Su, Huan Li, Xueming Li, and Jian Yang. Structure of a eukaryotic cyclic-nucleotide-gated channel. Nature, 542:60-65, Jan 2017. URL: https://doi.org/10.1038/nature20819, doi:10.1038/nature20819. This article has 185 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(bargmann2006chemosensationinc. pages 1-3): Cornelia Bargmann. Chemosensation in c. elegans. WormBook : the online review of C. elegans biology, pages 1-29, Oct 2006. URL: https://doi.org/10.1895/wormbook.1.123.1, doi:10.1895/wormbook.1.123.1. This article has 1160 citations.</p>
+</li>
+<li>
+<p>(bargmann2006chemosensationinc. pages 14-15): Cornelia Bargmann. Chemosensation in c. elegans. WormBook : the online review of C. elegans biology, pages 1-29, Oct 2006. URL: https://doi.org/10.1895/wormbook.1.123.1, doi:10.1895/wormbook.1.123.1. This article has 1160 citations.</p>
+</li>
+<li>
+<p>(hill2024feedforwardandfeedback pages 4-5): Tyler J. Hill and Piali Sengupta. Feedforward and feedback mechanisms cooperatively regulate rapid experience-dependent response adaptation in a single thermosensory neuron type. Proceedings of the National Academy of Sciences of the United States of America, Mar 2024. URL: https://doi.org/10.1073/pnas.2321430121, doi:10.1073/pnas.2321430121. This article has 10 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(hill2024molecularandneuronal pages 60-64): Tyler J Hill. Molecular and neuronal mechanisms underlying rapid experience-dependent plasticity in a single thermosensory neuron. Text, Jan 2024. URL: https://doi.org/10.48617/etd.1088, doi:10.48617/etd.1088. This article has 0 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(li2024inhibitionofa pages 10-11): Dongdong Li, Di Chen, Wei Li, and Guangshuo Ou. Inhibition of a cyclic nucleotide-gated channel on neuronal cilia activates unfolded protein response in intestinal cells to promote longevity. Proceedings of the National Academy of Sciences of the United States of America, Jun 2024. URL: https://doi.org/10.1073/pnas.2321228121, doi:10.1073/pnas.2321228121. This article has 3 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(rosero2026afdthermosensoryneurons pages 13-14): Manuel Rosero and Jihong Bai. Afd thermosensory neurons mediate tactile-dependent locomotion modulation in c. elegans. Apr 2026. URL: https://doi.org/10.7554/elife.106496, doi:10.7554/elife.106496. This article has 0 citations.</p>
+</li>
+</ol>
+<h2 id="artifacts">Artifacts</h2>
+<ul>
+<li><a href="tax-4-deep-research-falcon_artifacts/artifact-00.md">Edison artifact artifact-00</a></li>
+</ul>
+<h2 id="citations">Citations</h2>
+<ol>
+<li>li2017structureofa pages 2-4</li>
+<li>li2017structureofa pages 4-6</li>
+<li>li2017structureofa pages 27-32</li>
+<li>galande2025rolesofcyclic pages 15-16</li>
+<li>inada2006identificationofguanylyl pages 6-7</li>
+<li>li2024inhibitionofa pages 7-8</li>
+<li>hill2024feedforwardandfeedback pages 4-5</li>
+<li>hill2024molecularandneuronal pages 60-64</li>
+<li>inada2006identificationofguanylyl pages 10-11</li>
+<li>okahata2022molecularphysiologyregulating pages 2-4</li>
+<li>li2024inhibitionofa pages 6-7</li>
+<li>zallen2000neuronalcellshape pages 5-7</li>
+<li>rosero2026afdthermosensoryneurons pages 13-14</li>
+<li>inada2006identificationofguanylyl pages 1-2</li>
+<li>li2017structureofa pages 1-2</li>
+<li>troemel1999chemosensorysignalingin pages 5-6</li>
+<li>li2024inhibitionofa pages 8-9</li>
+<li>li2024inhibitionofa pages 1-2</li>
+<li>li2017structureofa pages 6-8</li>
+<li>li2017structureofa pages 14-20</li>
+<li>inada2006identificationofguanylyl pages 7-10</li>
+<li>inada2006identificationofguanylyl pages 11-13</li>
+<li>troemel1999chemosensorysignalingin pages 6-8</li>
+<li>li2017structureofa pages 25-27</li>
+<li>li2024inhibitionofa pages 10-11</li>
+<li>https://doi.org/10.1895/wormbook.1.123.1,</li>
+<li>https://doi.org/10.1534/genetics.105.050013,</li>
+<li>https://doi.org/10.1038/nature20819,</li>
+<li>https://doi.org/10.1002/(sici</li>
+<li>https://doi.org/10.2183/pjab.98.009,</li>
+<li>https://doi.org/10.1016/j.cub.2020.05.006,</li>
+<li>https://doi.org/10.3390/cells14151174,</li>
+<li>https://doi.org/10.1073/pnas.2321228121,</li>
+<li>https://doi.org/10.1091/mbc.11.9.3177,</li>
+<li>https://doi.org/10.1073/pnas.2321430121,</li>
+<li>https://doi.org/10.48617/etd.1088,</li>
+<li>https://doi.org/10.7554/elife.106496,</li>
+</ol>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(tax-4-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="Q03611" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="tax-4-q03611-cng_caeel-research-notes">tax-4 (Q03611, CNG_CAEEL) research notes</h1>
+<p>Research journal for the <em>C. elegans</em> gene <strong>tax-4</strong> (WormBase WBGene00006526; ZC84.2;<br />
+UniProt Q03611). Provenance is recorded inline as <code>[PMID:xxxx "verbatim quote"]</code>.</p>
+<h2 id="identity-one-line">Identity / one-line</h2>
+<p>TAX-4 is the <strong>alpha (principal, pore-forming) subunit of a cyclic nucleotide-gated<br />
+(CNG) cation channel</strong>. It is directly gated by intracellular cGMP (and, less<br />
+sensitively, cAMP), conducts Ca2+/Na+/K+ cations, and localizes to the sensory cilia<br />
+(and dendrites) of many ciliated sensory neurons, where it is the effector channel of<br />
+cGMP-based sensory transduction. TAX-4 forms functional <strong>homotetramers</strong> in vitro and<br />
+in structural studies, and in vivo partners with the modulatory beta subunit <strong>TAX-2</strong><br />
+to form the native heteromeric sensory channel.</p>
+<h2 id="known-well-supported">KNOWN (well supported)</h2>
+<h3 id="molecular-function-cgmp-gated-cation-channel-alpha-subunit">Molecular function: cGMP-gated cation channel (alpha subunit)</h3>
+<ul>
+<li>TAX-4 alone forms a functional, highly cGMP-sensitive channel when expressed in<br />
+  mammalian cells; TAX-2 alone does not.<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/10064800" title="TAX-4 has previously been shown to form a highly sensitive cGMP-gated channel when expressed in human HEK293 cells. Here we show that TAX-4 and TAX-2 form a heteromeric channel when expressed in HEK293 cells, but TAX-2 does not form a channel on its own.">PMID:10064800</a></li>
+<li>TAX-4 = alpha subunit, TAX-2 = modifying beta subunit; the native channel is a<br />
+  hetero-oligomer.<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/10064800" title="with TAX-4 as the alpha subunit and TAX-2 acting as a modifying beta subunit.">PMID:10064800</a></li>
+<li>The heteromeric channel is ~25-fold less cGMP-sensitive than the TAX-4 homomer but<br />
+  stays cGMP-selective; the two forms also differ in divalent-cation block and single-<br />
+  channel properties.<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/10064800" title="The heteromeric TAX-4/TAX-2 channel is 25-fold less sensitive to cGMP than the TAX-4 channel, but it remains highly selective for cGMP over cAMP. The heteromeric channel and the TAX-4 homomeric channel differ in their blockage by divalent cations and in their single channel properties.">PMID:10064800</a></li>
+<li>Original genetic/expression characterization: tax-4 mutants fail multiple sensory<br />
+  behaviors; TAX-4 is homologous to vertebrate CNG channels and functions as a CNG<br />
+  channel in cultured cells; cGMP is the intracellular messenger.<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/8893027" title="We show that the predicted tax-4 gene product is highly homologous to vertebrate cyclic nucleotide-gated channels. Tax-4 protein expressed in cultured cells functions as a cyclic nucleotide-gated channel.">PMID:8893027</a></li>
+</ul>
+<h3 id="structure-all-solved-on-the-c-elegans-tax-4-protein">Structure (all solved on the C. elegans TAX-4 protein)</h3>
+<ul>
+<li>cryo-EM of the C. elegans CNG channel in the cGMP-bound open state; homotetramer with<br />
+  an unusual voltage-sensor-like domain (deficient voltage dependence); C-linker gating<br />
+  ring couples cyclic-nucleotide binding to the gate; selectivity filter lined by a<br />
+  functionally important glutamate + backbone carbonyls.<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/28099415" title="Here we report a 3.5-Å-resolution single-particle electron cryo-microscopy structure of a cyclic-nucleotide-gated channel from Caenorhabditis elegans in the cyclic guanosine monophosphate (cGMP)-bound open state.">PMID:28099415</a><br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/28099415" title="The selectivity filter is lined by the carboxylate side chains of a functionally important glutamate and three rings of backbone carbonyls.">PMID:28099415</a></li>
+<li>Mechanism of ligand (cGMP) activation; open/closed states; central-gate residues<br />
+  (F403, V407) and CNBD contacts characterized by mutagenesis.<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/32483338" title="Mechanism of ligand activation of a eukaryotic cyclic nucleotide-gated channel.">PMID:32483338</a></li>
+<li>UniProt SUBUNIT: <code>Homotetramer. {ECO:0000269|PubMed:28099415, ...:32483338, ...:35233102}</code>.<br />
+  Note the IPI <code>identical protein binding</code> GOA annotations (PMID:28099415, PMID:32483338)<br />
+  reflect this homotetramer self-association.</li>
+</ul>
+<h3 id="cellular-localization">Cellular localization</h3>
+<ul>
+<li>Expressed at the sensory endings of thermosensory, gustatory, and olfactory neurons;<br />
+  TAX-4::GFP partly localized to sensory endings.<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/8893027" title="The Tax-4::GFP fusion is partly localized at the sensory endings of these neurons.">PMID:8893027</a></li>
+<li>Localizes to (non-motile) sensory cilia; ciliary trafficking/localization of the<br />
+  TAX-4 CNGA and TAX-2 CNGB subunits is cell- and subunit-specific.<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/23886944" title="identify sequences required for efficient ciliary targeting and localization of the TAX-2 CNGB and TAX-4 CNGA subunits.">PMID:23886944</a></li>
+<li>In AFD, the cGMP-gated channel is anchored within the proximal ciliary region by<br />
+  NPHP-2/inversin — the ciliary "inversin compartment".<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/25335890" title="requires NPHP-2 (known as inversin in mammals) to anchor a cGMP-gated ion channel within the proximal ciliary region.">PMID:25335890</a></li>
+<li>Cilia membrane composition/morphogenesis context (TUB-1/Tubby); CNG channel is a<br />
+  ciliary signaling cargo. <a href="https://pubmed.ncbi.nlm.nih.gov/31259686">PMID:31259686</a> (localization/tissue-specificity reference in<br />
+  UniProt; SUBCELLULAR LOCATION Cell projection, cilium.)</li>
+</ul>
+<h3 id="biological-processes-cgmp-sensory-transduction-as-effector-channel">Biological processes (cGMP sensory transduction as effector channel)</h3>
+<ul>
+<li><strong>Thermosensation / thermotaxis:</strong> tax-4 mutants fail temperature responses; TAX-4 is<br />
+  required for AFD thermosensitivity and isothermal tracking.<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/8893027" title="they fail to respond to temperature or to water-soluble or volatile chemical attractants.">PMID:8893027</a><br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/21315599" title="Mutations in the tax-4 cyclic nucleotide-gated (CNG) channel have been shown to abolish AFD thermosensitivity and IT">PMID:21315599</a></li>
+<li><strong>AFD gene expression / neuron function:</strong> CMK-1 and TAX-4 regulate AFD gene<br />
+  expression, morphology and function; TAX-4 needed in larval stages to maintain adult<br />
+  gene expression; acts cell-autonomously.<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/14711416" title="the CMK-1 Ca2+/calmodulin-dependent protein kinase I (CaMKI) and the TAX-4 cyclic nucleotide-gated channel regulate gene expression, morphology, and functions of the AFD thermosensory neurons.">PMID:14711416</a></li>
+<li><strong>O2 sensation / aerotaxis / hyperoxia avoidance:</strong> high-O2 avoidance requires the<br />
+  tax-2/tax-4 CNG channel + sGC gcy-35.<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/15220933" title="Avoidance of high oxygen levels by C. elegans requires the sensory cGMP-gated channel tax-2/tax-4 and a specific soluble guanylate cyclase homologue, gcy-35.">PMID:15220933</a></li>
+<li><strong>O2-evoked cGMP/Ca2+ dynamics:</strong> cGMP rise → sustained Ca2+ response that depends on<br />
+  cGMP-gated ion channels (negative-feedback architecture).<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/23940325" title="Increased cGMP leads to a sustained Ca2+ response in the neuron that depends on cGMP-gated ion channels.">PMID:23940325</a></li>
+<li><strong>CO2 sensation / avoidance:</strong> CO2-evoked Ca2+ responses in AFD and BAG neurons<br />
+  require cGMP-gated ion channels; CO2 avoidance requires channels containing TAX-2/TAX-4.<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/21435556" title="CO2-evoked Ca2+ responses in AFD and BAG neurons require cGMP-gated ion channels.">PMID:21435556</a><br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/21435556" title="Avoidance requires cGMP-gated ion channels containing the TAX-2 and TAX-4 subunits">PMID:21435556</a></li>
+<li><strong>Phototransduction (ASJ):</strong> light → G-protein → cGMP → opening of cGMP-sensitive CNG<br />
+  channels in ASJ photoreceptor neuron.<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/20436480" title="opening of cGMP-sensitive CNG channels and stimulation of photoreceptor cells.">PMID:20436480</a></li>
+<li><strong>Chemosensation / neuroendocrine signaling:</strong> chemosensory detection in ASJ of P.<br />
+  aeruginosa metabolites induces daf-7/TGF-β expression (UniProt: TAX-4 up-regulates daf-7<br />
+  transcription in ASI/ASJ). <a href="https://pubmed.ncbi.nlm.nih.gov/25303524">PMID:25303524</a> (positive regulation of gene expression).</li>
+<li><strong>Sensory axon maintenance:</strong> tax-2/tax-4 required for maintenance of correct sensory<br />
+  axon structure (inappropriate late-larval axon outgrowth in mutants).<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/9486798" title="tax-2 and tax-4 are required for the maintenance of correct axon structure">PMID:9486798</a></li>
+</ul>
+<h2 id="not-known-open-questions-candidate-knowledge_gaps">NOT known / open questions (candidate knowledge_gaps)</h2>
+<ol>
+<li><strong>In vivo subunit stoichiometry of the native TAX-4/TAX-2 channel.</strong> In vitro/structural<br />
+   work shows TAX-4 forms homotetramers <a href="https://pubmed.ncbi.nlm.nih.gov/28099415">PMID:28099415</a>, and TAX-4+TAX-2 form a heteromer<br />
+   in HEK293 <a href="https://pubmed.ncbi.nlm.nih.gov/10064800">PMID:10064800</a>, but the exact TAX-4:TAX-2 subunit ratio and arrangement of<br />
+   the <em>native</em> sensory channel in worm cilia is not established.</li>
+<li><strong>Homomeric vs heteromeric gating in vivo.</strong> The homomeric TAX-4 channel is ~25× more<br />
+   cGMP-sensitive than the TAX-4/TAX-2 heteromer <a href="https://pubmed.ncbi.nlm.nih.gov/10064800">PMID:10064800</a>; which form operates in<br />
+   which neuron, and how the beta subunit tunes ligand sensitivity/selectivity in the<br />
+   physiological setting, is unresolved. Subunit composition may even vary across ciliary<br />
+   subcompartments within one cell <a href="https://pubmed.ncbi.nlm.nih.gov/23886944">PMID:23886944</a>.</li>
+<li><strong>Ligand selectivity in vivo (cGMP vs cAMP).</strong> TAX-4 is cGMP-selective but also cAMP-<br />
+   responsive (GO:0005222); whether cAMP-gating is ever physiologically used, and what sets<br />
+   in-vivo ligand tuning, is unclear.</li>
+<li><strong>Ion selectivity / Ca2+ vs monovalent flux in vivo.</strong> The channel conducts Ca2+, Na+,<br />
+   K+ (UniProt CATALYTIC ACTIVITY / Rhea); the relative in-vivo permeation and how Ca2+<br />
+   entry vs depolarization is apportioned across the many neuron types is not quantified.</li>
+<li><strong>Mechanism of the non-channel/"regulatory" roles</strong> (AFD gene-expression maintenance<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/14711416">PMID:14711416</a>; daf-7 induction <a href="https://pubmed.ncbi.nlm.nih.gov/25303524">PMID:25303524</a>; axon-structure maintenance<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/9486798">PMID:9486798</a>) — presumably all downstream of channel-mediated Ca2+ signaling, but the<br />
+   causal chain from channel activity to transcriptional/morphological output is not fully<br />
+   defined.</li>
+</ol>
+<h2 id="annotation-review-orientation-core-vs-non-core">Annotation-review orientation (core vs non-core)</h2>
+<ul>
+<li><strong>CORE molecular function:</strong> cGMP-gated cation channel activity (GO:0005223,<br />
+  intracellularly cGMP-activated cation channel activity), cAMP-activated variant<br />
+  (GO:0005222), cGMP binding (GO:0030553); monoatomic cation transmembrane transport<br />
+  (GO:0098655).</li>
+<li><strong>CORE cellular component:</strong> plasma membrane (GO:0005886); non-motile cilium<br />
+  (GO:0097730); cation channel complex / CNG channel complex (GO:0034703, GO:0017071);<br />
+  dendrite (GO:0030425); ciliary inversin compartment (GO:0097543).</li>
+<li><strong>CORE-ish process:</strong> sensory perception of chemical stimulus (GO:0007606); detection of<br />
+  chemical stimulus involved in sensory perception (GO:0050907); the specific modalities<br />
+  (thermosensory behavior, thermotaxis, aerotaxis, response to hyperoxia/oxygen, detection<br />
+  of CO2, phototransduction, chemotaxis, olfactory behavior) are downstream sensory<br />
+  outputs — KEEP but as NON-CORE consequences of the one channel activity.</li>
+<li><strong>NON-CORE / pleiotropic consequences:</strong> regulation of axon extension (GO:0030516),<br />
+  neuron projection morphogenesis (GO:0048812), regulation of neuron differentiation<br />
+  (GO:0045664), positive regulation of transcription/gene expression (GO:0045944,<br />
+  GO:0010628), positive regulation of growth rate (GO:0040010), calcium-mediated signaling<br />
+  (GO:0019722), negative regulation of receptor guanylyl cyclase signaling (GO:0010754).</li>
+</ul>
+<h2 id="iea-over-annotations-to-flag-from-interproarba-electronic-mapping">IEA over-annotations to flag (from InterPro/ARBA electronic mapping)</h2>
+<ul>
+<li><strong>GO:0005249 voltage-gated potassium channel activity (IEA:InterPro)</strong> — misleading.<br />
+  TAX-4 belongs to the CNG family within the voltage-gated-channel superfamily but has an<br />
+<em>unusual voltage-sensor-like domain accounting for deficient voltage dependence</em><br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/28099415">PMID:28099415</a> and is a <strong>non-selective cation</strong> channel, not a K+-selective, voltage-<br />
+  gated K+ channel. Family-level InterPro (EAG/ELK/ERG signature) drags in this term.</li>
+<li><strong>GO:0006813 / GO:0071805 potassium ion transport / transmembrane transport (IEA)</strong> and<br />
+<strong>GO:0006811 monoatomic ion transport (IEA)</strong> — K+-specific process terms are an<br />
+  over-annotation of the same non-selective-cation reality; the channel does conduct K+ but<br />
+  is not a dedicated K+ transporter. General monoatomic cation transport (GO:0098655) is<br />
+  the accurate term.</li>
+</ul>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: Q03611
+gene_symbol: tax-4
+product_type: PROTEIN
+status: COMPLETE
+taxon:
+  id: NCBITaxon:6239
+  label: Caenorhabditis elegans
+description: &gt;-
+  tax-4 encodes the alpha (principal, pore-forming) subunit of a cyclic
+  nucleotide-gated (CNG) cation channel, the C. elegans ortholog of vertebrate
+  CNGA subunits. The channel is opened directly by intracellular cGMP (and, with
+  lower sensitivity, cAMP) rather than by membrane voltage, and conducts Ca2+,
+  Na+ and K+ across the membrane; a functionally important pore glutamate forms
+  the selectivity filter and a C-linker gating ring couples cyclic-nucleotide
+  binding in the cytoplasmic cyclic-nucleotide-binding domain to opening of the
+  central gate. TAX-4 assembles as a homotetramer and can form a functional
+  homomeric channel on its own, but in vivo it partners with the modulatory beta
+  subunit TAX-2 (which cannot form a channel alone) to build the native sensory
+  channel; the TAX-4/TAX-2 heteromer is markedly less cGMP-sensitive than the
+  TAX-4 homomer. TAX-4 is expressed in many ciliated sensory neurons and is
+  concentrated at their sensory endings, in the non-motile sensory cilium
+  (including an inversin/NPHP-2-anchored proximal ciliary compartment in the AFD
+  thermosensory neuron) and in dendrites. As the effector channel of
+  cGMP-mediated signal transduction, TAX-4 is required for a broad range of
+  sensory modalities, including thermosensation and thermotaxis, chemosensation
+  and chemotaxis (including detection of CO2), oxygen sensing and aerotaxis, and
+  light responses (phototransduction) in specific neurons; channel activity also
+  feeds into downstream outputs such as sensory-neuron gene expression and the
+  maintenance of sensory axon structure.
+existing_annotations:
+- term:
+    id: GO:0005886
+    label: plasma membrane
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: is_active_in
+  review:
+    summary: &gt;-
+      TAX-4 is a plasma-membrane cyclic nucleotide-gated cation channel; gating
+      cation flux across the plasma membrane at sensory endings is its site of
+      action. Correct and core.
+    action: ACCEPT
+- term:
+    id: GO:0007606
+    label: sensory perception of chemical stimulus
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Chemosensation is a defining role of TAX-4: tax-4 mutants fail responses to
+      water-soluble and volatile chemical attractants. Core process.
+    action: ACCEPT
+    supported_by:
+    - reference_id: PMID:8893027
+      supporting_text: &gt;-
+        The C. elegans tax-4 mutants are abnormal in multiple sensory behaviors:
+        they fail to respond to temperature or to water-soluble or volatile
+        chemical attractants.
+- term:
+    id: GO:0005222
+    label: intracellularly cAMP-activated cation channel activity
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: enables
+  review:
+    summary: &gt;-
+      TAX-4 is a cyclic-nucleotide-gated channel that can also be activated by
+      cAMP, though cGMP is the physiologically relevant ligand and the channel is
+      cGMP-selective. Retained as a genuine (if secondary) channel activity.
+    action: ACCEPT
+- term:
+    id: GO:0005223
+    label: intracellularly cGMP-activated cation channel activity
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: enables
+  review:
+    summary: &gt;-
+      This is the core molecular function of TAX-4: a directly cGMP-gated cation
+      channel that is the effector of cGMP sensory signal transduction.
+    action: ACCEPT
+- term:
+    id: GO:0030553
+    label: cGMP binding
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: enables
+  review:
+    summary: &gt;-
+      TAX-4 has a cyclic-nucleotide-binding domain that binds cGMP to open the
+      gate; cGMP binding is directly demonstrated by the cGMP-bound structures.
+      Core.
+    action: ACCEPT
+- term:
+    id: GO:0098655
+    label: monoatomic cation transmembrane transport
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      The channel conducts Ca2+, Na+ and K+ (non-selective cation permeation);
+      monoatomic cation transmembrane transport is the accurate transport-process
+      term. Core.
+    action: ACCEPT
+- term:
+    id: GO:0017071
+    label: intracellular cyclic nucleotide activated cation channel complex
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: part_of
+  review:
+    summary: &gt;-
+      TAX-4 is a subunit of the cyclic-nucleotide-gated cation channel complex
+      (homotetramer in vitro; native TAX-4/TAX-2 heteromer). Correct complex term.
+    action: ACCEPT
+- term:
+    id: GO:0005216
+    label: monoatomic ion channel activity
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Accurate but generic parent of the specific cGMP-gated cation channel
+      activity. Retained; the informative term is GO:0005223.
+    action: ACCEPT
+- term:
+    id: GO:0005221
+    label: intracellularly cyclic nucleotide-activated monoatomic cation channel activity
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Accurate family-level CNG channel molecular-function term; a direct parent
+      of the cGMP- and cAMP-activated specific terms already annotated.
+    action: ACCEPT
+- term:
+    id: GO:0005249
+    label: voltage-gated potassium channel activity
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Incorrect. TAX-4 is a non-selective cation CNG channel, NOT a
+      voltage-gated, K+-selective channel. The cryo-EM structure shows an unusual
+      voltage-sensor-like domain accounting for its deficient voltage dependence.
+      This IEA term is an over-propagation from the shared EAG/ELK/ERG-family
+      InterPro signature and should be removed.
+    action: REMOVE
+    supported_by:
+    - reference_id: PMID:28099415
+      supporting_text: &gt;-
+        The channel has an unusual voltage-sensor-like domain, accounting for its
+        deficient voltage dependence.
+- term:
+    id: GO:0005886
+    label: plasma membrane
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000044
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Plasma-membrane localization (UniProt subcellular-location mapping),
+      consistent with the cryo-EM cell-membrane assignment and ciliary/dendritic
+      membrane localization. Correct and core.
+    action: ACCEPT
+- term:
+    id: GO:0005929
+    label: cilium
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000044
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      TAX-4 localizes to sensory cilia; a more specific experimental term
+      (non-motile cilium, GO:0097730) is also annotated. Correct.
+    action: ACCEPT
+- term:
+    id: GO:0006811
+    label: monoatomic ion transport
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Accurate but generic parent of monoatomic cation transmembrane transport.
+      Retained.
+    action: ACCEPT
+- term:
+    id: GO:0006813
+    label: potassium ion transport
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Over-annotation. TAX-4 is a non-selective cation channel that does conduct
+      K+, but it is not a dedicated potassium transporter; the K+-specific process
+      term comes from the K-channel-family InterPro signature. The accurate term
+      is monoatomic cation transmembrane transport (GO:0098655).
+    action: MARK_AS_OVER_ANNOTATED
+- term:
+    id: GO:0016020
+    label: membrane
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Generic membrane location; true but superseded by plasma membrane / cilium.
+      Retained.
+    action: ACCEPT
+- term:
+    id: GO:0034703
+    label: cation channel complex
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000117
+  qualifier: part_of
+  review:
+    summary: &gt;-
+      TAX-4 is part of a cation channel complex (the CNG channel). Correct;
+      also supported experimentally (PMID:10064800).
+    action: ACCEPT
+- term:
+    id: GO:0055085
+    label: transmembrane transport
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Accurate but generic parent process. Retained.
+    action: ACCEPT
+- term:
+    id: GO:0070482
+    label: response to oxygen levels
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000117
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      The tax-2/tax-4 CNG channel is required for O2-evoked responses and
+      hyperoxia avoidance; also supported experimentally. A downstream sensory
+      output rather than the core channel function.
+    action: KEEP_AS_NON_CORE
+- term:
+    id: GO:0071805
+    label: potassium ion transmembrane transport
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000108
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Over-annotation, same rationale as GO:0006813: non-selective cation channel
+      wrongly cast as a K+-specific transporter via the K-channel InterPro
+      signature. Use monoatomic cation transmembrane transport (GO:0098655).
+    action: MARK_AS_OVER_ANNOTATED
+- term:
+    id: GO:0042802
+    label: identical protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:28099415
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Reflects TAX-4 self-association into a homotetramer, directly seen in the
+      cryo-EM structure (PMID:28099415), which solved the channel as a
+      homotetramer. Accurate but low-information on its own; the tetramer is
+      captured better by the channel-complex terms (GO:0017071, GO:0034703).
+      Kept as reported.
+    action: KEEP_AS_NON_CORE
+- term:
+    id: GO:0042802
+    label: identical protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:32483338
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Duplicate self-association (homotetramer) evidence from the second cryo-EM
+      structure. Kept as reported; non-core.
+    action: KEEP_AS_NON_CORE
+- term:
+    id: GO:0097730
+    label: non-motile cilium
+  evidence_type: IDA
+  original_reference_id: PMID:31259686
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      TAX-4 is a ciliary CNG channel; UniProt records ciliary subcellular
+      location from this study. Core cellular component.
+    action: ACCEPT
+- term:
+    id: GO:0034703
+    label: cation channel complex
+  evidence_type: IDA
+  original_reference_id: PMID:10064800
+  qualifier: part_of
+  review:
+    summary: &gt;-
+      Functional reconstitution shows TAX-4 and TAX-2 form a heteromeric cation
+      channel in cultured cells. Directly supports channel-complex membership.
+      Core.
+    action: ACCEPT
+    supported_by:
+    - reference_id: PMID:10064800
+      supporting_text: &gt;-
+        Here we show that TAX-4 and TAX-2 form a heteromeric channel when
+        expressed in HEK293 cells, but TAX-2 does not form a channel on its own.
+- term:
+    id: GO:0003031
+    label: detection of carbon dioxide
+  evidence_type: IMP
+  original_reference_id: PMID:24240097
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      CO2 detection in BAG (and other) neurons requires the tax-2/tax-4 cGMP-gated
+      channel downstream of the receptor guanylyl cyclase GCY-9. A specific
+      chemosensory modality; retained as a downstream consequence of the core
+      channel function. (Cited paper is abstract-only in the cache; the tax-4
+      requirement for CO2 responses is independently established in PMID:21435556.)
+    action: KEEP_AS_NON_CORE
+- term:
+    id: GO:0019722
+    label: calcium-mediated signaling
+  evidence_type: IMP
+  original_reference_id: PMID:24240097
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Channel opening admits Ca2+, driving the calcium signal in chemosensory
+      neurons. A downstream signaling consequence of cation channel activity;
+      non-core.
+    action: KEEP_AS_NON_CORE
+- term:
+    id: GO:0010628
+    label: positive regulation of gene expression
+  evidence_type: IMP
+  original_reference_id: PMID:25303524
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      In ASJ, TAX-4-dependent chemosensory signaling induces expression of the
+      DAF-7/TGF-beta neuromodulator on exposure to P. aeruginosa metabolites. An
+      indirect, activity-dependent transcriptional output; non-core.
+    action: KEEP_AS_NON_CORE
+    supported_by:
+    - reference_id: PMID:25303524
+      supporting_text: &gt;-
+        secondary metabolites produced by Pseudomonas aeruginosa modulates a
+        neuroendocrine signaling pathway that promotes avoidance behavior
+- term:
+    id: GO:0050907
+    label: detection of chemical stimulus involved in sensory perception
+  evidence_type: IMP
+  original_reference_id: PMID:24240097
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      TAX-4 is the effector channel for detection of chemical stimuli in sensory
+      neurons; an accurate general term for its core sensory role. Core.
+    action: ACCEPT
+- term:
+    id: GO:0007602
+    label: phototransduction
+  evidence_type: IMP
+  original_reference_id: PMID:20436480
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      In the ASJ photoreceptor neuron, light-evoked cGMP opens cGMP-sensitive CNG
+      channels; TAX-4 is required for this response. A specialized downstream
+      sensory modality; non-core.
+    action: KEEP_AS_NON_CORE
+    supported_by:
+    - reference_id: PMID:20436480
+      supporting_text: &gt;-
+        opening of cGMP-sensitive CNG channels and stimulation of photoreceptor
+        cells.
+- term:
+    id: GO:0007199
+    label: G protein-coupled receptor signaling pathway coupled to cGMP nucleotide
+      second messenger
+  evidence_type: IMP
+  original_reference_id: PMID:20436480
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      TAX-4 acts as the cGMP-gated effector at the end of a G-protein/cGMP
+      phototransduction cascade in ASJ. Retained as a downstream pathway role;
+      non-core.
+    action: KEEP_AS_NON_CORE
+    supported_by:
+    - reference_id: PMID:20436480
+      supporting_text: &gt;-
+        phototransduction in ASJ is a G protein-mediated process and requires
+        membrane-associated guanylate cyclases
+- term:
+    id: GO:0040040
+    label: thermosensory behavior
+  evidence_type: IMP
+  original_reference_id: PMID:21315599
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Mutations in the tax-4 CNG channel abolish AFD thermosensitivity and
+      isothermal tracking (per this study&#39;s electrophysiology and behavior).
+      Thermosensation is a flagship sensory role of TAX-4. Core.
+    action: ACCEPT
+    supported_by:
+    - reference_id: PMID:21315599
+      supporting_text: &gt;-
+        These results indicate that the AFD neurons and TAX-4 CNG channel are
+        required to both initiate and maintain isothermal tracks.
+- term:
+    id: GO:0043052
+    label: thermotaxis
+  evidence_type: IMP
+  original_reference_id: PMID:21315599
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Thermotaxis (isothermal tracking) is the behavioral output of AFD
+      thermosensation that requires TAX-4. A downstream behavior; non-core.
+    action: KEEP_AS_NON_CORE
+- term:
+    id: GO:0010754
+    label: negative regulation of receptor guanylyl cyclase signaling pathway
+  evidence_type: IMP
+  original_reference_id: PMID:23940325
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      In O2-sensing neurons, cGMP-gated channel activity (Ca2+ entry) drives
+      Ca2+-dependent negative-feedback loops that shape cGMP dynamics. A feedback
+      role secondary to the core channel function; non-core.
+    action: KEEP_AS_NON_CORE
+    supported_by:
+    - reference_id: PMID:23940325
+      supporting_text: &gt;-
+        Increased cGMP leads to a sustained Ca(2+) response in the neuron that
+        depends on cGMP-gated ion channels.
+- term:
+    id: GO:0070482
+    label: response to oxygen levels
+  evidence_type: IMP
+  original_reference_id: PMID:23940325
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      TAX-4-containing cGMP-gated channels transduce O2-evoked cGMP into sustained
+      Ca2+ responses in the gas-sensing neuron. Downstream sensory output;
+      non-core.
+    action: KEEP_AS_NON_CORE
+- term:
+    id: GO:0040010
+    label: positive regulation of growth rate
+  evidence_type: IGI
+  original_reference_id: PMID:15530424
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Genetic-interaction annotation from a study primarily on the cng-3 CNG
+      channel and thermotolerance, with tax-4 as background. A pleiotropic
+      physiological consequence; non-core. (Cited paper abstract-only in cache.)
+    action: KEEP_AS_NON_CORE
+- term:
+    id: GO:0097543
+    label: ciliary inversin compartment
+  evidence_type: IDA
+  original_reference_id: PMID:25335890
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      In AFD, NPHP-2/inversin anchors the cGMP-gated ion channel within the
+      proximal ciliary (inversin) compartment. Directly supports this specific
+      ciliary sub-compartment localization. Core cellular component.
+    action: ACCEPT
+    supported_by:
+    - reference_id: PMID:25335890
+      supporting_text: &gt;-
+        requires NPHP-2 (known as inversin in mammals) to anchor a cGMP-gated ion
+        channel within the proximal ciliary region.
+- term:
+    id: GO:0097730
+    label: non-motile cilium
+  evidence_type: IDA
+  original_reference_id: PMID:25335890
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      TAX-4/TAX-2 cGMP-gated channel localizes to the AFD sensory cilium. Core
+      cellular component.
+    action: ACCEPT
+- term:
+    id: GO:0005223
+    label: intracellularly cGMP-activated cation channel activity
+  evidence_type: IDA
+  original_reference_id: PMID:10064800
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Direct functional reconstitution in cultured cells demonstrates a
+      cGMP-gated cation channel. Core molecular function.
+    action: ACCEPT
+    supported_by:
+    - reference_id: PMID:10064800
+      supporting_text: &gt;-
+        The heteromeric TAX-4/TAX-2 channel is 25-fold less sensitive to cGMP
+        than the TAX-4 channel, but it remains highly selective for cGMP over
+        cAMP.
+- term:
+    id: GO:0098655
+    label: monoatomic cation transmembrane transport
+  evidence_type: IDA
+  original_reference_id: PMID:10064800
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Reconstituted channel conducts cations across the membrane. Core transport
+      process.
+    action: ACCEPT
+- term:
+    id: GO:0097730
+    label: non-motile cilium
+  evidence_type: IDA
+  original_reference_id: PMID:23886944
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Study defines sequences and trans-acting factors required for ciliary
+      targeting/localization of the TAX-4 CNGA and TAX-2 CNGB subunits. Directly
+      supports ciliary localization. Core cellular component.
+    action: ACCEPT
+    supported_by:
+    - reference_id: PMID:23886944
+      supporting_text: &gt;-
+        sequences required for efficient ciliary targeting and localization of
+        the TAX-2 CNGB and TAX-4 CNGA subunits.
+- term:
+    id: GO:0006935
+    label: chemotaxis
+  evidence_type: IMP
+  original_reference_id: PMID:21435556
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      CO2-evoked responses and CO2 avoidance behavior require cGMP-gated channels
+      containing TAX-2 and TAX-4. Chemotaxis is a behavioral output of the core
+      chemosensory channel function; retained as non-core for this study.
+    action: KEEP_AS_NON_CORE
+    supported_by:
+    - reference_id: PMID:21435556
+      supporting_text: &gt;-
+        CO(2)-evoked Ca(2+) responses in AFD and BAG neurons require cGMP-gated
+        ion channels.
+- term:
+    id: GO:0070482
+    label: response to oxygen levels
+  evidence_type: IMP
+  original_reference_id: PMID:19323996
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      URX and BAG O2-sensing neurons use cGMP signaling (via sGCs) that is
+      transduced by CNG channels; tax-4 is required for O2 responses. Downstream
+      sensory output; non-core.
+    action: KEEP_AS_NON_CORE
+- term:
+    id: GO:0005222
+    label: intracellularly cAMP-activated cation channel activity
+  evidence_type: IDA
+  original_reference_id: PMID:8893027
+  qualifier: enables
+  review:
+    summary: &gt;-
+      TAX-4 expressed in cultured cells functions as a cyclic-nucleotide-gated
+      channel (cAMP-responsive as well as cGMP-gated). Genuine channel activity,
+      though cGMP is physiologically dominant.
+    action: ACCEPT
+    supported_by:
+    - reference_id: PMID:8893027
+      supporting_text: &gt;-
+        Tax-4 protein expressed in cultured cells functions as a cyclic
+        nucleotide-gated channel.
+- term:
+    id: GO:0005223
+    label: intracellularly cGMP-activated cation channel activity
+  evidence_type: IDA
+  original_reference_id: PMID:8893027
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Original demonstration that TAX-4 forms a cyclic-nucleotide-gated channel;
+      cGMP is the key intracellular messenger in worm sensory transduction. Core
+      molecular function.
+    action: ACCEPT
+    supported_by:
+    - reference_id: PMID:8893027
+      supporting_text: &gt;-
+        The results suggest that a cyclic nucleotide-gated channel is required for
+        thermosensation and chemosensation
+- term:
+    id: GO:0030425
+    label: dendrite
+  evidence_type: IDA
+  original_reference_id: PMID:8893027
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      TAX-4::GFP localizes at the sensory endings of thermosensory, gustatory and
+      olfactory neurons (dendritic sensory endings/cilia). Core cellular component.
+    action: ACCEPT
+    supported_by:
+    - reference_id: PMID:8893027
+      supporting_text: &gt;-
+        The Tax-4::GFP fusion is partly localized at the sensory endings of these
+        neurons.
+- term:
+    id: GO:0097730
+    label: non-motile cilium
+  evidence_type: IDA
+  original_reference_id: PMID:8893027
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      TAX-4 localizes to the sensory endings (cilia) of ciliated sensory neurons.
+      Core cellular component.
+    action: ACCEPT
+    supported_by:
+    - reference_id: PMID:8893027
+      supporting_text: &gt;-
+        expressed in thermosensory, gustatory, and olfactory neurons mediating all
+        the sensory behaviors affected by the tax-4 mutations
+- term:
+    id: GO:0030516
+    label: regulation of axon extension
+  evidence_type: IMP
+  original_reference_id: PMID:9486798
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      tax-2/tax-4 are required to maintain correct sensory axon structure;
+      mutants show inappropriate late-larval axon outgrowth. A pleiotropic
+      developmental/maintenance role distinct from acute sensory transduction;
+      non-core.
+    action: KEEP_AS_NON_CORE
+    supported_by:
+    - reference_id: PMID:9486798
+      supporting_text: &gt;-
+        tax-2 and tax-4 are required for the maintenance of correct axon
+        structure
+- term:
+    id: GO:0009454
+    label: aerotaxis
+  evidence_type: IMP
+  original_reference_id: PMID:15220933
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Avoidance of high oxygen requires the sensory cGMP-gated channel tax-2/tax-4
+      plus the sGC gcy-35. Aerotaxis is a downstream O2-driven behavior; non-core.
+    action: KEEP_AS_NON_CORE
+    supported_by:
+    - reference_id: PMID:15220933
+      supporting_text: &gt;-
+        Avoidance of high oxygen levels by C. elegans requires the sensory
+        cGMP-gated channel tax-2/tax-4 and a specific soluble guanylate cyclase
+        homologue, gcy-35.
+- term:
+    id: GO:0055093
+    label: response to hyperoxia
+  evidence_type: IMP
+  original_reference_id: PMID:15220933
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      TAX-4-dependent O2 sensation mediates avoidance of hyperoxic environments.
+      Downstream sensory output; non-core.
+    action: KEEP_AS_NON_CORE
+- term:
+    id: GO:0040040
+    label: thermosensory behavior
+  evidence_type: IMP
+  original_reference_id: PMID:11879652
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Thermosensory behavior requiring TAX-4, assayed here in the context of the
+      TAX-6 calcineurin gain-control pathway. Thermosensation is a core TAX-4
+      sensory role.
+    action: ACCEPT
+- term:
+    id: GO:0040040
+    label: thermosensory behavior
+  evidence_type: IGI
+  original_reference_id: PMID:11879652
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Genetic-interaction (with tax-6) evidence corroborating TAX-4&#39;s core
+      thermosensory-behavior role.
+    action: ACCEPT
+- term:
+    id: GO:0042048
+    label: olfactory behavior
+  evidence_type: IMP
+  original_reference_id: PMID:11879652
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Olfaction is one of the sensory modalities requiring TAX-4; here in the
+      context of tax-6-mediated adaptation/gain control. A downstream behavioral
+      output; non-core.
+    action: KEEP_AS_NON_CORE
+- term:
+    id: GO:0042048
+    label: olfactory behavior
+  evidence_type: IGI
+  original_reference_id: PMID:11879652
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Genetic-interaction evidence for an olfactory-behavior role. Non-core.
+    action: KEEP_AS_NON_CORE
+- term:
+    id: GO:0043052
+    label: thermotaxis
+  evidence_type: IMP
+  original_reference_id: PMID:11879652
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Thermotaxis behavior involving TAX-4 in the tax-6 gain-control study.
+      Downstream behavior; non-core.
+    action: KEEP_AS_NON_CORE
+- term:
+    id: GO:0043052
+    label: thermotaxis
+  evidence_type: IGI
+  original_reference_id: PMID:11879652
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Genetic-interaction evidence for a thermotaxis role. Non-core.
+    action: KEEP_AS_NON_CORE
+- term:
+    id: GO:0040040
+    label: thermosensory behavior
+  evidence_type: IMP
+  original_reference_id: PMID:14711416
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      CMK-1 and TAX-4 regulate AFD thermosensory-neuron gene expression,
+      morphology and function. Thermosensation is a core TAX-4 role; well
+      supported.
+    action: ACCEPT
+    supported_by:
+    - reference_id: PMID:14711416
+      supporting_text: &gt;-
+        the CMK-1 Ca2+/calmodulin-dependent protein kinase I (CaMKI) and the TAX-4
+        cyclic nucleotide-gated channel regulate gene expression, morphology, and
+        functions of the AFD thermosensory neurons.
+- term:
+    id: GO:0045664
+    label: regulation of neuron differentiation
+  evidence_type: IMP
+  original_reference_id: PMID:14711416
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      TAX-4 activity is required to maintain AFD-specific gene expression and
+      morphology; an activity-dependent effect on neuronal differentiation state
+      rather than a direct role. Non-core.
+    action: KEEP_AS_NON_CORE
+- term:
+    id: GO:0045944
+    label: positive regulation of transcription by RNA polymerase II
+  evidence_type: IMP
+  original_reference_id: PMID:14711416
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      TAX-4 channel activity is required to maintain AFD-specific gene expression.
+      This is an indirect, activity-dependent transcriptional consequence; TAX-4
+      is a channel, not a transcriptional regulator. Non-core.
+    action: KEEP_AS_NON_CORE
+    supported_by:
+    - reference_id: PMID:14711416
+      supporting_text: &gt;-
+        TAX-4 functions are required during larval stages to maintain gene
+        expression in the adult.
+- term:
+    id: GO:0048812
+    label: neuron projection morphogenesis
+  evidence_type: IMP
+  original_reference_id: PMID:14711416
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      TAX-4 activity influences AFD sensory-ending morphology. A downstream,
+      activity-dependent morphological effect; non-core.
+    action: KEEP_AS_NON_CORE
+- term:
+    id: GO:0007635
+    label: chemosensory behavior
+  evidence_type: IMP
+  original_reference_id: PMID:8893027
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      tax-4 mutants are defective in chemosensory behaviors (gustation and
+      olfaction). Core sensory role.
+    action: ACCEPT
+    supported_by:
+    - reference_id: PMID:8893027
+      supporting_text: &gt;-
+        The C. elegans tax-4 mutants are abnormal in multiple sensory behaviors:
+        they fail to respond to temperature or to water-soluble or volatile
+        chemical attractants.
+- term:
+    id: GO:0016020
+    label: membrane
+  evidence_type: NAS
+  original_reference_id: PMID:8893027
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Generic membrane localization (NAS). True but superseded by plasma
+      membrane / cilium / dendrite. Retained.
+    action: ACCEPT
+- term:
+    id: GO:0030553
+    label: cGMP binding
+  evidence_type: NAS
+  original_reference_id: PMID:8893027
+  qualifier: enables
+  review:
+    summary: &gt;-
+      cGMP binding inferred (NAS) from the CNG-channel homology and cGMP-gated
+      activity; later confirmed structurally. Core molecular function.
+    action: ACCEPT
+- term:
+    id: GO:0040040
+    label: thermosensory behavior
+  evidence_type: IMP
+  original_reference_id: PMID:8893027
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Original genetic evidence that tax-4 is required for thermosensation
+      (mutants fail to respond to temperature). Core sensory role.
+    action: ACCEPT
+    supported_by:
+    - reference_id: PMID:8893027
+      supporting_text: &gt;-
+        they fail to respond to temperature or to water-soluble or volatile
+        chemical attractants.
+core_functions:
+- description: &gt;-
+    TAX-4 is the pore-forming alpha subunit of a cyclic nucleotide-gated (CNG)
+    cation channel that is opened directly by intracellular cGMP and conducts
+    Ca2+/Na+/K+ across the plasma membrane at the sensory endings, cilia and
+    dendrites of ciliated sensory neurons, serving as the effector channel of
+    cGMP-mediated sensory signal transduction. It assembles as a homotetramer and
+    in vivo forms the native sensory channel together with the modulatory beta
+    subunit TAX-2.
+  molecular_function:
+    id: GO:0005223
+    label: intracellularly cGMP-activated cation channel activity
+  directly_involved_in:
+  - id: GO:0007606
+    label: sensory perception of chemical stimulus
+  - id: GO:0050907
+    label: detection of chemical stimulus involved in sensory perception
+  - id: GO:0098655
+    label: monoatomic cation transmembrane transport
+  locations:
+  - id: GO:0005886
+    label: plasma membrane
+  - id: GO:0097730
+    label: non-motile cilium
+  - id: GO:0030425
+    label: dendrite
+  in_complex:
+    id: GO:0017071
+    label: intracellular cyclic nucleotide activated cation channel complex
+  supported_by:
+  - reference_id: PMID:8893027
+    supporting_text: &gt;-
+      Tax-4 protein expressed in cultured cells functions as a cyclic
+      nucleotide-gated channel.
+  - reference_id: PMID:10064800
+    supporting_text: &gt;-
+      with TAX-4 as the alpha subunit and TAX-2 acting as a modifying beta
+      subunit.
+  - reference_id: PMID:28099415
+    supporting_text: &gt;-
+      a cyclic-nucleotide-gated channel from Caenorhabditis elegans in the cyclic
+      guanosine monophosphate (cGMP)-bound open state.
+- description: &gt;-
+    TAX-4 binds cGMP through its cytoplasmic cyclic-nucleotide-binding domain;
+    ligand binding drives the conformational change (via the C-linker gating
+    ring) that opens the central gate, making cGMP binding the ligand-sensing
+    step of the channel&#39;s activity.
+  molecular_function:
+    id: GO:0030553
+    label: cGMP binding
+  supported_by:
+  - reference_id: PMID:28099415
+    supporting_text: &gt;-
+      A carboxy-terminal linker connecting S6 and the cyclic-nucleotide-binding
+      domain interacts directly with both the voltage-sensor-like domain and the
+      pore domain
+  - reference_id: PMID:32483338
+    supporting_text: &gt;-
+      Mechanism of ligand activation of a eukaryotic cyclic nucleotide-gated
+      channel.
+  knowledge_gaps:
+  - gap_statement: &gt;-
+      The in vivo subunit stoichiometry and arrangement of the native sensory CNG
+      channel (the TAX-4:TAX-2 ratio in the tetramer, and whether it varies
+      between neurons or even between ciliary subcompartments of one neuron) is
+      not established.
+    boundary: &gt;-
+      TAX-4 forms homotetramers in vitro and in cryo-EM structures, and TAX-4 +
+      TAX-2 co-assemble into a functional heteromer in HEK293 cells while TAX-2
+      alone cannot form a channel; but the composition of the endogenous channel
+      in worm cilia is inferred, not measured.
+    gap_kind:
+    - BIOLOGY
+    dark_aspect: RESIDUAL_SUBGAP
+    status: OPEN
+    significance: &gt;-
+      Subunit composition sets ligand sensitivity, ion handling and localization,
+      so it directly determines how each sensory neuron converts a cGMP signal
+      into a response.
+    resolution: &gt;-
+      Native-channel biochemistry / quantitative in vivo subunit stoichiometry
+      (e.g. calibrated fluorescence or single-molecule counting) per neuron and
+      per ciliary subcompartment.
+    provenance:
+    - reference_id: PMID:23886944
+      supporting_text: &gt;-
+        whether these mechanisms act in a protein- and cell-specific manner is
+        largely unknown
+    - reference_id: PMID:10064800
+      supporting_text: &gt;-
+        most of the native channels in C. elegans are likely to be
+        hetero-oligomers of TAX-4 and TAX-2 subunits
+  - gap_statement: &gt;-
+      Which channel form (the ~25-fold more cGMP-sensitive TAX-4 homomer versus
+      the less-sensitive TAX-4/TAX-2 heteromer) operates in which neuron in vivo,
+      and how the TAX-2 beta subunit tunes ligand sensitivity and selectivity in
+      the physiological setting, is unresolved.
+    boundary: &gt;-
+      In heterologous cells the heteromer is 25-fold less cGMP-sensitive than the
+      TAX-4 homomer yet remains cGMP-selective, and the two forms differ in
+      divalent-cation block and single-channel behavior; the in vivo deployment of
+      these forms is not mapped.
+    gap_kind:
+    - BIOLOGY
+    dark_aspect: RESIDUAL_SUBGAP
+    status: OPEN
+    significance: &gt;-
+      The homomer/heteromer choice would set each neuron&#39;s cGMP operating range
+      and thus its stimulus threshold and dynamic range.
+    resolution: &gt;-
+      Cell-specific electrophysiology / in vivo cGMP dose-response comparisons in
+      tax-2 wild-type versus mutant backgrounds.
+    provenance:
+    - reference_id: PMID:10064800
+      supporting_text: &gt;-
+        The heteromeric TAX-4/TAX-2 channel is 25-fold less sensitive to cGMP than
+        the TAX-4 channel, but it remains highly selective for cGMP over cAMP.
+  - gap_statement: &gt;-
+      Whether TAX-4&#39;s in vitro cAMP responsiveness is ever used physiologically,
+      and what sets the in vivo cGMP-versus-cAMP ligand tuning of the native
+      channel, is unknown.
+    boundary: &gt;-
+      TAX-4 is gated by cGMP and also by cAMP in heterologous assays but is
+      strongly cGMP-selective; all characterized worm sensory pathways using TAX-4
+      signal through cGMP produced by receptor/soluble guanylyl cyclases.
+    gap_kind:
+    - BIOLOGY
+    dark_aspect: RESIDUAL_SUBGAP
+    status: OPEN
+    significance: &gt;-
+      A physiological cAMP-gated mode would expand the signaling repertoire of
+      TAX-4-expressing neurons beyond cGMP transduction.
+    resolution: &gt;-
+      In vivo manipulation of cAMP versus cGMP in TAX-4-expressing neurons with
+      cell-specific functional imaging.
+    provenance:
+    - reference_id: PMID:10064800
+      supporting_text: &gt;-
+        it remains highly selective for cGMP over cAMP.
+references:
+- id: GO_REF:0000002
+  title: Gene Ontology annotation through association of InterPro records with GO
+    terms
+  findings: []
+- id: GO_REF:0000033
+  title: Annotation inferences using phylogenetic trees
+  findings: []
+- id: GO_REF:0000044
+  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location
+    vocabulary mapping, accompanied by conservative changes to GO terms applied by
+    UniProt
+  findings: []
+- id: GO_REF:0000108
+  title: Automatic assignment of GO terms using logical inference, based on on inter-ontology
+    links
+  findings: []
+- id: GO_REF:0000117
+  title: Electronic Gene Ontology annotations created by ARBA machine learning models
+  findings: []
+- id: PMID:10064800
+  title: Functional reconstitution of a heteromeric cyclic nucleotide-gated channel
+    of Caenorhabditis elegans in cultured cells.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PubMed-verified. Establishes TAX-4 as the alpha (pore-forming) subunit and
+      TAX-2 as a modifying beta subunit, that TAX-2 cannot form a channel alone,
+      and that the heteromer is ~25-fold less cGMP-sensitive than the TAX-4
+      homomer but stays cGMP-selective. Directly grounds the core molecular
+      function and the stoichiometry/gating knowledge gaps.
+- id: PMID:11879652
+  title: Negative regulation and gain control of sensory neurons by the C. elegans
+    calcineurin TAX-6.
+  findings: []
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Primarily a study of the TAX-6 calcineurin gain-control pathway; tax-4
+      appears as a sensory-transduction component in thermosensory and olfactory
+      contexts. Supports the thermosensory/olfactory behavior annotations. Cached
+      abstract-only.
+- id: PMID:14711416
+  title: The CMK-1 CaMKI and the TAX-4 Cyclic nucleotide-gated channel regulate thermosensory
+    neuron gene expression and function in C. elegans.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Directly assays TAX-4 in AFD; shows TAX-4 activity is required to maintain
+      AFD-specific gene expression, morphology and function. Grounds the
+      thermosensory core role and the indirect gene-expression/morphology
+      non-core annotations.
+- id: PMID:15220933
+  title: Oxygen sensation and social feeding mediated by a C. elegans guanylate cyclase
+    homologue.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Explicitly names the sensory cGMP-gated channel tax-2/tax-4 as required for
+      high-O2 avoidance, together with the sGC gcy-35. Solid support for the O2 /
+      aerotaxis / hyperoxia non-core annotations.
+- id: PMID:15530424
+  title: A new putative cyclic nucleotide-gated channel gene, cng-3, is critical for
+    thermotolerance in Caenorhabditis elegans.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Focused on the cng-3 CNG channel; tax-4 is background/comparator. Supports
+      only the peripheral positive-regulation-of-growth-rate IGI annotation.
+      Cached abstract-only.
+- id: PMID:19323996
+  title: Neurons detect increases and decreases in oxygen levels using distinct guanylate
+    cyclases.
+  findings: []
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Characterizes URX/BAG O2-sensing via distinct soluble guanylate cyclases;
+      the cGMP signal is transduced by CNG channels including TAX-4. Supports the
+      response-to-oxygen-levels non-core annotation.
+- id: PMID:20436480
+  title: C. elegans phototransduction requires a G protein-dependent cGMP pathway
+    and a taste receptor homolog.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Establishes a G-protein/cGMP phototransduction cascade in ASJ that opens
+      cGMP-sensitive CNG channels; supports the phototransduction and
+      GPCR-cGMP-second-messenger non-core annotations.
+- id: PMID:21315599
+  title: Regulation of response properties and operating range of the AFD thermosensory
+    neurons by cGMP signaling.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Full text states tax-4 CNG-channel mutations abolish AFD thermosensitivity
+      and isothermal tracking. Support for the thermosensory core role (the paper
+      centers on the upstream gcy receptor guanylyl cyclases).
+- id: PMID:21435556
+  title: Temperature, oxygen, and salt-sensing neurons in C. elegans are carbon dioxide
+    sensors that control avoidance behavior.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Shows CO2-evoked Ca2+ responses in AFD and BAG require cGMP-gated channels,
+      and CO2 avoidance requires channels containing the TAX-2 and TAX-4 subunits.
+      Grounds the CO2/chemotaxis non-core annotations and corroborates the
+      abstract-only PMID:24240097.
+- id: PMID:23886944
+  title: Cell- and subunit-specific mechanisms of CNG channel ciliary trafficking
+    and localization in C. elegans.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Defines cis-sequences and trans-factors for ciliary targeting of the TAX-4
+      CNGA and TAX-2 CNGB subunits, and reports heterogeneous, cell- and
+      subunit-specific channel composition across the cilium. Grounds ciliary
+      localization and the in vivo stoichiometry/composition knowledge gap.
+- id: PMID:23940325
+  title: In vivo genetic dissection of O2-evoked cGMP dynamics in a Caenorhabditis
+    elegans gas sensor.
+  findings: []
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: &gt;-
+      In vivo cGMP/Ca2+ imaging showing cGMP-gated channels are required for the
+      sustained Ca2+ response and participate in negative-feedback loops. Supports
+      the response-to-oxygen and negative-regulation-of-rGC-signaling annotations.
+- id: PMID:24240097
+  title: A chemoreceptor that detects molecular carbon dioxide.
+  findings: []
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Primary focus is the GCY-9 receptor guanylyl cyclase in BAG CO2 sensing; the
+      cached record is abstract-only and does not itself mention tax-4. The tax-4
+      requirement for CO2-evoked responses is independently supported
+      (PMID:21435556), so the IMP CO2/Ca2+/detection annotations are retained
+      (non-core) rather than removed.
+- id: PMID:25303524
+  title: Chemosensation of bacterial secondary metabolites modulates neuroendocrine
+    signaling and behavior of C. elegans.
+  findings: []
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: &gt;-
+      ASJ chemosensory detection of P. aeruginosa metabolites induces DAF-7/TGF-beta
+      expression; TAX-4 is the chemosensory channel upstream. Supports the
+      positive-regulation-of-gene-expression non-core annotation.
+- id: PMID:25335890
+  title: Ciliopathy proteins establish a bipartite signaling compartment in a C. elegans
+    thermosensory neuron.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Shows NPHP-2/inversin anchors the cGMP-gated ion channel within the proximal
+      ciliary (inversin) compartment of AFD. Directly grounds the ciliary inversin
+      compartment and non-motile cilium localizations.
+- id: PMID:28099415
+  title: Structure of a eukaryotic cyclic-nucleotide-gated channel.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      cryo-EM structure of the C. elegans TAX-4 channel (homotetramer) in the
+      cGMP-bound open state; documents the unusual voltage-sensor-like domain with
+      deficient voltage dependence (basis for removing the voltage-gated K+
+      channel IEA term) and the selectivity-filter glutamate.
+- id: PMID:31259686
+  title: The Caenorhabditis elegans Tubby homolog dynamically modulates olfactory
+    cilia membrane morphogenesis and phospholipid composition.
+  findings: []
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Study of TUB-1/Tubby regulation of olfactory cilia membrane; provides the
+      ciliary subcellular-location evidence for TAX-4 cited by UniProt. Supports
+      non-motile cilium localization.
+- id: PMID:32483338
+  title: Mechanism of ligand activation of a eukaryotic cyclic nucleotide-gated channel.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      cryo-EM of the C. elegans TAX-4 channel in cGMP-bound and unbound states;
+      defines the ligand-activation mechanism and central-gate residues.
+      Grounds the cGMP-binding core function and the gating knowledge gap.
+- id: PMID:8893027
+  title: Mutations in a cyclic nucleotide-gated channel lead to abnormal thermosensation
+    and chemosensation in C. elegans.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Foundational paper: tax-4 mutants fail thermo- and chemosensory behaviors;
+      TAX-4 is homologous to vertebrate CNG channels and functions as a CNG channel
+      in cultured cells; TAX-4::GFP localizes to sensory endings. Anchors the core
+      molecular function, localization and sensory-behavior annotations.
+- id: PMID:9486798
+  title: &#39;A cyclic nucleotide-gated channel inhibits sensory axon outgrowth in larval
+    and adult Caenorhabditis elegans: a distinct pathway for maintenance of sensory
+    axon structure.&#39;
+  findings: []
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Shows tax-2/tax-4 are required to maintain correct sensory axon structure
+      (late-larval/adult axon-outgrowth phenotype). Supports the non-core
+      regulation-of-axon-extension annotation.
+suggested_questions:
+- question: &gt;-
+    What is the endogenous TAX-4:TAX-2 subunit stoichiometry of the native sensory
+    channel, and does it differ between neuron types or between ciliary
+    subcompartments within a single neuron?
+- question: &gt;-
+    Which neurons rely on the highly cGMP-sensitive TAX-4 homomer versus the
+    less-sensitive TAX-4/TAX-2 heteromer, and how does that choice set each cell&#39;s
+    stimulus threshold and dynamic range?
+suggested_experiments:
+- description: &gt;-
+    Quantitative in vivo measurement of TAX-4 and TAX-2 subunit copy number /
+    ratio in defined sensory cilia (e.g. calibrated fluorescence or single-molecule
+    counting) combined with cell-specific cGMP dose-response electrophysiology in
+    tax-2(+) versus tax-2(-) backgrounds, to map homomeric versus heteromeric
+    channels onto neurons and quantify how TAX-2 tunes cGMP sensitivity in situ.
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/genes/worm/tin-44/tin-44-ai-review.html
+++ b/genes/worm/tin-44/tin-44-ai-review.html
@@ -1,0 +1,2893 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>tin-44 - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        .propagation-review {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f8fafc;
+            border-left: 3px solid #64748b;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .propagation-title {
+            font-weight: 600;
+            color: #334155;
+            margin-bottom: 0.25rem;
+        }
+
+        .propagation-row {
+            margin-top: 0.25rem;
+        }
+
+        .propagation-source {
+            margin-top: 0.5rem;
+            padding-top: 0.5rem;
+            border-top: 1px solid #e5e7eb;
+        }
+
+        .propagation-source-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #1d4ed8;
+        }
+
+        .propagation-comment {
+            color: #4b5563;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>tin-44</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/O02161" target="_blank" class="term-link">
+                        O02161
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Caenorhabditis elegans</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-complete">
+                    COMPLETE
+                </span>
+            </div>
+
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "tin-44";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="O02161" data-a="DESCRIPTION: tin-44 encodes the C. elegans ortholog of TIM44 (h..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>tin-44 encodes the C. elegans ortholog of TIM44 (human TIMM44 / yeast Tim44), a component of the mitochondrial protein-import machinery at the inner membrane. TIM44 is the central organizing subunit of the presequence translocase-associated import motor (PAM), the ATP-driven engine that pulls nucleus-encoded, presequence-bearing preproteins across the inner membrane into the matrix after they emerge from the TIM23 channel. Positioned on the matrix face of the TIM23 translocase, TIM44 recruits and tethers mitochondrial HSP70 (mtHsp70; HSP-6 in C. elegans) together with its regulatory co-chaperones — the J-protein Pam18/Tim14 (dnj-21), the J-like Pam16/Tim16 (tim-16), and the nucleotide-exchange factor GrpE/Mge1 — so that cycles of mtHsp70 ATP binding and hydrolysis are coupled to the vectorial, ratchet-like inward movement of the incoming polypeptide. Through this motor, TIM44/tin-44 supports import of the many nuclear-encoded matrix and inner-membrane proteins that build and maintain mitochondria. In C. elegans, tin-44 is transcriptionally co-induced with the rest of the TIM/TOM import machinery (including mtHsp70/hsp-6 and the mitochondrial processing peptidase subunits) when the mitochondrial unfolded protein response is activated, and its RNAi knockdown behaves as a mitochondrial protein-import defect.</p>
+    </div>
+
+
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0001405" target="_blank" class="term-link">
+                                    GO:0001405
+                                </a>
+                            </span>
+                            <span class="term-label">PAM complex, Tim23 associated import motor</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O02161" data-a="GO:0001405" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Core cellular-component / complex-membership annotation. tin-44 is the C. elegans Tim44 ortholog (Tim44 family, IPR017303) and, like its yeast/human counterparts, a subunit of the presequence translocase-associated import motor (PAM) that operates on the matrix side of the TIM23 complex. The direct worm evidence places tin-44 in the matrix-pulling step of import together with mtHsp70/HSP-6.
+                        </div>
+
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    UniProt:O02161
+
+                                </span>
+
+                                <div class="support-text">Essential component of the PAM complex</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/35608535" target="_blank" class="term-link">
+                                        PMID:35608535
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">the precursor proteins are pulled into the matrix by TIM44 and mtHSP70 (HSP-6)</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030150" target="_blank" class="term-link">
+                                    GO:0030150
+                                </a>
+                            </span>
+                            <span class="term-label">protein import into mitochondrial matrix</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O02161" data-a="GO:0030150" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Core biological-process annotation. As the PAM import-motor organizer, tin-44 functions in the ATP-dependent import of presequence-bearing preproteins across the inner membrane into the mitochondrial matrix. Direct worm genetics supports this process assignment: Bennett et al. group tin-44/T09B4.9 (TIM44) with the TIM23-complex components that transport proteins into the inner membrane and matrix, and tin-44 RNAi behaves as a mitochondrial-import knockdown (activating the UPRmt and shortening lifespan).
+                        </div>
+
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    UniProt:O02161
+
+                                </span>
+
+                                <div class="support-text">translocation of transit peptide-containing proteins from the inner membrane into the mitochondrial matrix in an ATP-dependent manner</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/24662282" target="_blank" class="term-link">
+                                        PMID:24662282
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">T09B4.9 (TIM44), F45G2.8 (TIM16), F15D3.7 (TIM23), and dnj-21 (TIM14), which function in the TIM23 complex that transports proteins into the inner membrane and the matrix</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/10339406" target="_blank" class="term-link">
+                                        PMID:10339406
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">translocation of preproteins into the matrix requires the membrane proteins Tim23, Tim17 and Tim44, which drive translocation in cooperation with mtHsp70 and its co-chaperone Mge1p</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051087" target="_blank" class="term-link">
+                                    GO:0051087
+                                </a>
+                            </span>
+                            <span class="term-label">protein-folding chaperone binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O02161" data-a="GO:0051087" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Core molecular-function annotation and the most specific MF available for a Tim44-family protein. tin-44&#39;s defining biochemical activity is binding/tethering the mitochondrial HSP70 chaperone (worm HSP-6) at the import channel so that mtHsp70&#39;s ATPase cycles power translocation; &#34;protein-folding chaperone binding&#34; captures this mtHsp70-binding activity. This is an informative MF, not an uninformative &#34;protein binding&#34; term.
+                        </div>
+
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    UniProt:O02161
+
+                                </span>
+
+                                <div class="support-text">Recruits mitochondrial HSP70 to drive protein translocation into the matrix using ATP as an energy source</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/35608535" target="_blank" class="term-link">
+                                        PMID:35608535
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">the precursor proteins are pulled into the matrix by TIM44 and mtHSP70 (HSP-6)</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005743" target="_blank" class="term-link">
+                                    GO:0005743
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial inner membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000044
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O02161" data-a="GO:0005743" data-r="GO_REF:0000044" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct core subcellular location: tin-44 acts at the mitochondrial inner membrane as part of the TIM23-associated import motor, consistent with the UniProt Swiss-Prot location. The precise submitochondrial disposition of the worm protein (integral vs. peripheral/matrix-side) is unverified — see the annotation-level knowledge gap — but the inner-membrane compartment assignment is appropriate.
+                        </div>
+
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    UniProt:O02161
+
+                                </span>
+
+                                <div class="support-text">Mitochondrion inner membrane</div>
+
+                            </div>
+
+                        </div>
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Knowledge gap:</div>
+
+                            <div class="support-item">
+                                <div>The submitochondrial topology of C. elegans TIN-44 is unverified. It is assigned to the mitochondrial inner membrane by ortholog/subcellular-mapping inference, but whether the worm protein is an integral inner-membrane protein, a peripheral protein on the matrix face of the TIM23 channel, or (as reported for the human ortholog) a matrix-localized protein only loosely associated with the inner membrane has not been tested.
+                                    <span class="badge">OPEN</span>
+                                    <span class="badge">BIOLOGY</span>
+                                    <span class="badge">RESIDUAL_SUBGAP</span>
+                                </div>
+
+                                <div class="support-text"><strong>Resolve:</strong> Sub-mitochondrial fractionation (alkaline/carbonate extraction, protease-protection) of endogenous or tagged worm TIN-44 to determine integral vs. peripheral membrane association and matrix vs. inner-membrane localization.</div>
+
+
+
+                                <div class="support-text"><em>"hTim44 is localized in the matrix and, in contrast to yeast, only loosely associated with the inner membrane"</em> — PMID:10339406</div>
+
+                                <div class="support-text"><em>"Mitochondrion inner membrane"</em> — UniProt:O02161</div>
+
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030150" target="_blank" class="term-link">
+                                    GO:0030150
+                                </a>
+                            </span>
+                            <span class="term-label">protein import into mitochondrial matrix</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O02161" data-a="GO:0030150" data-r="GO_REF:0000002" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Same core biological process as the IBA annotation above, here inferred electronically by InterPro2GO from the Tim44 family signature (IPR017303). Correct and consistent; redundant with the phylogenetic annotation but not wrong.
+                        </div>
+
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    UniProt:O02161
+
+                                </span>
+
+                                <div class="support-text">translocation of transit peptide-containing proteins from the inner membrane into the mitochondrial matrix in an ATP-dependent manner</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051087" target="_blank" class="term-link">
+                                    GO:0051087
+                                </a>
+                            </span>
+                            <span class="term-label">protein-folding chaperone binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O02161" data-a="GO:0051087" data-r="GO_REF:0000002" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Same core molecular function as the IBA annotation above, here inferred electronically by InterPro2GO from the Tim44 family signature (IPR017303). Captures the conserved mtHsp70-binding activity of Tim44; correct and consistent.
+                        </div>
+
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    UniProt:O02161
+
+                                </span>
+
+                                <div class="support-text">Recruits mitochondrial HSP70 to drive protein translocation into the matrix using ATP as an energy source</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>Organizing subunit of the mitochondrial presequence translocase-associated import motor (PAM): binds and tethers mitochondrial HSP70 (mtHsp70/HSP-6) at the matrix face of the TIM23 channel and, together with its co-chaperones, couples ATP-driven mtHsp70 cycles to the import of nucleus-encoded, presequence-bearing preproteins into the mitochondrial matrix. In C. elegans this activity is inferred from the conserved yeast/human Tim44 ortholog; direct worm evidence establishes tin-44 as a co-regulated component of the mitochondrial import machinery acting at the matrix-pulling step with mtHsp70/HSP-6.</h3>
+                <span class="vote-buttons" data-g="O02161" data-a="FUNCTION: Organizing subunit of the mitochondrial presequenc..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051087" target="_blank" class="term-link">
+                            protein-folding chaperone binding
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030150" target="_blank" class="term-link">
+                                protein import into mitochondrial matrix
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005743" target="_blank" class="term-link">
+                                mitochondrial inner membrane
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">In Complex:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0001405" target="_blank" class="term-link">
+                            PAM complex, Tim23 associated import motor
+                        </a>
+                    </span>
+                </div>
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            UniProt:O02161
+
+                        </span>
+
+                        <div class="finding-text">Recruits mitochondrial HSP70 to drive protein translocation into the matrix using ATP as an energy source</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/35608535" target="_blank" class="term-link">
+                                PMID:35608535
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">the precursor proteins are pulled into the matrix by TIM44 and mtHSP70 (HSP-6)</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000002.md" target="_blank" class="term-link">
+                            GO_REF:0000002
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation through association of InterPro records with GO terms</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
+                            GO_REF:0000033
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Annotation inferences using phylogenetic trees</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
+                            GO_REF:0000044
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/35608535" target="_blank" class="term-link">
+                            PMID:35608535
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">The UPRmt preserves mitochondrial import to extend lifespan.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/24662282" target="_blank" class="term-link">
+                            PMID:24662282
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Activation of the mitochondrial unfolded protein response does not predict longevity in Caenorhabditis elegans.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/10339406" target="_blank" class="term-link">
+                            PMID:10339406
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Genetic and structural characterization of the human mitochondrial inner membrane translocase.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        UniProt:O02161
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Probable mitochondrial import inner membrane translocase subunit tin-44 (C. elegans)</div>
+
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Questions for Experts</h2>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Does C. elegans TIN-44 bind mitochondrial HSP70 (HSP-6) directly and tether it to the TIM23 channel, as demonstrated for yeast and human Tim44?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="O02161" data-a="Q: Does C. elegans TIN-44 bind mitochondrial HSP70 (H..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Is tin-44 essential in C. elegans, and how does a genetic null differ from RNAi knockdown in developmental and mitochondrial-import phenotypes?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="O02161" data-a="Q: Is tin-44 essential in C. elegans, and how does a ..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Is worm TIN-44 an integral inner-membrane protein or a peripheral/matrix protein, given that the human ortholog is matrix-localized and only loosely membrane-associated?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="O02161" data-a="Q: Is worm TIN-44 an integral inner-membrane protein ..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Experiments</h2>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Reconstitute or co-immunoprecipitate recombinant/tagged worm TIN-44 with HSP-6 and test direct binding; deplete tin-44 (RNAi or null) and quantify import of a matrix-targeted reporter (e.g. su9-DHFR or MTS::GFP) relative to wild type.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: C. elegans TIN-44 is a bona fide import-motor subunit that binds mtHsp70 (HSP-6) and is required for matrix protein import.</em></p>
+
+
+                    <p style="margin-top: 0.5rem;">Type: biochemical interaction / in-organello import assay</p>
+
+                </div>
+                <span class="vote-buttons" data-g="O02161" data-a="EXPERIMENT: Reconstitute or co-immunoprecipitate recombinant/t..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Generate a tin-44 deletion allele (CRISPR) and score viability, developmental arrest, and UPRmt (hsp-6p::gfp) activation; compare with the milder phenotypes of outer-membrane receptor knockdowns.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: tin-44 is essential for C. elegans viability, like mammalian TIMM44.</em></p>
+
+
+                    <p style="margin-top: 0.5rem;">Type: genetics / phenotypic analysis</p>
+
+                </div>
+                <span class="vote-buttons" data-g="O02161" data-a="EXPERIMENT: Generate a tin-44 deletion allele (CRISPR) and sco..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Knowledge Gaps</h2>
+        <p style="color: #555; font-size: 0.92rem; margin-top: -0.3rem;">
+            What is <em>not</em> known — curated, literature-grounded statements of the open
+            unknowns (the inverse of core functions).
+        </p>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The molecular activity of C. elegans TIN-44 has never been directly measured. Its recruitment/tethering of mitochondrial HSP70 (HSP-6), its role as the scaffold that organizes the PAM import motor, and the coupling of mtHsp70 ATPase cycles to matrix translocation are all inferred from yeast and human Tim44. No worm biochemistry, protein-interaction, structural, or in-vitro import-assay data exist for the TIN-44 protein itself; the direct worm data are only genetic/transcriptional (RNAi that induces the UPRmt and stress co-regulation of the tin-44 transcript), which report import stress rather than the protein&#39;s activity.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span><span class="badge">CURATION</span>
+                <span class="badge">MF_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> It is firmly established that tin-44 is the C. elegans Tim44-family ortholog (IPR017303, PANTHER PTHR10721), that it is a component of the mitochondrial import machinery, that its RNAi knockdown behaves as an import-defect that activates the UPRmt (Bennett et al. 2014), and that it is transcriptionally co-regulated with mtHsp70/hsp-6 and the MPP subunits during the UPRmt (Xin et al. 2022). The PAM/import-motor mechanism — Tim44 as the membrane- associated mtHsp70 recruiter driving matrix translocation — is well characterized in yeast and human. What is missing is any assay of the worm protein&#39;s own activity.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> tin-44 is treated as a housekeeping component of the mitochondrial import motor in worm UPRmt/aging studies, yet whether the worm protein reproduces the mtHsp70-tethering and import-motor-organizing activities of its orthologs — or has any organism-specific features — is untested. Anchoring the molecular function in worm data would strengthen the interpretation of the mitochondrial-proteostasis literature that relies on this gene.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> In vitro reconstitution / interaction assays with recombinant worm TIN-44 and HSP-6 (mtHsp70) to demonstrate direct binding and stimulation of import; tagging endogenous TIN-44 to test co-assembly with tim-23/tim-16/dnj-21 and requirement in an in-organello or in-vitro import assay.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"Probable mitochondrial import inner membrane translocase subunit tin-44"</em> — UniProt:O02161</li>
+
+                <li><em>"which are C. elegans homologs of mammalian mtHsp70, tim44, and Mpp, respectively, were also upregulated by cco-1 RNAi"</em> — PMID:35608535</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The molecular consequences and essentiality of tin-44 loss in C. elegans have not been directly characterized. The only worm loss-of-function data are indirect: tin-44/T09B4.9 RNAi behaves as a mitochondrial-import knockdown that activates the UPRmt (hsp-6p::gfp) and shortens lifespan. No tin-44 null/deletion allele has been analyzed, its essentiality (the mammalian TIMM44 is essential) is untested, and no assay has directly measured how tin-44 depletion affects mitochondrial protein-import capacity or which preprotein classes depend on it.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">RESIDUAL_SUBGAP</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> tin-44 was recovered as an hsp-6p::gfp UPRmt-inducing RNAi clone and grouped with the lifespan-shortening mitochondrial-import knockdowns (tomm-22, TIM17/TIM16/TIM23/TIM14) (Bennett et al. 2014); UniProt still classifies the protein at evidence level &#34;Inferred from homology&#34; with the hedged name &#34;Probable&#34; import-motor subunit. These readouts report import stress, not the direct requirement for, or activity of, TIN-44.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Establishing the null phenotype and a direct import requirement would convert tin-44 from a by-similarity assignment supported only by stress-reporter readouts into an experimentally grounded import-motor gene, and clarify its place in the C. elegans mitochondrial-import and UPRmt network.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Characterize a tin-44 deletion/null allele for viability and developmental arrest, and quantify mitochondrial protein-import capacity on tin-44 depletion (e.g. MTS::GFP or su9-DHFR import) alongside UPRmt (hsp-6p::gfp) activation.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"Probable mitochondrial import inner membrane translocase subunit tin-44"</em> — UniProt:O02161</li>
+
+                <li><em>"a subset of RNAi clones related to mitochondrial protein import (tomm-22, E04A4.5, T09B4.9, F45G2.8, F15D3.7, and dnj-21)"</em> — PMID:24662282</li>
+
+            </ul>
+
+
+        </div>
+
+    </div>
+
+
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Deep Research Sections -->
+
+    <div class="section">
+        <h2 class="section-title">Deep Research</h2>
+
+        <details class="deep-research-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; gap: 1rem;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Falcon</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(tin-44-deep-research-falcon.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="O02161" data-a="DEEP_RESEARCH: Falcon" data-r="" data-act="DEEP_RESEARCH" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This deep research is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This deep research needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+
+                <div class="report-meta">
+
+                    <span class="report-meta-text">Comprehensive Research Report: *C. elegans* TIN-44 (T09B4.9) — Probable Mitochondrial Import Inner Membrane Translocase Subunit Tim44</span>
+
+
+                    <span class="report-badge">Falcon</span>
+
+
+                    <span class="report-badge">Edison Scientific Literature</span>
+
+
+                    <span class="report-badge">37 citations</span>
+
+
+                    <span class="report-badge">3 artifacts</span>
+
+
+                    <span class="report-meta-text">2026-07-04T13:55:51.639205</span>
+
+
+
+                </div>
+
+
+                <div class="artifact-list">
+
+
+
+                    <div class="artifact-link">
+                        <a href="tin-44-deep-research-falcon_artifacts/artifact-00.md" class="term-link">Edison artifact artifact-00</a>
+                        <span>(text/markdown)</span>
+                    </div>
+
+
+
+
+                    <div class="artifact-link">
+                        <a href="tin-44-deep-research-falcon_artifacts/artifact-01.md" class="term-link">Edison artifact artifact-01</a>
+                        <span>(text/markdown)</span>
+                    </div>
+
+
+
+
+                    <div class="artifact-link">
+                        <a href="tin-44-deep-research-falcon_artifacts/image-1.png" class="term-link">Image artifact created (ID artifact-01): &#39;TIM23-Tim44 Import Pathways&#39; ![TIM23-Tim44 Import Pathways](artifact:artifact-01) Artifact IDs that may be injected in</a>
+                        <span>(image/png)</span>
+                    </div>
+
+
+                </div>
+
+                <p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h1 id="comprehensive-research-report-c-elegans-tin-44-t09b49-probable-mitochondrial-import-inner-membrane-translocase-subunit-tim44">Comprehensive Research Report: <em>C. elegans</em> TIN-44 (T09B4.9) — Probable Mitochondrial Import Inner Membrane Translocase Subunit Tim44</h1>
+<h2 id="1-gene-identity-and-protein-overview">1. Gene Identity and Protein Overview</h2>
+<p>The <em>C. elegans</em> gene <strong>tin-44</strong> (ORF name T09B4.9; UniProt accession O02161) encodes a probable mitochondrial import inner membrane translocase subunit of the Tim44 family. The protein is annotated as a precursor with a cleavable N-terminal presequence, consistent with mitochondrial matrix-targeted proteins. Key domains include the Tim44 domain (PF04280/IPR007379), Tim44-like domain (IPR039544), and an NTF2-like domain superfamily fold (IPR032710). No dedicated primary study has been published on the <em>C. elegans</em> TIN-44 protein; however, considerable functional information can be derived from genome-wide screens in <em>C. elegans</em> and from extensive mechanistic studies on its yeast and mammalian orthologs, which are highly conserved.</p>
+<h2 id="2-primary-function-scaffold-protein-in-the-tim23-associated-import-motor-pam-complex">2. Primary Function: Scaffold Protein in the TIM23-Associated Import Motor (PAM Complex)</h2>
+<h3 id="21-molecular-function-of-tim44-family-proteins">2.1 Molecular Function of Tim44-Family Proteins</h3>
+<p>Tim44 is not an enzyme or transporter in the classical sense; rather, it is a <strong>peripheral membrane scaffold protein</strong> that resides on the matrix face of the inner mitochondrial membrane (IMM). Its primary function is to tether the presequence translocase-associated motor (PAM) complex to the TIM23 protein-conducting channel, thereby enabling ATP-dependent translocation of presequence-containing precursor proteins into the mitochondrial matrix (chaudhuri2020tim17updatesa pages 2-5, paschen2001proteinimportinto pages 5-7, fox2012mitochondrialproteinsynthesis pages 14-15).</p>
+<p>Tim44 performs several critical molecular functions:</p>
+<ol>
+<li>
+<p><strong>Recruitment of mtHsp70</strong>: Tim44 serves as the docking site for mitochondrial Hsp70 (mtHsp70/Ssc1 in yeast, mortalin/HSPA9 in humans), the ATP-driven motor chaperone that binds incoming polypeptide segments emerging from the TIM23 channel and prevents their retrograde movement (paschen2001proteinimportinto pages 5-7, bauer2000proteintranslocationinto pages 1-2).</p>
+</li>
+<li>
+<p><strong>Bridging TIM23 channel and PAM motor</strong>: Tim44 makes direct contacts with the integral membrane channel subunits Tim17 and Tim23 while simultaneously recruiting soluble motor components (mtHsp70 and nucleotide exchange factor Mge1), thereby physically linking the translocation channel to the import driving force (chaudhuri2020tim17updatesa pages 2-5, jain2025investigatingmitochondrialpresequence pages 15-17).</p>
+</li>
+<li>
+<p><strong>Differential regulation of motor subunits</strong>: Studies using the yeast temperature-sensitive mutant <em>tim44-804</em> have revealed that Tim44 is not merely a passive scaffold but actively regulates recruitment of distinct PAM modules. Tim44 promotes association of the J-complex (Pam18/Pam16) with the TIM23 complex while simultaneously keeping Pam17 binding at low levels. Inactivation of Tim44 leads to increased Pam17 binding, indicating both stimulatory and inhibitory regulatory functions (hutu2008mitochondrialproteinimport pages 7-7, hutu2008mitochondrialproteinimport pages 1-2).</p>
+</li>
+<li>
+<p><strong>Presequence interaction</strong>: The C-terminal domain of Tim44 can directly interact with incoming presequences, helping to guide precursor proteins toward the motor machinery (jain2025investigatingmitochondrialpresequence pages 15-17).</p>
+</li>
+</ol>
+<h3 id="22-two-functional-forms-of-the-tim23-complex">2.2 Two Functional Forms of the TIM23 Complex</h3>
+<p>The TIM23 complex exists in two functionally distinct configurations, and Tim44 is specifically associated with the motor form:</p>
+<ul>
+<li><strong>TIM23-SORT</strong>: Contains Tim21 but lacks the PAM complex. This form mediates lateral insertion of proteins with hydrophobic sorting signals into the inner membrane in a PAM-independent manner (laan2006mitochondrialpreproteintranslocases pages 7-8, hutu2008mitochondrialproteinimport pages 3-4).</li>
+<li><strong>TIM23-MOTOR</strong>: Lacks Tim21 but contains the full PAM complex including Tim44. This form is required for ATP-dependent translocation of soluble proteins into the matrix (jain2025investigatingmitochondrialpresequence pages 20-23, laan2006mitochondrialpreproteintranslocases pages 5-7, laan2006mitochondrialpreproteintranslocases pages 7-8).</li>
+</ul>
+<p>Consistent with this model, the yeast <em>tim44-804</em> mutant strongly inhibits import of matrix-targeted precursor proteins (such as the F1Fo-ATPase β-subunit) while import of inner membrane-sorted proteins remains unaffected (hutu2008mitochondrialproteinimport pages 3-4).</p>
+<p>The following schematic illustrates the two TIM23 configurations and the central role of Tim44 in the motor form:</p>
+<p><img alt="TIM23-Tim44 Import Pathways" src="artifact:artifact-01" /></p>
+<p><em>Image: Schematic of mitochondrial presequence import showing the TIM23 complex in its sorting and motor forms. The diagram highlights Tim44 as the matrix-side scaffold that recruits the PAM motor, including mtHsp70, for ATP-dependent matrix import.</em></p>
+<h2 id="3-subcellular-localization">3. Subcellular Localization</h2>
+<p>Tim44 is a <strong>hydrophilic, peripheral membrane protein</strong> associated with the inner face (matrix side) of the inner mitochondrial membrane (bauer2000proteintranslocationinto pages 1-2, paschen2001proteinimportinto pages 3-5). It lacks a classical hydrophobic transmembrane segment but contains a cleavable N-terminal mitochondrial targeting presequence. Tim44 associates with the membrane through interactions with the phospholipid cardiolipin and with integral membrane subunits Tim17 and Tim23 (bauer2000proteintranslocationinto pages 1-2, jain2025investigatingmitochondrialpresequence pages 15-17). In yeast, Tim44 exists as a dimer at the matrix side of the TIM23 complex, mediated by coiled-coil domains in its N-terminal region (bauer2000proteintranslocationinto pages 1-2, paschen2001proteinimportinto pages 5-7).</p>
+<h2 id="4-protein-structure-and-domain-architecture">4. Protein Structure and Domain Architecture</h2>
+<p>Tim44 has a modular architecture:<br />
+- <strong>N-terminal mitochondrial targeting presequence</strong>: Cleaved upon import into the matrix.<br />
+- <strong>N-terminal segment with intrinsically disordered region</strong>: Interacts with incoming presequences, Hsp70, Pam16, and Tim23 to guide precursor proteins (jain2025investigatingmitochondrialpresequence pages 15-17).<br />
+- <strong>Coiled-coil domains</strong> in the N-terminal half: Mediate dimerization (bauer2000proteintranslocationinto pages 1-2).<br />
+- <strong>C-terminal domain</strong> (containing the Tim44/NTF2-like fold): Interacts with presequences, mtHsp70, other PAM subunits, and the membrane itself. This is also the domain targeted by the pharmacological inhibitor MB-10 (jain2025investigatingmitochondrialpresequence pages 15-17, zhang2024afirstinclasstimm44 pages 1-2).</p>
+<p>Recent cryo-EM studies of the TIM23 complex core (Tim17-Tim23 heterodimer) noted that Tim44 tends to dissociate during purification, underscoring its peripheral/dynamic association with the translocase rather than forming a stably integrated structural component (sim2023structuralbasisof pages 1-4).</p>
+<h2 id="5-functional-evidence-in-c-elegans">5. Functional Evidence in <em>C. elegans</em></h2>
+<h3 id="51-rnai-phenotype-and-uprmt-activation">5.1 RNAi Phenotype and UPRmt Activation</h3>
+<p>Although no dedicated loss-of-function mutant study exists for <em>C. elegans</em> tin-44, the gene has been identified in multiple genome-wide RNAi screens:</p>
+<ul>
+<li>
+<p>In a <strong>genome-wide RNAi screen for negative regulators of the mitochondrial unfolded protein response (UPRmt)</strong>, Bennett et al. (2014) found that RNAi knockdown of T09B4.9 (tin-44) significantly induced expression of the <em>hsp-6p::gfp</em> UPRmt reporter and extended mean lifespan by <strong>11.1%</strong> (P = 2.4 × 10⁻¹⁴) (bennett2014activationofthe pages 2-3). However, the same study demonstrated that UPRmt activation is neither necessary nor sufficient for lifespan extension, and that some mitochondrial import gene knockdowns (including tin-44) that induce UPRmt actually reduced longevity in certain experimental contexts (bennett2014activationofthe pages 6-6).</p>
+</li>
+<li>
+<p>Hernando-Rodríguez and Artal-Sanz (2018) identified TIN-44 among mitochondrial import factors (alongside TOMM-22, DNJ-21, TIMM-17B.1, and TIMM-23) whose RNAi depletion induces mitochondrial stress responses in <em>C. elegans</em> (hernandorodriguez2018mitochondrialqualitycontrol pages 6-8).</p>
+</li>
+</ul>
+<h3 id="52-transcriptional-regulation-under-mitochondrial-stress">5.2 Transcriptional Regulation Under Mitochondrial Stress</h3>
+<p>Xin et al. (2022) demonstrated that upon UPRmt activation, the <em>C. elegans</em> mitochondrial import machinery is transcriptionally upregulated in an ATFS-1-dependent manner. Specifically, <strong>tin-44</strong> was among the import genes (alongside <em>hsp-6</em>, <em>mppa-1</em>, <em>mppb-1</em>, and <em>timm-23</em>) that are induced during mitochondrial stress, indicating a compensatory feedback mechanism to maintain import capacity under proteotoxic conditions (xin2022theuprmtpreserves pages 6-9).</p>
+<h3 id="53-role-in-the-uprmt-signaling-pathway">5.3 Role in the UPRmt Signaling Pathway</h3>
+<p>The connection between tin-44 and UPRmt is mechanistically coherent: the transcription factor ATFS-1 contains both a mitochondrial targeting sequence (MTS) and a nuclear localization signal. Under normal conditions, ATFS-1 is imported into mitochondria and degraded by the Lon protease. When mitochondrial import is compromised—including by depletion of import machinery components like TIN-44—ATFS-1 fails to be imported, accumulates in the cytosol, and translocates to the nucleus where it activates UPRmt gene expression (rolland2019compromisedmitochondrialprotein pages 1-2, hernandorodriguez2018mitochondrialqualitycontrol pages 3-5, xin2022theuprmtpreserves pages 1-2). Rolland et al. (2019) established that compromised mitochondrial protein import acts as a direct signal for UPRmt activation through this ATFS-1-dependent mechanism (rolland2019compromisedmitochondrialprotein pages 5-7, rolland2019compromisedmitochondrialprotein pages 1-2).</p>
+<h2 id="6-comparative-functional-summary">6. Comparative Functional Summary</h2>
+<p>The following table summarizes the key functional properties of TIN-44 and its orthologs:</p>
+<table>
+<thead>
+<tr>
+<th>Property</th>
+<th>C. elegans TIN-44</th>
+<th>Yeast Tim44</th>
+<th>Human TIMM44</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Gene name / synonym</td>
+<td><strong>tin-44</strong>; ORF <strong>T09B4.9</strong>; annotated as probable mitochondrial import inner membrane translocase subunit tin-44 (UniProt O02161) (bennett2014activationofthe pages 2-3)</td>
+<td><strong>Tim44</strong>; classic fungal TIM23/PAM motor subunit (bauer2000proteintranslocationinto pages 1-2, hutu2008mitochondrialproteinimport pages 3-4)</td>
+<td><strong>TIMM44</strong>; translocase of inner mitochondrial membrane 44 (OpenTargets Search: -TIMM44, zhang2024afirstinclasstimm44 pages 1-2)</td>
+</tr>
+<tr>
+<td>UniProt ID</td>
+<td><strong>O02161</strong> (user-provided target identity; consistent with T09B4.9/tin-44 annotation)</td>
+<td>Not directly established in gathered evidence</td>
+<td>Not directly established in gathered evidence</td>
+</tr>
+<tr>
+<td>Protein family</td>
+<td><strong>Tim44 family</strong>; inferred metazoan ortholog of mitochondrial import motor scaffold protein (bennett2014activationofthe pages 2-3, xin2022theuprmtpreserves pages 6-9)</td>
+<td>Tim44 family; docking/scaffold component of the PAM import motor associated with TIM23 (paschen2001proteinimportinto pages 5-7, laan2006mitochondrialpreproteintranslocases pages 5-7)</td>
+<td>TIMM44/Tim44 family; PAM-associated mitochondrial protein import factor (zhang2024afirstinclasstimm44 pages 1-2, michaelis2022proteinimportmotor pages 5-6)</td>
+</tr>
+<tr>
+<td>Subcellular localization</td>
+<td>Mitochondrial inner membrane import machinery; function inferred on the <strong>matrix side of the inner membrane</strong> from orthology and import-related phenotypes (bennett2014activationofthe pages 2-3, xin2022theuprmtpreserves pages 6-9)</td>
+<td><strong>Peripheral inner mitochondrial membrane protein</strong> on the <strong>matrix face</strong>; hydrophilic, membrane-associated, can interact with cardiolipin (bauer2000proteintranslocationinto pages 1-2, paschen2001proteinimportinto pages 3-5)</td>
+<td>Mitochondrial inner membrane import machinery / mitochondrial fraction; part of PAM/TIM23-associated import system (zhang2024afirstinclasstimm44 pages 1-2, zhang2024afirstinclasstimm44 pages 4-6)</td>
+</tr>
+<tr>
+<td>Primary function</td>
+<td>Likely <strong>scaffold/adaptor for matrix protein import</strong> through TIM23-PAM; required for efficient mitochondrial protein import, and its knockdown activates UPRmt (bennett2014activationofthe pages 2-3, xin2022theuprmtpreserves pages 6-9, rolland2019compromisedmitochondrialprotein pages 1-2)</td>
+<td><strong>Scaffold/docking protein</strong> that recruits <strong>mtHsp70</strong> and links the <strong>TIM23 channel</strong> to the <strong>PAM motor</strong> to drive ATP-dependent import of presequence-containing proteins into the matrix (chaudhuri2020tim17updatesa pages 2-5, paschen2001proteinimportinto pages 5-7)</td>
+<td>Essential mitochondrial import factor; supports <strong>pre-protein import</strong>, mitochondrial integrity, respiration/ATP production, and in cancer cells supports Akt-mTOR-linked growth programs (zhang2024afirstinclasstimm44 pages 1-2, zhang2024afirstinclasstimm44 pages 12-13, zhang2024afirstinclasstimm44 pages 10-12)</td>
+</tr>
+<tr>
+<td>Complex membership</td>
+<td>Inferred member of the <strong>TIM23/PAM mitochondrial import machinery</strong> in worms (bennett2014activationofthe pages 2-3, xin2022theuprmtpreserves pages 6-9)</td>
+<td>Part of <strong>TIM23MOTOR/PAM</strong>; distinguishes matrix-import motor form from TIM23SORT form (jain2025investigatingmitochondrialpresequence pages 20-23, laan2006mitochondrialpreproteintranslocases pages 5-7, laan2006mitochondrialpreproteintranslocases pages 7-8)</td>
+<td>Component of the <strong>PAM complex</strong> associated with TIM23 (zhang2024afirstinclasstimm44 pages 1-2, michaelis2022proteinimportmotor pages 5-6)</td>
+</tr>
+<tr>
+<td>Key interactions</td>
+<td>Functional association with mitochondrial import machinery and UPRmt signaling; transcriptionally co-upregulated with import genes such as <strong>timm-23</strong>, <strong>mppa-1</strong>, <strong>mppb-1</strong> during UPRmt (xin2022theuprmtpreserves pages 6-9)</td>
+<td>Interacts with <strong>mtHsp70</strong>, <strong>Mge1</strong>, <strong>Tim17</strong>, <strong>Tim23</strong>, <strong>Pam16/Pam18/Pam17</strong>, incoming presequences, and cardiolipin; recruits motor modules to the translocase (hutu2008mitochondrialproteinimport pages 7-7, hutu2008mitochondrialproteinimport pages 1-2, jain2025investigatingmitochondrialpresequence pages 15-17)</td>
+<td>Associated with <strong>TIMM23/TIM23</strong>, PAM components, and functionally linked to mitochondrial import and mitophagy signaling; MB-10 binds the <strong>C-terminal domain</strong> of TIMM44 (zhang2024afirstinclasstimm44 pages 1-2, zhang2024afirstinclasstimm44 pages 4-6, michaelis2022proteinimportmotor pages 5-6)</td>
+</tr>
+<tr>
+<td>Loss-of-function phenotype (RNAi / mutant)</td>
+<td><strong>RNAi induces hsp-6p::gfp UPRmt reporter</strong> and in one genome-wide screen increased mean lifespan by <strong>11.1%</strong>; import impairment is consistent with mitochondrial stress signaling (bennett2014activationofthe pages 2-3, bennett2014activationofthe pages 6-6). Reviews also place TIN-44 among import factors whose depletion induces mitochondrial stress and can reduce lifespan in some contexts (hernandorodriguez2018mitochondrialqualitycontrol pages 6-8)</td>
+<td><strong>Essential for matrix-targeted protein import</strong>; temperature-sensitive <strong>tim44-804</strong> strongly inhibits import of matrix-destined precursors while sparing inner-membrane sorting, showing a selective motor defect rather than gross TIM23 destruction (hutu2008mitochondrialproteinimport pages 3-4)</td>
+<td><strong>Genetic depletion</strong> or pharmacologic blockade (<strong>MB-10/MitoBloCK-10</strong>) causes mitochondrial depolarization, ROS increase, ATP reduction, apoptosis, and strong inhibition of bladder cancer cell growth; PAM sequestration involving TIMM44 can also reduce import and trigger mitophagy (zhang2024afirstinclasstimm44 pages 1-2, zhang2024afirstinclasstimm44 pages 6-8, michaelis2022proteinimportmotor pages 5-6)</td>
+</tr>
+<tr>
+<td>Disease associations</td>
+<td>No direct worm disease annotation; chiefly used as a model for mitochondrial import stress and UPRmt biology (bennett2014activationofthe pages 2-3, rolland2019compromisedmitochondrialprotein pages 1-2)</td>
+<td>Not applicable as a human disease gene; chiefly a mechanistic model for mitochondrial import (paschen2001proteinimportinto pages 5-7, hutu2008mitochondrialproteinimport pages 3-4)</td>
+<td>Open Targets reports associations with <strong>neurodegenerative disease</strong>, <strong>Parkinson disease</strong>, <strong>Alzheimer disease</strong>, <strong>multiple sclerosis</strong>, and <strong>lysosomal storage disease</strong>; recent work also implicates TIMM44 as a potential <strong>bladder cancer therapeutic target</strong> (OpenTargets Search: -TIMM44, zhang2024afirstinclasstimm44 pages 1-2)</td>
+</tr>
+</tbody>
+</table>
+<p><em>Table: This table compares key functional properties of C. elegans TIN-44 with its yeast and human orthologs. It highlights the conserved role of Tim44-family proteins in TIM23/PAM-mediated mitochondrial protein import and summarizes organism-specific phenotypes and disease relevance.</em></p>
+<h2 id="7-broader-biological-context-and-pathways">7. Broader Biological Context and Pathways</h2>
+<h3 id="71-mitochondrial-protein-import-pathway">7.1 Mitochondrial Protein Import Pathway</h3>
+<p>TIN-44 functions within the <strong>presequence import pathway</strong> (TIM23 pathway), the major route by which nuclear-encoded mitochondrial matrix proteins are imported. The pathway involves: (1) cytosolic recognition by chaperones; (2) passage through the TOM complex in the outer membrane; (3) transfer to the TIM23 complex in the inner membrane, driven by the membrane potential (Δψ); and (4) ATP-dependent pulling into the matrix by the PAM motor, in which Tim44 serves as the essential scaffold tethering mtHsp70 to the channel exit (paschen2001proteinimportinto pages 5-7, laan2006mitochondrialpreproteintranslocases pages 5-7, fox2012mitochondrialproteinsynthesis pages 11-13).</p>
+<h3 id="72-mitophagy-signaling">7.2 Mitophagy Signaling</h3>
+<p>In mammalian cells, the PAM complex containing TIMM44 has been implicated in mitophagy regulation. Michaelis et al. (2022) demonstrated that during mitochondrial protein misfolding, PAM components including TIMM44 dissociate from the TIM complex, reducing protein import and triggering mitophagy even in the absence of membrane depolarization. This establishes a novel mitophagy induction mechanism that is independent of the canonical PINK1 stabilization pathway (michaelis2022proteinimportmotor pages 5-6).</p>
+<h3 id="73-disease-relevance-of-the-tim44-family">7.3 Disease Relevance of the Tim44 Family</h3>
+<p>Human TIMM44 has been associated with several disease contexts:</p>
+<ul>
+<li>
+<p><strong>Cancer</strong>: TIMM44 is significantly overexpressed in bladder cancer tissues and cells. The first-in-class TIMM44 blocker MB-10 (MitoBloCK-10) binds the C-terminal domain of TIMM44, disrupts mitochondrial function (causing depolarization, oxidative stress, and ATP reduction), inhibits the Akt-mTOR pathway, and potently suppresses bladder cancer cell growth both <em>in vitro</em> and <em>in vivo</em> (zhang2024afirstinclasstimm44 pages 1-2, zhang2024afirstinclasstimm44 pages 12-13, zhang2024afirstinclasstimm44 pages 6-8).</p>
+</li>
+<li>
+<p><strong>Neurodegenerative diseases</strong>: OpenTargets database reports associations between TIMM44 and neurodegenerative diseases including Alzheimer's disease, Parkinson's disease, and multiple sclerosis, primarily through CRISPRi screening evidence in astrocyte models (OpenTargets Search: -TIMM44).</p>
+</li>
+<li>
+<p><strong>Diabetes</strong>: TIMM44 has been studied in the context of diabetic kidney disease and mitochondrial dysfunction in diabetes. Timm44 transgenic mice were used to study the effects of enhanced mitochondrial import on diabetic nephropathy (OpenTargets Search: -TIMM44).</p>
+</li>
+</ul>
+<h2 id="8-summary">8. Summary</h2>
+<p><em>C. elegans</em> <strong>tin-44</strong> (T09B4.9, UniProt O02161) encodes the nematode ortholog of the Tim44 family of mitochondrial protein import scaffold proteins. Based on extensive conservation within the Tim44 family and direct experimental evidence from <em>C. elegans</em> RNAi studies, TIN-44 functions as a <strong>peripheral inner mitochondrial membrane scaffold protein</strong> that tethers the PAM import motor to the TIM23 presequence translocase channel on the matrix side. Its primary role is to recruit mtHsp70 to the channel exit, enabling ATP-dependent vectorial translocation of presequence-containing precursor proteins into the mitochondrial matrix. TIN-44 is specifically required for the TIM23-MOTOR form of the translocase that drives matrix import, but not for the TIM23-SORT pathway that mediates lateral insertion into the inner membrane.</p>
+<p>In <em>C. elegans</em>, depletion of tin-44 by RNAi compromises mitochondrial protein import, which activates the mitochondrial unfolded protein response (UPRmt) through the ATFS-1 transcription factor pathway and can modulate lifespan. Conversely, UPRmt activation transcriptionally upregulates tin-44 expression as part of a compensatory response to maintain import capacity. The human ortholog TIMM44 has emerged as a potential therapeutic target in cancer, with the first-in-class blocker MB-10 demonstrating preclinical efficacy against bladder cancer. The Tim44 protein family thus represents a conserved, essential component of mitochondrial biogenesis whose dysfunction intersects with aging, stress signaling, and disease.</p>
+<p>References</p>
+<ol>
+<li>
+<p>(chaudhuri2020tim17updatesa pages 2-5): Minu Chaudhuri, Chauncey Darden, Fidel Soto Gonzalez, Ujjal K. Singha, Linda Quinones, and Anuj Tripathi. Tim17 updates: a comprehensive review of an ancient mitochondrial protein translocator. Biomolecules, 10:1643, Dec 2020. URL: https://doi.org/10.3390/biom10121643, doi:10.3390/biom10121643. This article has 26 citations.</p>
+</li>
+<li>
+<p>(paschen2001proteinimportinto pages 5-7): Stefan A. Paschen and Walter Neupert. Protein import into mitochondria. IUBMB Life, 52:101-112, Sep 2001. URL: https://doi.org/10.1080/15216540152845894, doi:10.1080/15216540152845894. This article has 150 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(fox2012mitochondrialproteinsynthesis pages 14-15): Thomas D Fox. Mitochondrial protein synthesis, import, and assembly. Genetics, 192:1203-1234, Dec 2012. URL: https://doi.org/10.1534/genetics.112.141267, doi:10.1534/genetics.112.141267. This article has 283 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(bauer2000proteintranslocationinto pages 1-2): Matthias F Bauer, Sabine Hofmann, Walter Neupert, and Michael Brunner. Protein translocation into mitochondria: the role of tim complexes. Trends in cell biology, 10 1:25-31, Jan 2000. URL: https://doi.org/10.1016/s0962-8924(99)01684-0, doi:10.1016/s0962-8924(99)01684-0. This article has 334 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(jain2025investigatingmitochondrialpresequence pages 15-17): Naintara Jain. Investigating Mitochondrial Presequence Import. PhD thesis, University Goettingen, 2025. URL: https://doi.org/10.53846/goediss-11596, doi:10.53846/goediss-11596.</p>
+</li>
+<li>
+<p>(hutu2008mitochondrialproteinimport pages 7-7): Dana P. Hutu, Bernard Guiard, Agnieszka Chacinska, Dorothea Becker, Nikolaus Pfanner, Peter Rehling, and Martin van der Laan. Mitochondrial protein import motor: differential role of tim44 in the recruitment of pam17 and j-complex to the presequence translocase. Molecular biology of the cell, 19 6:2642-9, Jun 2008. URL: https://doi.org/10.1091/mbc.e07-12-1226, doi:10.1091/mbc.e07-12-1226. This article has 104 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(hutu2008mitochondrialproteinimport pages 1-2): Dana P. Hutu, Bernard Guiard, Agnieszka Chacinska, Dorothea Becker, Nikolaus Pfanner, Peter Rehling, and Martin van der Laan. Mitochondrial protein import motor: differential role of tim44 in the recruitment of pam17 and j-complex to the presequence translocase. Molecular biology of the cell, 19 6:2642-9, Jun 2008. URL: https://doi.org/10.1091/mbc.e07-12-1226, doi:10.1091/mbc.e07-12-1226. This article has 104 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(laan2006mitochondrialpreproteintranslocases pages 7-8): Martin van der Laan, Michael Rissler, and Peter Rehling. Mitochondrial preprotein translocases as dynamic molecular machines. FEMS yeast research, 6 6:849-61, Sep 2006. URL: https://doi.org/10.1111/j.1567-1364.2006.00134.x, doi:10.1111/j.1567-1364.2006.00134.x. This article has 76 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(hutu2008mitochondrialproteinimport pages 3-4): Dana P. Hutu, Bernard Guiard, Agnieszka Chacinska, Dorothea Becker, Nikolaus Pfanner, Peter Rehling, and Martin van der Laan. Mitochondrial protein import motor: differential role of tim44 in the recruitment of pam17 and j-complex to the presequence translocase. Molecular biology of the cell, 19 6:2642-9, Jun 2008. URL: https://doi.org/10.1091/mbc.e07-12-1226, doi:10.1091/mbc.e07-12-1226. This article has 104 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(jain2025investigatingmitochondrialpresequence pages 20-23): Naintara Jain. Investigating Mitochondrial Presequence Import. PhD thesis, University Goettingen, 2025. URL: https://doi.org/10.53846/goediss-11596, doi:10.53846/goediss-11596.</p>
+</li>
+<li>
+<p>(laan2006mitochondrialpreproteintranslocases pages 5-7): Martin van der Laan, Michael Rissler, and Peter Rehling. Mitochondrial preprotein translocases as dynamic molecular machines. FEMS yeast research, 6 6:849-61, Sep 2006. URL: https://doi.org/10.1111/j.1567-1364.2006.00134.x, doi:10.1111/j.1567-1364.2006.00134.x. This article has 76 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(paschen2001proteinimportinto pages 3-5): Stefan A. Paschen and Walter Neupert. Protein import into mitochondria. IUBMB Life, 52:101-112, Sep 2001. URL: https://doi.org/10.1080/15216540152845894, doi:10.1080/15216540152845894. This article has 150 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(zhang2024afirstinclasstimm44 pages 1-2): Lifeng Zhang, Xiaokai Shi, Lei Zhang, Yuanyuan Mi, Li Zuo, and Shenglin Gao. A first-in-class timm44 blocker inhibits bladder cancer cell growth. Cell Death &amp; Disease, Mar 2024. URL: https://doi.org/10.1038/s41419-024-06585-x, doi:10.1038/s41419-024-06585-x. This article has 11 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(sim2023structuralbasisof pages 1-4): Sue Im Sim, Yuanyuan Chen, Diane L. Lynch, James C. Gumbart, and Eunyong Park. Structural basis of mitochondrial protein import by the tim23 complex. Nature, 621:620-626, Jun 2023. URL: https://doi.org/10.1038/s41586-023-06239-6, doi:10.1038/s41586-023-06239-6. This article has 113 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(bennett2014activationofthe pages 2-3): Christopher F. Bennett, Helen Vander Wende, Marissa Simko, Shannon Klum, Sarah Barfield, Haeri Choi, Victor V. Pineda, and Matt Kaeberlein. Activation of the mitochondrial unfolded protein response does not predict longevity in caenorhabditis elegans. Nature communications, 5:3483-3483, Mar 2014. URL: https://doi.org/10.1038/ncomms4483, doi:10.1038/ncomms4483. This article has 272 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(bennett2014activationofthe pages 6-6): Christopher F. Bennett, Helen Vander Wende, Marissa Simko, Shannon Klum, Sarah Barfield, Haeri Choi, Victor V. Pineda, and Matt Kaeberlein. Activation of the mitochondrial unfolded protein response does not predict longevity in caenorhabditis elegans. Nature communications, 5:3483-3483, Mar 2014. URL: https://doi.org/10.1038/ncomms4483, doi:10.1038/ncomms4483. This article has 272 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(hernandorodriguez2018mitochondrialqualitycontrol pages 6-8): Blanca Hernando-Rodríguez and Marta Artal-Sanz. Mitochondrial quality control mechanisms and the phb (prohibitin) complex. Cells, Nov 2018. URL: https://doi.org/10.3390/cells7120238, doi:10.3390/cells7120238. This article has 93 citations.</p>
+</li>
+<li>
+<p>(xin2022theuprmtpreserves pages 6-9): Nan Xin, Jenni Durieux, Chunxia Yang, Suzanne Wolff, Hyun-Eui Kim, and Andrew Dillin. The uprmt preserves mitochondrial import to extend lifespan. May 2022. URL: https://doi.org/10.1083/jcb.202201071, doi:10.1083/jcb.202201071. This article has 64 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(rolland2019compromisedmitochondrialprotein pages 1-2): Stéphane G. Rolland, Sandra Schneid, Melanie Schwarz, Elisabeth Rackles, Christian Fischer, Simon Haeussler, Saroj G. Regmi, Assa Yeroslaviz, Bianca Habermann, Dejana Mokranjac, Eric Lambie, and Barbara Conradt. Compromised mitochondrial protein import acts as a signal for uprmt. Cell Reports, 28:1659-1669.e5, Aug 2019. URL: https://doi.org/10.1016/j.celrep.2019.07.049, doi:10.1016/j.celrep.2019.07.049. This article has 184 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(hernandorodriguez2018mitochondrialqualitycontrol pages 3-5): Blanca Hernando-Rodríguez and Marta Artal-Sanz. Mitochondrial quality control mechanisms and the phb (prohibitin) complex. Cells, Nov 2018. URL: https://doi.org/10.3390/cells7120238, doi:10.3390/cells7120238. This article has 93 citations.</p>
+</li>
+<li>
+<p>(xin2022theuprmtpreserves pages 1-2): Nan Xin, Jenni Durieux, Chunxia Yang, Suzanne Wolff, Hyun-Eui Kim, and Andrew Dillin. The uprmt preserves mitochondrial import to extend lifespan. May 2022. URL: https://doi.org/10.1083/jcb.202201071, doi:10.1083/jcb.202201071. This article has 64 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(rolland2019compromisedmitochondrialprotein pages 5-7): Stéphane G. Rolland, Sandra Schneid, Melanie Schwarz, Elisabeth Rackles, Christian Fischer, Simon Haeussler, Saroj G. Regmi, Assa Yeroslaviz, Bianca Habermann, Dejana Mokranjac, Eric Lambie, and Barbara Conradt. Compromised mitochondrial protein import acts as a signal for uprmt. Cell Reports, 28:1659-1669.e5, Aug 2019. URL: https://doi.org/10.1016/j.celrep.2019.07.049, doi:10.1016/j.celrep.2019.07.049. This article has 184 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(OpenTargets Search: -TIMM44): Open Targets Query (-TIMM44, 5 results). Buniello, A. et al. (2025). Open Targets Platform: facilitating therapeutic hypotheses building in drug discovery. Nucleic Acids Research.</p>
+</li>
+<li>
+<p>(michaelis2022proteinimportmotor pages 5-6): Jonas Benjamin Michaelis, Melinda Elaine Brunstein, Süleyman Bozkurt, Ludovico Alves, Martin Wegner, Manuel Kaulich, Christian Pohl, and Christian Münch. Protein import motor complex reacts to mitochondrial misfolding by reducing protein import and activating mitophagy. Nature Communications, Sep 2022. URL: https://doi.org/10.1038/s41467-022-32564-x, doi:10.1038/s41467-022-32564-x. This article has 86 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(zhang2024afirstinclasstimm44 pages 4-6): Lifeng Zhang, Xiaokai Shi, Lei Zhang, Yuanyuan Mi, Li Zuo, and Shenglin Gao. A first-in-class timm44 blocker inhibits bladder cancer cell growth. Cell Death &amp; Disease, Mar 2024. URL: https://doi.org/10.1038/s41419-024-06585-x, doi:10.1038/s41419-024-06585-x. This article has 11 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(zhang2024afirstinclasstimm44 pages 12-13): Lifeng Zhang, Xiaokai Shi, Lei Zhang, Yuanyuan Mi, Li Zuo, and Shenglin Gao. A first-in-class timm44 blocker inhibits bladder cancer cell growth. Cell Death &amp; Disease, Mar 2024. URL: https://doi.org/10.1038/s41419-024-06585-x, doi:10.1038/s41419-024-06585-x. This article has 11 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(zhang2024afirstinclasstimm44 pages 10-12): Lifeng Zhang, Xiaokai Shi, Lei Zhang, Yuanyuan Mi, Li Zuo, and Shenglin Gao. A first-in-class timm44 blocker inhibits bladder cancer cell growth. Cell Death &amp; Disease, Mar 2024. URL: https://doi.org/10.1038/s41419-024-06585-x, doi:10.1038/s41419-024-06585-x. This article has 11 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(zhang2024afirstinclasstimm44 pages 6-8): Lifeng Zhang, Xiaokai Shi, Lei Zhang, Yuanyuan Mi, Li Zuo, and Shenglin Gao. A first-in-class timm44 blocker inhibits bladder cancer cell growth. Cell Death &amp; Disease, Mar 2024. URL: https://doi.org/10.1038/s41419-024-06585-x, doi:10.1038/s41419-024-06585-x. This article has 11 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(fox2012mitochondrialproteinsynthesis pages 11-13): Thomas D Fox. Mitochondrial protein synthesis, import, and assembly. Genetics, 192:1203-1234, Dec 2012. URL: https://doi.org/10.1534/genetics.112.141267, doi:10.1534/genetics.112.141267. This article has 283 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+</ol>
+<h2 id="artifacts">Artifacts</h2>
+<ul>
+<li><a href="tin-44-deep-research-falcon_artifacts/artifact-00.md">Edison artifact artifact-00</a></li>
+<li><a href="tin-44-deep-research-falcon_artifacts/artifact-01.md">Edison artifact artifact-01</a><br />
+<img alt="Image artifact created (ID artifact-01): 'TIM23-Tim44 Import Pathways' ![TIM23-Tim44 Import Pathways](artifact:artifact-01) Artifact IDs that may be injected in" src="tin-44-deep-research-falcon_artifacts/image-1.png" /></li>
+</ul>
+<h2 id="citations">Citations</h2>
+<ol>
+<li>jain2025investigatingmitochondrialpresequence pages 15-17</li>
+<li>hutu2008mitochondrialproteinimport pages 3-4</li>
+<li>bauer2000proteintranslocationinto pages 1-2</li>
+<li>sim2023structuralbasisof pages 1-4</li>
+<li>bennett2014activationofthe pages 2-3</li>
+<li>bennett2014activationofthe pages 6-6</li>
+<li>hernandorodriguez2018mitochondrialqualitycontrol pages 6-8</li>
+<li>xin2022theuprmtpreserves pages 6-9</li>
+<li>michaelis2022proteinimportmotor pages 5-6</li>
+<li>paschen2001proteinimportinto pages 5-7</li>
+<li>fox2012mitochondrialproteinsynthesis pages 14-15</li>
+<li>hutu2008mitochondrialproteinimport pages 7-7</li>
+<li>hutu2008mitochondrialproteinimport pages 1-2</li>
+<li>laan2006mitochondrialpreproteintranslocases pages 7-8</li>
+<li>jain2025investigatingmitochondrialpresequence pages 20-23</li>
+<li>laan2006mitochondrialpreproteintranslocases pages 5-7</li>
+<li>paschen2001proteinimportinto pages 3-5</li>
+<li>rolland2019compromisedmitochondrialprotein pages 1-2</li>
+<li>hernandorodriguez2018mitochondrialqualitycontrol pages 3-5</li>
+<li>xin2022theuprmtpreserves pages 1-2</li>
+<li>rolland2019compromisedmitochondrialprotein pages 5-7</li>
+<li>fox2012mitochondrialproteinsynthesis pages 11-13</li>
+<li>TIM23-Tim44 Import Pathways</li>
+<li>https://doi.org/10.3390/biom10121643,</li>
+<li>https://doi.org/10.1080/15216540152845894,</li>
+<li>https://doi.org/10.1534/genetics.112.141267,</li>
+<li>https://doi.org/10.1016/s0962-8924(99</li>
+<li>https://doi.org/10.53846/goediss-11596,</li>
+<li>https://doi.org/10.1091/mbc.e07-12-1226,</li>
+<li>https://doi.org/10.1111/j.1567-1364.2006.00134.x,</li>
+<li>https://doi.org/10.1038/s41419-024-06585-x,</li>
+<li>https://doi.org/10.1038/s41586-023-06239-6,</li>
+<li>https://doi.org/10.1038/ncomms4483,</li>
+<li>https://doi.org/10.3390/cells7120238,</li>
+<li>https://doi.org/10.1083/jcb.202201071,</li>
+<li>https://doi.org/10.1016/j.celrep.2019.07.049,</li>
+<li>https://doi.org/10.1038/s41467-022-32564-x,</li>
+</ol>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(tin-44-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="O02161" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="tin-44-c-elegans-research-notes">tin-44 (C. elegans) — research notes</h1>
+<p>Gene: <strong>tin-44</strong> (WormBase <code>T09B4.9</code>, WBGene00020383); UniProt <strong>O02161</strong> (TIM44_CAEEL).<br />
+Ortholog of human <strong>TIMM44</strong> / yeast <strong>Tim44</strong>. Protein Existence level <strong>PE=3 (Inferred from<br />
+homology)</strong> — the worm protein's own biochemistry has NOT been directly characterized.</p>
+<h2 id="summary-of-what-this-gene-is">Summary of what this gene is</h2>
+<p>TIM44 is the central organizing subunit of the <strong>presequence translocase-associated import<br />
+motor (PAM)</strong>, the ATP-driven engine on the matrix side of the TIM23 (presequence) translocase<br />
+that pulls nucleus-encoded, presequence-bearing preproteins across the mitochondrial inner<br />
+membrane into the matrix. TIM44 docks on the matrix face of the TIM23 channel and<br />
+recruits/tethers <strong>mitochondrial HSP70</strong> (mtHsp70; worm <strong>HSP-6</strong>) together with its regulatory<br />
+co-chaperones (J-protein Pam18/Tim14 = worm <strong>dnj-21</strong>, J-like Pam16/Tim16 = worm <strong>tim-16</strong>,<br />
+and nucleotide-exchange factor GrpE/Mge1), coupling cycles of mtHsp70 ATP binding/hydrolysis to<br />
+the vectorial (ratchet/motor) inward movement of the incoming polypeptide.</p>
+<h2 id="known-established">KNOWN (established)</h2>
+<ul>
+<li><strong>Family/orthology.</strong> tin-44 belongs to the Tim44 family (InterPro IPR017303 Tim44;<br />
+  Pfam PF04280; PANTHER PTHR10721 "MITOCHONDRIAL IMPORT INNER MEMBRANE TRANSLOCASE SUBUNIT<br />
+  TIM44"). Contains an NTF2-like C-terminal domain fold (IPR032710). [UniProt:O02161]</li>
+<li><strong>Worm identity + import-machinery membership + co-regulation (direct worm data).</strong><br />
+  Xin et al. 2022 (worm, full text) explicitly identify tin-44 as the C. elegans homolog of<br />
+  mammalian tim44 and place it in the matrix-pulling step of import:<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/35608535" title="After passing through the inner membrane pore formed by TIM17 and TIM23, the   precursor proteins are pulled into the matrix by TIM44 and mtHSP70 (HSP-6)">PMID:35608535</a> and<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/35608535" title="We found that hsp-6 and tin-44, as well as mppa-1 and mppb-1, which are   C. elegans homologs of mammalian mtHsp70, tim44, and Mpp, respectively, were also upregulated   by cco-1 RNAi">PMID:35608535</a>. i.e. tin-44 is transcriptionally co-induced with the rest of the TIM/TOM<br />
+  import machinery upon activation of the mitochondrial UPR (UPRmt).</li>
+<li><strong>Conserved PAM/import-motor mechanism (by-similarity basis).</strong> In yeast/human, matrix import<br />
+  requires Tim23/Tim17/Tim44 acting with mtHsp70:<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/10339406" title="translocation of preproteins into the matrix requires the membrane proteins   Tim23, Tim17 and Tim44, which drive translocation in cooperation with mtHsp70 and its   co-chaperone Mge1p">PMID:10339406</a>. Human Tim44 topology differs from yeast:<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/10339406" title="hTim44 is localized in the matrix and, in contrast to yeast, only loosely   associated with the inner membrane">PMID:10339406</a>.</li>
+<li><strong>UniProt curated FUNCTION/SUBUNIT (by similarity to human Q07914).</strong><br />
+  FUNCTION: "Essential component of the PAM complex ... Recruits mitochondrial HSP70 to drive<br />
+  protein translocation into the matrix using ATP as an energy source." SUBUNIT: "Probable<br />
+  component of the PAM complex at least composed of a mitochondrial HSP70 protein, GrpE, tin-44,<br />
+  tim-16 and tim-14/dnj-21. The complex interacts with the tim-23 component of the TIM23<br />
+  complex." SUBCELLULAR LOCATION: "Mitochondrion inner membrane {ECO:0000305}". [UniProt:O02161]</li>
+</ul>
+<h2 id="not-known-knowledge-gaps">NOT known (knowledge gaps)</h2>
+<ul>
+<li><strong>The molecular activity of worm TIN-44 has never been directly measured.</strong> Its recruitment/<br />
+  tethering of mtHsp70 (HSP-6), its role as the PAM scaffold, and the coupling of mtHsp70 ATPase<br />
+  cycles to matrix translocation are all inferred from yeast/human Tim44. The only direct worm<br />
+  evidence is transcriptional co-regulation (PMID:35608535); there is no worm biochemistry,<br />
+  interaction, structure, or import-assay data on the TIN-44 protein itself. (UniProt keeps the<br />
+  name "<strong>Probable</strong> mitochondrial import inner membrane translocase subunit" and all FUNCTION/<br />
+  SUBUNIT annotations at evidence ECO:0000250 "by similarity".)</li>
+<li><strong>Submitochondrial topology of worm TIN-44 is unverified.</strong> It is annotated to the<br />
+  mitochondrial <em>inner membrane</em>, but the human ortholog is matrix-localized and only <em>loosely</em><br />
+  membrane-associated (PMID:10339406); whether worm TIN-44 is peripheral on the matrix face or<br />
+  more tightly membrane-anchored is untested.</li>
+<li><strong>Loss-of-function phenotype / essentiality in C. elegans not characterized</strong> in the cached<br />
+  literature. (Mammalian TIMM44 is essential; worm phenotype not established here.)</li>
+</ul>
+<h2 id="existing-goa-annotations-6-review-plan">Existing GOA annotations (6) — review plan</h2>
+<ol>
+<li>GO:0001405 PAM complex, Tim23 associated import motor (CC, part_of, IBA) → <strong>ACCEPT</strong> (core complex membership)</li>
+<li>GO:0030150 protein import into mitochondrial matrix (BP, involved_in, IBA) → <strong>ACCEPT</strong> (core BP)</li>
+<li>GO:0051087 protein-folding chaperone binding (MF, enables, IBA) → <strong>ACCEPT</strong> (core MF — binds/tethers mtHsp70)</li>
+<li>GO:0005743 mitochondrial inner membrane (CC, located_in, IEA) → <strong>ACCEPT</strong> (core location; see topology caveat)</li>
+<li>GO:0030150 protein import into mitochondrial matrix (BP, involved_in, IEA/InterPro) → <strong>ACCEPT</strong> (same correct BP, InterPro2GO)</li>
+<li>GO:0051087 protein-folding chaperone binding (MF, enables, IEA/InterPro) → <strong>ACCEPT</strong> (same correct MF, InterPro2GO)</li>
+</ol>
+<p>No <code>protein binding</code>-type uninformative MF present. All 6 annotations are consistent with the<br />
+Tim44 family assignment and the conserved PAM function; none contradicted by worm data.</p>
+<h2 id="key-references">Key references</h2>
+<ul>
+<li><strong>PMID:35608535</strong> — Xin et al., "The UPRmt preserves mitochondrial import to extend lifespan"<br />
+  (worm, full text). Only direct-worm reference for tin-44: homolog identity + import-machinery<br />
+  membership + UPRmt co-induction. HIGH relevance.</li>
+<li><strong>PMID:10339406</strong> — Bauer et al. 1999, "Genetic and structural characterization of the human<br />
+  mitochondrial inner membrane translocase" (abstract only). Establishes the conserved<br />
+  Tim23/Tim17/Tim44 + mtHsp70 matrix-import mechanism and human Tim44 matrix/loose-membrane<br />
+  topology. MEDIUM relevance (by-similarity basis).</li>
+<li><strong>UniProt:O02161</strong> — Swiss-Prot record; curated FUNCTION/SUBUNIT (by similarity to human<br />
+  TIMM44 Q07914) and inner-membrane location.</li>
+<li><strong>PMID:24662282</strong> — Bennett et al. 2014, "Activation of the mitochondrial unfolded protein<br />
+  response does not predict longevity in C. elegans" (worm, full text). Direct worm RNAi data:<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/24662282" title="E04A4.5 (TIM17), T09B4.9 (TIM44), F45G2.8 (TIM16), F15D3.7 (TIM23), and   dnj-21 (TIM14), which function in the TIM23 complex that transports proteins into the inner   membrane and the matrix">PMID:24662282</a> and <a href="https://pubmed.ncbi.nlm.nih.gov/24662282" title="a subset of RNAi clones related to   mitochondrial protein import (tomm-22, E04A4.5, T09B4.9, F45G2.8, F15D3.7, and dnj-21)">PMID:24662282</a>.<br />
+  tin-44 (T09B4.9) was an hsp-6p::gfp UPRmt-inducing clone and is grouped with the<br />
+  lifespan-SHORTENING import knockdowns. HIGH relevance.</li>
+</ul>
+<h2 id="deep-research-provenance-falcon-verification">Deep research provenance / falcon verification</h2>
+<ul>
+<li>Falcon (Edison) deep research completed at 2026-07-04T13:55 (1210 s, 37 citations):<br />
+<code>tin-44-deep-research-falcon.md</code>. Verified as a real Edison output (proper frontmatter,<br />
+  real artifacts, real papers e.g. <code>xin2022theuprmtpreserves</code> = PMID:35608535,<br />
+<code>bennett2014activationofthe</code> = PMID:24662282). The perplexity-lite fallback failed (401<br />
+  quota), but the falcon file itself is genuine.</li>
+<li><strong>Falcon fact-check caveat:</strong> the falcon report asserted tin-44 RNAi "extended mean lifespan<br />
+  by 11.1% (P = 2.4 × 10⁻¹⁴)". This is a falcon ERROR — the cited Bennett 2014 full text<br />
+  instead places tin-44/T09B4.9 among RNAi clones that SIGNIFICANTLY REDUCED lifespan. The<br />
+  falcon claim was NOT used; only verbatim, verified quotes from the cached paper were used.</li>
+</ul>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: O02161
+gene_symbol: tin-44
+product_type: PROTEIN
+status: COMPLETE
+taxon:
+  id: NCBITaxon:6239
+  label: Caenorhabditis elegans
+description: &gt;-
+  tin-44 encodes the C. elegans ortholog of TIM44 (human TIMM44 / yeast Tim44), a component
+  of the mitochondrial protein-import machinery at the inner membrane. TIM44 is the central
+  organizing subunit of the presequence translocase-associated import motor (PAM), the
+  ATP-driven engine that pulls nucleus-encoded, presequence-bearing preproteins across the
+  inner membrane into the matrix after they emerge from the TIM23 channel. Positioned on the
+  matrix face of the TIM23 translocase, TIM44 recruits and tethers mitochondrial HSP70
+  (mtHsp70; HSP-6 in C. elegans) together with its regulatory co-chaperones — the J-protein
+  Pam18/Tim14 (dnj-21), the J-like Pam16/Tim16 (tim-16), and the nucleotide-exchange factor
+  GrpE/Mge1 — so that cycles of mtHsp70 ATP binding and hydrolysis are coupled to the
+  vectorial, ratchet-like inward movement of the incoming polypeptide. Through this motor,
+  TIM44/tin-44 supports import of the many nuclear-encoded matrix and inner-membrane proteins
+  that build and maintain mitochondria. In C. elegans, tin-44 is transcriptionally co-induced
+  with the rest of the TIM/TOM import machinery (including mtHsp70/hsp-6 and the mitochondrial
+  processing peptidase subunits) when the mitochondrial unfolded protein response is activated,
+  and its RNAi knockdown behaves as a mitochondrial protein-import defect.
+existing_annotations:
+- term:
+    id: GO:0001405
+    label: PAM complex, Tim23 associated import motor
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: part_of
+  review:
+    summary: &gt;-
+      Core cellular-component / complex-membership annotation. tin-44 is the C. elegans Tim44
+      ortholog (Tim44 family, IPR017303) and, like its yeast/human counterparts, a subunit of
+      the presequence translocase-associated import motor (PAM) that operates on the matrix
+      side of the TIM23 complex. The direct worm evidence places tin-44 in the matrix-pulling
+      step of import together with mtHsp70/HSP-6.
+    action: ACCEPT
+    supported_by:
+    - reference_id: UniProt:O02161
+      supporting_text: Essential component of the PAM complex
+    - reference_id: PMID:35608535
+      supporting_text: &gt;-
+        the precursor proteins are pulled into the matrix by TIM44 and mtHSP70 (HSP-6)
+- term:
+    id: GO:0030150
+    label: protein import into mitochondrial matrix
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Core biological-process annotation. As the PAM import-motor organizer, tin-44 functions
+      in the ATP-dependent import of presequence-bearing preproteins across the inner membrane
+      into the mitochondrial matrix. Direct worm genetics supports this process assignment:
+      Bennett et al. group tin-44/T09B4.9 (TIM44) with the TIM23-complex components that
+      transport proteins into the inner membrane and matrix, and tin-44 RNAi behaves as a
+      mitochondrial-import knockdown (activating the UPRmt and shortening lifespan).
+    action: ACCEPT
+    supported_by:
+    - reference_id: UniProt:O02161
+      supporting_text: &gt;-
+        translocation of transit peptide-containing proteins from the inner membrane into the
+        mitochondrial matrix in an ATP-dependent manner
+    - reference_id: PMID:24662282
+      supporting_text: &gt;-
+        T09B4.9 (TIM44), F45G2.8 (TIM16), F15D3.7 (TIM23), and dnj-21 (TIM14), which function
+        in the TIM23 complex that transports proteins into the inner membrane and the matrix
+    - reference_id: PMID:10339406
+      supporting_text: &gt;-
+        translocation of preproteins into the matrix requires the membrane proteins Tim23,
+        Tim17 and Tim44, which drive translocation in cooperation with mtHsp70 and its
+        co-chaperone Mge1p
+- term:
+    id: GO:0051087
+    label: protein-folding chaperone binding
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Core molecular-function annotation and the most specific MF available for a Tim44-family
+      protein. tin-44&#39;s defining biochemical activity is binding/tethering the mitochondrial
+      HSP70 chaperone (worm HSP-6) at the import channel so that mtHsp70&#39;s ATPase cycles power
+      translocation; &#34;protein-folding chaperone binding&#34; captures this mtHsp70-binding activity.
+      This is an informative MF, not an uninformative &#34;protein binding&#34; term.
+    action: ACCEPT
+    supported_by:
+    - reference_id: UniProt:O02161
+      supporting_text: &gt;-
+        Recruits mitochondrial HSP70 to drive protein translocation into the matrix using ATP
+        as an energy source
+    - reference_id: PMID:35608535
+      supporting_text: &gt;-
+        the precursor proteins are pulled into the matrix by TIM44 and mtHSP70 (HSP-6)
+- term:
+    id: GO:0005743
+    label: mitochondrial inner membrane
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000044
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Correct core subcellular location: tin-44 acts at the mitochondrial inner membrane as
+      part of the TIM23-associated import motor, consistent with the UniProt Swiss-Prot
+      location. The precise submitochondrial disposition of the worm protein (integral vs.
+      peripheral/matrix-side) is unverified — see the annotation-level knowledge gap — but the
+      inner-membrane compartment assignment is appropriate.
+    action: ACCEPT
+    supported_by:
+    - reference_id: UniProt:O02161
+      supporting_text: Mitochondrion inner membrane
+    knowledge_gaps:
+    - gap_statement: &gt;-
+        The submitochondrial topology of C. elegans TIN-44 is unverified. It is assigned to the
+        mitochondrial inner membrane by ortholog/subcellular-mapping inference, but whether the
+        worm protein is an integral inner-membrane protein, a peripheral protein on the matrix
+        face of the TIM23 channel, or (as reported for the human ortholog) a matrix-localized
+        protein only loosely associated with the inner membrane has not been tested.
+      boundary: &gt;-
+        UniProt assigns tin-44 to the mitochondrion inner membrane (ECO:0000305). For the human
+        ortholog, biochemical characterization showed hTim44 is matrix-localized and, unlike
+        yeast Tim44, only loosely membrane-associated (Bauer et al. 1999), so the family&#39;s
+        membrane disposition is not uniform across species and has never been measured in worm.
+      gap_kind:
+      - BIOLOGY
+      dark_aspect: RESIDUAL_SUBGAP
+      status: OPEN
+      significance: &gt;-
+        Whether TIN-44 is membrane-embedded or a peripheral/matrix protein affects how its
+        recruitment of mtHsp70 to the channel is interpreted and how import-motor assembly is
+        modeled in C. elegans.
+      resolution: &gt;-
+        Sub-mitochondrial fractionation (alkaline/carbonate extraction, protease-protection) of
+        endogenous or tagged worm TIN-44 to determine integral vs. peripheral membrane
+        association and matrix vs. inner-membrane localization.
+      provenance:
+      - reference_id: PMID:10339406
+        supporting_text: &gt;-
+          hTim44 is localized in the matrix and, in contrast to yeast, only loosely associated
+          with the inner membrane
+      - reference_id: UniProt:O02161
+        supporting_text: Mitochondrion inner membrane
+- term:
+    id: GO:0030150
+    label: protein import into mitochondrial matrix
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Same core biological process as the IBA annotation above, here inferred electronically by
+      InterPro2GO from the Tim44 family signature (IPR017303). Correct and consistent; redundant
+      with the phylogenetic annotation but not wrong.
+    action: ACCEPT
+    supported_by:
+    - reference_id: UniProt:O02161
+      supporting_text: &gt;-
+        translocation of transit peptide-containing proteins from the inner membrane into the
+        mitochondrial matrix in an ATP-dependent manner
+- term:
+    id: GO:0051087
+    label: protein-folding chaperone binding
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Same core molecular function as the IBA annotation above, here inferred electronically by
+      InterPro2GO from the Tim44 family signature (IPR017303). Captures the conserved
+      mtHsp70-binding activity of Tim44; correct and consistent.
+    action: ACCEPT
+    supported_by:
+    - reference_id: UniProt:O02161
+      supporting_text: &gt;-
+        Recruits mitochondrial HSP70 to drive protein translocation into the matrix using ATP
+        as an energy source
+core_functions:
+- description: &gt;-
+    Organizing subunit of the mitochondrial presequence translocase-associated import motor
+    (PAM): binds and tethers mitochondrial HSP70 (mtHsp70/HSP-6) at the matrix face of the
+    TIM23 channel and, together with its co-chaperones, couples ATP-driven mtHsp70 cycles to
+    the import of nucleus-encoded, presequence-bearing preproteins into the mitochondrial
+    matrix. In C. elegans this activity is inferred from the conserved yeast/human Tim44
+    ortholog; direct worm evidence establishes tin-44 as a co-regulated component of the
+    mitochondrial import machinery acting at the matrix-pulling step with mtHsp70/HSP-6.
+  molecular_function:
+    id: GO:0051087
+    label: protein-folding chaperone binding
+  directly_involved_in:
+  - id: GO:0030150
+    label: protein import into mitochondrial matrix
+  locations:
+  - id: GO:0005743
+    label: mitochondrial inner membrane
+  in_complex:
+    id: GO:0001405
+    label: PAM complex, Tim23 associated import motor
+  supported_by:
+  - reference_id: UniProt:O02161
+    supporting_text: &gt;-
+      Recruits mitochondrial HSP70 to drive protein translocation into the matrix using ATP as
+      an energy source
+  - reference_id: PMID:35608535
+    supporting_text: &gt;-
+      the precursor proteins are pulled into the matrix by TIM44 and mtHSP70 (HSP-6)
+proposed_new_terms: []
+knowledge_gaps:
+- gap_statement: &gt;-
+    The molecular activity of C. elegans TIN-44 has never been directly measured. Its
+    recruitment/tethering of mitochondrial HSP70 (HSP-6), its role as the scaffold that
+    organizes the PAM import motor, and the coupling of mtHsp70 ATPase cycles to matrix
+    translocation are all inferred from yeast and human Tim44. No worm biochemistry,
+    protein-interaction, structural, or in-vitro import-assay data exist for the TIN-44 protein
+    itself; the direct worm data are only genetic/transcriptional (RNAi that induces the UPRmt
+    and stress co-regulation of the tin-44 transcript), which report import stress rather than
+    the protein&#39;s activity.
+  boundary: &gt;-
+    It is firmly established that tin-44 is the C. elegans Tim44-family ortholog (IPR017303,
+    PANTHER PTHR10721), that it is a component of the mitochondrial import machinery, that its
+    RNAi knockdown behaves as an import-defect that activates the UPRmt (Bennett et al. 2014),
+    and that it is transcriptionally co-regulated with mtHsp70/hsp-6 and the MPP subunits during
+    the UPRmt (Xin et al. 2022). The PAM/import-motor mechanism — Tim44 as the membrane-
+    associated mtHsp70 recruiter driving matrix translocation — is well characterized in yeast
+    and human. What is missing is any assay of the worm protein&#39;s own activity.
+  gap_kind:
+  - BIOLOGY
+  - CURATION
+  dark_aspect: MF_DARK
+  status: OPEN
+  significance: &gt;-
+    tin-44 is treated as a housekeeping component of the mitochondrial import motor in worm
+    UPRmt/aging studies, yet whether the worm protein reproduces the mtHsp70-tethering and
+    import-motor-organizing activities of its orthologs — or has any organism-specific
+    features — is untested. Anchoring the molecular function in worm data would strengthen the
+    interpretation of the mitochondrial-proteostasis literature that relies on this gene.
+  resolution: &gt;-
+    In vitro reconstitution / interaction assays with recombinant worm TIN-44 and HSP-6
+    (mtHsp70) to demonstrate direct binding and stimulation of import; tagging endogenous
+    TIN-44 to test co-assembly with tim-23/tim-16/dnj-21 and requirement in an in-organello or
+    in-vitro import assay.
+  provenance:
+  - reference_id: UniProt:O02161
+    supporting_text: Probable mitochondrial import inner membrane translocase subunit tin-44
+  - reference_id: PMID:35608535
+    supporting_text: &gt;-
+      which are C. elegans homologs of mammalian mtHsp70, tim44, and Mpp, respectively, were
+      also upregulated by cco-1 RNAi
+- gap_statement: &gt;-
+    The molecular consequences and essentiality of tin-44 loss in C. elegans have not been
+    directly characterized. The only worm loss-of-function data are indirect: tin-44/T09B4.9
+    RNAi behaves as a mitochondrial-import knockdown that activates the UPRmt (hsp-6p::gfp) and
+    shortens lifespan. No tin-44 null/deletion allele has been analyzed, its essentiality (the
+    mammalian TIMM44 is essential) is untested, and no assay has directly measured how tin-44
+    depletion affects mitochondrial protein-import capacity or which preprotein classes depend
+    on it.
+  boundary: &gt;-
+    tin-44 was recovered as an hsp-6p::gfp UPRmt-inducing RNAi clone and grouped with the
+    lifespan-shortening mitochondrial-import knockdowns (tomm-22, TIM17/TIM16/TIM23/TIM14)
+    (Bennett et al. 2014); UniProt still classifies the protein at evidence level &#34;Inferred
+    from homology&#34; with the hedged name &#34;Probable&#34; import-motor subunit. These readouts report
+    import stress, not the direct requirement for, or activity of, TIN-44.
+  gap_kind:
+  - BIOLOGY
+  dark_aspect: RESIDUAL_SUBGAP
+  status: OPEN
+  significance: &gt;-
+    Establishing the null phenotype and a direct import requirement would convert tin-44 from a
+    by-similarity assignment supported only by stress-reporter readouts into an experimentally
+    grounded import-motor gene, and clarify its place in the C. elegans mitochondrial-import
+    and UPRmt network.
+  resolution: &gt;-
+    Characterize a tin-44 deletion/null allele for viability and developmental arrest, and
+    quantify mitochondrial protein-import capacity on tin-44 depletion (e.g. MTS::GFP or
+    su9-DHFR import) alongside UPRmt (hsp-6p::gfp) activation.
+  provenance:
+  - reference_id: UniProt:O02161
+    supporting_text: Probable mitochondrial import inner membrane translocase subunit tin-44
+  - reference_id: PMID:24662282
+    supporting_text: &gt;-
+      a subset of RNAi clones related to mitochondrial protein import (tomm-22, E04A4.5,
+      T09B4.9, F45G2.8, F15D3.7, and dnj-21)
+suggested_questions:
+- question: &gt;-
+    Does C. elegans TIN-44 bind mitochondrial HSP70 (HSP-6) directly and tether it to the
+    TIM23 channel, as demonstrated for yeast and human Tim44?
+  experts: []
+- question: &gt;-
+    Is tin-44 essential in C. elegans, and how does a genetic null differ from RNAi knockdown
+    in developmental and mitochondrial-import phenotypes?
+  experts: []
+- question: &gt;-
+    Is worm TIN-44 an integral inner-membrane protein or a peripheral/matrix protein, given
+    that the human ortholog is matrix-localized and only loosely membrane-associated?
+  experts: []
+suggested_experiments:
+- hypothesis: &gt;-
+    C. elegans TIN-44 is a bona fide import-motor subunit that binds mtHsp70 (HSP-6) and is
+    required for matrix protein import.
+  description: &gt;-
+    Reconstitute or co-immunoprecipitate recombinant/tagged worm TIN-44 with HSP-6 and test
+    direct binding; deplete tin-44 (RNAi or null) and quantify import of a matrix-targeted
+    reporter (e.g. su9-DHFR or MTS::GFP) relative to wild type.
+  experiment_type: biochemical interaction / in-organello import assay
+- hypothesis: &gt;-
+    tin-44 is essential for C. elegans viability, like mammalian TIMM44.
+  description: &gt;-
+    Generate a tin-44 deletion allele (CRISPR) and score viability, developmental arrest, and
+    UPRmt (hsp-6p::gfp) activation; compare with the milder phenotypes of outer-membrane
+    receptor knockdowns.
+  experiment_type: genetics / phenotypic analysis
+references:
+- id: GO_REF:0000002
+  title: Gene Ontology annotation through association of InterPro records with GO terms
+  findings: []
+- id: GO_REF:0000033
+  title: Annotation inferences using phylogenetic trees
+  findings: []
+- id: GO_REF:0000044
+  title: &gt;-
+    Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary
+    mapping, accompanied by conservative changes to GO terms applied by UniProt
+  findings: []
+- id: PMID:35608535
+  title: The UPRmt preserves mitochondrial import to extend lifespan.
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Only direct-worm reference for tin-44 (full text, PMC-available). Explicitly identifies
+      tin-44 as the C. elegans homolog of mammalian tim44, places it at the matrix-pulling step
+      of import with mtHSP70/HSP-6, and shows it is transcriptionally co-induced with the rest
+      of the TIM/TOM import machinery upon UPRmt activation. Quoted sentences are verbatim from
+      the cached full text. Note: the worm data here are transcriptional, not biochemical.
+- id: PMID:24662282
+  title: &gt;-
+    Activation of the mitochondrial unfolded protein response does not predict longevity in
+    Caenorhabditis elegans.
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Genome-wide hsp-6p::gfp UPRmt RNAi screen (full text, verified). Directly assays tin-44:
+      T09B4.9 (TIM44) is recovered as a UPRmt-inducing clone, grouped with the TIM23-complex
+      import components, and is among the mitochondrial-import knockdowns that shorten lifespan.
+      This is the strongest direct worm loss-of-function evidence that tin-44 acts in
+      mitochondrial protein import. NOTE: a falcon deep-research summary claimed tin-44 RNAi
+      &#34;extended lifespan by 11.1%&#34;; the paper&#39;s verified text instead groups tin-44 with the
+      lifespan-SHORTENING import knockdowns, so that falcon claim was not used.
+- id: PMID:10339406
+  title: &gt;-
+    Genetic and structural characterization of the human mitochondrial inner membrane
+    translocase.
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Human/yeast Tim44 characterization (abstract only). Establishes the conserved
+      Tim23/Tim17/Tim44 + mtHsp70 matrix-import mechanism that is the by-similarity basis for
+      the worm annotations, and reports that human Tim44 is matrix-localized and only loosely
+      membrane-associated — the source for the submitochondrial-topology knowledge gap.
+- id: UniProt:O02161
+  title: Probable mitochondrial import inner membrane translocase subunit tin-44 (C. elegans)
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      UniProt/Swiss-Prot record. Source of the curated FUNCTION (essential PAM component that
+      recruits mtHsp70 to drive ATP-dependent matrix translocation) and SUBUNIT (PAM composed
+      of mtHsp70, GrpE, tin-44, tim-16, tim-14/dnj-21; interacts with tim-23), the
+      inner-membrane location, and the Tim44-family assignment. All FUNCTION/SUBUNIT statements
+      are ECO:0000250 &#34;by similarity&#34; (PE=3), the basis for the by-orthology framing and the
+      knowledge gaps.
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/genes/worm/wago-4/wago-4-ai-review.html
+++ b/genes/worm/wago-4/wago-4-ai-review.html
@@ -1,0 +1,3893 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>wago-4 - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        .propagation-review {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f8fafc;
+            border-left: 3px solid #64748b;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .propagation-title {
+            font-weight: 600;
+            color: #334155;
+            margin-bottom: 0.25rem;
+        }
+
+        .propagation-row {
+            margin-top: 0.25rem;
+        }
+
+        .propagation-source {
+            margin-top: 0.5rem;
+            padding-top: 0.5rem;
+            border-top: 1px solid #e5e7eb;
+        }
+
+        .propagation-source-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #1d4ed8;
+        }
+
+        .propagation-comment {
+            color: #4b5563;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>wago-4</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/O62275" target="_blank" class="term-link">
+                        O62275
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Caenorhabditis elegans</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-initialized">
+                    INITIALIZED
+                </span>
+            </div>
+
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "wago-4";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="O62275" data-a="DESCRIPTION: wago-4 encodes a germline-restricted, worm-specifi..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>wago-4 encodes a germline-restricted, worm-specific Argonaute (WAGO clade) of Caenorhabditis elegans. It is a secondary Argonaute that binds RNA-dependent RNA polymerase-derived 22G-RNAs (22-nucleotide small interfering RNAs bearing a 5&#39; guanosine) together with their complementary target mRNAs, acting as an effector of small-RNA-directed post-transcriptional gene silencing rather than as a catalytic slicer; like other WAGO-subfamily proteins it lacks the conserved catalytic metal-binding residues of cleavage-competent Argonautes. WAGO-4 is essential for the germline RNA interference response and, in particular, for the transgenerational inheritance of RNAi-triggered silencing, operating in the cytoplasmic branch of the pathway downstream of primary Argonautes. It concentrates in perinuclear germ-granule compartments, transiently associating with P granules and, together with the helicase ZNFX-1, defining the Z granule, a liquid-like condensate positioned between P granules and Mutator foci, and it is required for ZNFX-1 to engage silenced mRNAs. Expression is confined to the hermaphrodite (and at low level the male) germline and oocytes, and the protein segregates asymmetrically with the germline lineage during early embryogenesis. Its endogenous 22G-RNA repertoire overlaps that of the Argonaute CSR-1.</p>
+    </div>
+
+
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
+                                    GO:0005737
+                                </a>
+                            </span>
+                            <span class="term-label">cytoplasm</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O62275" data-a="GO:0005737" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> WAGO-4 is a cytoplasmic Argonaute; cytoplasmic activity is well supported.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> WAGO-4 functions in the cytoplasmic branch of the RNAi pathway and is experimentally shown to be cytoplasmic/perinuclear. The IBA is consistent with the experimental localization, though a more specific germ-granule location is captured in core_functions.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/29791857" target="_blank" class="term-link">
+                                        PMID:29791857
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">we identified a cytoplasmic Argonaute protein, WAGO-4, necessary for the inheritance of RNAi.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0035194" target="_blank" class="term-link">
+                                    GO:0035194
+                                </a>
+                            </span>
+                            <span class="term-label">regulatory ncRNA-mediated post-transcriptional gene silencing</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O62275" data-a="GO:0035194" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Core biological process. WAGO-4 uses 22G-RNAs to silence target mRNAs post-transcriptionally.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> WAGO-4 binds 22G-RNAs and their mRNA targets and is required for germline RNAi, placing it squarely in small-RNA-directed post-transcriptional gene silencing.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/29791857" target="_blank" class="term-link">
+                                        PMID:29791857
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">WAGO-4 binds to 22G-RNAs and their mRNA targets.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005634" target="_blank" class="term-link">
+                                    GO:0005634
+                                </a>
+                            </span>
+                            <span class="term-label">nucleus</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-remove">
+                            REMOVE
+                        </span>
+                        <span class="vote-buttons" data-g="O62275" data-a="GO:0005634" data-r="GO_REF:0000033" data-act="REMOVE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> WAGO-4 is a cytoplasmic Argonaute; there is no evidence it acts in the nucleus. This IBA is over-propagated from nuclear members of the Argonaute family.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> WAGO-4 is explicitly the cytoplasmic-branch Argonaute and is experimentally cytoplasmic/perinuclear/germ-granule; nuclear RNAi in C. elegans is executed by the distinct nuclear WAGOs (HRDE-1, NRDE-3). The nucleus term is inherited from nuclear Argonautes across the phylogenetic tree and is not warranted for this protein (argued against on biological grounds, not paralog confusion of an experimental annotation).
+                        </div>
+
+
+
+                        <div class="propagation-review">
+                            <div class="propagation-title">Propagation Review</div>
+                            <div class="propagation-row">
+                                <strong>Root cause:</strong>
+                                <span class="badge">PROPAGATION BAD</span>
+                            </div>
+
+                            <div class="propagation-row">
+                                <strong>Failure modes:</strong>
+
+                                <span class="badge">COMPARTMENT OR COMPLEX MISMATCH</span>
+
+                            </div>
+
+
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/29791857" target="_blank" class="term-link">
+                                        PMID:29791857
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">we identified a cytoplasmic Argonaute protein, WAGO-4, necessary for the inheritance of RNAi.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004521" target="_blank" class="term-link">
+                                    GO:0004521
+                                </a>
+                            </span>
+                            <span class="term-label">RNA endonuclease activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-remove">
+                            REMOVE
+                        </span>
+                        <span class="vote-buttons" data-g="O62275" data-a="GO:0004521" data-r="GO_REF:0000033" data-act="REMOVE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> WAGO-subfamily Argonautes lack the conserved catalytic/metal-binding residues needed for target cleavage; endonuclease (slicer) activity is not warranted for WAGO-4.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> This catalytic MF is propagated by IBA from cleavage-competent Argonautes, but WAGO-clade proteins including WAGO-4 lack the residues required for mRNA cleavage and probably do not slice. Removing this over-propagated electronic inference on biological grounds; the supported molecular function is siRNA binding, captured separately.
+                        </div>
+
+
+
+                        <div class="propagation-review">
+                            <div class="propagation-title">Propagation Review</div>
+                            <div class="propagation-row">
+                                <strong>Root cause:</strong>
+                                <span class="badge">PROPAGATION BAD</span>
+                            </div>
+
+                            <div class="propagation-row">
+                                <strong>Failure modes:</strong>
+
+                                <span class="badge">PSEUDO OR SUBACTIVITY LOSS</span>
+
+                            </div>
+
+
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/17110334" target="_blank" class="term-link">
+                                        PMID:17110334
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Interestingly, these AGO proteins lack key residues required for mRNA cleavage.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016442" target="_blank" class="term-link">
+                                    GO:0016442
+                                </a>
+                            </span>
+                            <span class="term-label">RISC complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O62275" data-a="GO:0016442" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> As a small-RNA-loaded Argonaute that engages target mRNAs, WAGO-4 is the core of an RNA-induced silencing (effector) complex.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> WAGO-4 binds 22G-RNA guides and their target mRNAs, the defining composition of a RISC/effector complex.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/29791857" target="_blank" class="term-link">
+                                        PMID:29791857
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">WAGO-4 binds to 22G-RNAs and their mRNA targets.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0036464" target="_blank" class="term-link">
+                                    GO:0036464
+                                </a>
+                            </span>
+                            <span class="term-label">cytoplasmic ribonucleoprotein granule</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O62275" data-a="GO:0036464" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> WAGO-4 localizes to cytoplasmic RNP germ granules (P granules and the Z granule); the IBA is correct and is refined to P granule in core_functions.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Experimentally, WAGO-4 is a transient component of P granules and defines the Z granule, both cytoplasmic ribonucleoprotein granules.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/29769721" target="_blank" class="term-link">
+                                        PMID:29769721
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">ZNFX-1 and WAGO-4, that localize to Caenorhabditis elegans germ granules (P granules) in early germline blastomeres.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0043186" target="_blank" class="term-link">
+                                    GO:0043186
+                                </a>
+                            </span>
+                            <span class="term-label">P granule</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/29769721" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:29769721
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Spatiotemporal regulation of liquid-like condensates in epig...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-new">
+                            NEW
+                        </span>
+                        <span class="vote-buttons" data-g="O62275" data-a="GO:0043186" data-r="PMID:29769721" data-act="NEW">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> WAGO-4 is experimentally shown to localize to P granules in early germline blastomeres; a more specific term than the IBA cytoplasmic ribonucleoprotein granule annotation.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Direct imaging shows WAGO-4 (with ZNFX-1) at C. elegans germ granules (P granules) in early germline blastomeres, and WAGO-4 is a transient P-granule component in adult germ cells. GO:0043186 captures this experimentally supported localization, which is only implicit in the existing IBA GO:0036464 annotation.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/29769721" target="_blank" class="term-link">
+                                        PMID:29769721
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">ZNFX-1 and WAGO-4, that localize to Caenorhabditis elegans germ granules (P granules) in early germline blastomeres.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0035198" target="_blank" class="term-link">
+                                    GO:0035198
+                                </a>
+                            </span>
+                            <span class="term-label">miRNA binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-modify">
+                            MODIFY
+                        </span>
+                        <span class="vote-buttons" data-g="O62275" data-a="GO:0035198" data-r="GO_REF:0000033" data-act="MODIFY">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> WAGO-4 binds 22G-RNAs (RdRP-derived endo-siRNAs), not miRNAs. The correct molecular function is siRNA binding.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The miRNA-binding term is inherited by IBA from miRNA-class Argonautes, but the experimentally defined WAGO-4 guides are 22-nucleotide secondary siRNAs, not miRNAs. Replace with the class-appropriate siRNA binding term.
+                        </div>
+
+
+
+                        <div class="propagation-review">
+                            <div class="propagation-title">Propagation Review</div>
+                            <div class="propagation-row">
+                                <strong>Root cause:</strong>
+                                <span class="badge">TERM SCOPING PROBLEM</span>
+                            </div>
+
+                            <div class="propagation-row">
+                                <strong>Failure modes:</strong>
+
+                                <span class="badge">FUNCTIONAL DIVERGENCE</span>
+
+                            </div>
+
+
+                        </div>
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0035197" target="_blank" class="term-link">
+                                    siRNA binding
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/29791857" target="_blank" class="term-link">
+                                        PMID:29791857
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">WAGO-4 binds to 22G-RNAs and their mRNA targets.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003727" target="_blank" class="term-link">
+                                    GO:0003727
+                                </a>
+                            </span>
+                            <span class="term-label">single-stranded RNA binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="O62275" data-a="GO:0003727" data-r="GO_REF:0000033" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct but general. WAGO-4 binds single-stranded RNA (its 22G-RNA guide and target mRNA); the more informative term is siRNA binding.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Accurate at the ssRNA level but subsumed by the specific siRNA-binding activity recorded as the core molecular function; retained as a true, non-core general term.
+                        </div>
+
+
+
+                        <div class="propagation-review">
+                            <div class="propagation-title">Propagation Review</div>
+                            <div class="propagation-row">
+                                <strong>Root cause:</strong>
+                                <span class="badge">NO FAILURE NON CORE</span>
+                            </div>
+
+                            <div class="propagation-row">
+                                <strong>Failure modes:</strong>
+
+                                <span class="badge">GRANULARITY MISMATCH</span>
+
+                            </div>
+
+
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/29791857" target="_blank" class="term-link">
+                                        PMID:29791857
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">WAGO-4 binds to 22G-RNAs and their mRNA targets.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003676" target="_blank" class="term-link">
+                                    GO:0003676
+                                </a>
+                            </span>
+                            <span class="term-label">nucleic acid binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="O62275" data-a="GO:0003676" data-r="GO_REF:0000002" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Generic InterPro-derived parent term; true but uninformative.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> High-level ancestor of the specific RNA/siRNA-binding activity of WAGO-4; correct but not informative of the actual function.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003723" target="_blank" class="term-link">
+                                    GO:0003723
+                                </a>
+                            </span>
+                            <span class="term-label">RNA binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="O62275" data-a="GO:0003723" data-r="GO_REF:0000002" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Generic InterPro-derived term; accurate but subsumed by siRNA binding.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> WAGO-4 is an RNA-binding protein, but the informative molecular function is siRNA (22G-RNA) binding; retained as a correct general parent.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
+                                    GO:0005737
+                                </a>
+                            </span>
+                            <span class="term-label">cytoplasm</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000044
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O62275" data-a="GO:0005737" data-r="GO_REF:0000044" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Cytoplasmic localization, consistent with experimental data.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> UniProt SubCell mapping agrees with the experimental cytoplasmic/perinuclear localization of WAGO-4.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/29791857" target="_blank" class="term-link">
+                                        PMID:29791857
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">accumulates at the perinuclear foci in the germline</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0048471" target="_blank" class="term-link">
+                                    GO:0048471
+                                </a>
+                            </span>
+                            <span class="term-label">perinuclear region of cytoplasm</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000044
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O62275" data-a="GO:0048471" data-r="GO_REF:0000044" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Well-supported specific localization; WAGO-4 accumulates at germline perinuclear foci.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Directly corroborated by experimental imaging of WAGO-4 at perinuclear foci in the germline.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/29791857" target="_blank" class="term-link">
+                                        PMID:29791857
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">accumulates at the perinuclear foci in the germline</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
+                                    GO:0005737
+                                </a>
+                            </span>
+                            <span class="term-label">cytoplasm</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">EXP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/29791857" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:29791857
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    A Cytoplasmic Argonaute Protein Promotes the Inheritance of ...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O62275" data-a="GO:0005737" data-r="PMID:29791857" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Experimental cytoplasmic localization of WAGO-4.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Direct experimental support; WAGO-4 is the cytoplasmic Argonaute of the RNAi pathway.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/29791857" target="_blank" class="term-link">
+                                        PMID:29791857
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">we identified a cytoplasmic Argonaute protein, WAGO-4, necessary for the inheritance of RNAi.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0060966" target="_blank" class="term-link">
+                                    GO:0060966
+                                </a>
+                            </span>
+                            <span class="term-label">regulation of gene silencing by regulatory ncRNA</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/30728462" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:30728462
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    MINA-1 and WAGO-4 are part of regulatory network coordinatin...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O62275" data-a="GO:0060966" data-r="PMID:30728462" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> WAGO-4 level positively regulates RNAi efficacy; its overexpression causes RNAi hypersensitivity, supporting a positive-regulator role in ncRNA-mediated silencing.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Experimental (IMP) evidence that WAGO-4 dosage governs silencing efficiency; consistent with secondary Argonautes being limiting for RNAi.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/30728462" target="_blank" class="term-link">
+                                        PMID:30728462
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">upregulation of WAGO-4 in mina-1 mutant animals causes hypersensitivity to exogenous RNAi.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031048" target="_blank" class="term-link">
+                                    GO:0031048
+                                </a>
+                            </span>
+                            <span class="term-label">regulatory ncRNA-mediated heterochromatin formation</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IGI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/22231482" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:22231482
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Amplification of siRNA in Caenorhabditis elegans generates a...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="O62275" data-a="GO:0031048" data-r="PMID:22231482" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> wago-4 was assayed only within a six-gene MAGO secondary-Argonaute group whose collective loss impairs RNAi-triggered H3K9me3; a redundant, indirect contribution for this cytoplasmic Argonaute.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Experimental (IGI) and therefore retained, but the phenotype reflects the combined loss of six secondary Argonautes, not a WAGO-4-specific nuclear function. WAGO-4&#39;s core role is cytoplasmic 22G-RNA-directed post-transcriptional silencing; its input to heterochromatin formation is as part of the redundant secondary-siRNA machinery that feeds the nuclear pathway.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/22231482" target="_blank" class="term-link">
+                                        PMID:22231482
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">MAGO (ppw-1(tm914), sago-1(tm1195), sago-2(tm894), F58G1.1(tm1019), C06A1.4(tm887), and M03D4.6(tm1144)]</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>WAGO-4 is a secondary, germline Argonaute that binds RdRP-derived 22G-RNA guides (small interfering RNAs) and their complementary target mRNAs to effect small-RNA-directed post-transcriptional gene silencing, and is specifically required for the transgenerational inheritance of RNAi. It acts non-catalytically (the WAGO subfamily lacks slicer residues), operating with the helicase ZNFX-1 in perinuclear germ granules.</h3>
+                <span class="vote-buttons" data-g="O62275" data-a="FUNCTION: WAGO-4 is a secondary, germline Argonaute that bin..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0035197" target="_blank" class="term-link">
+                            siRNA binding
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0035194" target="_blank" class="term-link">
+                                regulatory ncRNA-mediated post-transcriptional gene silencing
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0060966" target="_blank" class="term-link">
+                                regulation of gene silencing by regulatory ncRNA
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0043186" target="_blank" class="term-link">
+                                P granule
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0048471" target="_blank" class="term-link">
+                                perinuclear region of cytoplasm
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">In Complex:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016442" target="_blank" class="term-link">
+                            RISC complex
+                        </a>
+                    </span>
+                </div>
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/29791857" target="_blank" class="term-link">
+                                PMID:29791857
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">WAGO-4 binds to 22G-RNAs and their mRNA targets.</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/29791857" target="_blank" class="term-link">
+                                PMID:29791857
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">is required for the inheritance of exogenous RNAi targeting both germline- and soma-expressed genes.</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/29769721" target="_blank" class="term-link">
+                                PMID:29769721
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">Here we show that the inheritance factors ZNFX-1 and WAGO-4 localize to a liquid-like condensate that we name the Z granule.</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/29769721" target="_blank" class="term-link">
+                                PMID:29769721
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">in early P1-P3 germline blastomeres, ZNFX-1 and WAGO-4 localize to P granules.</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000002.md" target="_blank" class="term-link">
+                            GO_REF:0000002
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation through association of InterPro records with GO terms</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
+                            GO_REF:0000033
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Annotation inferences using phylogenetic trees</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
+                            GO_REF:0000044
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/17110334" target="_blank" class="term-link">
+                            PMID:17110334
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Analysis of the C. elegans Argonaute family reveals that distinct Argonautes act sequentially during RNAi.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">The downstream/secondary Argonautes of C. elegans (the WAGO clade, which includes WAGO-4/F58G1.1) act after the primary Argonaute RDE-1 and lack the catalytic residues required for target-mRNA cleavage.</div>
+
+                        <div class="finding-text">"Interestingly, these AGO proteins lack key residues required for mRNA cleavage."</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/22231482" target="_blank" class="term-link">
+                            PMID:22231482
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Amplification of siRNA in Caenorhabditis elegans generates a transgenerational sequence-targeted histone H3 lysine 9 methylation footprint.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">wago-4 (F58G1.1, allele tm1019) was tested only as one member of the six-gene MAGO secondary-Argonaute group whose collective loss impairs dsRNA-triggered H3K9me3 chromatin modification.</div>
+
+                        <div class="finding-text">"MAGO (ppw-1(tm914), sago-1(tm1195), sago-2(tm894), F58G1.1(tm1019), C06A1.4(tm887), and M03D4.6(tm1144)]"</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/29769721" target="_blank" class="term-link">
+                            PMID:29769721
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Spatiotemporal regulation of liquid-like condensates in epigenetic inheritance.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">WAGO-4 is required for RNAi inheritance, physically associates with the helicase ZNFX-1, and with ZNFX-1 defines the Z granule, a liquid-like condensate between P granules and Mutator foci.</div>
+
+                        <div class="finding-text">"Here we show that the inheritance factors ZNFX-1 and WAGO-4 localize to a liquid-like condensate that we name the Z granule."</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/29791857" target="_blank" class="term-link">
+                            PMID:29791857
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">A Cytoplasmic Argonaute Protein Promotes the Inheritance of RNAi.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">WAGO-4 is a cytoplasmic Argonaute required for RNAi inheritance that binds 22G-RNAs and their mRNA targets; its 22G-RNAs overlap the CSR-1 germline cohort and carry 3&#39; untemplated uridylation.</div>
+
+                        <div class="finding-text">"WAGO-4 binds to 22G-RNAs and their mRNA targets."</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/30728462" target="_blank" class="term-link">
+                            PMID:30728462
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">MINA-1 and WAGO-4 are part of regulatory network coordinating germ cell death and RNAi in C. elegans.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">WAGO-4 is a germline-specific Argonaute whose level is a dosage-sensitive positive determinant of RNAi (overexpression causes RNAi hypersensitivity), it co-precipitates with MINA-1, and it is a transient P-granule component.</div>
+
+                        <div class="finding-text">"we found that the germline-specific Argonaute WAGO-4 protein levels are increased in mina-1 mutant background."</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Questions for Experts</h2>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Is WAGO-4 catalytically inactive in vivo, or does it retain a cryptic slicer or other nuclease-recruiting activity on its target mRNAs?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="O62275" data-a="Q: Is WAGO-4 catalytically inactive in vivo, or does ..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> What distinguishes a WAGO-4-silenced target from a CSR-1-protected target when both share the same 22G-RNA cohort?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="O62275" data-a="Q: What distinguishes a WAGO-4-silenced target from a..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Experiments</h2>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Reconstitute recombinant WAGO-4 loaded with a defined synthetic 22G-RNA and assay cleavage of a perfectly complementary target RNA in vitro, alongside a cleavage-competent control Argonaute; combine with structure-guided mutagenesis of the putative catalytic tetrad.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: WAGO-4 silences targets without slicing them, acting through target sequestration and recruitment of the RdRP amplification/inheritance machinery.</em></p>
+
+
+                    <p style="margin-top: 0.5rem;">Type: in vitro biochemistry / slicer assay</p>
+
+                </div>
+                <span class="vote-buttons" data-g="O62275" data-a="EXPERIMENT: Reconstitute recombinant WAGO-4 loaded with a defi..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Perform WAGO-4 small-RNA and mRNA CLIP/IP-seq in parallel with CSR-1 in wild-type, wago-4(-), and WAGO-4-overexpressing germlines, integrating transcript stability and ribosome-profiling readouts to define target-specific outcomes.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: WAGO-4 and CSR-1 act on overlapping 22G-RNA targets but produce opposite transcript-level outcomes.</em></p>
+
+
+                    <p style="margin-top: 0.5rem;">Type: comparative CLIP-seq / functional genomics</p>
+
+                </div>
+                <span class="vote-buttons" data-g="O62275" data-a="EXPERIMENT: Perform WAGO-4 small-RNA and mRNA CLIP/IP-seq in p..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Knowledge Gaps</h2>
+        <p style="color: #555; font-size: 0.92rem; margin-top: -0.3rem;">
+            What is <em>not</em> known — curated, literature-grounded statements of the open
+            unknowns (the inverse of core functions).
+        </p>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> Whether WAGO-4 has any catalytic (slicer/endonuclease) activity is undetermined. It is inferred to be a non-catalytic, siRNA-guided mRNA-binding effector, but no biochemical assay has directly tested WAGO-4 for target cleavage.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">RESIDUAL_SUBGAP</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> It is firmly established that WAGO-4 binds 22G-RNA guides and their target mRNAs and is required for germline RNAi and its inheritance, and that WAGO-subfamily Argonautes lack the conserved catalytic metal-binding residues of cleavage-competent Argonautes.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Whether silencing is achieved by slicing, by recruiting downstream nucleases or the RdRP amplification loop, or purely by target sequestration/marking determines the molecular mechanism of WAGO-4 and how it differs from cleavage-competent Argonautes.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> In vitro slicer assays with recombinant WAGO-4 loaded with a defined 22G-RNA on a complementary target, and structural confirmation of the (in)complete catalytic tetrad, would settle the activity.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"Interestingly, these AGO proteins lack key residues required for mRNA cleavage."</em> — PMID:17110334</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The direct molecular consequence of WAGO-4 engaging a target mRNA, and how the shared 22G-RNA target space with CSR-1 yields opposite (silencing versus licensing) outcomes, is unresolved. The full endogenous target-mRNA repertoire that WAGO-4 functionally silences is not defined.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">BP_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> It is established that WAGO-4-associated 22G-RNAs target the same cohort of germline genes as CSR-1 and carry 3&#39; untemplated uridylation, and that WAGO-4 is a dosage-sensitive positive regulator of silencing.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Distinguishing which targets WAGO-4 silences (versus those CSR-1 protects), and the readout (transcript destabilization, translational repression, or a heritable mark), is required to place WAGO-4 precisely within the germline 22G-RNA network.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Target-resolved WAGO-4 IP-seq/CLIP paired with transcript-level and translational profiling in wago-4 loss- and gain-of-function backgrounds, contrasted with CSR-1, would define the functional target set and outcome.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"WAGO-4-associated endogenous 22G-RNAs target the same cohort of germline genes as CSR-1 and contain untemplated addition of uracil at the 3&#39; ends."</em> — PMID:29791857</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The mechanism by which WAGO-4 (with ZNFX-1 in the Z granule) transports and transmits 22G-RNA/mRNA silencing information across generations is unknown, including how material is handed between P granules, Z granules, and Mutator foci.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">RESIDUAL_SUBGAP</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> It is established that WAGO-4 is required for RNAi inheritance, that it physically associates with ZNFX-1, that WAGO-4 is needed for ZNFX-1 to engage silenced mRNA, and that WAGO-4/ZNFX-1 define the Z granule between P granules and Mutator foci.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> How a cytoplasmic small-RNA/mRNA complex is physically routed through germ-granule sub-compartments and loaded into progeny germ cells is the central mechanistic question of transgenerational epigenetic inheritance in this pathway.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Live imaging of tagged WAGO-4/ZNFX-1 with sub-granule resolution during the germline-to-embryo transition, plus separation-of-function alleles that uncouple condensate residence from RNA binding, would test the transport model.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"the mechanism by which parental-acquired trait-specific information from RNAi is inherited by the progenies is not fully understood"</em> — PMID:29791857</li>
+
+                <li><em>"The relationship between the Z and M segments of the PZM granule"</em> — PMID:29769721</li>
+
+            </ul>
+
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Tags</h2>
+        <div class="aliases">
+
+            <span class="badge">caeel-p-granules</span>
+
+        </div>
+    </div>
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Deep Research Sections -->
+
+    <div class="section">
+        <h2 class="section-title">Deep Research</h2>
+
+        <details class="deep-research-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; gap: 1rem;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Falcon</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(wago-4-deep-research-falcon.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="O62275" data-a="DEEP_RESEARCH: Falcon" data-r="" data-act="DEEP_RESEARCH" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This deep research is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This deep research needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+
+                <div class="report-meta">
+
+                    <span class="report-meta-text">Comprehensive Research Report: WAGO-4 (F58G1.1) — A Z-Granule Argonaute Protein Essential for Transgenerational Epigenetic Inheritance in *Caenorhabditis elegans*</span>
+
+
+                    <span class="report-badge">Falcon</span>
+
+
+                    <span class="report-badge">Edison Scientific Literature</span>
+
+
+                    <span class="report-badge">34 citations</span>
+
+
+                    <span class="report-badge">1 artifacts</span>
+
+
+                    <span class="report-meta-text">2026-07-04T14:59:37.545911</span>
+
+
+
+                </div>
+
+
+                <div class="artifact-list">
+
+
+
+                    <div class="artifact-link">
+                        <a href="wago-4-deep-research-falcon_artifacts/artifact-00.md" class="term-link">Edison artifact artifact-00</a>
+                        <span>(text/markdown)</span>
+                    </div>
+
+
+                </div>
+
+                <p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h1 id="comprehensive-research-report-wago-4-f58g11-a-z-granule-argonaute-protein-essential-for-transgenerational-epigenetic-inheritance-in-caenorhabditis-elegans">Comprehensive Research Report: WAGO-4 (F58G1.1) — A Z-Granule Argonaute Protein Essential for Transgenerational Epigenetic Inheritance in <em>Caenorhabditis elegans</em></h1>
+<h2 id="1-gene-and-protein-identity">1. Gene and Protein Identity</h2>
+<p>WAGO-4 (UniProt: O62275; ORF: F58G1.1) is a worm-specific Argonaute (AGO) protein encoded in the genome of <em>Caenorhabditis elegans</em>. It belongs to the WAGO (Worm-specific AGO) subfamily of the Argonaute protein family, which has undergone significant expansion in nematodes (seroussi2023acomprehensivesurvey pages 2-3, rees2020investigatingtherole pages 35-38). The <em>C. elegans</em> genome encodes 19 functional Argonaute proteins, of which approximately 11 belong to the WAGO clade (chen2026decodingargonautespecificity pages 47-49, seistrup2026crosstalkbetweenand pages 1-5). WAGO-4 contains the canonical Argonaute domain architecture, including PAZ and PIWI domains, and carries a divergent HKQK motif in its small RNA binding pocket that is characteristic of nematode WAGO proteins and determines preference for 22G-RNAs bearing 5′ triphosphate modifications (chen2026decodingargonautespecificity pages 15-18).</p>
+<p>The following table summarizes the key properties of WAGO-4:</p>
+<table>
+<thead>
+<tr>
+<th>Property</th>
+<th>Summary</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Gene name</td>
+<td><strong>wago-4</strong>; ORF <strong>F58G1.1</strong>; encodes worm-specific Argonaute protein 4 in <em>Caenorhabditis elegans</em> (seroussi2023acomprehensivesurvey pages 2-3, sendoel2019mina1andwago4 pages 2-4)</td>
+</tr>
+<tr>
+<td>UniProt ID</td>
+<td><strong>O62275</strong> (user-supplied target identifier; matches <em>C. elegans</em> WAGO-4 Argonaute context summarized in the cited literature)</td>
+</tr>
+<tr>
+<td>Organism</td>
+<td><strong>Caenorhabditis elegans</strong> (wan2017transgenerationalepigeneticinheritance pages 1-5, seroussi2023acomprehensivesurvey pages 2-3)</td>
+</tr>
+<tr>
+<td>Protein family</td>
+<td>Argonaute family, <strong>WAGO subfamily</strong>; one of the expanded nematode worm-specific Argonautes involved in endogenous and heritable RNA silencing (chen2026decodingargonautespecificity pages 47-49, seroussi2023acomprehensivesurvey pages 2-3, rees2020investigatingtherole pages 35-38)</td>
+</tr>
+<tr>
+<td>Domain architecture</td>
+<td>Canonical Argonaute architecture with <strong>PAZ</strong> and <strong>PIWI</strong> domains; WAGO proteins also show a divergent <strong>HKQK</strong> motif associated with 22G-RNA loading specificity rather than the canonical Argonaute catalytic configuration (chen2026decodingargonautespecificity pages 15-18)</td>
+</tr>
+<tr>
+<td>Subcellular localization</td>
+<td>Germline <strong>perinuclear granules</strong>; localizes with <strong>P granules</strong> in early embryonic germline blastomeres, then demixes with ZNFX-1 into <strong>Z granules</strong>; in adults participates in ordered <strong>PZM</strong> assemblages with P granules and Mutator foci; loss of GLH FG repeats shifts WAGO-4 toward the <strong>cytoplasm</strong> (wan2017transgenerationalepigeneticinheritance pages 1-5, wan2017transgenerationalepigeneticinheritance pages 8-11, jelenic2025germgranulelocalization pages 5-6, jelenic2025germgranulelocalization pages 1-2, jelenic2025germgranulelocalization pages 10-11)</td>
+</tr>
+<tr>
+<td>Small RNA binding specificity</td>
+<td>Binds <strong>22G-RNAs</strong>; literature supports association with <strong>CSR-class 22G-RNAs</strong> and also cross-loading/binding of <strong>both CSR-class and WAGO-class 22G-RNAs</strong> under wild-type conditions; proper granule localization helps preserve correct loading specificity (sundby2021connectingthedots pages 7-9, chen2026decodingargonautespecificity pages 47-49, chen2026decodingargonautespecificity pages 12-15, jelenic2025germgranulelocalization pages 10-11, jelenic2025germgranulelocalization pages 12-13)</td>
+</tr>
+<tr>
+<td>Primary function</td>
+<td>Cytoplasmic/heritable silencing Argonaute required for <strong>RNAi inheritance</strong> and <strong>transgenerational epigenetic inheritance (TEI)</strong>; acts with ZNFX-1 to mark target mRNAs and maintain heritable siRNA expression across generations (xu2018distinctnuclearand pages 2-4, wan2017transgenerationalepigeneticinheritance pages 1-5, quarato2022inheritanceandmaintenance pages 3-3)</td>
+</tr>
+<tr>
+<td>Functional pathway context</td>
+<td>Part of the germline 22G-RNA network and a <strong>CSR-1/WAGO-4 regulatory hub</strong>; helps coordinate post-transcriptional silencing and inherited small-RNA responses in germ granules/Z granules (seroussi2023acomprehensivesurvey pages 16-17, sundby2021connectingthedots pages 7-9)</td>
+</tr>
+<tr>
+<td>Key interaction partners</td>
+<td><strong>ZNFX-1</strong> (co-localized and cooperative factor in Z granules/TEI), <strong>MINA-1</strong> (physical and regulatory interactor that represses WAGO-4 expression), <strong>CDE-1</strong> (3' uridylation promotes WAGO-4 association with heritable small RNAs per review evidence), <strong>GLH proteins</strong> including GLH-1/4 FG repeats (promote granule partitioning), and <strong>EGO-1</strong> (proposed RdRP recruited in the inheritance pathway) (xu2018distinctnuclearand pages 2-4, wan2017transgenerationalepigeneticinheritance pages 1-5, sundby2021connectingthedots pages 7-9, jelenic2025germgranulelocalization pages 5-6, jelenic2025germgranulelocalization pages 10-11, sendoel2019mina1andwago4 pages 1-2, sendoel2019mina1andwago4 pages 11-13, sendoel2019mina1andwago4 pages 13-16)</td>
+</tr>
+<tr>
+<td>Phenotypes of loss-of-function</td>
+<td><strong>Heritable RNAi defective</strong> phenotype; impaired transgenerational silencing/RNAi inheritance; altered endogenous target regulation; fertility defects and <strong>Mortal Germline (Mrt)</strong> phenotype are observed when WAGO-4 function or granule localization is compromised, especially at elevated temperature (sundby2021connectingthedots pages 7-9, xu2018distinctnuclearand pages 2-4, jelenic2025germgranulelocalization pages 1-2, jelenic2025germgranulelocalization pages 6-7, jelenic2025germgranulelocalization pages 7-8)</td>
+</tr>
+<tr>
+<td>Phenotypes of mislocalization</td>
+<td>Reduced enrichment in germ granules causes altered 22G-RNA loading, increased reliance on CSR-1-like targets, reduced regulation of WAGO-4-specific/piRNA- and MUT-16-dependent targets, and defective fertility/gene silencing fidelity (jelenic2025germgranulelocalization pages 1-2, jelenic2025germgranulelocalization pages 10-11, jelenic2025germgranulelocalization pages 12-13, jelenic2025germgranulelocalization pages 8-10)</td>
+</tr>
+<tr>
+<td>Germline/apoptosis role</td>
+<td>WAGO-4 also participates in a regulatory network with <strong>MINA-1</strong> that links RNAi machinery to <strong>germ cell apoptosis</strong>; elevated WAGO-4 in <em>mina-1</em> mutants increases RNAi sensitivity and germ cell death, while <em>wago-4</em> loss suppresses these phenotypes (sendoel2019mina1andwago4 pages 1-2, sendoel2019mina1andwago4 pages 11-13, sendoel2019mina1andwago4 pages 9-11, sendoel2019mina1andwago4 pages 13-16)</td>
+</tr>
+</tbody>
+</table>
+<p><em>Table: This table summarizes the identity, localization, molecular associations, small-RNA specificity, and phenotypes of the </em>C. elegans<em> Argonaute WAGO-4. It is useful as a compact reference for functional annotation of UniProt O62275.</em></p>
+<h2 id="2-primary-function-effector-of-rna-mediated-transgenerational-epigenetic-inheritance">2. Primary Function: Effector of RNA-Mediated Transgenerational Epigenetic Inheritance</h2>
+<p>WAGO-4 is a cytoplasmic Argonaute protein whose primary function is to mediate <strong>transgenerational epigenetic inheritance (TEI)</strong> of RNA interference (RNAi) responses. It was identified in a genetic screen for factors required for RNAi inheritance in <em>C. elegans</em> (wan2017transgenerationalepigeneticinheritance pages 1-5). WAGO-4 acts cooperatively with ZNFX-1, a conserved RNA helicase/zinc finger protein, to mark mRNAs of genes undergoing heritable silencing and to maintain small interfering RNA (siRNA) expression across multiple generations (xu2018distinctnuclearand pages 2-4, wan2017transgenerationalepigeneticinheritance pages 1-5). Specifically, WAGO-4 associates with heritable siRNAs to target mRNAs and recruit the RNA-dependent RNA polymerase EGO-1, which synthesizes a pool of heritable siRNAs that propagate the silencing signal to progeny (xu2018distinctnuclearand pages 2-4).</p>
+<p>Importantly, WAGO-4 is not required for the initiation of RNAi in the parental generation but is essential for the transmission of silencing signals to offspring, a phenotype described as <strong>Heritable RNAi Defective (Hrde)</strong> (sundby2021connectingthedots pages 7-9). Loss of WAGO-4 results in failure to propagate RNAi-mediated gene silencing across generations, while within-generation silencing remains largely intact (sundby2021connectingthedots pages 7-9, wan2017transgenerationalepigeneticinheritance pages 1-5).</p>
+<h2 id="3-small-rna-binding-specificity">3. Small RNA Binding Specificity</h2>
+<p>WAGO-4 binds <strong>22G-RNAs</strong>, which are 22-nucleotide small RNAs with a 5′ guanine bias and 5′ triphosphate groups, synthesized by RNA-dependent RNA polymerases (RdRPs) (quarato2022inheritanceandmaintenance pages 2-3, chen2026decodingargonautespecificity pages 12-15). These secondary siRNAs are the major effector molecules of heritable silencing pathways in <em>C. elegans</em> (frolows2021smallrnasand pages 2-3).</p>
+<p>A distinctive feature of WAGO-4 is its broader small RNA binding specificity compared to other WAGO proteins. Under wild-type conditions, WAGO-4 binds both <strong>WAGO-class and CSR-class 22G-RNAs</strong>, demonstrating a degree of cross-loading capability that is unusual among WAGO proteins (chen2026decodingargonautespecificity pages 12-15). In contrast, WAGO-1 and HRDE-1 specifically associate with WAGO-class 22G-RNAs, and CSR-1 binds CSR-class 22G-RNAs (chen2026decodingargonautespecificity pages 47-49, chen2026decodingargonautespecificity pages 12-15). This dual specificity positions WAGO-4 at the interface between the silencing (WAGO) and licensing (CSR-1) branches of the 22G-RNA pathway. The 3′ uridylation of 22G-RNAs by the terminal uridyltransferase CDE-1/CID-1 promotes their association with WAGO-4 and appears to drive its role in TEI (sundby2021connectingthedots pages 7-9).</p>
+<p>The structural basis for 22G-RNA recognition involves the divergent <strong>HKQK motif</strong> in the small RNA binding pocket, which is critical for small RNA loading and silencing function—mutations disrupting this motif abolish binding and proper localization (chen2026decodingargonautespecificity pages 15-18).</p>
+<h2 id="4-subcellular-localization-z-granules-and-pzm-assemblages">4. Subcellular Localization: Z Granules and PZM Assemblages</h2>
+<p>WAGO-4 expression is specific to the germline in adult worms, where it localizes to <strong>perinuclear germ granules</strong> (sendoel2019mina1andwago4 pages 2-4). Its subcellular localization undergoes a developmentally regulated transition:</p>
+<ul>
+<li><strong>Early embryogenesis:</strong> WAGO-4 co-localizes with ZNFX-1 within <strong>P granules</strong> in germline blastomeres (wan2017transgenerationalepigeneticinheritance pages 1-5).</li>
+<li><strong>Later development:</strong> WAGO-4 and ZNFX-1 undergo a demixing process, separating from P granule components to form an independent liquid-like condensate termed the <strong>Z granule</strong> (wan2017transgenerationalepigeneticinheritance pages 8-11, wan2017transgenerationalepigeneticinheritance pages 1-5). This demixing correlates temporally with P granule association with nuclear pores and the onset of germline transcription.</li>
+<li><strong>Adult germline:</strong> Z granules containing WAGO-4 assemble into spatially ordered tri-condensate structures called <strong>PZM (P granule–Z granule–Mutator foci) assemblages</strong>, in which Z granules spatially bridge P granules and Mutator foci (wan2017transgenerationalepigeneticinheritance pages 8-11, wan2017transgenerationalepigeneticinheritance pages 1-5).</li>
+</ul>
+<p>The partitioning of WAGO-4 into germ granules is determined by <strong>FG dipeptide repeats</strong> in the Vasa-like GLH proteins (GLH-1, GLH-2, and GLH-4). Mutations converting phenylalanine to alanine in these FG motifs significantly reduce WAGO-4 enrichment in perinuclear puncta, causing it to redistribute to the cytoplasm (jelenic2025germgranulelocalization pages 5-6, jelenic2025germgranulelocalization pages 1-2, jelenic2025germgranulelocalization pages 10-11). In vitro phase separation experiments confirmed that FG dipeptides contribute to WAGO-4 recruitment into phase-separated granules, though their loss alone does not completely prevent recruitment, indicating additional mechanisms are also involved (jelenic2025germgranulelocalization pages 10-11).</p>
+<h2 id="5-functional-significance-of-germ-granule-localization">5. Functional Significance of Germ Granule Localization</h2>
+<p>A landmark study by Jelenic et al. (2025) demonstrated that WAGO-4's localization within germ granules is essential for maintaining <strong>fidelity in small RNA loading</strong> (jelenic2025germgranulelocalization pages 1-2, jelenic2025germgranulelocalization pages 10-11, jelenic2025germgranulelocalization pages 12-13). When WAGO-4 is mislocalized to the cytoplasm (in FG-repeat mutants):</p>
+<ul>
+<li>WAGO-4 loses preferential binding to its specific targets, particularly genes not co-regulated by CSR-1 (jelenic2025germgranulelocalization pages 1-2, jelenic2025germgranulelocalization pages 10-11).</li>
+<li>The small RNA profile bound by WAGO-4 shifts to more closely resemble CSR-1's targeting pattern, with increased association with CSR-1-class targets (jelenic2025germgranulelocalization pages 10-11, jelenic2025germgranulelocalization pages 12-13).</li>
+<li>Targets dependent on germ granule-based small RNA biogenesis pathways (piRNA-dependent and MUT-16-dependent targets) show reduced WAGO-4 association (jelenic2025germgranulelocalization pages 10-11).</li>
+<li>Mislocalized WAGO-4 predominantly downregulates its targets, with 94% of downregulated targets also being CSR-1 targets, suggesting aberrant silencing of genes that CSR-1 normally licenses for expression (jelenic2025germgranulelocalization pages 12-13).</li>
+<li>WAGO-4 dysfunction is associated with downregulation of histone genes, which has been linked to chromatin instability and fertility defects (jelenic2025germgranulelocalization pages 8-10).</li>
+</ul>
+<p>Similarly, when the P body component CGH-1 is absent, WAGO-4 is displaced from Z granules, leading to disturbed 22G-RNA loading, WAGO-4 instability, and defective RNAi inheritance (du2022pbodiescoat pages 54-56).</p>
+<h2 id="6-role-in-germ-cell-death-and-the-mina-1-regulatory-network">6. Role in Germ Cell Death and the MINA-1 Regulatory Network</h2>
+<p>Beyond its role in TEI, WAGO-4 participates in a regulatory network coordinating <strong>germ cell apoptosis</strong> with RNAi. Sendoel et al. (2019) showed that MINA-1, an RNA-binding protein, physically interacts with WAGO-4 and negatively regulates its expression by binding to the <em>wago-4</em> 3′-UTR to repress translation (sendoel2019mina1andwago4 pages 13-16, sendoel2019mina1andwago4 pages 7-9). In <em>mina-1</em> mutants:</p>
+<ul>
+<li>WAGO-4 protein levels increase up to fourfold (sendoel2019mina1andwago4 pages 11-13, sendoel2019mina1andwago4 pages 7-9).</li>
+<li>This overexpression leads to elevated germ cell apoptosis and RNAi hypersensitivity (sendoel2019mina1andwago4 pages 1-2, sendoel2019mina1andwago4 pages 11-13).</li>
+<li>Loss of WAGO-4 function suppresses the increased apoptosis and P granule defects in <em>mina-1</em> mutants (sendoel2019mina1andwago4 pages 11-13, sendoel2019mina1andwago4 pages 9-11).</li>
+</ul>
+<p>MINA-1 and WAGO-4 are part of a broader RNA regulon including FBF-1, FBF-2, GLD-1, and PPW-2 that coordinately regulates stem cell proliferation, gene silencing, meiotic entry, and apoptosis (sendoel2019mina1andwago4 pages 7-9). This demonstrates that WAGO-4 protein levels must be tightly controlled for proper germline homeostasis.</p>
+<h2 id="7-wago-4-in-the-context-of-the-wago-argonaute-family">7. WAGO-4 in the Context of the WAGO Argonaute Family</h2>
+<p>Within the expanded family of <em>C. elegans</em> Argonautes, WAGO-4 occupies a unique niche. Seroussi et al. (2023) showed that <strong>CSR-1 and WAGO-4 form a regulatory hub</strong> that targets most constitutively expressed germline Argonautes, distinguishing them from other WAGO proteins (seroussi2023acomprehensivesurvey pages 16-17). Other WAGO family members serve distinct functions: WAGO-1 and WAGO-3 mediate post-transcriptional gene silencing by binding WAGO-class 22G-RNAs; HRDE-1 (WAGO-9) operates in the nucleus for co-transcriptional silencing; and NRDE-3 (WAGO-12) functions in somatic nuclear RNAi (chen2026decodingargonautespecificity pages 47-49). WAGO-4's primary distinction is its dedicated role in <strong>cytoplasmic RNAi inheritance</strong> and its localization to Z granules (chen2026decodingargonautespecificity pages 47-49).</p>
+<h2 id="8-nucleus-independent-inheritance">8. Nucleus-Independent Inheritance</h2>
+<p>Recent work by Rieger et al. (2023) demonstrated that RNAi can be inherited independently of nuclear factors via the ooplasm, relying on cytoplasmic components including germ granule-resident proteins. WAGO-4, which colocalizes with ZNFX-1 in germ granules, is implicated in this <strong>nucleus-independent transgenerational inheritance</strong> mechanism, supporting the model that small RNA-loaded Argonaute complexes within cytoplasmic granules serve as vehicles for transmitting epigenetic information from parents to embryos (quarato2022inheritanceandmaintenance pages 3-3).</p>
+<h2 id="9-fertility-and-mortal-germline-phenotype">9. Fertility and Mortal Germline Phenotype</h2>
+<p>Loss of WAGO-4 function or its mislocalization from germ granules is associated with <strong>Mortal Germline (Mrt)</strong> phenotypes, in which worms become progressively sterile over multiple generations, particularly at elevated temperatures (jelenic2025germgranulelocalization pages 7-8). Reduced WAGO-4 partitioning in germ granules leads to fertility defects including reduced progeny numbers and unfertilized oocytes (jelenic2025germgranulelocalization pages 6-7). These phenotypes underscore the importance of WAGO-4-mediated small RNA pathways for long-term germline maintenance and transgenerational genome integrity.</p>
+<h2 id="10-summary">10. Summary</h2>
+<p>WAGO-4 is a germline-specific, Z granule-localized Argonaute protein that serves as a critical effector of transgenerational epigenetic inheritance in <em>C. elegans</em>. It binds 22G-RNAs (both CSR-class and WAGO-class), cooperates with ZNFX-1 within Z granules to propagate heritable gene silencing signals across generations, and requires proper germ granule localization for faithful small RNA loading. Its protein levels are post-transcriptionally regulated by MINA-1, linking RNAi machinery to germ cell apoptosis control. WAGO-4 occupies a unique position at the intersection of the CSR-1 licensing and WAGO silencing pathways, and its dysfunction leads to heritable RNAi defects, mortal germline phenotypes, and compromised germline integrity.</p>
+<p>References</p>
+<ol>
+<li>
+<p>(seroussi2023acomprehensivesurvey pages 2-3): Uri Seroussi, Andrew Lugowski, Lina Wadi, Robert X Lao, Alexandra R Willis, Winnie Zhao, Adam E Sundby, Amanda G Charlesworth, Aaron W Reinke, and Julie M Claycomb. A comprehensive survey of c. elegans argonaute proteins reveals organism-wide gene regulatory networks and functions. Feb 2023. URL: https://doi.org/10.7554/elife.83853, doi:10.7554/elife.83853. This article has 129 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(rees2020investigatingtherole pages 35-38): Alice Rees. Investigating the role of the ip3 signalling pathway in rna interference in c. elegans. ArXiv, Jul 2020. URL: https://doi.org/10.17863/cam.55509, doi:10.17863/cam.55509. This article has 0 citations.</p>
+</li>
+<li>
+<p>(chen2026decodingargonautespecificity pages 47-49): Shihui Chen and C. Phillips. Decoding argonaute specificity: insights from c. elegans and beyond. RNA, 32:290-310, Dec 2026. URL: https://doi.org/10.1261/rna.080816.125, doi:10.1261/rna.080816.125. This article has 2 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(seistrup2026crosstalkbetweenand pages 1-5): Ann-Sophie Seistrup, Emily Nischwitz, Falk Butter, and René F. Ketting. Crosstalk between and developmental dynamics of <i>c. elegans</i> argonaute proteins. bioRxiv, Dec 2025. URL: https://doi.org/10.64898/2025.12.17.694999, doi:10.64898/2025.12.17.694999. This article has 1 citations.</p>
+</li>
+<li>
+<p>(chen2026decodingargonautespecificity pages 15-18): Shihui Chen and C. Phillips. Decoding argonaute specificity: insights from c. elegans and beyond. RNA, 32:290-310, Dec 2026. URL: https://doi.org/10.1261/rna.080816.125, doi:10.1261/rna.080816.125. This article has 2 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(sendoel2019mina1andwago4 pages 2-4): Ataman Sendoel, Deni Subasic, Luca Ducoli, Martin Keller, Erich Michel, Ines Kohler, Kapil Dev Singh, Xue Zheng, Anneke Brümmer, Jochen Imig, Shivendra Kishore, Yibo Wu, Alexander Kanitz, Andres Kaech, Nitish Mittal, Ana M. Matia-González, André P. Gerber, Mihaela Zavolan, Ruedi Aebersold, Jonathan Hall, Frédéric H.-T. Allain, and Michael O. Hengartner. Mina-1 and wago-4 are part of regulatory network coordinating germ cell death and rnai in c. elegans. Cell Death &amp; Differentiation, 26:2157-2178, Feb 2019. URL: https://doi.org/10.1038/s41418-019-0291-z, doi:10.1038/s41418-019-0291-z. This article has 6 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(wan2017transgenerationalepigeneticinheritance pages 1-5): Gang Wan, Brandon D. Fields, George Spracklin, Carolyn Phillips, and Scott Kennedy. Transgenerational epigenetic inheritance factors localize to spatially and temporally ordered liquid droplet assemblages. bioRxiv, Nov 2017. URL: https://doi.org/10.1101/220111, doi:10.1101/220111. This article has 4 citations.</p>
+</li>
+<li>
+<p>(wan2017transgenerationalepigeneticinheritance pages 8-11): Gang Wan, Brandon D. Fields, George Spracklin, Carolyn Phillips, and Scott Kennedy. Transgenerational epigenetic inheritance factors localize to spatially and temporally ordered liquid droplet assemblages. bioRxiv, Nov 2017. URL: https://doi.org/10.1101/220111, doi:10.1101/220111. This article has 4 citations.</p>
+</li>
+<li>
+<p>(jelenic2025germgranulelocalization pages 5-6): Stela Jelenic, Mathias S Renaud, Samantha Del Borrello, Joseph Gokcezade, Janos Bindics, Lisa Frasz, Philipp Czermak, Peter Duchek, and Julie M Claycomb. Germ granule localization of nematode argonaute wago-4 ensures fidelity in small rna loading. The EMBO Journal, 44:7211-7241, Oct 2025. URL: https://doi.org/10.1038/s44318-025-00606-x, doi:10.1038/s44318-025-00606-x. This article has 3 citations.</p>
+</li>
+<li>
+<p>(jelenic2025germgranulelocalization pages 1-2): Stela Jelenic, Mathias S Renaud, Samantha Del Borrello, Joseph Gokcezade, Janos Bindics, Lisa Frasz, Philipp Czermak, Peter Duchek, and Julie M Claycomb. Germ granule localization of nematode argonaute wago-4 ensures fidelity in small rna loading. The EMBO Journal, 44:7211-7241, Oct 2025. URL: https://doi.org/10.1038/s44318-025-00606-x, doi:10.1038/s44318-025-00606-x. This article has 3 citations.</p>
+</li>
+<li>
+<p>(jelenic2025germgranulelocalization pages 10-11): Stela Jelenic, Mathias S Renaud, Samantha Del Borrello, Joseph Gokcezade, Janos Bindics, Lisa Frasz, Philipp Czermak, Peter Duchek, and Julie M Claycomb. Germ granule localization of nematode argonaute wago-4 ensures fidelity in small rna loading. The EMBO Journal, 44:7211-7241, Oct 2025. URL: https://doi.org/10.1038/s44318-025-00606-x, doi:10.1038/s44318-025-00606-x. This article has 3 citations.</p>
+</li>
+<li>
+<p>(sundby2021connectingthedots pages 7-9): Adam E. Sundby, Ruxandra I. Molnar, and Julie M. Claycomb. Connecting the dots: linking caenorhabditis elegans small rna pathways and germ granules. May 2021. URL: https://doi.org/10.1016/j.tcb.2020.12.012, doi:10.1016/j.tcb.2020.12.012. This article has 74 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(chen2026decodingargonautespecificity pages 12-15): Shihui Chen and C. Phillips. Decoding argonaute specificity: insights from c. elegans and beyond. RNA, 32:290-310, Dec 2026. URL: https://doi.org/10.1261/rna.080816.125, doi:10.1261/rna.080816.125. This article has 2 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(jelenic2025germgranulelocalization pages 12-13): Stela Jelenic, Mathias S Renaud, Samantha Del Borrello, Joseph Gokcezade, Janos Bindics, Lisa Frasz, Philipp Czermak, Peter Duchek, and Julie M Claycomb. Germ granule localization of nematode argonaute wago-4 ensures fidelity in small rna loading. The EMBO Journal, 44:7211-7241, Oct 2025. URL: https://doi.org/10.1038/s44318-025-00606-x, doi:10.1038/s44318-025-00606-x. This article has 3 citations.</p>
+</li>
+<li>
+<p>(xu2018distinctnuclearand pages 2-4): Fei Xu, Shouhong Guang, and Xuezhu Feng. Distinct nuclear and cytoplasmic machineries cooperatively promote the inheritance of rnai in caenorhabditis elegans. Biology of the Cell, 110:217-224, Sep 2018. URL: https://doi.org/10.1111/boc.201800031, doi:10.1111/boc.201800031. This article has 9 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(quarato2022inheritanceandmaintenance pages 3-3): Piergiuseppe Quarato, Meetali Singh, Loan Bourdon, and Germano Cecere. Inheritance and maintenance of small rna‐mediated epigenetic effects. BioEssays, Mar 2022. URL: https://doi.org/10.1002/bies.202100284, doi:10.1002/bies.202100284. This article has 24 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(seroussi2023acomprehensivesurvey pages 16-17): Uri Seroussi, Andrew Lugowski, Lina Wadi, Robert X Lao, Alexandra R Willis, Winnie Zhao, Adam E Sundby, Amanda G Charlesworth, Aaron W Reinke, and Julie M Claycomb. A comprehensive survey of c. elegans argonaute proteins reveals organism-wide gene regulatory networks and functions. Feb 2023. URL: https://doi.org/10.7554/elife.83853, doi:10.7554/elife.83853. This article has 129 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(sendoel2019mina1andwago4 pages 1-2): Ataman Sendoel, Deni Subasic, Luca Ducoli, Martin Keller, Erich Michel, Ines Kohler, Kapil Dev Singh, Xue Zheng, Anneke Brümmer, Jochen Imig, Shivendra Kishore, Yibo Wu, Alexander Kanitz, Andres Kaech, Nitish Mittal, Ana M. Matia-González, André P. Gerber, Mihaela Zavolan, Ruedi Aebersold, Jonathan Hall, Frédéric H.-T. Allain, and Michael O. Hengartner. Mina-1 and wago-4 are part of regulatory network coordinating germ cell death and rnai in c. elegans. Cell Death &amp; Differentiation, 26:2157-2178, Feb 2019. URL: https://doi.org/10.1038/s41418-019-0291-z, doi:10.1038/s41418-019-0291-z. This article has 6 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(sendoel2019mina1andwago4 pages 11-13): Ataman Sendoel, Deni Subasic, Luca Ducoli, Martin Keller, Erich Michel, Ines Kohler, Kapil Dev Singh, Xue Zheng, Anneke Brümmer, Jochen Imig, Shivendra Kishore, Yibo Wu, Alexander Kanitz, Andres Kaech, Nitish Mittal, Ana M. Matia-González, André P. Gerber, Mihaela Zavolan, Ruedi Aebersold, Jonathan Hall, Frédéric H.-T. Allain, and Michael O. Hengartner. Mina-1 and wago-4 are part of regulatory network coordinating germ cell death and rnai in c. elegans. Cell Death &amp; Differentiation, 26:2157-2178, Feb 2019. URL: https://doi.org/10.1038/s41418-019-0291-z, doi:10.1038/s41418-019-0291-z. This article has 6 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(sendoel2019mina1andwago4 pages 13-16): Ataman Sendoel, Deni Subasic, Luca Ducoli, Martin Keller, Erich Michel, Ines Kohler, Kapil Dev Singh, Xue Zheng, Anneke Brümmer, Jochen Imig, Shivendra Kishore, Yibo Wu, Alexander Kanitz, Andres Kaech, Nitish Mittal, Ana M. Matia-González, André P. Gerber, Mihaela Zavolan, Ruedi Aebersold, Jonathan Hall, Frédéric H.-T. Allain, and Michael O. Hengartner. Mina-1 and wago-4 are part of regulatory network coordinating germ cell death and rnai in c. elegans. Cell Death &amp; Differentiation, 26:2157-2178, Feb 2019. URL: https://doi.org/10.1038/s41418-019-0291-z, doi:10.1038/s41418-019-0291-z. This article has 6 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(jelenic2025germgranulelocalization pages 6-7): Stela Jelenic, Mathias S Renaud, Samantha Del Borrello, Joseph Gokcezade, Janos Bindics, Lisa Frasz, Philipp Czermak, Peter Duchek, and Julie M Claycomb. Germ granule localization of nematode argonaute wago-4 ensures fidelity in small rna loading. The EMBO Journal, 44:7211-7241, Oct 2025. URL: https://doi.org/10.1038/s44318-025-00606-x, doi:10.1038/s44318-025-00606-x. This article has 3 citations.</p>
+</li>
+<li>
+<p>(jelenic2025germgranulelocalization pages 7-8): Stela Jelenic, Mathias S Renaud, Samantha Del Borrello, Joseph Gokcezade, Janos Bindics, Lisa Frasz, Philipp Czermak, Peter Duchek, and Julie M Claycomb. Germ granule localization of nematode argonaute wago-4 ensures fidelity in small rna loading. The EMBO Journal, 44:7211-7241, Oct 2025. URL: https://doi.org/10.1038/s44318-025-00606-x, doi:10.1038/s44318-025-00606-x. This article has 3 citations.</p>
+</li>
+<li>
+<p>(jelenic2025germgranulelocalization pages 8-10): Stela Jelenic, Mathias S Renaud, Samantha Del Borrello, Joseph Gokcezade, Janos Bindics, Lisa Frasz, Philipp Czermak, Peter Duchek, and Julie M Claycomb. Germ granule localization of nematode argonaute wago-4 ensures fidelity in small rna loading. The EMBO Journal, 44:7211-7241, Oct 2025. URL: https://doi.org/10.1038/s44318-025-00606-x, doi:10.1038/s44318-025-00606-x. This article has 3 citations.</p>
+</li>
+<li>
+<p>(sendoel2019mina1andwago4 pages 9-11): Ataman Sendoel, Deni Subasic, Luca Ducoli, Martin Keller, Erich Michel, Ines Kohler, Kapil Dev Singh, Xue Zheng, Anneke Brümmer, Jochen Imig, Shivendra Kishore, Yibo Wu, Alexander Kanitz, Andres Kaech, Nitish Mittal, Ana M. Matia-González, André P. Gerber, Mihaela Zavolan, Ruedi Aebersold, Jonathan Hall, Frédéric H.-T. Allain, and Michael O. Hengartner. Mina-1 and wago-4 are part of regulatory network coordinating germ cell death and rnai in c. elegans. Cell Death &amp; Differentiation, 26:2157-2178, Feb 2019. URL: https://doi.org/10.1038/s41418-019-0291-z, doi:10.1038/s41418-019-0291-z. This article has 6 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(quarato2022inheritanceandmaintenance pages 2-3): Piergiuseppe Quarato, Meetali Singh, Loan Bourdon, and Germano Cecere. Inheritance and maintenance of small rna‐mediated epigenetic effects. BioEssays, Mar 2022. URL: https://doi.org/10.1002/bies.202100284, doi:10.1002/bies.202100284. This article has 24 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(frolows2021smallrnasand pages 2-3): Natalya Frolows and Alyson Ashe. Small rnas and chromatin in the multigenerational epigenetic landscape of caenorhabditis elegans. Philosophical Transactions of the Royal Society B, 376:20200112, Apr 2021. URL: https://doi.org/10.1098/rstb.2020.0112, doi:10.1098/rstb.2020.0112. This article has 61 citations.</p>
+</li>
+<li>
+<p>(du2022pbodiescoat pages 54-56): Zhenzhen Du, Kun Shi, Jordan S. Brown, Tao He, Wei-Sheng Wu, Ying Zhang, Heng-Chi Lee, and Donglei Zhang. P bodies coat germ granules to promote transgenerational gene silencing in c. elegans. bioRxiv, Nov 2022. URL: https://doi.org/10.1101/2022.11.01.514641, doi:10.1101/2022.11.01.514641. This article has 1 citations.</p>
+</li>
+<li>
+<p>(sendoel2019mina1andwago4 pages 7-9): Ataman Sendoel, Deni Subasic, Luca Ducoli, Martin Keller, Erich Michel, Ines Kohler, Kapil Dev Singh, Xue Zheng, Anneke Brümmer, Jochen Imig, Shivendra Kishore, Yibo Wu, Alexander Kanitz, Andres Kaech, Nitish Mittal, Ana M. Matia-González, André P. Gerber, Mihaela Zavolan, Ruedi Aebersold, Jonathan Hall, Frédéric H.-T. Allain, and Michael O. Hengartner. Mina-1 and wago-4 are part of regulatory network coordinating germ cell death and rnai in c. elegans. Cell Death &amp; Differentiation, 26:2157-2178, Feb 2019. URL: https://doi.org/10.1038/s41418-019-0291-z, doi:10.1038/s41418-019-0291-z. This article has 6 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+</ol>
+<h2 id="artifacts">Artifacts</h2>
+<ul>
+<li><a href="wago-4-deep-research-falcon_artifacts/artifact-00.md">Edison artifact artifact-00</a></li>
+</ul>
+<h2 id="citations">Citations</h2>
+<ol>
+<li>chen2026decodingargonautespecificity pages 15-18</li>
+<li>wan2017transgenerationalepigeneticinheritance pages 1-5</li>
+<li>xu2018distinctnuclearand pages 2-4</li>
+<li>sundby2021connectingthedots pages 7-9</li>
+<li>frolows2021smallrnasand pages 2-3</li>
+<li>chen2026decodingargonautespecificity pages 12-15</li>
+<li>jelenic2025germgranulelocalization pages 10-11</li>
+<li>jelenic2025germgranulelocalization pages 12-13</li>
+<li>jelenic2025germgranulelocalization pages 8-10</li>
+<li>du2022pbodiescoat pages 54-56</li>
+<li>seroussi2023acomprehensivesurvey pages 16-17</li>
+<li>chen2026decodingargonautespecificity pages 47-49</li>
+<li>quarato2022inheritanceandmaintenance pages 3-3</li>
+<li>jelenic2025germgranulelocalization pages 7-8</li>
+<li>jelenic2025germgranulelocalization pages 6-7</li>
+<li>seroussi2023acomprehensivesurvey pages 2-3</li>
+<li>rees2020investigatingtherole pages 35-38</li>
+<li>seistrup2026crosstalkbetweenand pages 1-5</li>
+<li>wan2017transgenerationalepigeneticinheritance pages 8-11</li>
+<li>jelenic2025germgranulelocalization pages 5-6</li>
+<li>jelenic2025germgranulelocalization pages 1-2</li>
+<li>quarato2022inheritanceandmaintenance pages 2-3</li>
+<li>https://doi.org/10.7554/elife.83853,</li>
+<li>https://doi.org/10.17863/cam.55509,</li>
+<li>https://doi.org/10.1261/rna.080816.125,</li>
+<li>https://doi.org/10.64898/2025.12.17.694999,</li>
+<li>https://doi.org/10.1038/s41418-019-0291-z,</li>
+<li>https://doi.org/10.1101/220111,</li>
+<li>https://doi.org/10.1038/s44318-025-00606-x,</li>
+<li>https://doi.org/10.1016/j.tcb.2020.12.012,</li>
+<li>https://doi.org/10.1111/boc.201800031,</li>
+<li>https://doi.org/10.1002/bies.202100284,</li>
+<li>https://doi.org/10.1098/rstb.2020.0112,</li>
+<li>https://doi.org/10.1101/2022.11.01.514641,</li>
+</ol>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(wago-4-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="O62275" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="wago-4-f58g11-o62275-research-notes">wago-4 (F58G1.1, O62275) — research notes</h1>
+<p>Curator research journal. Provenance is recorded inline as <code>[PMID:xxxx "verbatim quote"]</code>.<br />
+All quotes below were verified as verbatim substrings of the cached <code>publications/PMID_*.md</code>.</p>
+<h2 id="identity">Identity</h2>
+<ul>
+<li><strong>Gene:</strong> wago-4 / F58G1.1 / WBGene00010263. UniProt <strong>O62275</strong> (WAGO4_CAEEL, 965 aa).</li>
+<li><strong>Family:</strong> Argonaute family, <strong>WAGO (worm-specific Argonaute) subfamily</strong>. Domains: PAZ (318–428) and Piwi (594–924) [from UniProt record].</li>
+<li>One of the ~27 C. elegans Argonautes; a <em>secondary</em> Argonaute of the WAGO clade.</li>
+</ul>
+<h2 id="what-is-known-wago-4-specific-experimental">What is KNOWN (wago-4-specific, experimental)</h2>
+<h3 id="small-rna-binding-molecular-function">Small-RNA binding / molecular function</h3>
+<ul>
+<li>WAGO-4 binds secondary <strong>22G-RNAs</strong> and their target mRNAs (not miRNAs):<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/29791857" title="WAGO-4 binds to 22G-RNAs and their mRNA targets.">PMID:29791857</a></li>
+<li>Its 22G-RNAs overlap the CSR-1 germline gene cohort and carry 3′ uridylation:<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/29791857" title="WAGO-4-associated endogenous 22G-RNAs target the same cohort of germline genes as CSR-1 and contain untemplated addition of uracil at the 3' ends.">PMID:29791857</a></li>
+<li>22G-RNAs are RdRP-derived endo-siRNAs (~22 nt, 5′ G) — i.e. siRNAs, not miRNAs. So the<br />
+  correct MF is <strong>siRNA binding (GO:0035197)</strong>, and the IBA <strong>miRNA binding (GO:0035198)</strong> is a<br />
+  mischaracterization inherited from the pan-Argonaute tree.</li>
+</ul>
+<h3 id="catalytic-slicer-activity-likely-absent">Catalytic (slicer) activity — likely ABSENT</h3>
+<ul>
+<li>The downstream/secondary WAGO-clade Argonautes lack the catalytic residues for target cleavage:<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/17110334" title="Interestingly, these AGO proteins lack key residues required for mRNA cleavage.">PMID:17110334</a></li>
+<li>UniProt concurs (MISCELLANEOUS): "Members of the WAGO (worm-specific argonaute) subfamily<br />
+  lack conserved metal-binding residues found in other argonaute proteins and probably do not<br />
+  cleave target mRNAs directly." (ECO:0000303|PubMed:17110334).</li>
+<li>=&gt; The IBA <strong>RNA endonuclease activity (GO:0004521)</strong>, propagated from catalytically active<br />
+  Argonautes elsewhere in the family tree, is not warranted for WAGO-4. This is the crux of the<br />
+  "is it catalytically active?" question and remains formally unproven for WAGO-4 (see gaps).</li>
+</ul>
+<h3 id="biological-process-rnai-inheritance-germline-ptgs">Biological process — RNAi inheritance / germline PTGS</h3>
+<ul>
+<li>WAGO-4 is required for the inheritance (transgenerational maintenance) of RNAi:<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/29791857" title="we identified a cytoplasmic Argonaute protein, WAGO-4, necessary for the inheritance of RNAi.">PMID:29791857</a><br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/29791857" title="is required for the inheritance of exogenous RNAi targeting both germline- and soma-expressed genes.">PMID:29791857</a></li>
+<li>Independent screen (Wan/Kennedy) reached the same conclusion:<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/29769721" title="like ZNFX-1, WAGO-4 is required for RNAi inheritance.">PMID:29769721</a></li>
+<li>Essential for germline RNAi (Sendoel):<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/30728462" title="we additionally identified WAGO-4 as an essential Argonaute for germline-specific RNAi.">PMID:30728462</a></li>
+<li>Dosage-sensitive positive regulator of silencing: WAGO-4 overexpression enhances RNAi:<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/30728462" title="upregulation of WAGO-4 in mina-1 mutant animals causes hypersensitivity to exogenous RNAi.">PMID:30728462</a><br />
+  (consistent with the general secondary-Argonaute behavior <a href="https://pubmed.ncbi.nlm.nih.gov/17110334" title="Overexpression of downstream AGOs enhances silencing, suggesting that these proteins are limiting for RNAi.">PMID:17110334</a>)</li>
+</ul>
+<h3 id="partners-mechanism-of-transgenerational-transport">Partners / mechanism of transgenerational transport</h3>
+<ul>
+<li>Physically and functionally partners with the helicase <strong>ZNFX-1</strong>:<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/29769721" title="3xFLAG::WAGO-4 co-precipitates with HA::ZNFX-1, but not a HA tagged negative control protein HA::HRDE-1,">PMID:29769721</a></li>
+<li>WAGO-4 is required for ZNFX-1 to engage target mRNA:<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/29769721" title="in wago-4 mutant animals, ZNFX-1 failed [to] interact with the oma-1 mRNA in response to oma-1 RNAi">PMID:29769721</a><br />
+  (verbatim string in text: "in wago-4 mutant animals, ZNFX-1 faile")</li>
+<li>Genetically/physically interacts with the KH-domain RBP <strong>MINA-1</strong>:<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/30728462" title="WAGO-4 co-precipitated with MINA-1, suggesting a potential protein–protein interaction.">PMID:30728462</a></li>
+</ul>
+<h3 id="localization-experimental">Localization (experimental)</h3>
+<ul>
+<li>Cytoplasmic; germline perinuclear foci:<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/29791857" title="accumulates at the perinuclear foci in the germline">PMID:29791857</a></li>
+<li>P-granule associated (transient component), adjacent to P granules:<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/30728462" title="WAGO-4, like several other Argonautes including ALG-3, PRG-1, and CSR-1, is a transient component of P granules and localizes adjacent to P granules in germ cells.">PMID:30728462</a></li>
+<li>With ZNFX-1, localizes to P granules in early germline blastomeres:<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/29769721" title="in early P1-P3 germline blastomeres, ZNFX-1 and WAGO-4 localize to P granules.">PMID:29769721</a></li>
+<li>Defines a distinct condensate, the <strong>Z granule</strong>, between P granules and Mutator foci:<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/29769721" title="Here we show that the inheritance factors ZNFX-1 and WAGO-4 localize to a liquid-like condensate that we name the Z granule.">PMID:29769721</a></li>
+<li>Germline-restricted expression (UniProt TISSUE SPECIFICITY): hermaphrodite germline and oocytes;<br />
+  not in soma.</li>
+</ul>
+<h3 id="heterochromatin-chromatin-redundant-indirect">Heterochromatin / chromatin (redundant, indirect)</h3>
+<ul>
+<li>In Gu 2012, wago-4 (F58G1.1, allele tm1019) was tested only as one member of the 6-gene "MAGO"<br />
+  secondary-Argonaute group required for dsRNA-triggered H3K9me3 chromatin modification:<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/22231482" title="MAGO (ppw-1(tm914), sago-1(tm1195), sago-2(tm894), F58G1.1(tm1019), C06A1.4(tm887), and M03D4.6(tm1144)]">PMID:22231482</a><br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/22231482" title="The requirement of rde-1 and MAGO genes for dsRNA-triggered chromatin modification strongly suggests that secondary siRNAs may participate in a connection">PMID:22231482</a><br />
+  =&gt; This is a genetic-redundancy (group knockout) contribution; WAGO-4's own core role is<br />
+  cytoplasmic PTGS/inheritance, and heterochromatin formation is executed by the nuclear WAGOs<br />
+  (HRDE-1/NRDE-3). Keep the IGI (experimental) but as non-core.</li>
+</ul>
+<h2 id="what-is-not-known-knowledge-gaps">What is NOT known (knowledge gaps)</h2>
+<ol>
+<li><strong>Is WAGO-4 catalytically active?</strong> It lacks the conserved catalytic/metal-binding residues and<br />
+   "probably" does not slice, but no biochemical assay directly tests WAGO-4 slicer activity; a<br />
+   non-catalytic, siRNA-guided mRNA-binding/silencing mechanism is inferred, not proven.</li>
+<li><strong>Full target-mRNA repertoire and the silencing readout.</strong> WAGO-4 22G-RNAs overlap the CSR-1<br />
+   cohort, yet CSR-1 and WAGO-4 have divergent (protective vs silencing/inheritance) outputs; how<br />
+   the same target space yields different outcomes, and the direct mRNA-level consequence of<br />
+   WAGO-4 binding (destabilization vs translational block vs licensing), is undefined.</li>
+<li><strong>Mechanism of transgenerational transport.</strong> WAGO-4 and ZNFX-1 mark a Z granule between P<br />
+   granules and Mutator foci, but how 22G-RNA/mRNA information is physically handed across the<br />
+   PZM assemblage and transmitted to progeny is a model, not a mechanism.</li>
+</ol>
+<h2 id="annotation-review-plan-summary">Annotation-review plan (summary)</h2>
+<ul>
+<li>GO:0035198 miRNA binding (IBA) → <strong>MODIFY</strong> to GO:0035197 siRNA binding (binds 22G-RNAs, not miRNAs).</li>
+<li>GO:0004521 RNA endonuclease activity (IBA) → <strong>REMOVE</strong> (WAGO subfamily lacks catalytic residues; over-propagated IBA).</li>
+<li>GO:0005634 nucleus (IBA) → <strong>REMOVE</strong> (WAGO-4 is a <em>cytoplasmic</em> Argonaute; no nuclear-action evidence; over-propagated IBA).</li>
+<li>GO:0003676 nucleic acid binding (IEA) / GO:0003723 RNA binding (IEA) → generic parents; KEEP_AS_NON_CORE.</li>
+<li>GO:0003727 single-stranded RNA binding (IBA) → ACCEPT (binds ss 22G guide + mRNA), non-core relative to siRNA binding.</li>
+<li>GO:0005737 cytoplasm (IBA/IEA/EXP), GO:0048471 perinuclear region (IEA), GO:0036464 cytoplasmic RNP granule (IBA) → ACCEPT; RNP granule refined to P granule in core_functions.</li>
+<li>GO:0016442 RISC complex (IBA) → ACCEPT.</li>
+<li>GO:0035194 regulatory ncRNA-mediated PTGS (IBA) → ACCEPT (core BP).</li>
+<li>GO:0060966 regulation of gene silencing by regulatory ncRNA (IMP, PMID:30728462) → ACCEPT (experimental).</li>
+<li>GO:0031048 regulatory ncRNA-mediated heterochromatin formation (IGI, PMID:22231482) → KEEP_AS_NON_CORE (redundant MAGO-group, indirect for a cytoplasmic Ago).</li>
+</ul>
+<h2 id="deep-research-provenance">Deep research provenance</h2>
+<p>Falcon deep research (<code>just deep-research-falcon worm wago-4 --fallback perplexity-lite</code>) was<br />
+launched but the Edison endpoint was congested (multiple concurrent gene jobs) and had not<br />
+returned a file at review time. This review is therefore built entirely on the cached primary<br />
+literature below plus the UniProt/GOA records; every claim is PMID-anchored and independently<br />
+verified against the cached full text/abstract. No <code>file:</code> deep-research quotes are used, so the<br />
+review is self-contained. (If a real falcon file lands later it can be added as a supplementary<br />
+reference; it is not required for any conclusion here.) No annotation required UNDECIDED — each<br />
+had sufficient primary-literature evidence.</p>
+<h2 id="references-used-all-cached">References used (all cached)</h2>
+<ul>
+<li>PMID:29791857 Xu et al. 2018 Cell Rep — abstract-only cache; WAGO-4 = cytoplasmic Ago for RNAi inheritance; binds 22G-RNAs + mRNA targets.</li>
+<li>PMID:29769721 Wan et al. 2018 Nature — full text; Z granule, ZNFX-1 interaction, RNAi inheritance.</li>
+<li>PMID:30728462 Sendoel et al. 2019 Cell Death Differ — full text; MINA-1/WAGO-4 network; germline RNAi; P-granule.</li>
+<li>PMID:17110334 Yigit et al. 2006 Cell — abstract-only; WAGO clade lacks cleavage residues; secondary Argonautes act downstream.</li>
+<li>PMID:22231482 Gu et al. 2012 Nat Genet — full text; MAGO 6-gene group (incl. F58G1.1/wago-4) required for RNAi-triggered H3K9me3.</li>
+</ul>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: O62275
+gene_symbol: wago-4
+product_type: PROTEIN
+status: INITIALIZED
+taxon:
+  id: NCBITaxon:6239
+  label: Caenorhabditis elegans
+tags:
+  - caeel-p-granules
+description: &gt;-
+  wago-4 encodes a germline-restricted, worm-specific Argonaute (WAGO clade) of
+  Caenorhabditis elegans. It is a secondary Argonaute that binds RNA-dependent RNA
+  polymerase-derived 22G-RNAs (22-nucleotide small interfering RNAs bearing a 5&#39;
+  guanosine) together with their complementary target mRNAs, acting as an effector of
+  small-RNA-directed post-transcriptional gene silencing rather than as a catalytic
+  slicer; like other WAGO-subfamily proteins it lacks the conserved catalytic
+  metal-binding residues of cleavage-competent Argonautes. WAGO-4 is essential for the
+  germline RNA interference response and, in particular, for the transgenerational
+  inheritance of RNAi-triggered silencing, operating in the cytoplasmic branch of the
+  pathway downstream of primary Argonautes. It concentrates in perinuclear germ-granule
+  compartments, transiently associating with P granules and, together with the helicase
+  ZNFX-1, defining the Z granule, a liquid-like condensate positioned between P granules
+  and Mutator foci, and it is required for ZNFX-1 to engage silenced mRNAs. Expression is
+  confined to the hermaphrodite (and at low level the male) germline and oocytes, and the
+  protein segregates asymmetrically with the germline lineage during early embryogenesis.
+  Its endogenous 22G-RNA repertoire overlaps that of the Argonaute CSR-1.
+references:
+  - id: GO_REF:0000002
+    title: Gene Ontology annotation through association of InterPro records with GO
+      terms
+    findings: []
+  - id: GO_REF:0000033
+    title: Annotation inferences using phylogenetic trees
+    findings: []
+  - id: GO_REF:0000044
+    title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location
+      vocabulary mapping, accompanied by conservative changes to GO terms applied by
+      UniProt
+    findings: []
+  - id: PMID:17110334
+    title: Analysis of the C. elegans Argonaute family reveals that distinct Argonautes
+      act sequentially during RNAi.
+    findings:
+      - statement: The downstream/secondary Argonautes of C. elegans (the WAGO clade,
+          which includes WAGO-4/F58G1.1) act after the primary Argonaute RDE-1 and lack
+          the catalytic residues required for target-mRNA cleavage.
+        supporting_text: Interestingly, these AGO proteins lack key residues required
+          for mRNA cleavage.
+    reference_review:
+      relevance: HIGH
+      correctness: VERIFIED
+      review_notes: PubMed-verified. Family-level analysis establishing that WAGO-clade
+        Argonautes act as non-catalytic secondary effectors; the direct basis for treating
+        the IBA RNA endonuclease activity as an over-propagation for WAGO-4.
+  - id: PMID:22231482
+    title: Amplification of siRNA in Caenorhabditis elegans generates a transgenerational
+      sequence-targeted histone H3 lysine 9 methylation footprint.
+    findings:
+      - statement: wago-4 (F58G1.1, allele tm1019) was tested only as one member of the
+          six-gene MAGO secondary-Argonaute group whose collective loss impairs
+          dsRNA-triggered H3K9me3 chromatin modification.
+        supporting_text: &#34;MAGO (ppw-1(tm914), sago-1(tm1195), sago-2(tm894), F58G1.1(tm1019),
+          C06A1.4(tm887), and M03D4.6(tm1144)]&#34;
+    reference_review:
+      relevance: MEDIUM
+      correctness: VERIFIED
+      review_notes: PubMed-verified. wago-4 contributes only within a redundant six-gene
+        MAGO group knockout; the heterochromatin phenotype is a group-level, indirect
+        readout for this cytoplasmic Argonaute.
+  - id: PMID:29769721
+    title: Spatiotemporal regulation of liquid-like condensates in epigenetic inheritance.
+    findings:
+      - statement: WAGO-4 is required for RNAi inheritance, physically associates with the
+          helicase ZNFX-1, and with ZNFX-1 defines the Z granule, a liquid-like condensate
+          between P granules and Mutator foci.
+        supporting_text: Here we show that the inheritance factors ZNFX-1 and WAGO-4 localize
+          to a liquid-like condensate that we name the Z granule.
+    reference_review:
+      relevance: HIGH
+      correctness: VERIFIED
+      review_notes: PubMed-verified. Kennedy-lab study; primary evidence for the Z-granule
+        localization and the WAGO-4/ZNFX-1 interaction underlying transgenerational
+        inheritance.
+  - id: PMID:29791857
+    title: A Cytoplasmic Argonaute Protein Promotes the Inheritance of RNAi.
+    findings:
+      - statement: WAGO-4 is a cytoplasmic Argonaute required for RNAi inheritance that binds
+          22G-RNAs and their mRNA targets; its 22G-RNAs overlap the CSR-1 germline cohort and
+          carry 3&#39; untemplated uridylation.
+        supporting_text: WAGO-4 binds to 22G-RNAs and their mRNA targets.
+    reference_review:
+      relevance: HIGH
+      correctness: VERIFIED
+      review_notes: PubMed-verified (cache is abstract-only; claims used are all stated in the
+        abstract). Primary evidence for the 22G-RNA/siRNA-binding molecular function and the
+        cytoplasmic RNAi-inheritance role.
+  - id: PMID:30728462
+    title: MINA-1 and WAGO-4 are part of regulatory network coordinating germ cell death
+      and RNAi in C. elegans.
+    findings:
+      - statement: WAGO-4 is a germline-specific Argonaute whose level is a dosage-sensitive
+          positive determinant of RNAi (overexpression causes RNAi hypersensitivity), it
+          co-precipitates with MINA-1, and it is a transient P-granule component.
+        supporting_text: we found that the germline-specific Argonaute WAGO-4 protein levels
+          are increased in mina-1 mutant background.
+    reference_review:
+      relevance: HIGH
+      correctness: VERIFIED
+      review_notes: PubMed-verified, full text available. Provides the IMP evidence for
+        WAGO-4 as a positive regulator of ncRNA-mediated gene silencing and the MINA-1
+        interaction.
+existing_annotations:
+  - term:
+      id: GO:0005737
+      label: cytoplasm
+    evidence_type: IBA
+    original_reference_id: GO_REF:0000033
+    qualifier: is_active_in
+    review:
+      summary: WAGO-4 is a cytoplasmic Argonaute; cytoplasmic activity is well supported.
+      action: ACCEPT
+      reason: WAGO-4 functions in the cytoplasmic branch of the RNAi pathway and is
+        experimentally shown to be cytoplasmic/perinuclear. The IBA is consistent with the
+        experimental localization, though a more specific germ-granule location is captured
+        in core_functions.
+      supported_by:
+        - reference_id: PMID:29791857
+          supporting_text: we identified a cytoplasmic Argonaute protein, WAGO-4, necessary
+            for the inheritance of RNAi.
+  - term:
+      id: GO:0035194
+      label: regulatory ncRNA-mediated post-transcriptional gene silencing
+    evidence_type: IBA
+    original_reference_id: GO_REF:0000033
+    qualifier: involved_in
+    review:
+      summary: Core biological process. WAGO-4 uses 22G-RNAs to silence target mRNAs
+        post-transcriptionally.
+      action: ACCEPT
+      reason: WAGO-4 binds 22G-RNAs and their mRNA targets and is required for germline
+        RNAi, placing it squarely in small-RNA-directed post-transcriptional gene silencing.
+      supported_by:
+        - reference_id: PMID:29791857
+          supporting_text: WAGO-4 binds to 22G-RNAs and their mRNA targets.
+  - term:
+      id: GO:0005634
+      label: nucleus
+    evidence_type: IBA
+    original_reference_id: GO_REF:0000033
+    qualifier: is_active_in
+    review:
+      summary: WAGO-4 is a cytoplasmic Argonaute; there is no evidence it acts in the
+        nucleus. This IBA is over-propagated from nuclear members of the Argonaute family.
+      action: REMOVE
+      reason: WAGO-4 is explicitly the cytoplasmic-branch Argonaute and is experimentally
+        cytoplasmic/perinuclear/germ-granule; nuclear RNAi in C. elegans is executed by the
+        distinct nuclear WAGOs (HRDE-1, NRDE-3). The nucleus term is inherited from
+        nuclear Argonautes across the phylogenetic tree and is not warranted for this
+        protein (argued against on biological grounds, not paralog confusion of an
+        experimental annotation).
+      supported_by:
+        - reference_id: PMID:29791857
+          supporting_text: we identified a cytoplasmic Argonaute protein, WAGO-4, necessary
+            for the inheritance of RNAi.
+      propagation_review:
+        root_cause: PROPAGATION_BAD
+        failure_modes:
+          - COMPARTMENT_OR_COMPLEX_MISMATCH
+  - term:
+      id: GO:0004521
+      label: RNA endonuclease activity
+    evidence_type: IBA
+    original_reference_id: GO_REF:0000033
+    qualifier: enables
+    review:
+      summary: WAGO-subfamily Argonautes lack the conserved catalytic/metal-binding residues
+        needed for target cleavage; endonuclease (slicer) activity is not warranted for
+        WAGO-4.
+      action: REMOVE
+      reason: This catalytic MF is propagated by IBA from cleavage-competent Argonautes, but
+        WAGO-clade proteins including WAGO-4 lack the residues required for mRNA cleavage and
+        probably do not slice. Removing this over-propagated electronic inference on
+        biological grounds; the supported molecular function is siRNA binding, captured
+        separately.
+      supported_by:
+        - reference_id: PMID:17110334
+          supporting_text: Interestingly, these AGO proteins lack key residues required for
+            mRNA cleavage.
+      propagation_review:
+        root_cause: PROPAGATION_BAD
+        failure_modes:
+          - PSEUDO_OR_SUBACTIVITY_LOSS
+  - term:
+      id: GO:0016442
+      label: RISC complex
+    evidence_type: IBA
+    original_reference_id: GO_REF:0000033
+    qualifier: part_of
+    review:
+      summary: As a small-RNA-loaded Argonaute that engages target mRNAs, WAGO-4 is the core
+        of an RNA-induced silencing (effector) complex.
+      action: ACCEPT
+      reason: WAGO-4 binds 22G-RNA guides and their target mRNAs, the defining composition of
+        a RISC/effector complex.
+      supported_by:
+        - reference_id: PMID:29791857
+          supporting_text: WAGO-4 binds to 22G-RNAs and their mRNA targets.
+  - term:
+      id: GO:0036464
+      label: cytoplasmic ribonucleoprotein granule
+    evidence_type: IBA
+    original_reference_id: GO_REF:0000033
+    qualifier: is_active_in
+    review:
+      summary: WAGO-4 localizes to cytoplasmic RNP germ granules (P granules and the Z
+        granule); the IBA is correct and is refined to P granule in core_functions.
+      action: ACCEPT
+      reason: Experimentally, WAGO-4 is a transient component of P granules and defines the Z
+        granule, both cytoplasmic ribonucleoprotein granules.
+      supported_by:
+        - reference_id: PMID:29769721
+          supporting_text: ZNFX-1 and WAGO-4, that localize to Caenorhabditis elegans germ
+            granules (P granules) in early germline blastomeres.
+  - term:
+      id: GO:0043186
+      label: P granule
+    evidence_type: IDA
+    original_reference_id: PMID:29769721
+    review:
+      summary: WAGO-4 is experimentally shown to localize to P granules in early germline
+        blastomeres; a more specific term than the IBA cytoplasmic ribonucleoprotein granule
+        annotation.
+      action: NEW
+      reason: Direct imaging shows WAGO-4 (with ZNFX-1) at C. elegans germ granules (P
+        granules) in early germline blastomeres, and WAGO-4 is a transient P-granule
+        component in adult germ cells. GO:0043186 captures this experimentally supported
+        localization, which is only implicit in the existing IBA GO:0036464 annotation.
+      supported_by:
+        - reference_id: PMID:29769721
+          supporting_text: ZNFX-1 and WAGO-4, that localize to Caenorhabditis elegans germ
+            granules (P granules) in early germline blastomeres.
+  - term:
+      id: GO:0035198
+      label: miRNA binding
+    evidence_type: IBA
+    original_reference_id: GO_REF:0000033
+    qualifier: enables
+    review:
+      summary: WAGO-4 binds 22G-RNAs (RdRP-derived endo-siRNAs), not miRNAs. The correct
+        molecular function is siRNA binding.
+      action: MODIFY
+      reason: The miRNA-binding term is inherited by IBA from miRNA-class Argonautes, but the
+        experimentally defined WAGO-4 guides are 22-nucleotide secondary siRNAs, not miRNAs.
+        Replace with the class-appropriate siRNA binding term.
+      proposed_replacement_terms:
+        - id: GO:0035197
+          label: siRNA binding
+      supported_by:
+        - reference_id: PMID:29791857
+          supporting_text: WAGO-4 binds to 22G-RNAs and their mRNA targets.
+      propagation_review:
+        root_cause: TERM_SCOPING_PROBLEM
+        failure_modes:
+          - FUNCTIONAL_DIVERGENCE
+  - term:
+      id: GO:0003727
+      label: single-stranded RNA binding
+    evidence_type: IBA
+    original_reference_id: GO_REF:0000033
+    qualifier: enables
+    review:
+      summary: Correct but general. WAGO-4 binds single-stranded RNA (its 22G-RNA guide and
+        target mRNA); the more informative term is siRNA binding.
+      action: KEEP_AS_NON_CORE
+      reason: Accurate at the ssRNA level but subsumed by the specific siRNA-binding activity
+        recorded as the core molecular function; retained as a true, non-core general term.
+      supported_by:
+        - reference_id: PMID:29791857
+          supporting_text: WAGO-4 binds to 22G-RNAs and their mRNA targets.
+      propagation_review:
+        root_cause: NO_FAILURE_NON_CORE
+        failure_modes:
+          - GRANULARITY_MISMATCH
+  - term:
+      id: GO:0003676
+      label: nucleic acid binding
+    evidence_type: IEA
+    original_reference_id: GO_REF:0000002
+    qualifier: enables
+    review:
+      summary: Generic InterPro-derived parent term; true but uninformative.
+      action: KEEP_AS_NON_CORE
+      reason: High-level ancestor of the specific RNA/siRNA-binding activity of WAGO-4;
+        correct but not informative of the actual function.
+  - term:
+      id: GO:0003723
+      label: RNA binding
+    evidence_type: IEA
+    original_reference_id: GO_REF:0000002
+    qualifier: enables
+    review:
+      summary: Generic InterPro-derived term; accurate but subsumed by siRNA binding.
+      action: KEEP_AS_NON_CORE
+      reason: WAGO-4 is an RNA-binding protein, but the informative molecular function is
+        siRNA (22G-RNA) binding; retained as a correct general parent.
+  - term:
+      id: GO:0005737
+      label: cytoplasm
+    evidence_type: IEA
+    original_reference_id: GO_REF:0000044
+    qualifier: located_in
+    review:
+      summary: Cytoplasmic localization, consistent with experimental data.
+      action: ACCEPT
+      reason: UniProt SubCell mapping agrees with the experimental cytoplasmic/perinuclear
+        localization of WAGO-4.
+      supported_by:
+        - reference_id: PMID:29791857
+          supporting_text: accumulates at the perinuclear foci in the germline
+  - term:
+      id: GO:0048471
+      label: perinuclear region of cytoplasm
+    evidence_type: IEA
+    original_reference_id: GO_REF:0000044
+    qualifier: located_in
+    review:
+      summary: Well-supported specific localization; WAGO-4 accumulates at germline
+        perinuclear foci.
+      action: ACCEPT
+      reason: Directly corroborated by experimental imaging of WAGO-4 at perinuclear foci in
+        the germline.
+      supported_by:
+        - reference_id: PMID:29791857
+          supporting_text: accumulates at the perinuclear foci in the germline
+  - term:
+      id: GO:0005737
+      label: cytoplasm
+    evidence_type: EXP
+    original_reference_id: PMID:29791857
+    qualifier: located_in
+    review:
+      summary: Experimental cytoplasmic localization of WAGO-4.
+      action: ACCEPT
+      reason: Direct experimental support; WAGO-4 is the cytoplasmic Argonaute of the RNAi
+        pathway.
+      supported_by:
+        - reference_id: PMID:29791857
+          supporting_text: we identified a cytoplasmic Argonaute protein, WAGO-4, necessary
+            for the inheritance of RNAi.
+  - term:
+      id: GO:0060966
+      label: regulation of gene silencing by regulatory ncRNA
+    evidence_type: IMP
+    original_reference_id: PMID:30728462
+    qualifier: acts_upstream_of_or_within_positive_effect
+    review:
+      summary: WAGO-4 level positively regulates RNAi efficacy; its overexpression causes
+        RNAi hypersensitivity, supporting a positive-regulator role in ncRNA-mediated
+        silencing.
+      action: ACCEPT
+      reason: Experimental (IMP) evidence that WAGO-4 dosage governs silencing efficiency;
+        consistent with secondary Argonautes being limiting for RNAi.
+      supported_by:
+        - reference_id: PMID:30728462
+          supporting_text: upregulation of WAGO-4 in mina-1 mutant animals causes
+            hypersensitivity to exogenous RNAi.
+  - term:
+      id: GO:0031048
+      label: regulatory ncRNA-mediated heterochromatin formation
+    evidence_type: IGI
+    original_reference_id: PMID:22231482
+    qualifier: involved_in
+    review:
+      summary: wago-4 was assayed only within a six-gene MAGO secondary-Argonaute group whose
+        collective loss impairs RNAi-triggered H3K9me3; a redundant, indirect contribution
+        for this cytoplasmic Argonaute.
+      action: KEEP_AS_NON_CORE
+      reason: Experimental (IGI) and therefore retained, but the phenotype reflects the
+        combined loss of six secondary Argonautes, not a WAGO-4-specific nuclear function.
+        WAGO-4&#39;s core role is cytoplasmic 22G-RNA-directed post-transcriptional silencing;
+        its input to heterochromatin formation is as part of the redundant secondary-siRNA
+        machinery that feeds the nuclear pathway.
+      supported_by:
+        - reference_id: PMID:22231482
+          supporting_text: &#34;MAGO (ppw-1(tm914), sago-1(tm1195), sago-2(tm894), F58G1.1(tm1019),
+            C06A1.4(tm887), and M03D4.6(tm1144)]&#34;
+core_functions:
+  - description: WAGO-4 is a secondary, germline Argonaute that binds RdRP-derived 22G-RNA
+      guides (small interfering RNAs) and their complementary target mRNAs to effect
+      small-RNA-directed post-transcriptional gene silencing, and is specifically required
+      for the transgenerational inheritance of RNAi. It acts non-catalytically (the WAGO
+      subfamily lacks slicer residues), operating with the helicase ZNFX-1 in perinuclear
+      germ granules.
+    molecular_function:
+      id: GO:0035197
+      label: siRNA binding
+    directly_involved_in:
+      - id: GO:0035194
+        label: regulatory ncRNA-mediated post-transcriptional gene silencing
+      - id: GO:0060966
+        label: regulation of gene silencing by regulatory ncRNA
+    locations:
+      - id: GO:0043186
+        label: P granule
+      - id: GO:0048471
+        label: perinuclear region of cytoplasm
+    in_complex:
+      id: GO:0016442
+      label: RISC complex
+    supported_by:
+      - reference_id: PMID:29791857
+        supporting_text: WAGO-4 binds to 22G-RNAs and their mRNA targets.
+      - reference_id: PMID:29791857
+        supporting_text: is required for the inheritance of exogenous RNAi targeting both
+          germline- and soma-expressed genes.
+      - reference_id: PMID:29769721
+        supporting_text: Here we show that the inheritance factors ZNFX-1 and WAGO-4 localize
+          to a liquid-like condensate that we name the Z granule.
+      - reference_id: PMID:29769721
+        supporting_text: in early P1-P3 germline blastomeres, ZNFX-1 and WAGO-4 localize to P
+          granules.
+proposed_new_terms: []
+knowledge_gaps:
+  - gap_statement: Whether WAGO-4 has any catalytic (slicer/endonuclease) activity is
+      undetermined. It is inferred to be a non-catalytic, siRNA-guided mRNA-binding effector,
+      but no biochemical assay has directly tested WAGO-4 for target cleavage.
+    boundary: It is firmly established that WAGO-4 binds 22G-RNA guides and their target
+      mRNAs and is required for germline RNAi and its inheritance, and that WAGO-subfamily
+      Argonautes lack the conserved catalytic metal-binding residues of cleavage-competent
+      Argonautes.
+    gap_kind:
+      - BIOLOGY
+    dark_aspect: RESIDUAL_SUBGAP
+    status: OPEN
+    significance: Whether silencing is achieved by slicing, by recruiting downstream
+      nucleases or the RdRP amplification loop, or purely by target sequestration/marking
+      determines the molecular mechanism of WAGO-4 and how it differs from cleavage-competent
+      Argonautes.
+    resolution: In vitro slicer assays with recombinant WAGO-4 loaded with a defined 22G-RNA
+      on a complementary target, and structural confirmation of the (in)complete catalytic
+      tetrad, would settle the activity.
+    provenance:
+      - reference_id: PMID:17110334
+        supporting_text: Interestingly, these AGO proteins lack key residues required for
+          mRNA cleavage.
+  - gap_statement: The direct molecular consequence of WAGO-4 engaging a target mRNA, and how
+      the shared 22G-RNA target space with CSR-1 yields opposite (silencing versus licensing)
+      outcomes, is unresolved. The full endogenous target-mRNA repertoire that WAGO-4
+      functionally silences is not defined.
+    boundary: It is established that WAGO-4-associated 22G-RNAs target the same cohort of
+      germline genes as CSR-1 and carry 3&#39; untemplated uridylation, and that WAGO-4 is a
+      dosage-sensitive positive regulator of silencing.
+    gap_kind:
+      - BIOLOGY
+    dark_aspect: BP_DARK
+    status: OPEN
+    significance: Distinguishing which targets WAGO-4 silences (versus those CSR-1 protects),
+      and the readout (transcript destabilization, translational repression, or a heritable
+      mark), is required to place WAGO-4 precisely within the germline 22G-RNA network.
+    resolution: Target-resolved WAGO-4 IP-seq/CLIP paired with transcript-level and
+      translational profiling in wago-4 loss- and gain-of-function backgrounds, contrasted
+      with CSR-1, would define the functional target set and outcome.
+    provenance:
+      - reference_id: PMID:29791857
+        supporting_text: WAGO-4-associated endogenous 22G-RNAs target the same cohort of
+          germline genes as CSR-1 and contain untemplated addition of uracil at the 3&#39; ends.
+  - gap_statement: The mechanism by which WAGO-4 (with ZNFX-1 in the Z granule) transports and
+      transmits 22G-RNA/mRNA silencing information across generations is unknown, including
+      how material is handed between P granules, Z granules, and Mutator foci.
+    boundary: It is established that WAGO-4 is required for RNAi inheritance, that it
+      physically associates with ZNFX-1, that WAGO-4 is needed for ZNFX-1 to engage silenced
+      mRNA, and that WAGO-4/ZNFX-1 define the Z granule between P granules and Mutator foci.
+    gap_kind:
+      - BIOLOGY
+    dark_aspect: RESIDUAL_SUBGAP
+    status: OPEN
+    significance: How a cytoplasmic small-RNA/mRNA complex is physically routed through
+      germ-granule sub-compartments and loaded into progeny germ cells is the central
+      mechanistic question of transgenerational epigenetic inheritance in this pathway.
+    resolution: Live imaging of tagged WAGO-4/ZNFX-1 with sub-granule resolution during the
+      germline-to-embryo transition, plus separation-of-function alleles that uncouple
+      condensate residence from RNA binding, would test the transport model.
+    provenance:
+      - reference_id: PMID:29791857
+        supporting_text: the mechanism by which parental-acquired trait-specific information
+          from RNAi is inherited by the progenies is not fully understood
+      - reference_id: PMID:29769721
+        supporting_text: The relationship between the Z and M segments of the PZM granule
+suggested_questions:
+  - question: Is WAGO-4 catalytically inactive in vivo, or does it retain a cryptic slicer or
+      other nuclease-recruiting activity on its target mRNAs?
+    experts: []
+  - question: What distinguishes a WAGO-4-silenced target from a CSR-1-protected target when
+      both share the same 22G-RNA cohort?
+    experts: []
+suggested_experiments:
+  - hypothesis: WAGO-4 silences targets without slicing them, acting through target
+      sequestration and recruitment of the RdRP amplification/inheritance machinery.
+    description: Reconstitute recombinant WAGO-4 loaded with a defined synthetic 22G-RNA and
+      assay cleavage of a perfectly complementary target RNA in vitro, alongside a
+      cleavage-competent control Argonaute; combine with structure-guided mutagenesis of the
+      putative catalytic tetrad.
+    experiment_type: in vitro biochemistry / slicer assay
+  - hypothesis: WAGO-4 and CSR-1 act on overlapping 22G-RNA targets but produce opposite
+      transcript-level outcomes.
+    description: Perform WAGO-4 small-RNA and mRNA CLIP/IP-seq in parallel with CSR-1 in
+      wild-type, wago-4(-), and WAGO-4-overexpressing germlines, integrating transcript
+      stability and ribosome-profiling readouts to define target-specific outcomes.
+    experiment_type: comparative CLIP-seq / functional genomics
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/pages/projects/BIOREASON_COMPARISON.html
+++ b/pages/projects/BIOREASON_COMPARISON.html
@@ -727,7 +727,7 @@
 <td><a href="../../genes/worm/csr-1/csr-1-ai-review.html">csr-1</a></td>
 <td>worm</td>
 <td>1</td>
-<td>Wrong input sequence (nhr-47 instead of <a href="../../genes/worm/csr-1/csr-1-ai-review.html">CSR-1</a> Argonaute)</td>
+<td>Wrong input sequence (<a href="../../genes/worm/nhr-47/nhr-47-ai-review.html">nhr-47</a> instead of <a href="../../genes/worm/csr-1/csr-1-ai-review.html">CSR-1</a> Argonaute)</td>
 </tr>
 <tr>
 <td><a href="../../genes/worm/pgl-1/pgl-1-ai-review.html">pgl-1</a></td>
@@ -806,7 +806,7 @@ term) leave no discordant term to tag and are recorded only in the RL narrative 
 </ul>
 <h3 id="8-wrong-input-data">8. Wrong input data</h3>
 <ul>
-<li><strong><a href="../../genes/worm/csr-1/csr-1-ai-review.html">csr-1</a></strong> (worm, 1/5): BioReason received the nhr-47 sequence instead of the <a href="../../genes/worm/csr-1/csr-1-ai-review.html">CSR-1</a> Argonaute. All predictions are for the wrong protein.</li>
+<li><strong><a href="../../genes/worm/csr-1/csr-1-ai-review.html">csr-1</a></strong> (worm, 1/5): BioReason received the <a href="../../genes/worm/nhr-47/nhr-47-ai-review.html">nhr-47</a> sequence instead of the <a href="../../genes/worm/csr-1/csr-1-ai-review.html">CSR-1</a> Argonaute. All predictions are for the wrong protein.</li>
 </ul>
 <h2 id="comparison-with-interpro2go">Comparison with interpro2go</h2>
 <p>A central question is whether BioReason provides value beyond the automated interpro2go pipeline (GO_REF:0000002). Our reviews assessed this for each gene.</p>

--- a/pages/projects/CAEEL_CILIOPATHY.html
+++ b/pages/projects/CAEEL_CILIOPATHY.html
@@ -385,25 +385,25 @@
 - <strong><a href="../../genes/worm/osm-3/osm-3-ai-review.html">osm-3</a></strong> - Kinesin-2 motor (homodimeric)<br />
 - <strong>klp-11</strong> - Kinesin-2 motor (heterotrimeric with klp-20/kap-1)<br />
 - <strong><a href="../../genes/worm/osm-5/osm-5-ai-review.html">osm-5</a></strong> - IFT88 ortholog (IFT-B complex)<br />
-- <strong>osm-6</strong> - IFT52 ortholog<br />
+- <strong><a href="../../genes/worm/osm-6/osm-6-ai-review.html">osm-6</a></strong> - IFT52 ortholog<br />
 - <strong><a href="../../genes/worm/che-2/che-2-ai-review.html">che-2</a></strong> - IFT80 ortholog<br />
 - <strong>che-13</strong> - IFT57 ortholog<br />
 - <strong><a href="../../genes/worm/dyf-1/dyf-1-ai-review.html">dyf-1</a></strong> - Required for <a href="../../genes/worm/osm-3/osm-3-ai-review.html">osm-3</a> function<br />
 - <strong><a href="../../genes/worm/dyf-3/dyf-3-ai-review.html">dyf-3</a></strong> - IFT54 ortholog<br />
 - <strong>dyf-6</strong> - IFT46 ortholog<br />
-- <strong>dyf-11</strong> - IFT54 ortholog<br />
+- <strong><a href="../../genes/worm/dyf-11/dyf-11-ai-review.html">dyf-11</a></strong> - IFT54 ortholog<br />
 - <strong>dyf-13</strong> - TTC26 ortholog</p>
 <h3 id="3-intraflagellar-transport-ift-retrograde">3. Intraflagellar Transport (IFT) - Retrograde</h3>
 <p>Dynein motor and IFT-A complex:<br />
 - <strong><a href="../../genes/worm/che-3/che-3-ai-review.html">che-3</a></strong> - Cytoplasmic dynein heavy chain<br />
 - <strong>xbx-1</strong> - Dynein light intermediate chain<br />
 - <strong><a href="../../genes/worm/dyf-2/dyf-2-ai-review.html">dyf-2</a></strong> - IFT144/WDR19 ortholog (IFT-A)<br />
-- <strong>daf-10</strong> - IFT122 ortholog (IFT-A)<br />
-- <strong>che-11</strong> - IFT140 ortholog (IFT-A)</p>
+- <strong><a href="../../genes/worm/daf-10/daf-10-ai-review.html">daf-10</a></strong> - IFT122 ortholog (IFT-A)<br />
+- <strong><a href="../../genes/worm/che-11/che-11-ai-review.html">che-11</a></strong> - IFT140 ortholog (IFT-A)</p>
 <h3 id="4-transition-zone-mksnphp-complexes">4. Transition Zone (MKS/NPHP Complexes)</h3>
 <p>Gatekeepers of ciliary compartment:<br />
 - <strong><a href="../../genes/worm/mks-1/mks-1-ai-review.html">mks-1</a></strong> - MKS1 ortholog (B9 domain)<br />
-- <strong>mks-2</strong> - TMEM216 ortholog<br />
+- <strong><a href="../../genes/worm/mks-2/mks-2-ai-review.html">mks-2</a></strong> - TMEM216 ortholog<br />
 - <strong><a href="../../genes/worm/mks-3/mks-3-ai-review.html">mks-3</a></strong> - <a href="../../genes/human/TMEM67/TMEM67-ai-review.html">TMEM67</a> ortholog<br />
 - <strong><a href="../../genes/worm/mks-5/mks-5-ai-review.html">mks-5</a></strong> - RPGRIP1L ortholog<br />
 - <strong><a href="../../genes/worm/mks-6/mks-6-ai-review.html">mks-6</a></strong> - CC2D2A ortholog<br />
@@ -416,7 +416,7 @@
 <p>Bardet-Biedl syndrome proteins:<br />
 - <strong><a href="../../genes/worm/bbs-1/bbs-1-ai-review.html">bbs-1</a></strong> - <a href="../../genes/human/BBS1/BBS1-ai-review.html">BBS1</a> ortholog<br />
 - <strong><a href="../../genes/worm/bbs-2/bbs-2-ai-review.html">bbs-2</a></strong> - <a href="../../genes/human/BBS2/BBS2-ai-review.html">BBS2</a> ortholog<br />
-- <strong>bbs-4</strong> - <a href="../../genes/human/BBS4/BBS4-ai-review.html">BBS4</a> ortholog<br />
+- <strong><a href="../../genes/worm/bbs-4/bbs-4-ai-review.html">bbs-4</a></strong> - <a href="../../genes/human/BBS4/BBS4-ai-review.html">BBS4</a> ortholog<br />
 - <strong><a href="../../genes/worm/bbs-5/bbs-5-ai-review.html">bbs-5</a></strong> - <a href="../../genes/human/BBS5/BBS5-ai-review.html">BBS5</a> ortholog<br />
 - <strong><a href="../../genes/worm/bbs-7/bbs-7-ai-review.html">bbs-7</a></strong> - <a href="../../genes/human/BBS7/BBS7-ai-review.html">BBS7</a> ortholog<br />
 - <strong><a href="../../genes/worm/bbs-8/bbs-8-ai-review.html">bbs-8</a></strong> - BBS8/TTC8 ortholog<br />
@@ -429,7 +429,7 @@
 <h3 id="7-ciliary-signalingfunction">7. Ciliary Signaling/Function</h3>
 <ul>
 <li><strong>tax-2</strong> - Cyclic nucleotide-gated channel alpha</li>
-<li><strong>tax-4</strong> - Cyclic nucleotide-gated channel beta</li>
+<li><strong><a href="../../genes/worm/tax-4/tax-4-ai-review.html">tax-4</a></strong> - Cyclic nucleotide-gated channel beta</li>
 <li><strong>odr-1</strong> - Guanylyl cyclase</li>
 <li><strong><a href="../../genes/worm/pef-1/pef-1-ai-review.html">pef-1</a></strong> - PPEF phosphatase (2024 discovery)</li>
 </ul>

--- a/pages/projects/CAEEL_MITOPHAGY.html
+++ b/pages/projects/CAEEL_MITOPHAGY.html
@@ -401,7 +401,7 @@
 - <strong><a href="../../genes/worm/fzo-1/fzo-1-ai-review.html">fzo-1</a></strong> - Mitofusin (outer membrane fusion)<br />
 - <strong><a href="../../genes/worm/eat-3/eat-3-ai-review.html">eat-3</a></strong> - <a href="../../genes/DANRE/opa1/opa1-ai-review.html">OPA1</a> ortholog (inner membrane fusion)<br />
 - <strong><a href="../../genes/worm/fis-1/fis-1-ai-review.html">fis-1</a></strong> - FIS1 (fission factor)<br />
-- <strong>fis-2</strong> - MFF ortholog (fission)<br />
+- <strong><a href="../../genes/worm/fis-2/fis-2-ai-review.html">fis-2</a></strong> - MFF ortholog (fission)<br />
 - <strong>mff-1</strong> - MFF ortholog</p>
 <h3 id="4-core-autophagy-machinery">4. Core Autophagy Machinery</h3>
 <p>Shared with other autophagy pathways:<br />
@@ -426,17 +426,17 @@
 </ul>
 <h3 id="7-mitochondrial-importproteostasis">7. Mitochondrial Import/Proteostasis</h3>
 <ul>
-<li><strong>tin-44</strong> - TIM44 (import machinery)</li>
+<li><strong><a href="../../genes/worm/tin-44/tin-44-ai-review.html">tin-44</a></strong> - TIM44 (import machinery)</li>
 <li><strong><a href="../../genes/worm/tomm-22/tomm-22-ai-review.html">tomm-22</a></strong> - <a href="../../genes/yeast/TOM22/TOM22-ai-review.html">TOM22</a> (import machinery)</li>
 <li><strong><a href="../../genes/worm/spg-7/spg-7-ai-review.html">spg-7</a></strong> - SPG7/Paraplegin (m-AAA protease)</li>
-<li><strong>phb-1/phb-2</strong> - Prohibitins</li>
+<li><strong><a href="../../genes/worm/phb-1/phb-1-ai-review.html">phb-1</a>/phb-2</strong> - Prohibitins</li>
 </ul>
 <h3 id="8-ros-and-damage-sensing">8. ROS and Damage Sensing</h3>
 <ul>
-<li><strong>sod-2</strong> - Mn-SOD (mitochondrial)</li>
-<li><strong>sod-3</strong> - Fe-SOD</li>
+<li><strong><a href="../../genes/worm/sod-2/sod-2-ai-review.html">sod-2</a></strong> - Mn-SOD (mitochondrial)</li>
+<li><strong><a href="../../genes/worm/sod-3/sod-3-ai-review.html">sod-3</a></strong> - Fe-SOD</li>
 <li><strong>clk-1</strong> - COQ7 (ubiquinone synthesis)</li>
-<li><strong>isp-1</strong> - Rieske iron-sulfur protein</li>
+<li><strong><a href="../../genes/worm/isp-1/isp-1-ai-review.html">isp-1</a></strong> - Rieske iron-sulfur protein</li>
 </ul>
 <h2 id="genes-for-review-priority-order">Genes for Review (Priority Order)</h2>
 <h3 id="priority-1-core-mitophagy-pathway-6-genes">Priority 1: Core Mitophagy Pathway (~6 genes)</h3>
@@ -726,7 +726,7 @@
 <li><a href="../../genes/worm/hlh-30/hlh-30-ai-review.html">HLH-30</a> integrates longevity, autophagy, lysosome biogenesis, and innate immunity in a unified transcriptional program</li>
 <li><a href="../../genes/worm/skn-1/skn-1-ai-review.html">SKN-1</a> is the hub for oxidative stress response; overlaps with <a href="../../genes/worm/daf-16/daf-16-ai-review.html">DAF-16</a>/FOXO and HIF-1 networks</li>
 <li><a href="../../genes/worm/miro-1/miro-1-ai-review.html">MIRO-1</a> serves as both mitochondrial transport adaptor AND mitophagy switch (degraded by Parkin to halt transport)</li>
-<li><a href="../../genes/worm/spg-7/spg-7-ai-review.html">SPG-7</a> nomenclature is misleading - it's <a href="../../genes/human/AFG3L2/AFG3L2-ai-review.html">AFG3L2</a>, not SPG7 ortholog; true SPG7 ortholog is ppgn-1</li>
+<li><a href="../../genes/worm/spg-7/spg-7-ai-review.html">SPG-7</a> nomenclature is misleading - it's <a href="../../genes/human/AFG3L2/AFG3L2-ai-review.html">AFG3L2</a>, not SPG7 ortholog; true SPG7 ortholog is <a href="../../genes/worm/ppgn-1/ppgn-1-ai-review.html">ppgn-1</a></li>
 </ol>
 <h3 id="project-complete">Project Complete!</h3>
 <p>All 17 genes (6 + 6 + 5) across 3 priority levels have been reviewed. Only pathway summary integration remains.</p>

--- a/pages/projects/CAEEL_MITOPHAGY/CAEEL_MITOPHAGY-pathway.html
+++ b/pages/projects/CAEEL_MITOPHAGY/CAEEL_MITOPHAGY-pathway.html
@@ -475,7 +475,7 @@ flowchart TD
 - Accumulation of dysfunctional mitochondria<br />
 - Increased mitochondrial mass with decreased ATP<br />
 - Elevated ROS and membrane depolarization<br />
-- Shortened lifespan in long-lived mutants (<a href="../../../genes/worm/daf-2/daf-2-ai-review.html">daf-2</a>, isp-1, clk-1)</p>
+- Shortened lifespan in long-lived mutants (<a href="../../../genes/worm/daf-2/daf-2-ai-review.html">daf-2</a>, <a href="../../../genes/worm/isp-1/isp-1-ai-review.html">isp-1</a>, clk-1)</p>
 <hr />
 <h2 id="mitochondrial-dynamics-fission-vs-fusion">Mitochondrial Dynamics: Fission vs Fusion</h2>
 <h3 id="drp-1-the-fission-gtpase"><a href="../../../genes/worm/drp-1/drp-1-ai-review.html">DRP-1</a> - The Fission GTPase</h3>
@@ -556,7 +556,7 @@ The balance between ATFS-1-mediated repair (UPRmt) and <a href="../../../genes/w
 2. TOR inhibition (let-363)<br />
 3. Dietary restriction (eat-2)<br />
 4. Reduced insulin/IGF signaling (<a href="../../../genes/worm/daf-2/daf-2-ai-review.html">daf-2</a>)<br />
-5. Reduced mitochondrial respiration (clk-1, isp-1)<br />
+5. Reduced mitochondrial respiration (clk-1, <a href="../../../genes/worm/isp-1/isp-1-ai-review.html">isp-1</a>)<br />
 6. Reduced translation (rsks-1)</p>
 <p><a href="../../../genes/worm/hlh-30/hlh-30-ai-review.html">HLH-30</a> overexpression extends lifespan by 15-20%. Nuclear localization is enhanced in all six longevity models [PMID:23925298].</p>
 <p><strong>Innate Immunity:</strong><br />

--- a/pages/projects/CAEEL_PROTEOSTASIS.html
+++ b/pages/projects/CAEEL_PROTEOSTASIS.html
@@ -393,8 +393,8 @@
 <h3 id="3-hsp70-co-chaperones">3. HSP70 Co-chaperones</h3>
 <ul>
 <li><strong>dnj-* family</strong> - <a href="../../genes/ECOLI/DnaJ/DnaJ-ai-review.html">DnaJ</a>/HSP40 proteins (&gt;30 members)</li>
-<li><strong>bag-1</strong> - BAG family regulator</li>
-<li><strong>hip-1</strong> - HSP70 interacting protein</li>
+<li><strong><a href="../../genes/worm/bag-1/bag-1-ai-review.html">bag-1</a></strong> - BAG family regulator</li>
+<li><strong><a href="../../genes/worm/hip-1/hip-1-ai-review.html">hip-1</a></strong> - HSP70 interacting protein</li>
 <li><strong>unc-23</strong> - <a href="../../genes/human/BAG2/BAG2-ai-review.html">BAG2</a> ortholog</li>
 </ul>
 <h3 id="4-ubiquitin-proteasome-system-ups">4. Ubiquitin-Proteasome System (UPS)</h3>
@@ -424,7 +424,7 @@
 </ul>
 <h3 id="8-disaggregases">8. Disaggregases</h3>
 <p>Protein aggregate dissolution:<br />
-- <strong>hsp-110</strong> - HSP110 (NEF for HSP70)<br />
+- <strong><a href="../../genes/worm/hsp-110/hsp-110-ai-review.html">hsp-110</a></strong> - HSP110 (NEF for HSP70)<br />
 - <strong>torsin</strong> - Torsin ATPase</p>
 <h3 id="9-disease-models-aggregation-prone-proteins">9. Disease Models (Aggregation-Prone Proteins)</h3>
 <p>Transgenic models:<br />

--- a/pages/projects/CAEEL_PROTEOSTASIS/CAEEL_PROTEOSTASIS-pathway.html
+++ b/pages/projects/CAEEL_PROTEOSTASIS/CAEEL_PROTEOSTASIS-pathway.html
@@ -424,7 +424,7 @@
 <li><strong>ATP hydrolysis cycle</strong>: Uses ATP energy to bind misfolded proteins</li>
 <li><strong>Co-chaperone cooperation</strong>: STI-1 (Hop ortholog) works with <a href="../../../genes/worm/hsp-1/hsp-1-ai-review.html">HSP-1</a> to deliver substrates to <a href="../../../genes/worm/hsp-90/hsp-90-ai-review.html">HSP-90</a></li>
 <li><strong>Protein refolding</strong>: ATP-dependent unfolding and refolding of partially folded proteins</li>
-<li><strong>Disaggregation</strong>: With HSP-110 and AAA+ ATPases, dissolves small aggregates</li>
+<li><strong>Disaggregation</strong>: With <a href="../../../genes/worm/hsp-110/hsp-110-ai-review.html">HSP-110</a> and AAA+ ATPases, dissolves small aggregates</li>
 </ol>
 <h4 id="cellular-localizations-accept">Cellular Localizations (ACCEPT)</h4>
 <ul>
@@ -1019,7 +1019,7 @@
 <h4 id="antioxidant-gene-network">Antioxidant Gene Network</h4>
 <p><a href="../../../genes/worm/skn-1/skn-1-ai-review.html">SKN-1</a> target genes include:</p>
 <ul>
-<li><strong>SOD isoforms</strong>: sod-2 (Mn-SOD), sod-3 (Fe-SOD)</li>
+<li><strong>SOD isoforms</strong>: <a href="../../../genes/worm/sod-2/sod-2-ai-review.html">sod-2</a> (Mn-SOD), <a href="../../../genes/worm/sod-3/sod-3-ai-review.html">sod-3</a> (Fe-SOD)</li>
 <li><strong>Glutathione enzymes</strong>: GST enzymes for xenobiotic conjugation</li>
 <li><strong>Thioredoxin system</strong>: TRX-1, TRXR-1 (thioredoxin reductase)</li>
 <li><strong>Phase I detoxification</strong>: CYP genes for toxic metabolite activation</li>

--- a/pages/projects/CAEEL_P_GRANULES.html
+++ b/pages/projects/CAEEL_P_GRANULES.html
@@ -384,7 +384,7 @@
 <h3 id="2-vasa-like-rna-helicases-glh-family">2. VASA-like RNA Helicases (GLH Family)</h3>
 <p>DEAD-box helicases essential for P granule integrity:<br />
 - <strong><a href="../../genes/worm/glh-1/glh-1-ai-review.html">glh-1</a></strong> - Germline helicase 1 (DDX4/VASA ortholog)<br />
-- <strong>glh-2</strong> - Germline helicase 2<br />
+- <strong><a href="../../genes/worm/glh-2/glh-2-ai-review.html">glh-2</a></strong> - Germline helicase 2<br />
 - <strong><a href="../../genes/worm/glh-4/glh-4-ai-review.html">glh-4</a></strong> - Germline helicase 4</p>
 <h3 id="3-meg-proteins-p-granule-regulators">3. MEG Proteins (P Granule Regulators)</h3>
 <p>Intrinsically disordered proteins regulating P granule dynamics:<br />
@@ -406,12 +406,12 @@
 <p>Kinases and factors controlling condensation:<br />
 - <strong><a href="../../genes/worm/mbk-2/mbk-2-ai-review.html">mbk-2</a></strong> - Minibrain kinase (DYRK ortholog, regulates MEG proteins)<br />
 - <strong><a href="../../genes/worm/mex-5/mex-5-ai-review.html">mex-5</a></strong> - Muscle excess 5 (RNA-binding, polarity)<br />
-- <strong>mex-6</strong> - Muscle excess 6 (redundant with <a href="../../genes/worm/mex-5/mex-5-ai-review.html">mex-5</a>)<br />
+- <strong><a href="../../genes/worm/mex-6/mex-6-ai-review.html">mex-6</a></strong> - Muscle excess 6 (redundant with <a href="../../genes/worm/mex-5/mex-5-ai-review.html">mex-5</a>)<br />
 - <strong>par-1</strong> - Partitioning defective 1 (polarity kinase)</p>
 <h3 id="7-z-granule-components">7. Z Granule Components</h3>
 <p>Adjacent condensate for secondary siRNA amplification:<br />
 - <strong><a href="../../genes/worm/znfx-1/znfx-1-ai-review.html">znfx-1</a></strong> - Zinc finger NFX1-type 1 (Z granule marker)<br />
-- <strong>wago-4</strong> - Z granule Argonaute</p>
+- <strong><a href="../../genes/worm/wago-4/wago-4-ai-review.html">wago-4</a></strong> - Z granule Argonaute</p>
 <h3 id="8-mutator-foci-components">8. Mutator Foci Components</h3>
 <p>Adjacent condensate for siRNA amplification:<br />
 - <strong><a href="../../genes/worm/mut-16/mut-16-ai-review.html">mut-16</a></strong> - Mutator 16 (Mutator focus scaffold)<br />
@@ -652,7 +652,7 @@
 <h3 id="priority-2-summary-rna-silencing-machinery">Priority 2 Summary (RNA Silencing Machinery):</h3>
 <ul>
 <li><strong><a href="../../genes/worm/prg-1/prg-1-ai-review.html">prg-1</a></strong>: Piwi/21U-RNA pathway, 28 annotations, removed incorrect nucleus and pole cell annotations</li>
-<li><strong><a href="../../genes/worm/csr-1/csr-1-ai-review.html">csr-1</a></strong>: NOTE - fetched data was for wrong gene (nhr-47), proposed corrections for actual <a href="../../genes/worm/csr-1/csr-1-ai-review.html">CSR-1</a> Argonaute</li>
+<li><strong><a href="../../genes/worm/csr-1/csr-1-ai-review.html">csr-1</a></strong>: NOTE - fetched data was for wrong gene (<a href="../../genes/worm/nhr-47/nhr-47-ai-review.html">nhr-47</a>), proposed corrections for actual <a href="../../genes/worm/csr-1/csr-1-ai-review.html">CSR-1</a> Argonaute</li>
 <li><strong><a href="../../genes/worm/deps-1/deps-1-ai-review.html">deps-1</a></strong>: P granule scaffold, added molecular condensate scaffold activity</li>
 <li><strong><a href="../../genes/worm/wago-1/wago-1-ai-review.html">wago-1</a></strong>: 22G-RNA pathway, removed nuclear localization and RNA endonuclease (lacks catalytic residues)</li>
 <li><strong><a href="../../genes/worm/znfx-1/znfx-1-ai-review.html">znfx-1</a></strong>: Z granule marker for transgenerational RNAi inheritance, removed incorrect nuclear annotations</li>

--- a/pages/projects/CAEEL_SURVEILLANCE_IMMUNITY.html
+++ b/pages/projects/CAEEL_SURVEILLANCE_IMMUNITY.html
@@ -420,8 +420,8 @@
 <h3 id="7-epidermal-immunity-antifungal">7. Epidermal Immunity (Antifungal)</h3>
 <p>Distinct pathway in epidermis:<br />
 - <strong><a href="../../genes/worm/sta-2/sta-2-ai-review.html">sta-2</a></strong> - STAT-like TF<br />
-- <strong>dcar-1</strong> - GPCR for damage sensing<br />
-- <strong>gpa-12</strong> - G-alpha protein<br />
+- <strong><a href="../../genes/worm/dcar-1/dcar-1-ai-review.html">dcar-1</a></strong> - GPCR for damage sensing<br />
+- <strong><a href="../../genes/worm/gpa-12/gpa-12-ai-review.html">gpa-12</a></strong> - G-alpha protein<br />
 - <strong><a href="../../genes/worm/nipi-3/nipi-3-ai-review.html">nipi-3</a></strong> - Tribbles kinase</p>
 <h3 id="8-autophagy-immunity-interface">8. Autophagy-Immunity Interface</h3>
 <ul>


### PR DESCRIPTION
## Summary

Automated regeneration of static assets after gene review or template changes.

## Generated Assets

| Asset | Count/Status |
|-------|--------------|
| Gene review YAML files | 2889 |
| Gene review HTML pages | 2889 |
| Project pages | 1098 |
| Module pages | 87 |
| Browser app (data.js) | Updated |
| Validation report | Updated |

## Trigger

This PR was triggered by changes to:
- genes/**/*.yaml - gene review data files
- src/ai_gene_review/schema/** - LinkML schema files
- src/ai_gene_review/templates/** - Jinja2 templates
- src/ai_gene_review/render.py - rendering code
- src/ai_gene_review/render_modules.py - module rendering code
- src/ai_gene_review/export/** - export code
- src/ai_gene_review/browser/** - browser app assets
- src/ai_gene_review/tools/minify_linkml_browser_data.py - browser data compaction
- projects/*.md - project definitions
- modules/**/*.yaml - module definitions
- project.justfile - just recipes used by CI
- .github/workflows/generate-pages.yaml - workflow definition

## Review

- [ ] Spot-check a few gene review HTML pages render correctly
- [ ] Spot-check module tree browser pages render correctly
- [ ] Verify browser app loads and filters work
- [ ] Check validation report for new issues
