### PR TITLE
Add FBXL16 knowledge gaps

### DIFF
--- a/genes/human/FBXL16/FBXL16-ai-review.html
+++ b/genes/human/FBXL16/FBXL16-ai-review.html
@@ -2122,6 +2122,38 @@
                 <div class="reference-header">
                     <span class="reference-id">
 
+                        file:human/FBXL16/FBXL16-pn-notes.md
+
+                    </span>
+                </div>
+
+                <div class="reference-title">FBXL16 PN consistency notes</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">The proteostasis-network projection treats FBXL16 as a Cul1 substrate receptor, but the local review identifies this as a caveated mapping because FBXL16 is SKP1-positive and CUL1-negative in reported assays.</div>
+
+                        <div class="finding-text">"PN places FBXL16 as a canonical Cul1 substrate receptor, but falcon + review establish FBXL16 is **non-canonical**: it binds SKP1 but shows **no detectable CUL1 interaction** (Shah 2022)"</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <div class="finding-statement">The stabilizing, anti-degradative mode is a real curation and ontology pressure point because no precise GO molecular-function term exists for it yet.</div>
+
+                        <div class="finding-text">"The novel pressure is the **stabilizing/anti-degradative mode** with no GO MF — review proposes a new term &#34;protein stabilization by inhibition of ubiquitin-dependent degradation&#34; (candidate, UNVERIFIED — not yet a real GO ID; defensible but needs OLS/GO submission)."</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
                         Reactome:R-HSA-8952618
 
                     </span>
@@ -2348,6 +2380,106 @@
     </div>
 
 
+
+    <div class="section">
+        <h2 class="section-title">Knowledge Gaps</h2>
+        <p style="color: #555; font-size: 0.92rem; margin-top: -0.3rem;">
+            What is <em>not</em> known — curated, literature-grounded statements of the open
+            unknowns (the inverse of core functions).
+        </p>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The exact E3-ligase architecture used by FBXL16 remains unresolved. FBXL16 can bind SKP1 and is mapped here to ubiquitin-like ligase-substrate adaptor activity, but reported failure to detect CUL1 leaves open whether the degradative HIF1alpha/APP activities use a canonical productive SCF complex, a non-canonical cullin/RBX module, or modulation of other ligases.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span><span class="badge">CURATION</span>
+                <span class="badge">RESIDUAL_SUBGAP</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> The review supports FBXL16 as an F-box/LRR substrate-recognition factor that can promote proteasomal degradation of HIF1alpha and APP, while excluding catalytic ubiquitin ligase activity from the core function.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> This boundary determines how confidently GO:1990756 and SCF-dependent-proteasomal-catabolism annotations should be propagated to FBXL16. Treating it as an ordinary Cul1-SCF receptor may overstate the molecular mechanism if FBXL16 instead acts through a non-canonical complex or through antagonism of other ligases.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Endogenous and reconstituted FBXL16 complex profiling should test SKP1, CUL1, RBX1, neddylated cullin, and alternative ligase partners, then compare FBXL16-dependent HIF1alpha/APP turnover under cullin/neddylation inhibition and with F-box or LRR mutants.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"breast cancer-focused mechanistic work reports that FBXL16 can associate with **SKP1** yet shows **no detectable interaction with CUL1**, implying **non-canonical behavior** for an F-box protein and leaving the precise E3 architecture context-dependent or unresolved."</em> — file:human/FBXL16/FBXL16-deep-research-falcon.md</li>
+
+                <li><em>"The group adaptor mapping (GO:1990756) is defensible for the degradative HIF1alpha/APP mode, but the &#34;no CUL1 binding&#34; finding means FBXL16 may not be a productive Cul1-SCF"</em> — file:human/FBXL16/FBXL16-pn-notes.md</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The molecular basis of FBXL16&#39;s substrate-stabilizing mode is still dark. Current evidence indicates FBXL16 can degrade some clients while stabilizing others, but it is unresolved whether the stabilizing activity is direct substrate-adaptor behavior, competition with another E3 ligase, inhibition of ubiquitination, or an indirect signaling consequence.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span><span class="badge">ONTOLOGY</span><span class="badge">CURATION</span>
+                <span class="badge">MF_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> The review supports context-dependent regulation of substrate protein stability, including degradative and stabilizing modes, but the current GO molecular-function term captures the adaptor/degradative side better than anti-degradative stabilization.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> This is the main ontology pressure point for FBXL16. Without a resolved mechanism and a precise GO term, the stabilizing activities on IRS1, ERalpha, c-MYC, SRC-3, and beta-catenin can only be represented awkwardly by a broad adaptor function or by a proposed, not-yet-real term.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> For each stabilized client, measure direct FBXL16 binding, client ubiquitination, half-life, competing ligase involvement, and dependence on the FBXL16 F-box/LRR domains; in parallel, submit or refine a GO term if the direct anti-degradative activity is experimentally supported.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"Recent literature converges on FBXL16 as a regulator of **protein stability** with at least two modes"</em> — file:human/FBXL16/FBXL16-deep-research-falcon.md</li>
+
+                <li><em>"In ER+ breast cancer, FBXL16 is presented as a positive regulator of **ERα stability** and endocrine resistance (via reduced ubiquitination), and also reported to stabilize oncoproteins such as c-MYC and β-catenin in related contexts."</em> — file:human/FBXL16/FBXL16-deep-research-falcon.md</li>
+
+                <li><em>"The novel pressure is the **stabilizing/anti-degradative mode** with no GO MF — review proposes a new term &#34;protein stabilization by inhibition of ubiquitin-dependent degradation&#34; (candidate, UNVERIFIED — not yet a real GO ID; defensible but needs OLS/GO submission)."</em> — file:human/FBXL16/FBXL16-pn-notes.md</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The normal physiological substrate repertoire and tissue role of FBXL16, especially in brain, remain incompletely defined. APP and several cancer signaling proteins are useful leads, but it is not yet clear which clients and processes represent conserved endogenous FBXL16 biology rather than disease-model or tumor-context readouts.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span><span class="badge">CURATION</span>
+                <span class="badge">BP_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> APP degradation, HIF1alpha degradation, and stabilization of selected signaling regulators are captured as supported examples, and brain is noted as the highest-expression tissue, but the review does not convert those examples into a broad normal brain or disease-process annotation.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Resolving this gap would decide whether FBXL16 should receive additional biological-process annotations for neuronal proteostasis, cognition, neuroinflammation, cancer signaling, or drug resistance, or whether those claims should remain context-specific findings rather than core function.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Combine FBXL16 loss-of-function and rescue in physiological brain-derived systems with quantitative substrate proteomics, ubiquitinomics, and phenotype assays, then compare the validated endogenous clients with the APP, HIF1alpha, IRS1, and ERalpha disease-model literature.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"Direct localization evidence in the retrieved set includes **cytoplasmic co-localization of FBXL16 with APP** in neuronal cell models"</em> — file:human/FBXL16/FBXL16-deep-research-falcon.md</li>
+
+                <li><em>"Overexpression + Flag-IP LC–MS/MS identified **141 interacting proteins**, enriched for ubiquitin-dependent catabolic processes"</em> — file:human/FBXL16/FBXL16-deep-research-falcon.md</li>
+
+                <li><em>"It is expressed most highly in brain."</em> — file:human/FBXL16/FBXL16-pn-notes.md</li>
+
+            </ul>
+
+
+        </div>
+
+    </div>
 
 
 
@@ -3010,6 +3142,17 @@ references:
     relevance: HIGH
     correctness: UNVERIFIED
     review_notes: Falcon (Edison Scientific) deep research synthesis. Substantially expands FBXL16 beyond the HIF1alpha/TNBC story (PMID:34818544) to a context-dependent stability regulator with both degradative (HIF1alpha, APP) and stabilizing (IRS1, ERalpha, c-MYC, beta-catenin) modes, and surfaces the key non-canonical caveat that FBXL16 binds SKP1 but not CUL1. Primary leads (Qu et al. 2024 Biomarker Research; Morel &amp; Long 2024 Molecular Oncology; Shah 2022; Yao et al. 2024 Respiratory Research) cite DOIs not PMIDs and are not in the local cache, so are not independently PubMed-verified here; treated as leads informing the description and core-function framing.
+- id: file:human/FBXL16/FBXL16-pn-notes.md
+  title: FBXL16 PN consistency notes
+  findings:
+  - statement: The proteostasis-network projection treats FBXL16 as a Cul1 substrate receptor, but the local review identifies this as a caveated mapping because FBXL16 is SKP1-positive and CUL1-negative in reported assays.
+    supporting_text: &#34;PN places FBXL16 as a canonical Cul1 substrate receptor, but falcon + review establish FBXL16 is **non-canonical**: it binds SKP1 but shows **no detectable CUL1 interaction** (Shah 2022)&#34;
+  - statement: The stabilizing, anti-degradative mode is a real curation and ontology pressure point because no precise GO molecular-function term exists for it yet.
+    supporting_text: The novel pressure is the **stabilizing/anti-degradative mode** with no GO MF — review proposes a new term &#34;protein stabilization by inhibition of ubiquitin-dependent degradation&#34; (candidate, UNVERIFIED — not yet a real GO ID; defensible but needs OLS/GO submission).
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: Local PN consistency note comparing the FBXL16 review with the Proteostasis Network mapping. Used here to record the unresolved mapping pressure around non-canonical CUL1 association and the proposed anti-degradative stabilization term.
 - id: Reactome:R-HSA-8952618
   title: AcM-UBE2M transfers NEDD8 to CRL1 E3 ubiquitin ligase complex
   findings: []
@@ -3076,6 +3219,105 @@ suggested_questions:
 suggested_experiments:
 - description: Test whether FBXL16 assembles a productive SCF (immunoprecipitate FBXL16 and probe for CUL1/RBX1/NEDD8) and whether neddylation inhibition (MLN4924) alters FBXL16-dependent turnover of HIF1alpha and APP versus stabilization of IRS1/ERalpha, distinguishing canonical-SCF from non-canonical mechanisms.
 - description: Identify the endogenous FBXL16 substrate repertoire by AP-MS and quantitative proteomics in FBXL16 knockout versus wild-type cells across brain-derived and cancer models, classifying each interactor as stabilized or degraded, and test whether stabilization requires antagonism of competing ligases (e.g. FBXO45 for ERalpha).
+knowledge_gaps:
+- gap_statement: &gt;-
+    The exact E3-ligase architecture used by FBXL16 remains unresolved. FBXL16 can
+    bind SKP1 and is mapped here to ubiquitin-like ligase-substrate adaptor
+    activity, but reported failure to detect CUL1 leaves open whether the
+    degradative HIF1alpha/APP activities use a canonical productive SCF complex,
+    a non-canonical cullin/RBX module, or modulation of other ligases.
+  boundary: &gt;-
+    The review supports FBXL16 as an F-box/LRR substrate-recognition factor that
+    can promote proteasomal degradation of HIF1alpha and APP, while excluding
+    catalytic ubiquitin ligase activity from the core function.
+  gap_kind:
+  - BIOLOGY
+  - CURATION
+  dark_aspect: RESIDUAL_SUBGAP
+  status: OPEN
+  significance: &gt;-
+    This boundary determines how confidently GO:1990756 and
+    SCF-dependent-proteasomal-catabolism annotations should be propagated to
+    FBXL16. Treating it as an ordinary Cul1-SCF receptor may overstate the
+    molecular mechanism if FBXL16 instead acts through a non-canonical complex or
+    through antagonism of other ligases.
+  resolution: &gt;-
+    Endogenous and reconstituted FBXL16 complex profiling should test SKP1, CUL1,
+    RBX1, neddylated cullin, and alternative ligase partners, then compare
+    FBXL16-dependent HIF1alpha/APP turnover under cullin/neddylation inhibition
+    and with F-box or LRR mutants.
+  provenance:
+  - reference_id: file:human/FBXL16/FBXL16-deep-research-falcon.md
+    supporting_text: breast cancer-focused mechanistic work reports that FBXL16 can associate with **SKP1** yet shows **no detectable interaction with CUL1**, implying **non-canonical behavior** for an F-box protein and leaving the precise E3 architecture context-dependent or unresolved.
+  - reference_id: file:human/FBXL16/FBXL16-pn-notes.md
+    supporting_text: The group adaptor mapping (GO:1990756) is defensible for the degradative HIF1alpha/APP mode, but the &#34;no CUL1 binding&#34; finding means FBXL16 may not be a productive Cul1-SCF
+- gap_statement: &gt;-
+    The molecular basis of FBXL16&#39;s substrate-stabilizing mode is still dark.
+    Current evidence indicates FBXL16 can degrade some clients while stabilizing
+    others, but it is unresolved whether the stabilizing activity is direct
+    substrate-adaptor behavior, competition with another E3 ligase, inhibition of
+    ubiquitination, or an indirect signaling consequence.
+  boundary: &gt;-
+    The review supports context-dependent regulation of substrate protein
+    stability, including degradative and stabilizing modes, but the current GO
+    molecular-function term captures the adaptor/degradative side better than
+    anti-degradative stabilization.
+  gap_kind:
+  - BIOLOGY
+  - ONTOLOGY
+  - CURATION
+  dark_aspect: MF_DARK
+  status: OPEN
+  significance: &gt;-
+    This is the main ontology pressure point for FBXL16. Without a resolved
+    mechanism and a precise GO term, the stabilizing activities on IRS1, ERalpha,
+    c-MYC, SRC-3, and beta-catenin can only be represented awkwardly by a broad
+    adaptor function or by a proposed, not-yet-real term.
+  resolution: &gt;-
+    For each stabilized client, measure direct FBXL16 binding, client
+    ubiquitination, half-life, competing ligase involvement, and dependence on the
+    FBXL16 F-box/LRR domains; in parallel, submit or refine a GO term if the
+    direct anti-degradative activity is experimentally supported.
+  provenance:
+  - reference_id: file:human/FBXL16/FBXL16-deep-research-falcon.md
+    supporting_text: Recent literature converges on FBXL16 as a regulator of **protein stability** with at least two modes
+  - reference_id: file:human/FBXL16/FBXL16-deep-research-falcon.md
+    supporting_text: In ER+ breast cancer, FBXL16 is presented as a positive regulator of **ERα stability** and endocrine resistance (via reduced ubiquitination), and also reported to stabilize oncoproteins such as c-MYC and β-catenin in related contexts.
+  - reference_id: file:human/FBXL16/FBXL16-pn-notes.md
+    supporting_text: The novel pressure is the **stabilizing/anti-degradative mode** with no GO MF — review proposes a new term &#34;protein stabilization by inhibition of ubiquitin-dependent degradation&#34; (candidate, UNVERIFIED — not yet a real GO ID; defensible but needs OLS/GO submission).
+- gap_statement: &gt;-
+    The normal physiological substrate repertoire and tissue role of FBXL16,
+    especially in brain, remain incompletely defined. APP and several cancer
+    signaling proteins are useful leads, but it is not yet clear which clients and
+    processes represent conserved endogenous FBXL16 biology rather than
+    disease-model or tumor-context readouts.
+  boundary: &gt;-
+    APP degradation, HIF1alpha degradation, and stabilization of selected
+    signaling regulators are captured as supported examples, and brain is noted as
+    the highest-expression tissue, but the review does not convert those examples
+    into a broad normal brain or disease-process annotation.
+  gap_kind:
+  - BIOLOGY
+  - CURATION
+  dark_aspect: BP_DARK
+  status: OPEN
+  significance: &gt;-
+    Resolving this gap would decide whether FBXL16 should receive additional
+    biological-process annotations for neuronal proteostasis, cognition,
+    neuroinflammation, cancer signaling, or drug resistance, or whether those
+    claims should remain context-specific findings rather than core function.
+  resolution: &gt;-
+    Combine FBXL16 loss-of-function and rescue in physiological brain-derived
+    systems with quantitative substrate proteomics, ubiquitinomics, and
+    phenotype assays, then compare the validated endogenous clients with the APP,
+    HIF1alpha, IRS1, and ERalpha disease-model literature.
+  provenance:
+  - reference_id: file:human/FBXL16/FBXL16-deep-research-falcon.md
+    supporting_text: Direct localization evidence in the retrieved set includes **cytoplasmic co-localization of FBXL16 with APP** in neuronal cell models
+  - reference_id: file:human/FBXL16/FBXL16-deep-research-falcon.md
+    supporting_text: Overexpression + Flag-IP LC–MS/MS identified **141 interacting proteins**, enriched for ubiquitin-dependent catabolic processes
+  - reference_id: file:human/FBXL16/FBXL16-pn-notes.md
+    supporting_text: It is expressed most highly in brain.
 </code></pre>
             </div>
         </details>

--- a/genes/human/FBXL16/FBXL16-ai-review.yaml
+++ b/genes/human/FBXL16/FBXL16-ai-review.yaml
@@ -249,6 +249,17 @@ references:
     relevance: HIGH
     correctness: UNVERIFIED
     review_notes: Falcon (Edison Scientific) deep research synthesis. Substantially expands FBXL16 beyond the HIF1alpha/TNBC story (PMID:34818544) to a context-dependent stability regulator with both degradative (HIF1alpha, APP) and stabilizing (IRS1, ERalpha, c-MYC, beta-catenin) modes, and surfaces the key non-canonical caveat that FBXL16 binds SKP1 but not CUL1. Primary leads (Qu et al. 2024 Biomarker Research; Morel & Long 2024 Molecular Oncology; Shah 2022; Yao et al. 2024 Respiratory Research) cite DOIs not PMIDs and are not in the local cache, so are not independently PubMed-verified here; treated as leads informing the description and core-function framing.
+- id: file:human/FBXL16/FBXL16-pn-notes.md
+  title: FBXL16 PN consistency notes
+  findings:
+  - statement: The proteostasis-network projection treats FBXL16 as a Cul1 substrate receptor, but the local review identifies this as a caveated mapping because FBXL16 is SKP1-positive and CUL1-negative in reported assays.
+    supporting_text: "PN places FBXL16 as a canonical Cul1 substrate receptor, but falcon + review establish FBXL16 is **non-canonical**: it binds SKP1 but shows **no detectable CUL1 interaction** (Shah 2022)"
+  - statement: The stabilizing, anti-degradative mode is a real curation and ontology pressure point because no precise GO molecular-function term exists for it yet.
+    supporting_text: The novel pressure is the **stabilizing/anti-degradative mode** with no GO MF — review proposes a new term "protein stabilization by inhibition of ubiquitin-dependent degradation" (candidate, UNVERIFIED — not yet a real GO ID; defensible but needs OLS/GO submission).
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: Local PN consistency note comparing the FBXL16 review with the Proteostasis Network mapping. Used here to record the unresolved mapping pressure around non-canonical CUL1 association and the proposed anti-degradative stabilization term.
 - id: Reactome:R-HSA-8952618
   title: AcM-UBE2M transfers NEDD8 to CRL1 E3 ubiquitin ligase complex
   findings: []
@@ -315,3 +326,102 @@ suggested_questions:
 suggested_experiments:
 - description: Test whether FBXL16 assembles a productive SCF (immunoprecipitate FBXL16 and probe for CUL1/RBX1/NEDD8) and whether neddylation inhibition (MLN4924) alters FBXL16-dependent turnover of HIF1alpha and APP versus stabilization of IRS1/ERalpha, distinguishing canonical-SCF from non-canonical mechanisms.
 - description: Identify the endogenous FBXL16 substrate repertoire by AP-MS and quantitative proteomics in FBXL16 knockout versus wild-type cells across brain-derived and cancer models, classifying each interactor as stabilized or degraded, and test whether stabilization requires antagonism of competing ligases (e.g. FBXO45 for ERalpha).
+knowledge_gaps:
+- gap_statement: >-
+    The exact E3-ligase architecture used by FBXL16 remains unresolved. FBXL16 can
+    bind SKP1 and is mapped here to ubiquitin-like ligase-substrate adaptor
+    activity, but reported failure to detect CUL1 leaves open whether the
+    degradative HIF1alpha/APP activities use a canonical productive SCF complex,
+    a non-canonical cullin/RBX module, or modulation of other ligases.
+  boundary: >-
+    The review supports FBXL16 as an F-box/LRR substrate-recognition factor that
+    can promote proteasomal degradation of HIF1alpha and APP, while excluding
+    catalytic ubiquitin ligase activity from the core function.
+  gap_kind:
+  - BIOLOGY
+  - CURATION
+  dark_aspect: RESIDUAL_SUBGAP
+  status: OPEN
+  significance: >-
+    This boundary determines how confidently GO:1990756 and
+    SCF-dependent-proteasomal-catabolism annotations should be propagated to
+    FBXL16. Treating it as an ordinary Cul1-SCF receptor may overstate the
+    molecular mechanism if FBXL16 instead acts through a non-canonical complex or
+    through antagonism of other ligases.
+  resolution: >-
+    Endogenous and reconstituted FBXL16 complex profiling should test SKP1, CUL1,
+    RBX1, neddylated cullin, and alternative ligase partners, then compare
+    FBXL16-dependent HIF1alpha/APP turnover under cullin/neddylation inhibition
+    and with F-box or LRR mutants.
+  provenance:
+  - reference_id: file:human/FBXL16/FBXL16-deep-research-falcon.md
+    supporting_text: breast cancer-focused mechanistic work reports that FBXL16 can associate with **SKP1** yet shows **no detectable interaction with CUL1**, implying **non-canonical behavior** for an F-box protein and leaving the precise E3 architecture context-dependent or unresolved.
+  - reference_id: file:human/FBXL16/FBXL16-pn-notes.md
+    supporting_text: The group adaptor mapping (GO:1990756) is defensible for the degradative HIF1alpha/APP mode, but the "no CUL1 binding" finding means FBXL16 may not be a productive Cul1-SCF
+- gap_statement: >-
+    The molecular basis of FBXL16's substrate-stabilizing mode is still dark.
+    Current evidence indicates FBXL16 can degrade some clients while stabilizing
+    others, but it is unresolved whether the stabilizing activity is direct
+    substrate-adaptor behavior, competition with another E3 ligase, inhibition of
+    ubiquitination, or an indirect signaling consequence.
+  boundary: >-
+    The review supports context-dependent regulation of substrate protein
+    stability, including degradative and stabilizing modes, but the current GO
+    molecular-function term captures the adaptor/degradative side better than
+    anti-degradative stabilization.
+  gap_kind:
+  - BIOLOGY
+  - ONTOLOGY
+  - CURATION
+  dark_aspect: MF_DARK
+  status: OPEN
+  significance: >-
+    This is the main ontology pressure point for FBXL16. Without a resolved
+    mechanism and a precise GO term, the stabilizing activities on IRS1, ERalpha,
+    c-MYC, SRC-3, and beta-catenin can only be represented awkwardly by a broad
+    adaptor function or by a proposed, not-yet-real term.
+  resolution: >-
+    For each stabilized client, measure direct FBXL16 binding, client
+    ubiquitination, half-life, competing ligase involvement, and dependence on the
+    FBXL16 F-box/LRR domains; in parallel, submit or refine a GO term if the
+    direct anti-degradative activity is experimentally supported.
+  provenance:
+  - reference_id: file:human/FBXL16/FBXL16-deep-research-falcon.md
+    supporting_text: Recent literature converges on FBXL16 as a regulator of **protein stability** with at least two modes
+  - reference_id: file:human/FBXL16/FBXL16-deep-research-falcon.md
+    supporting_text: In ER+ breast cancer, FBXL16 is presented as a positive regulator of **ERα stability** and endocrine resistance (via reduced ubiquitination), and also reported to stabilize oncoproteins such as c-MYC and β-catenin in related contexts.
+  - reference_id: file:human/FBXL16/FBXL16-pn-notes.md
+    supporting_text: The novel pressure is the **stabilizing/anti-degradative mode** with no GO MF — review proposes a new term "protein stabilization by inhibition of ubiquitin-dependent degradation" (candidate, UNVERIFIED — not yet a real GO ID; defensible but needs OLS/GO submission).
+- gap_statement: >-
+    The normal physiological substrate repertoire and tissue role of FBXL16,
+    especially in brain, remain incompletely defined. APP and several cancer
+    signaling proteins are useful leads, but it is not yet clear which clients and
+    processes represent conserved endogenous FBXL16 biology rather than
+    disease-model or tumor-context readouts.
+  boundary: >-
+    APP degradation, HIF1alpha degradation, and stabilization of selected
+    signaling regulators are captured as supported examples, and brain is noted as
+    the highest-expression tissue, but the review does not convert those examples
+    into a broad normal brain or disease-process annotation.
+  gap_kind:
+  - BIOLOGY
+  - CURATION
+  dark_aspect: BP_DARK
+  status: OPEN
+  significance: >-
+    Resolving this gap would decide whether FBXL16 should receive additional
+    biological-process annotations for neuronal proteostasis, cognition,
+    neuroinflammation, cancer signaling, or drug resistance, or whether those
+    claims should remain context-specific findings rather than core function.
+  resolution: >-
+    Combine FBXL16 loss-of-function and rescue in physiological brain-derived
+    systems with quantitative substrate proteomics, ubiquitinomics, and
+    phenotype assays, then compare the validated endogenous clients with the APP,
+    HIF1alpha, IRS1, and ERalpha disease-model literature.
+  provenance:
+  - reference_id: file:human/FBXL16/FBXL16-deep-research-falcon.md
+    supporting_text: Direct localization evidence in the retrieved set includes **cytoplasmic co-localization of FBXL16 with APP** in neuronal cell models
+  - reference_id: file:human/FBXL16/FBXL16-deep-research-falcon.md
+    supporting_text: Overexpression + Flag-IP LC–MS/MS identified **141 interacting proteins**, enriched for ubiquitin-dependent catabolic processes
+  - reference_id: file:human/FBXL16/FBXL16-pn-notes.md
+    supporting_text: It is expressed most highly in brain.


### PR DESCRIPTION
## Summary
- add structured FBXL16 knowledge gaps for non-canonical SCF/E3 architecture, the anti-degradative stabilization ontology gap, and unresolved brain/physiological substrate context
- add the FBXL16 PN consistency note as a file reference and render the updated review HTML

## Validation
- `just validate human FBXL16` passes with 4 warnings: both core-function entries use GO:1990756 and GO:0005737 terms not reflected as NEW existing_annotations
- `just render human FBXL16`
- `git diff --check`