### PR TITLE
Add DCAF10 knowledge gaps

### DIFF
--- a/genes/human/DCAF10/DCAF10-ai-review.html
+++ b/genes/human/DCAF10/DCAF10-ai-review.html
@@ -2278,6 +2278,84 @@
                 <div class="reference-header">
                     <span class="reference-id">
 
+                        file:human/DCAF10/DCAF10-uniprot.txt
+
+                    </span>
+                </div>
+
+                <div class="reference-title">UniProt record for human DCAF10</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">UniProt summarizes DCAF10 as a possible CUL4-DDB1 substrate receptor that interacts with DDB1.</div>
+
+                        <div class="finding-text">"May function as a substrate receptor for CUL4-DDB1 E3"</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <div class="finding-statement">UniProt carries a Bgee sperm expression cross-reference.</div>
+
+                        <div class="finding-text">"Expressed in sperm and 189 other cell types or tissues."</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <div class="finding-statement">UniProt carries a Reactome-derived nucleoplasm GO annotation.</div>
+
+                        <div class="finding-text">"GO; GO:0005654; C:nucleoplasm; TAS:Reactome."</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <div class="finding-statement">UniProt lists phosphoserine sites on DCAF10.</div>
+
+                        <div class="finding-text">"Phosphoserine"</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <div class="finding-statement">UniProt lists an omega-N-methylarginine site on DCAF10.</div>
+
+                        <div class="finding-text">"Omega-N-methylarginine"</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        file:human/DCAF10/DCAF10-notes.md
+
+                    </span>
+                </div>
+
+                <div class="reference-title">DCAF10 reviewer notes</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Reviewer notes flag DCAF10 N-terminal phosphoserine and methylarginine sites as uncharacterized.</div>
+
+                        <div class="finding-text">"N-terminal disordered region (1-119), with phosphoserine sites (S53, S63, S89, S92, S349) and methylarginine R134 from large-scale proteomics; no functional studies on these PTMs"</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
                         file:human/DCAF10/DCAF10-deep-research-falcon.md
 
                     </span>
@@ -2493,6 +2571,108 @@
     </div>
 
 
+
+    <div class="section">
+        <h2 class="section-title">Knowledge Gaps</h2>
+        <p style="color: #555; font-size: 0.92rem; margin-top: -0.3rem;">
+            What is <em>not</em> known — curated, literature-grounded statements of the open
+            unknowns (the inverse of core functions).
+        </p>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The breadth and physiological specificity of DCAF10&#39;s Ac-Gly/MO N-degron substrate-recognition activity remain unresolved. A recent primary study supports direct recognition and ubiquitination of acetylated Src-family kinases, but it is still unclear how broadly DCAF10 recognizes N-terminally acetylated glycine degrons across the proteome, which endogenous clients are core substrates, and how this activity should be represented by a precise GO molecular-function term.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span><span class="badge">ONTOLOGY</span><span class="badge">CURATION</span>
+                <span class="badge">MF_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> DCAF10 is established as a CRL4 substrate receptor, and the current review accepts protein ubiquitination/CRL4 complex membership while proposing a more specific Ac-Gly N-recognin term cautiously. The gap is the scope and term-level precision of the substrate-recognition activity, not whether DCAF10 can associate with DDB1/CUL4.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Resolving this gap would determine whether DCAF10 should receive a specific N-degron-recognin molecular-function annotation, how broadly that annotation applies beyond Lyn/Fyn/Src, and which proposed pathway/process annotations should be treated as direct DCAF10 biology rather than context-specific substrate leads.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Independent replication of Ac-Gly binding and CUL4A-DDB1-DCAF10 ubiquitination with endogenous substrates, proteome-wide Ac-Gly candidate testing, degron mutagenesis, and substrate-rescue assays would define the direct substrate class and support a precise GO term request.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"Recent breakthrough research by Kremer et al. (2026) identified DCAF10 as an N-recognin for proteins bearing N-terminally acetylated glycine (Ac-Gly) residues, particularly those that normally undergo N-myristoylation"</em> — file:human/DCAF10/DCAF10-deep-research-falcon.md</li>
+
+                <li><em>"The recognition motif is not simply Ac-Gly but includes downstream residues, with a preference for serine at position 6 and lysine at position 7"</em> — file:human/DCAF10/DCAF10-deep-research-falcon.md</li>
+
+                <li><em>"It is useful for separating direct DCAF10 substrates from cases, such as IRF3, where the evidence currently supports indirect regulation."</em> — file:human/DCAF10/DCAF10-deep-research-falcon.md</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> DCAF10&#39;s normal testis and spermatogenesis role is still largely undefined. Transcript-level evidence points to strong testis/sperm expression, but the relevant germ-cell substrates, developmental stage, and reproductive phenotype have not been resolved.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span><span class="badge">CURATION</span>
+                <span class="badge">BP_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> The review treats testis enrichment as a biological lead rather than as a curated spermatogenesis process annotation. DCAF10&#39;s established CRL4 substrate-receptor function provides a plausible mechanism, but not a specific reproductive process or substrate set.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> This gap controls whether DCAF10 should acquire biological-process annotations for spermatogenesis, germ-cell proteostasis, or male fertility, or whether testis expression should remain contextual evidence without direct functional annotation.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Stage-resolved germ-cell expression, DCAF10 loss-of-function in spermatogenic systems, fertility phenotyping, and testis-specific substrate/ubiquitin-remnant proteomics would establish whether DCAF10 has a specialized reproductive role.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"DCAF10 shows highest transcript levels in testis with very low expression in other tissues, suggesting a specialized role in spermatogenesis"</em> — file:human/DCAF10/DCAF10-deep-research-falcon.md</li>
+
+                <li><em>"Further research is needed to characterize DCAF10&#39;s specific role in spermatogenesis and whether defects in DCAF10 contribute to male infertility."</em> — file:human/DCAF10/DCAF10-deep-research-falcon.md</li>
+
+                <li><em>"Expressed in sperm and 189 other cell types or tissues."</em> — file:human/DCAF10/DCAF10-uniprot.txt</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The compartment-specific and regulatory context of DCAF10 activity is underdetermined. GOA/Reactome place DCAF10 in nucleoplasm, the literature synthesis points to both nuclear and cytoplasmic substrate contexts, and the N-terminal region contains phosphoserine and methylarginine marks whose effects on DDB1 docking, substrate selection, localization, or stability are unknown.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span><span class="badge">CURATION</span>
+                <span class="badge">CC_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> The review accepts CRL4-DCAF10 complex membership and keeps Reactome-derived nucleoplasm annotations as non-core. It does not yet define which cellular pools of DCAF10 perform which substrate-recognition functions, nor whether post-translational modifications regulate those pools.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Clarifying localization and regulatory PTMs would make DCAF10 annotations more precise, separating generic CRL4-pathway compartment projections from DCAF10-specific nuclear, cytoplasmic, or germ-cell substrate-recognition contexts.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Endogenous localization under basal, N-myristoylation-stress, viral, cancer, and germ-cell conditions, paired with phosphosite/methylarginine mutagenesis and DDB1/CUL4/substrate-binding assays, would define the regulated active pools of DCAF10.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"DCAF10 functions in both nuclear and cytoplasmic compartments as part of the ubiquitin-proteasome system"</em> — file:human/DCAF10/DCAF10-deep-research-falcon.md</li>
+
+                <li><em>"GO; GO:0005654; C:nucleoplasm; TAS:Reactome."</em> — file:human/DCAF10/DCAF10-uniprot.txt</li>
+
+                <li><em>"N-terminal disordered region (1-119), with phosphoserine sites (S53, S63, S89, S92, S349) and methylarginine R134 from large-scale proteomics; no functional studies on these PTMs"</em> — file:human/DCAF10/DCAF10-notes.md</li>
+
+            </ul>
+
+
+        </div>
+
+    </div>
 
 
 
@@ -3245,6 +3425,110 @@ suggested_experiments:
 - description: Affinity purification-mass spectrometry of endogenous (or epitope-tagged) DCAF10 followed by ubiquitin-remnant (diGly) proteomics in DCAF10-knockout vs wild-type cells to identify bona fide substrates.
 - description: Structural or mutational mapping of the DCAF10 WD40 surface and its WDxR/DWD motif to confirm and characterize DDB1 docking.
 - description: Quantitative proteomics of MCL1 and AIF-pathway components in DCAF10-knockout cells across multiple lineages to test the proposed apoptosis-regulatory role independently of the original ESCC context.
+knowledge_gaps:
+- gap_statement: &gt;-
+    The breadth and physiological specificity of DCAF10&#39;s Ac-Gly/MO N-degron
+    substrate-recognition activity remain unresolved. A recent primary study
+    supports direct recognition and ubiquitination of acetylated Src-family
+    kinases, but it is still unclear how broadly DCAF10 recognizes N-terminally
+    acetylated glycine degrons across the proteome, which endogenous clients are
+    core substrates, and how this activity should be represented by a precise GO
+    molecular-function term.
+  boundary: &gt;-
+    DCAF10 is established as a CRL4 substrate receptor, and the current review
+    accepts protein ubiquitination/CRL4 complex membership while proposing a more
+    specific Ac-Gly N-recognin term cautiously. The gap is the scope and
+    term-level precision of the substrate-recognition activity, not whether DCAF10
+    can associate with DDB1/CUL4.
+  gap_kind:
+  - BIOLOGY
+  - ONTOLOGY
+  - CURATION
+  dark_aspect: MF_DARK
+  status: OPEN
+  significance: &gt;-
+    Resolving this gap would determine whether DCAF10 should receive a specific
+    N-degron-recognin molecular-function annotation, how broadly that annotation
+    applies beyond Lyn/Fyn/Src, and which proposed pathway/process annotations
+    should be treated as direct DCAF10 biology rather than context-specific
+    substrate leads.
+  resolution: &gt;-
+    Independent replication of Ac-Gly binding and CUL4A-DDB1-DCAF10 ubiquitination
+    with endogenous substrates, proteome-wide Ac-Gly candidate testing, degron
+    mutagenesis, and substrate-rescue assays would define the direct substrate
+    class and support a precise GO term request.
+  provenance:
+  - reference_id: file:human/DCAF10/DCAF10-deep-research-falcon.md
+    supporting_text: Recent breakthrough research by Kremer et al. (2026) identified DCAF10 as an N-recognin for proteins bearing N-terminally acetylated glycine (Ac-Gly) residues, particularly those that normally undergo N-myristoylation
+  - reference_id: file:human/DCAF10/DCAF10-deep-research-falcon.md
+    supporting_text: The recognition motif is not simply Ac-Gly but includes downstream residues, with a preference for serine at position 6 and lysine at position 7
+  - reference_id: file:human/DCAF10/DCAF10-deep-research-falcon.md
+    supporting_text: It is useful for separating direct DCAF10 substrates from cases, such as IRF3, where the evidence currently supports indirect regulation.
+- gap_statement: &gt;-
+    DCAF10&#39;s normal testis and spermatogenesis role is still largely undefined.
+    Transcript-level evidence points to strong testis/sperm expression, but the
+    relevant germ-cell substrates, developmental stage, and reproductive phenotype
+    have not been resolved.
+  boundary: &gt;-
+    The review treats testis enrichment as a biological lead rather than as a
+    curated spermatogenesis process annotation. DCAF10&#39;s established CRL4
+    substrate-receptor function provides a plausible mechanism, but not a
+    specific reproductive process or substrate set.
+  gap_kind:
+  - BIOLOGY
+  - CURATION
+  dark_aspect: BP_DARK
+  status: OPEN
+  significance: &gt;-
+    This gap controls whether DCAF10 should acquire biological-process annotations
+    for spermatogenesis, germ-cell proteostasis, or male fertility, or whether
+    testis expression should remain contextual evidence without direct functional
+    annotation.
+  resolution: &gt;-
+    Stage-resolved germ-cell expression, DCAF10 loss-of-function in spermatogenic
+    systems, fertility phenotyping, and testis-specific substrate/ubiquitin-remnant
+    proteomics would establish whether DCAF10 has a specialized reproductive role.
+  provenance:
+  - reference_id: file:human/DCAF10/DCAF10-deep-research-falcon.md
+    supporting_text: DCAF10 shows highest transcript levels in testis with very low expression in other tissues, suggesting a specialized role in spermatogenesis
+  - reference_id: file:human/DCAF10/DCAF10-deep-research-falcon.md
+    supporting_text: Further research is needed to characterize DCAF10&#39;s specific role in spermatogenesis and whether defects in DCAF10 contribute to male infertility.
+  - reference_id: file:human/DCAF10/DCAF10-uniprot.txt
+    supporting_text: Expressed in sperm and 189 other cell types or tissues.
+- gap_statement: &gt;-
+    The compartment-specific and regulatory context of DCAF10 activity is
+    underdetermined. GOA/Reactome place DCAF10 in nucleoplasm, the literature
+    synthesis points to both nuclear and cytoplasmic substrate contexts, and the
+    N-terminal region contains phosphoserine and methylarginine marks whose
+    effects on DDB1 docking, substrate selection, localization, or stability are
+    unknown.
+  boundary: &gt;-
+    The review accepts CRL4-DCAF10 complex membership and keeps Reactome-derived
+    nucleoplasm annotations as non-core. It does not yet define which cellular
+    pools of DCAF10 perform which substrate-recognition functions, nor whether
+    post-translational modifications regulate those pools.
+  gap_kind:
+  - BIOLOGY
+  - CURATION
+  dark_aspect: CC_DARK
+  status: OPEN
+  significance: &gt;-
+    Clarifying localization and regulatory PTMs would make DCAF10 annotations more
+    precise, separating generic CRL4-pathway compartment projections from
+    DCAF10-specific nuclear, cytoplasmic, or germ-cell substrate-recognition
+    contexts.
+  resolution: &gt;-
+    Endogenous localization under basal, N-myristoylation-stress, viral, cancer,
+    and germ-cell conditions, paired with phosphosite/methylarginine mutagenesis
+    and DDB1/CUL4/substrate-binding assays, would define the regulated active
+    pools of DCAF10.
+  provenance:
+  - reference_id: file:human/DCAF10/DCAF10-deep-research-falcon.md
+    supporting_text: DCAF10 functions in both nuclear and cytoplasmic compartments as part of the ubiquitin-proteasome system
+  - reference_id: file:human/DCAF10/DCAF10-uniprot.txt
+    supporting_text: GO; GO:0005654; C:nucleoplasm; TAS:Reactome.
+  - reference_id: file:human/DCAF10/DCAF10-notes.md
+    supporting_text: N-terminal disordered region (1-119), with phosphoserine sites (S53, S63, S89, S92, S349) and methylarginine R134 from large-scale proteomics; no functional studies on these PTMs
 references:
 - id: GO_REF:0000033
   title: Annotation inferences using phylogenetic trees
@@ -3286,6 +3570,32 @@ references:
 - id: Reactome:R-HSA-8956045
   title: COP9 signalosome deneddylates nuclear CRL4 E3 ubiquitin ligase complex
   findings: []
+- id: file:human/DCAF10/DCAF10-uniprot.txt
+  title: UniProt record for human DCAF10
+  findings:
+  - statement: UniProt summarizes DCAF10 as a possible CUL4-DDB1 substrate receptor that interacts with DDB1.
+    supporting_text: May function as a substrate receptor for CUL4-DDB1 E3
+  - statement: UniProt carries a Bgee sperm expression cross-reference.
+    supporting_text: Expressed in sperm and 189 other cell types or tissues.
+  - statement: UniProt carries a Reactome-derived nucleoplasm GO annotation.
+    supporting_text: GO; GO:0005654; C:nucleoplasm; TAS:Reactome.
+  - statement: UniProt lists phosphoserine sites on DCAF10.
+    supporting_text: Phosphoserine
+  - statement: UniProt lists an omega-N-methylarginine site on DCAF10.
+    supporting_text: Omega-N-methylarginine
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: Local UniProt record used for stable protein summary, GO cross-references, expression cross-reference, and PTM feature evidence.
+- id: file:human/DCAF10/DCAF10-notes.md
+  title: DCAF10 reviewer notes
+  findings:
+  - statement: Reviewer notes flag DCAF10 N-terminal phosphoserine and methylarginine sites as uncharacterized.
+    supporting_text: N-terminal disordered region (1-119), with phosphoserine sites (S53, S63, S89, S92, S349) and methylarginine R134 from large-scale proteomics; no functional studies on these PTMs
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: Local reviewer notes summarizing curation-relevant evidence gaps and provenance already checked against local UniProt and annotation files.
 - id: file:human/DCAF10/DCAF10-deep-research-falcon.md
   title: Falcon deep research report for DCAF10
   findings:

--- a/genes/human/DCAF10/DCAF10-ai-review.yaml
+++ b/genes/human/DCAF10/DCAF10-ai-review.yaml
@@ -243,6 +243,110 @@ suggested_experiments:
 - description: Affinity purification-mass spectrometry of endogenous (or epitope-tagged) DCAF10 followed by ubiquitin-remnant (diGly) proteomics in DCAF10-knockout vs wild-type cells to identify bona fide substrates.
 - description: Structural or mutational mapping of the DCAF10 WD40 surface and its WDxR/DWD motif to confirm and characterize DDB1 docking.
 - description: Quantitative proteomics of MCL1 and AIF-pathway components in DCAF10-knockout cells across multiple lineages to test the proposed apoptosis-regulatory role independently of the original ESCC context.
+knowledge_gaps:
+- gap_statement: >-
+    The breadth and physiological specificity of DCAF10's Ac-Gly/MO N-degron
+    substrate-recognition activity remain unresolved. A recent primary study
+    supports direct recognition and ubiquitination of acetylated Src-family
+    kinases, but it is still unclear how broadly DCAF10 recognizes N-terminally
+    acetylated glycine degrons across the proteome, which endogenous clients are
+    core substrates, and how this activity should be represented by a precise GO
+    molecular-function term.
+  boundary: >-
+    DCAF10 is established as a CRL4 substrate receptor, and the current review
+    accepts protein ubiquitination/CRL4 complex membership while proposing a more
+    specific Ac-Gly N-recognin term cautiously. The gap is the scope and
+    term-level precision of the substrate-recognition activity, not whether DCAF10
+    can associate with DDB1/CUL4.
+  gap_kind:
+  - BIOLOGY
+  - ONTOLOGY
+  - CURATION
+  dark_aspect: MF_DARK
+  status: OPEN
+  significance: >-
+    Resolving this gap would determine whether DCAF10 should receive a specific
+    N-degron-recognin molecular-function annotation, how broadly that annotation
+    applies beyond Lyn/Fyn/Src, and which proposed pathway/process annotations
+    should be treated as direct DCAF10 biology rather than context-specific
+    substrate leads.
+  resolution: >-
+    Independent replication of Ac-Gly binding and CUL4A-DDB1-DCAF10 ubiquitination
+    with endogenous substrates, proteome-wide Ac-Gly candidate testing, degron
+    mutagenesis, and substrate-rescue assays would define the direct substrate
+    class and support a precise GO term request.
+  provenance:
+  - reference_id: file:human/DCAF10/DCAF10-deep-research-falcon.md
+    supporting_text: Recent breakthrough research by Kremer et al. (2026) identified DCAF10 as an N-recognin for proteins bearing N-terminally acetylated glycine (Ac-Gly) residues, particularly those that normally undergo N-myristoylation
+  - reference_id: file:human/DCAF10/DCAF10-deep-research-falcon.md
+    supporting_text: The recognition motif is not simply Ac-Gly but includes downstream residues, with a preference for serine at position 6 and lysine at position 7
+  - reference_id: file:human/DCAF10/DCAF10-deep-research-falcon.md
+    supporting_text: It is useful for separating direct DCAF10 substrates from cases, such as IRF3, where the evidence currently supports indirect regulation.
+- gap_statement: >-
+    DCAF10's normal testis and spermatogenesis role is still largely undefined.
+    Transcript-level evidence points to strong testis/sperm expression, but the
+    relevant germ-cell substrates, developmental stage, and reproductive phenotype
+    have not been resolved.
+  boundary: >-
+    The review treats testis enrichment as a biological lead rather than as a
+    curated spermatogenesis process annotation. DCAF10's established CRL4
+    substrate-receptor function provides a plausible mechanism, but not a
+    specific reproductive process or substrate set.
+  gap_kind:
+  - BIOLOGY
+  - CURATION
+  dark_aspect: BP_DARK
+  status: OPEN
+  significance: >-
+    This gap controls whether DCAF10 should acquire biological-process annotations
+    for spermatogenesis, germ-cell proteostasis, or male fertility, or whether
+    testis expression should remain contextual evidence without direct functional
+    annotation.
+  resolution: >-
+    Stage-resolved germ-cell expression, DCAF10 loss-of-function in spermatogenic
+    systems, fertility phenotyping, and testis-specific substrate/ubiquitin-remnant
+    proteomics would establish whether DCAF10 has a specialized reproductive role.
+  provenance:
+  - reference_id: file:human/DCAF10/DCAF10-deep-research-falcon.md
+    supporting_text: DCAF10 shows highest transcript levels in testis with very low expression in other tissues, suggesting a specialized role in spermatogenesis
+  - reference_id: file:human/DCAF10/DCAF10-deep-research-falcon.md
+    supporting_text: Further research is needed to characterize DCAF10's specific role in spermatogenesis and whether defects in DCAF10 contribute to male infertility.
+  - reference_id: file:human/DCAF10/DCAF10-uniprot.txt
+    supporting_text: Expressed in sperm and 189 other cell types or tissues.
+- gap_statement: >-
+    The compartment-specific and regulatory context of DCAF10 activity is
+    underdetermined. GOA/Reactome place DCAF10 in nucleoplasm, the literature
+    synthesis points to both nuclear and cytoplasmic substrate contexts, and the
+    N-terminal region contains phosphoserine and methylarginine marks whose
+    effects on DDB1 docking, substrate selection, localization, or stability are
+    unknown.
+  boundary: >-
+    The review accepts CRL4-DCAF10 complex membership and keeps Reactome-derived
+    nucleoplasm annotations as non-core. It does not yet define which cellular
+    pools of DCAF10 perform which substrate-recognition functions, nor whether
+    post-translational modifications regulate those pools.
+  gap_kind:
+  - BIOLOGY
+  - CURATION
+  dark_aspect: CC_DARK
+  status: OPEN
+  significance: >-
+    Clarifying localization and regulatory PTMs would make DCAF10 annotations more
+    precise, separating generic CRL4-pathway compartment projections from
+    DCAF10-specific nuclear, cytoplasmic, or germ-cell substrate-recognition
+    contexts.
+  resolution: >-
+    Endogenous localization under basal, N-myristoylation-stress, viral, cancer,
+    and germ-cell conditions, paired with phosphosite/methylarginine mutagenesis
+    and DDB1/CUL4/substrate-binding assays, would define the regulated active
+    pools of DCAF10.
+  provenance:
+  - reference_id: file:human/DCAF10/DCAF10-deep-research-falcon.md
+    supporting_text: DCAF10 functions in both nuclear and cytoplasmic compartments as part of the ubiquitin-proteasome system
+  - reference_id: file:human/DCAF10/DCAF10-uniprot.txt
+    supporting_text: GO; GO:0005654; C:nucleoplasm; TAS:Reactome.
+  - reference_id: file:human/DCAF10/DCAF10-notes.md
+    supporting_text: N-terminal disordered region (1-119), with phosphoserine sites (S53, S63, S89, S92, S349) and methylarginine R134 from large-scale proteomics; no functional studies on these PTMs
 references:
 - id: GO_REF:0000033
   title: Annotation inferences using phylogenetic trees
@@ -284,6 +388,32 @@ references:
 - id: Reactome:R-HSA-8956045
   title: COP9 signalosome deneddylates nuclear CRL4 E3 ubiquitin ligase complex
   findings: []
+- id: file:human/DCAF10/DCAF10-uniprot.txt
+  title: UniProt record for human DCAF10
+  findings:
+  - statement: UniProt summarizes DCAF10 as a possible CUL4-DDB1 substrate receptor that interacts with DDB1.
+    supporting_text: May function as a substrate receptor for CUL4-DDB1 E3
+  - statement: UniProt carries a Bgee sperm expression cross-reference.
+    supporting_text: Expressed in sperm and 189 other cell types or tissues.
+  - statement: UniProt carries a Reactome-derived nucleoplasm GO annotation.
+    supporting_text: GO; GO:0005654; C:nucleoplasm; TAS:Reactome.
+  - statement: UniProt lists phosphoserine sites on DCAF10.
+    supporting_text: Phosphoserine
+  - statement: UniProt lists an omega-N-methylarginine site on DCAF10.
+    supporting_text: Omega-N-methylarginine
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: Local UniProt record used for stable protein summary, GO cross-references, expression cross-reference, and PTM feature evidence.
+- id: file:human/DCAF10/DCAF10-notes.md
+  title: DCAF10 reviewer notes
+  findings:
+  - statement: Reviewer notes flag DCAF10 N-terminal phosphoserine and methylarginine sites as uncharacterized.
+    supporting_text: N-terminal disordered region (1-119), with phosphoserine sites (S53, S63, S89, S92, S349) and methylarginine R134 from large-scale proteomics; no functional studies on these PTMs
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: Local reviewer notes summarizing curation-relevant evidence gaps and provenance already checked against local UniProt and annotation files.
 - id: file:human/DCAF10/DCAF10-deep-research-falcon.md
   title: Falcon deep research report for DCAF10
   findings:


### PR DESCRIPTION
## Summary
- add structured DCAF10 knowledge gaps for Ac-Gly/MO N-degron substrate scope, testis/spermatogenesis biology, and compartment/PTM regulation
- add local UniProt and reviewer-notes file references used by the new gap provenance
- render the updated DCAF10 review HTML

## Validation
- `just validate human DCAF10`
- `just render human DCAF10`
- `git diff --check`