### PR TITLE
Add FBXO34 knowledge gaps

### DIFF
--- a/genes/human/FBXO34/FBXO34-ai-review.html
+++ b/genes/human/FBXO34/FBXO34-ai-review.html
@@ -1657,6 +1657,106 @@
 
 
 
+    <div class="section">
+        <h2 class="section-title">Knowledge Gaps</h2>
+        <p style="color: #555; font-size: 0.92rem; margin-top: -0.3rem;">
+            What is <em>not</em> known — curated, literature-grounded statements of the open
+            unknowns (the inverse of core functions).
+        </p>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The endogenous substrate repertoire of human FBXO34-SCF remains largely undefined. HNRNPU is the only clearly supported human substrate in the retrieved mechanistic literature, while many high-throughput protein-binding partners have not been shown to be FBXO34-dependent ubiquitination substrates.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span><span class="badge">CURATION</span>
+                <span class="badge">MF_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> The review supports FBXO34 as an SCF substrate-recognition adaptor and accepts HNRNPU-linked ubiquitination/degradation as the best-supported human substrate example. The gap is which additional interactors, if any, are bona fide physiological substrates and whether the inferred SCF adaptor function has broader substrate-specific biological roles.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Substrate scope determines whether FBXO34 should receive only the generic ubiquitin-like ligase-substrate adaptor annotation or additional substrate/pathway-specific process annotations. It also determines whether current protein-binding annotations should remain non-core interactome noise or be converted into mechanistically supported substrate relationships.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Endogenous FBXO34 knockout/rescue, substrate-trapping mutants, quantitative proteomics, ubiquitin-remnant profiling, and direct reconstitution of candidate ubiquitination reactions would distinguish degradative substrates from non-substrate interactors.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"Across the retrieved literature, **hnRNP U** is the only clearly identified substrate/target of human FBXO34 with direct mechanistic support."</em> — file:human/FBXO34/FBXO34-deep-research-falcon.md</li>
+
+                <li><em>"Many large-scale interactome entries list binary partners, but none establish bona fide ubiquitination substrates for FBXO34 in the extracted passages."</em> — file:human/FBXO34/FBXO34-deep-research-falcon.md</li>
+
+                <li><em>"broader roles in cell-cycle or disease biology remain plausible but underdefined."</em> — file:human/FBXO34/FBXO34-deep-research-falcon.md</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The relationship between FBXO34&#39;s human HNRNPU/HIV-latency function and the mouse oocyte cell-cycle phenotype remains unresolved. Mouse data suggest FBXO34 can influence meiotic G2/M transition, MPF/CCNB1 activity, spindle checkpoint behavior, and anaphase entry, but the direct substrate(s) and relevance to human FBXO34 biology are unknown.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span><span class="badge">CURATION</span>
+                <span class="badge">BP_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> The review treats mouse oocyte findings as orthology-based, hypothesis- generating evidence, not as a direct human core biological-process annotation. HNRNPU degradation is the supported human pathway-level example.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Resolving this gap would determine whether FBXO34 should be annotated to cell-cycle or meiotic processes in human, or whether those findings should remain non-human context while the human review stays focused on HNRNPU-linked post-transcriptional regulation of HIV latency.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Test FBXO34 perturbation in human germ-cell or cell-cycle models, identify FBXO34-dependent ubiquitination substrates in those systems, and ask whether CCNB1/MPF phenotypes can be rescued by substrate-specific manipulation.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"mouse oocyte phenotypes indicate FBXO34 can influence meiosis and checkpoint progression, but the direct substrate(s) in that setting are unknown, and the extent to which this translates to human tissues is not resolved by the retrieved evidence."</em> — file:human/FBXO34/FBXO34-deep-research-falcon.md</li>
+
+                <li><em>"Supports conserved biology for FBXO34 as an **SCF-type F-box regulator of cell-cycle control**, likely acting upstream of **CCNB1/CDK1/MPF** and checkpoint progression."</em> — file:human/FBXO34/FBXO34-deep-research-falcon.md</li>
+
+                <li><em>"This is informative for function but is **not direct human evidence**."</em> — file:human/FBXO34/FBXO34-deep-research-falcon.md</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> Human FBXO34 subcellular localization remains experimentally underdefined. Mouse oocyte data suggest nuclear and F-actin-associated localization, but direct human localization evidence, and the compartment in which FBXO34 acts on HNRNPU or other substrates, were not recovered.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span><span class="badge">CURATION</span>
+                <span class="badge">CC_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> The review supports intracellular SCF-substrate-adaptor activity but does not assign a core cellular component beyond SCF complex membership. Mouse oocyte localization is treated as a hypothesis for human work, not a direct human cellular-component annotation.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Localization would refine where FBXO34 performs substrate recognition and would help separate generic SCF complex membership from human nuclear, cytoplasmic, RNP-associated, or cytoskeletal substrate contexts.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Endogenous tagging or validated antibodies should map FBXO34 localization in human cells under basal, HIV-latency, proteasome-inhibited, and cell-cycle conditions, paired with substrate colocalization and compartment-specific degradation assays.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"Direct human subcellular localization data for FBXO34 was not recovered from the accessible text snippets; localization statements come from mouse oocytes and should be treated as context rather than definitive for human somatic cells."</em> — file:human/FBXO34/FBXO34-deep-research-falcon.md</li>
+
+                <li><em>"In mouse oocytes, FBXO34 was reported to localize mainly in the **nucleus** and to **colocalize with F-actin** during meiotic maturation."</em> — file:human/FBXO34/FBXO34-deep-research-falcon.md</li>
+
+            </ul>
+
+
+        </div>
+
+    </div>
+
 
 
 
@@ -2258,6 +2358,101 @@ suggested_experiments:
 - description: Reconstitute the FBXO34 SCF complex (SKP1-CUL1-RBX1-FBXO34) in vitro with purified components and an E1/E2/ubiquitin system to demonstrate direct, F-box-dependent ubiquitination of candidate substrates (starting with HNRNPU) and to map ubiquitin-chain linkage type.
 - description: Perform quantitative proteomics/ubiquitinomics in FBXO34-knockout versus wild-type cells (and with a substrate-binding-deficient mutant) to define the endogenous substrate set and distinguish degradative substrates from non-substrate interactors.
 - description: Test the substrate-receptor model directly by co-immunoprecipitation and degradation assays confirming SKP1/CUL1 association via the F-box domain and substrate stabilization upon FBXO34 loss or proteasome inhibition.
+knowledge_gaps:
+- gap_statement: &gt;-
+    The endogenous substrate repertoire of human FBXO34-SCF remains largely
+    undefined. HNRNPU is the only clearly supported human substrate in the
+    retrieved mechanistic literature, while many high-throughput protein-binding
+    partners have not been shown to be FBXO34-dependent ubiquitination substrates.
+  boundary: &gt;-
+    The review supports FBXO34 as an SCF substrate-recognition adaptor and accepts
+    HNRNPU-linked ubiquitination/degradation as the best-supported human
+    substrate example. The gap is which additional interactors, if any, are bona
+    fide physiological substrates and whether the inferred SCF adaptor function
+    has broader substrate-specific biological roles.
+  gap_kind:
+  - BIOLOGY
+  - CURATION
+  dark_aspect: MF_DARK
+  status: OPEN
+  significance: &gt;-
+    Substrate scope determines whether FBXO34 should receive only the generic
+    ubiquitin-like ligase-substrate adaptor annotation or additional
+    substrate/pathway-specific process annotations. It also determines whether
+    current protein-binding annotations should remain non-core interactome noise
+    or be converted into mechanistically supported substrate relationships.
+  resolution: &gt;-
+    Endogenous FBXO34 knockout/rescue, substrate-trapping mutants, quantitative
+    proteomics, ubiquitin-remnant profiling, and direct reconstitution of candidate
+    ubiquitination reactions would distinguish degradative substrates from
+    non-substrate interactors.
+  provenance:
+  - reference_id: file:human/FBXO34/FBXO34-deep-research-falcon.md
+    supporting_text: Across the retrieved literature, **hnRNP U** is the only clearly identified substrate/target of human FBXO34 with direct mechanistic support.
+  - reference_id: file:human/FBXO34/FBXO34-deep-research-falcon.md
+    supporting_text: Many large-scale interactome entries list binary partners, but none establish bona fide ubiquitination substrates for FBXO34 in the extracted passages.
+  - reference_id: file:human/FBXO34/FBXO34-deep-research-falcon.md
+    supporting_text: broader roles in cell-cycle or disease biology remain plausible but underdefined.
+- gap_statement: &gt;-
+    The relationship between FBXO34&#39;s human HNRNPU/HIV-latency function and the
+    mouse oocyte cell-cycle phenotype remains unresolved. Mouse data suggest
+    FBXO34 can influence meiotic G2/M transition, MPF/CCNB1 activity, spindle
+    checkpoint behavior, and anaphase entry, but the direct substrate(s) and
+    relevance to human FBXO34 biology are unknown.
+  boundary: &gt;-
+    The review treats mouse oocyte findings as orthology-based, hypothesis-
+    generating evidence, not as a direct human core biological-process annotation.
+    HNRNPU degradation is the supported human pathway-level example.
+  gap_kind:
+  - BIOLOGY
+  - CURATION
+  dark_aspect: BP_DARK
+  status: OPEN
+  significance: &gt;-
+    Resolving this gap would determine whether FBXO34 should be annotated to
+    cell-cycle or meiotic processes in human, or whether those findings should
+    remain non-human context while the human review stays focused on HNRNPU-linked
+    post-transcriptional regulation of HIV latency.
+  resolution: &gt;-
+    Test FBXO34 perturbation in human germ-cell or cell-cycle models, identify
+    FBXO34-dependent ubiquitination substrates in those systems, and ask whether
+    CCNB1/MPF phenotypes can be rescued by substrate-specific manipulation.
+  provenance:
+  - reference_id: file:human/FBXO34/FBXO34-deep-research-falcon.md
+    supporting_text: mouse oocyte phenotypes indicate FBXO34 can influence meiosis and checkpoint progression, but the direct substrate(s) in that setting are unknown, and the extent to which this translates to human tissues is not resolved by the retrieved evidence.
+  - reference_id: file:human/FBXO34/FBXO34-deep-research-falcon.md
+    supporting_text: Supports conserved biology for FBXO34 as an **SCF-type F-box regulator of cell-cycle control**, likely acting upstream of **CCNB1/CDK1/MPF** and checkpoint progression.
+  - reference_id: file:human/FBXO34/FBXO34-deep-research-falcon.md
+    supporting_text: This is informative for function but is **not direct human evidence**.
+- gap_statement: &gt;-
+    Human FBXO34 subcellular localization remains experimentally underdefined.
+    Mouse oocyte data suggest nuclear and F-actin-associated localization, but
+    direct human localization evidence, and the compartment in which FBXO34 acts
+    on HNRNPU or other substrates, were not recovered.
+  boundary: &gt;-
+    The review supports intracellular SCF-substrate-adaptor activity but does not
+    assign a core cellular component beyond SCF complex membership. Mouse oocyte
+    localization is treated as a hypothesis for human work, not a direct human
+    cellular-component annotation.
+  gap_kind:
+  - BIOLOGY
+  - CURATION
+  dark_aspect: CC_DARK
+  status: OPEN
+  significance: &gt;-
+    Localization would refine where FBXO34 performs substrate recognition and
+    would help separate generic SCF complex membership from human nuclear,
+    cytoplasmic, RNP-associated, or cytoskeletal substrate contexts.
+  resolution: &gt;-
+    Endogenous tagging or validated antibodies should map FBXO34 localization in
+    human cells under basal, HIV-latency, proteasome-inhibited, and cell-cycle
+    conditions, paired with substrate colocalization and compartment-specific
+    degradation assays.
+  provenance:
+  - reference_id: file:human/FBXO34/FBXO34-deep-research-falcon.md
+    supporting_text: Direct human subcellular localization data for FBXO34 was not recovered from the accessible text snippets; localization statements come from mouse oocytes and should be treated as context rather than definitive for human somatic cells.
+  - reference_id: file:human/FBXO34/FBXO34-deep-research-falcon.md
+    supporting_text: In mouse oocytes, FBXO34 was reported to localize mainly in the **nucleus** and to **colocalize with F-actin** during meiotic maturation.
 </code></pre>
             </div>
         </details>

--- a/genes/human/FBXO34/FBXO34-ai-review.html
+++ b/genes/human/FBXO34/FBXO34-ai-review.html
@@ -1686,7 +1686,7 @@
 
                 <li><em>"Across the retrieved literature, **hnRNP U** is the only clearly identified substrate/target of human FBXO34 with direct mechanistic support."</em> — file:human/FBXO34/FBXO34-deep-research-falcon.md</li>
 
-                <li><em>"Many large-scale interactome entries list binary partners, but none establish bona fide ubiquitination substrates for FBXO34 in the extracted passages."</em> — file:human/FBXO34/FBXO34-deep-research-falcon.md</li>
+                <li><em>"direct biochemical details (e.g., linkage type, E2 usage, proteasome-inhibition rescue) were not captured in the available evidence snippets."</em> — file:human/FBXO34/FBXO34-deep-research-falcon.md</li>
 
                 <li><em>"broader roles in cell-cycle or disease biology remain plausible but underdefined."</em> — file:human/FBXO34/FBXO34-deep-research-falcon.md</li>
 
@@ -1746,7 +1746,7 @@
             <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
             <ul style="margin-top: 0.2rem;">
 
-                <li><em>"Direct human subcellular localization data for FBXO34 was not recovered from the accessible text snippets; localization statements come from mouse oocytes and should be treated as context rather than definitive for human somatic cells."</em> — file:human/FBXO34/FBXO34-deep-research-falcon.md</li>
+                <li><em>"Direct **human subcellular localization** data for FBXO34 was not recovered from the accessible text snippets; localization statements come from mouse oocytes and should be treated as context rather than definitive for human somatic cells."</em> — file:human/FBXO34/FBXO34-deep-research-falcon.md</li>
 
                 <li><em>"In mouse oocytes, FBXO34 was reported to localize mainly in the **nucleus** and to **colocalize with F-actin** during meiotic maturation."</em> — file:human/FBXO34/FBXO34-deep-research-falcon.md</li>
 
@@ -2390,7 +2390,7 @@ knowledge_gaps:
   - reference_id: file:human/FBXO34/FBXO34-deep-research-falcon.md
     supporting_text: Across the retrieved literature, **hnRNP U** is the only clearly identified substrate/target of human FBXO34 with direct mechanistic support.
   - reference_id: file:human/FBXO34/FBXO34-deep-research-falcon.md
-    supporting_text: Many large-scale interactome entries list binary partners, but none establish bona fide ubiquitination substrates for FBXO34 in the extracted passages.
+    supporting_text: direct biochemical details (e.g., linkage type, E2 usage, proteasome-inhibition rescue) were not captured in the available evidence snippets.
   - reference_id: file:human/FBXO34/FBXO34-deep-research-falcon.md
     supporting_text: broader roles in cell-cycle or disease biology remain plausible but underdefined.
 - gap_statement: &gt;-
@@ -2450,7 +2450,7 @@ knowledge_gaps:
     degradation assays.
   provenance:
   - reference_id: file:human/FBXO34/FBXO34-deep-research-falcon.md
-    supporting_text: Direct human subcellular localization data for FBXO34 was not recovered from the accessible text snippets; localization statements come from mouse oocytes and should be treated as context rather than definitive for human somatic cells.
+    supporting_text: Direct **human subcellular localization** data for FBXO34 was not recovered from the accessible text snippets; localization statements come from mouse oocytes and should be treated as context rather than definitive for human somatic cells.
   - reference_id: file:human/FBXO34/FBXO34-deep-research-falcon.md
     supporting_text: In mouse oocytes, FBXO34 was reported to localize mainly in the **nucleus** and to **colocalize with F-actin** during meiotic maturation.
 </code></pre>

--- a/genes/human/FBXO34/FBXO34-ai-review.yaml
+++ b/genes/human/FBXO34/FBXO34-ai-review.yaml
@@ -250,7 +250,7 @@ knowledge_gaps:
   - reference_id: file:human/FBXO34/FBXO34-deep-research-falcon.md
     supporting_text: Across the retrieved literature, **hnRNP U** is the only clearly identified substrate/target of human FBXO34 with direct mechanistic support.
   - reference_id: file:human/FBXO34/FBXO34-deep-research-falcon.md
-    supporting_text: Many large-scale interactome entries list binary partners, but none establish bona fide ubiquitination substrates for FBXO34 in the extracted passages.
+    supporting_text: direct biochemical details (e.g., linkage type, E2 usage, proteasome-inhibition rescue) were not captured in the available evidence snippets.
   - reference_id: file:human/FBXO34/FBXO34-deep-research-falcon.md
     supporting_text: broader roles in cell-cycle or disease biology remain plausible but underdefined.
 - gap_statement: >-
@@ -310,6 +310,6 @@ knowledge_gaps:
     degradation assays.
   provenance:
   - reference_id: file:human/FBXO34/FBXO34-deep-research-falcon.md
-    supporting_text: Direct human subcellular localization data for FBXO34 was not recovered from the accessible text snippets; localization statements come from mouse oocytes and should be treated as context rather than definitive for human somatic cells.
+    supporting_text: Direct **human subcellular localization** data for FBXO34 was not recovered from the accessible text snippets; localization statements come from mouse oocytes and should be treated as context rather than definitive for human somatic cells.
   - reference_id: file:human/FBXO34/FBXO34-deep-research-falcon.md
     supporting_text: In mouse oocytes, FBXO34 was reported to localize mainly in the **nucleus** and to **colocalize with F-actin** during meiotic maturation.

--- a/genes/human/FBXO34/FBXO34-ai-review.yaml
+++ b/genes/human/FBXO34/FBXO34-ai-review.yaml
@@ -218,3 +218,98 @@ suggested_experiments:
 - description: Reconstitute the FBXO34 SCF complex (SKP1-CUL1-RBX1-FBXO34) in vitro with purified components and an E1/E2/ubiquitin system to demonstrate direct, F-box-dependent ubiquitination of candidate substrates (starting with HNRNPU) and to map ubiquitin-chain linkage type.
 - description: Perform quantitative proteomics/ubiquitinomics in FBXO34-knockout versus wild-type cells (and with a substrate-binding-deficient mutant) to define the endogenous substrate set and distinguish degradative substrates from non-substrate interactors.
 - description: Test the substrate-receptor model directly by co-immunoprecipitation and degradation assays confirming SKP1/CUL1 association via the F-box domain and substrate stabilization upon FBXO34 loss or proteasome inhibition.
+knowledge_gaps:
+- gap_statement: >-
+    The endogenous substrate repertoire of human FBXO34-SCF remains largely
+    undefined. HNRNPU is the only clearly supported human substrate in the
+    retrieved mechanistic literature, while many high-throughput protein-binding
+    partners have not been shown to be FBXO34-dependent ubiquitination substrates.
+  boundary: >-
+    The review supports FBXO34 as an SCF substrate-recognition adaptor and accepts
+    HNRNPU-linked ubiquitination/degradation as the best-supported human
+    substrate example. The gap is which additional interactors, if any, are bona
+    fide physiological substrates and whether the inferred SCF adaptor function
+    has broader substrate-specific biological roles.
+  gap_kind:
+  - BIOLOGY
+  - CURATION
+  dark_aspect: MF_DARK
+  status: OPEN
+  significance: >-
+    Substrate scope determines whether FBXO34 should receive only the generic
+    ubiquitin-like ligase-substrate adaptor annotation or additional
+    substrate/pathway-specific process annotations. It also determines whether
+    current protein-binding annotations should remain non-core interactome noise
+    or be converted into mechanistically supported substrate relationships.
+  resolution: >-
+    Endogenous FBXO34 knockout/rescue, substrate-trapping mutants, quantitative
+    proteomics, ubiquitin-remnant profiling, and direct reconstitution of candidate
+    ubiquitination reactions would distinguish degradative substrates from
+    non-substrate interactors.
+  provenance:
+  - reference_id: file:human/FBXO34/FBXO34-deep-research-falcon.md
+    supporting_text: Across the retrieved literature, **hnRNP U** is the only clearly identified substrate/target of human FBXO34 with direct mechanistic support.
+  - reference_id: file:human/FBXO34/FBXO34-deep-research-falcon.md
+    supporting_text: Many large-scale interactome entries list binary partners, but none establish bona fide ubiquitination substrates for FBXO34 in the extracted passages.
+  - reference_id: file:human/FBXO34/FBXO34-deep-research-falcon.md
+    supporting_text: broader roles in cell-cycle or disease biology remain plausible but underdefined.
+- gap_statement: >-
+    The relationship between FBXO34's human HNRNPU/HIV-latency function and the
+    mouse oocyte cell-cycle phenotype remains unresolved. Mouse data suggest
+    FBXO34 can influence meiotic G2/M transition, MPF/CCNB1 activity, spindle
+    checkpoint behavior, and anaphase entry, but the direct substrate(s) and
+    relevance to human FBXO34 biology are unknown.
+  boundary: >-
+    The review treats mouse oocyte findings as orthology-based, hypothesis-
+    generating evidence, not as a direct human core biological-process annotation.
+    HNRNPU degradation is the supported human pathway-level example.
+  gap_kind:
+  - BIOLOGY
+  - CURATION
+  dark_aspect: BP_DARK
+  status: OPEN
+  significance: >-
+    Resolving this gap would determine whether FBXO34 should be annotated to
+    cell-cycle or meiotic processes in human, or whether those findings should
+    remain non-human context while the human review stays focused on HNRNPU-linked
+    post-transcriptional regulation of HIV latency.
+  resolution: >-
+    Test FBXO34 perturbation in human germ-cell or cell-cycle models, identify
+    FBXO34-dependent ubiquitination substrates in those systems, and ask whether
+    CCNB1/MPF phenotypes can be rescued by substrate-specific manipulation.
+  provenance:
+  - reference_id: file:human/FBXO34/FBXO34-deep-research-falcon.md
+    supporting_text: mouse oocyte phenotypes indicate FBXO34 can influence meiosis and checkpoint progression, but the direct substrate(s) in that setting are unknown, and the extent to which this translates to human tissues is not resolved by the retrieved evidence.
+  - reference_id: file:human/FBXO34/FBXO34-deep-research-falcon.md
+    supporting_text: Supports conserved biology for FBXO34 as an **SCF-type F-box regulator of cell-cycle control**, likely acting upstream of **CCNB1/CDK1/MPF** and checkpoint progression.
+  - reference_id: file:human/FBXO34/FBXO34-deep-research-falcon.md
+    supporting_text: This is informative for function but is **not direct human evidence**.
+- gap_statement: >-
+    Human FBXO34 subcellular localization remains experimentally underdefined.
+    Mouse oocyte data suggest nuclear and F-actin-associated localization, but
+    direct human localization evidence, and the compartment in which FBXO34 acts
+    on HNRNPU or other substrates, were not recovered.
+  boundary: >-
+    The review supports intracellular SCF-substrate-adaptor activity but does not
+    assign a core cellular component beyond SCF complex membership. Mouse oocyte
+    localization is treated as a hypothesis for human work, not a direct human
+    cellular-component annotation.
+  gap_kind:
+  - BIOLOGY
+  - CURATION
+  dark_aspect: CC_DARK
+  status: OPEN
+  significance: >-
+    Localization would refine where FBXO34 performs substrate recognition and
+    would help separate generic SCF complex membership from human nuclear,
+    cytoplasmic, RNP-associated, or cytoskeletal substrate contexts.
+  resolution: >-
+    Endogenous tagging or validated antibodies should map FBXO34 localization in
+    human cells under basal, HIV-latency, proteasome-inhibited, and cell-cycle
+    conditions, paired with substrate colocalization and compartment-specific
+    degradation assays.
+  provenance:
+  - reference_id: file:human/FBXO34/FBXO34-deep-research-falcon.md
+    supporting_text: Direct human subcellular localization data for FBXO34 was not recovered from the accessible text snippets; localization statements come from mouse oocytes and should be treated as context rather than definitive for human somatic cells.
+  - reference_id: file:human/FBXO34/FBXO34-deep-research-falcon.md
+    supporting_text: In mouse oocytes, FBXO34 was reported to localize mainly in the **nucleus** and to **colocalize with F-actin** during meiotic maturation.


### PR DESCRIPTION
## Summary
- add structured FBXO34 knowledge gaps for thin substrate repertoire, unresolved human relevance of mouse meiotic cell-cycle findings, and missing direct human localization evidence
- render the updated FBXO34 review HTML

## Validation
- `just validate human FBXO34` passes with 2 warnings: both core-function entries use GO:1990756 not reflected as NEW existing_annotations
- `just render human FBXO34`
- `git diff --check`