### PR TITLE
Add HSPA12A knowledge gaps

### DIFF
--- a/genes/human/HSPA12A/HSPA12A-ai-review.html
+++ b/genes/human/HSPA12A/HSPA12A-ai-review.html
@@ -2290,6 +2290,108 @@
 
 
 
+    <div class="section">
+        <h2 class="section-title">Knowledge Gaps</h2>
+        <p style="color: #555; font-size: 0.92rem; margin-top: -0.3rem;">
+            What is <em>not</em> known — curated, literature-grounded statements of the open
+            unknowns (the inverse of core functions).
+        </p>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The biochemical nucleotide behavior of HSPA12A remains unresolved at the boundary between divergent HSP70-family architecture and non-chaperone adaptor function. Current evidence argues against assigning canonical ATP-dependent protein-folding chaperone activity, but direct ATP binding, ATP hydrolysis rate, and possible nucleotide-regulated conformational switching have not been experimentally defined.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">NARROWING</span>
+                <span class="badge">BIOLOGY</span><span class="badge">CURATION</span>
+                <span class="badge">RESIDUAL_SUBGAP</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> The review treats HSPA12A as a SorLA/SORL1-tail binding adaptor-like protein, not as a canonical HSP70 folding chaperone. The gap is whether the retained divergent nucleotide-binding domain has measurable ATP/ADP binding or hydrolysis that regulates adaptor interactions, not whether HSPA12A should be annotated to ATP-dependent folding chaperone activity.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Resolving this would determine whether ATP-binding or ATPase-related annotations are appropriate as narrow mechanistic qualifiers, while avoiding over-propagation of canonical HSP70 chaperone terms from family membership.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Purified HSPA12A ATP/ADP binding measurements, basal and cofactor-stimulated ATPase assays, and nucleotide-dependent SorLA-binding/conformation assays should be compared directly with canonical HSP70 controls.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"Current evidence in retrieved primary literature is insufficient to support canonical HSP70 chaperone/protein-folding activity for HSPA12A."</em> — file:human/HSPA12A/HSPA12A-deep-research-falcon.md</li>
+
+                <li><em>"ATP hydrolysis rate unknown | No published ATPase kinetics for HSPA12A"</em> — file:human/HSPA12A/HSPA12A-hypotheses/hsp70-folding-machinery-check/openscientist.md</li>
+
+                <li><em>"ATP binding unconfirmed experimentally | Only IEA annotation exists"</em> — file:human/HSPA12A/HSPA12A-hypotheses/hsp70-folding-machinery-check/openscientist.md</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The endogenous mechanism by which HSPA12A changes SorLA/SORL1 internalization and trafficking remains underdefined. SorLA-tail binding and delayed internalization are supported, but it is not clear whether HSPA12A acts by competing with GGA/AP adaptor machinery, by altering vesicle identity, by nucleotide-regulated tail binding, or by another receptor-scaffold mechanism.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span><span class="badge">ONTOLOGY</span><span class="badge">CURATION</span>
+                <span class="badge">BP_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> The review supports negative regulation of receptor internalization for SorLA and proposes a more specific sorting-receptor cytoplasmic-tail binding term. The gap is the mechanistic bridge from tail binding to trafficking outcome, especially in endogenous neuronal or glial systems.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> This gap determines how specific HSPA12A&#39;s process annotations should be, and whether a new molecular-function term should represent simple receptor-tail binding, cargo-adaptor competition, or a more specific trafficking-adaptor activity.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Endogenous knock-in/co-IP or proximity-labeling in neuronal and glial models, SorLA-tail motif mutants, GGA/AP adaptor competition assays, and vesicle identity markers would define the direct trafficking mechanism.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"The D47D48 motif overlaps a reported GGA2 binding site, raising a mechanistic possibility of adaptor competition"</em> — file:human/HSPA12A/HSPA12A-deep-research-falcon.md</li>
+
+                <li><em>"Many trafficking/localization effects were measured in HEK293 transfectants, and localization includes tagged HSPA12A constructs; these are strong for mechanistic hypotheses but should be curated with appropriate evidence codes and caution"</em> — file:human/HSPA12A/HSPA12A-deep-research-falcon.md</li>
+
+                <li><em>"direct effects on APP processing/amyloid output were not required to support the GO-relevant trafficking statements"</em> — file:human/HSPA12A/HSPA12A-deep-research-falcon.md</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> HSPA12A&#39;s broader adaptor/regulatory interaction network outside SorLA is not settled. Disease-context studies report signaling or scaffold-like effects, but it is unclear which partners are direct endogenous HSPA12A clients and which phenotypes are downstream consequences of stress, metabolic, or tissue-specific contexts.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span><span class="badge">CURATION</span>
+                <span class="badge">MF_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> The review keeps the core function narrow around SorLA cytosolic-tail binding and receptor internalization. It does not convert PCNA, Smurf1/HIF1alpha, PGC-1alpha/AOAH, PKM2, or other disease-context reports into broad core proteostasis or signaling annotations.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> A resolved endogenous interaction network would show whether HSPA12A is a mostly SorLA-selective trafficking adaptor or a broader regulatory scaffold with additional curated molecular functions and biological-process roles.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> AP-MS/BioID/TurboID in relevant primary cell types, endogenous rescue with interaction-defective HSPA12A mutants, and direct partner-binding assays should separate direct adaptor interactions from downstream disease phenotypes.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"Complete interaction network | SORL1 adapter function established; other partners unknown"</em> — file:human/HSPA12A/HSPA12A-hypotheses/hsp70-folding-machinery-check/openscientist.md</li>
+
+                <li><em>"Several published phenotypes associated with HSPA12A — cardioprotection during ischemia/reperfusion, attenuation of septic liver injury, neuroprotection after seizures, roles in NASH and diabetes — are downstream consequences of its adapter/regulatory functions, not evidence of chaperone activity."</em> — file:human/HSPA12A/HSPA12A-hypotheses/hsp70-folding-machinery-check/openscientist.md</li>
+
+                <li><em>"Additional adapter/regulatory functions may exist"</em> — file:human/HSPA12A/HSPA12A-hypotheses/hsp70-folding-machinery-check/openscientist.md</li>
+
+            </ul>
+
+
+        </div>
+
+    </div>
+
 
 
 
@@ -3838,6 +3940,104 @@ suggested_experiments:
     co-immunoprecipitation/proximity labeling
   hypothesis: The best-supported direct HSPA12A function is SORL1/SorLA trafficking
     control, but this should be reproducible outside overexpression-heavy systems
+knowledge_gaps:
+- gap_statement: &gt;-
+    The biochemical nucleotide behavior of HSPA12A remains unresolved at the
+    boundary between divergent HSP70-family architecture and non-chaperone
+    adaptor function. Current evidence argues against assigning canonical
+    ATP-dependent protein-folding chaperone activity, but direct ATP binding,
+    ATP hydrolysis rate, and possible nucleotide-regulated conformational
+    switching have not been experimentally defined.
+  boundary: &gt;-
+    The review treats HSPA12A as a SorLA/SORL1-tail binding adaptor-like protein,
+    not as a canonical HSP70 folding chaperone. The gap is whether the retained
+    divergent nucleotide-binding domain has measurable ATP/ADP binding or
+    hydrolysis that regulates adaptor interactions, not whether HSPA12A should be
+    annotated to ATP-dependent folding chaperone activity.
+  gap_kind:
+  - BIOLOGY
+  - CURATION
+  dark_aspect: RESIDUAL_SUBGAP
+  status: NARROWING
+  significance: &gt;-
+    Resolving this would determine whether ATP-binding or ATPase-related
+    annotations are appropriate as narrow mechanistic qualifiers, while avoiding
+    over-propagation of canonical HSP70 chaperone terms from family membership.
+  resolution: &gt;-
+    Purified HSPA12A ATP/ADP binding measurements, basal and cofactor-stimulated
+    ATPase assays, and nucleotide-dependent SorLA-binding/conformation assays
+    should be compared directly with canonical HSP70 controls.
+  provenance:
+  - reference_id: file:human/HSPA12A/HSPA12A-deep-research-falcon.md
+    supporting_text: Current evidence in retrieved primary literature is insufficient to support canonical HSP70 chaperone/protein-folding activity for HSPA12A.
+  - reference_id: file:human/HSPA12A/HSPA12A-hypotheses/hsp70-folding-machinery-check/openscientist.md
+    supporting_text: ATP hydrolysis rate unknown | No published ATPase kinetics for HSPA12A
+  - reference_id: file:human/HSPA12A/HSPA12A-hypotheses/hsp70-folding-machinery-check/openscientist.md
+    supporting_text: ATP binding unconfirmed experimentally | Only IEA annotation exists
+- gap_statement: &gt;-
+    The endogenous mechanism by which HSPA12A changes SorLA/SORL1 internalization
+    and trafficking remains underdefined. SorLA-tail binding and delayed
+    internalization are supported, but it is not clear whether HSPA12A acts by
+    competing with GGA/AP adaptor machinery, by altering vesicle identity, by
+    nucleotide-regulated tail binding, or by another receptor-scaffold mechanism.
+  boundary: &gt;-
+    The review supports negative regulation of receptor internalization for SorLA
+    and proposes a more specific sorting-receptor cytoplasmic-tail binding term.
+    The gap is the mechanistic bridge from tail binding to trafficking outcome,
+    especially in endogenous neuronal or glial systems.
+  gap_kind:
+  - BIOLOGY
+  - ONTOLOGY
+  - CURATION
+  dark_aspect: BP_DARK
+  status: OPEN
+  significance: &gt;-
+    This gap determines how specific HSPA12A&#39;s process annotations should be, and
+    whether a new molecular-function term should represent simple receptor-tail
+    binding, cargo-adaptor competition, or a more specific trafficking-adaptor
+    activity.
+  resolution: &gt;-
+    Endogenous knock-in/co-IP or proximity-labeling in neuronal and glial models,
+    SorLA-tail motif mutants, GGA/AP adaptor competition assays, and vesicle
+    identity markers would define the direct trafficking mechanism.
+  provenance:
+  - reference_id: file:human/HSPA12A/HSPA12A-deep-research-falcon.md
+    supporting_text: The D47D48 motif overlaps a reported GGA2 binding site, raising a mechanistic possibility of adaptor competition
+  - reference_id: file:human/HSPA12A/HSPA12A-deep-research-falcon.md
+    supporting_text: Many trafficking/localization effects were measured in HEK293 transfectants, and localization includes tagged HSPA12A constructs; these are strong for mechanistic hypotheses but should be curated with appropriate evidence codes and caution
+  - reference_id: file:human/HSPA12A/HSPA12A-deep-research-falcon.md
+    supporting_text: direct effects on APP processing/amyloid output were not required to support the GO-relevant trafficking statements
+- gap_statement: &gt;-
+    HSPA12A&#39;s broader adaptor/regulatory interaction network outside SorLA is not
+    settled. Disease-context studies report signaling or scaffold-like effects,
+    but it is unclear which partners are direct endogenous HSPA12A clients and
+    which phenotypes are downstream consequences of stress, metabolic, or
+    tissue-specific contexts.
+  boundary: &gt;-
+    The review keeps the core function narrow around SorLA cytosolic-tail binding
+    and receptor internalization. It does not convert PCNA, Smurf1/HIF1alpha,
+    PGC-1alpha/AOAH, PKM2, or other disease-context reports into broad core
+    proteostasis or signaling annotations.
+  gap_kind:
+  - BIOLOGY
+  - CURATION
+  dark_aspect: MF_DARK
+  status: OPEN
+  significance: &gt;-
+    A resolved endogenous interaction network would show whether HSPA12A is a
+    mostly SorLA-selective trafficking adaptor or a broader regulatory scaffold
+    with additional curated molecular functions and biological-process roles.
+  resolution: &gt;-
+    AP-MS/BioID/TurboID in relevant primary cell types, endogenous rescue with
+    interaction-defective HSPA12A mutants, and direct partner-binding assays should
+    separate direct adaptor interactions from downstream disease phenotypes.
+  provenance:
+  - reference_id: file:human/HSPA12A/HSPA12A-hypotheses/hsp70-folding-machinery-check/openscientist.md
+    supporting_text: Complete interaction network | SORL1 adapter function established; other partners unknown
+  - reference_id: file:human/HSPA12A/HSPA12A-hypotheses/hsp70-folding-machinery-check/openscientist.md
+    supporting_text: Several published phenotypes associated with HSPA12A — cardioprotection during ischemia/reperfusion, attenuation of septic liver injury, neuroprotection after seizures, roles in NASH and diabetes — are downstream consequences of its adapter/regulatory functions, not evidence of chaperone activity.
+  - reference_id: file:human/HSPA12A/HSPA12A-hypotheses/hsp70-folding-machinery-check/openscientist.md
+    supporting_text: Additional adapter/regulatory functions may exist
 </code></pre>
             </div>
         </details>

--- a/genes/human/HSPA12A/HSPA12A-ai-review.yaml
+++ b/genes/human/HSPA12A/HSPA12A-ai-review.yaml
@@ -399,3 +399,101 @@ suggested_experiments:
     co-immunoprecipitation/proximity labeling
   hypothesis: The best-supported direct HSPA12A function is SORL1/SorLA trafficking
     control, but this should be reproducible outside overexpression-heavy systems
+knowledge_gaps:
+- gap_statement: >-
+    The biochemical nucleotide behavior of HSPA12A remains unresolved at the
+    boundary between divergent HSP70-family architecture and non-chaperone
+    adaptor function. Current evidence argues against assigning canonical
+    ATP-dependent protein-folding chaperone activity, but direct ATP binding,
+    ATP hydrolysis rate, and possible nucleotide-regulated conformational
+    switching have not been experimentally defined.
+  boundary: >-
+    The review treats HSPA12A as a SorLA/SORL1-tail binding adaptor-like protein,
+    not as a canonical HSP70 folding chaperone. The gap is whether the retained
+    divergent nucleotide-binding domain has measurable ATP/ADP binding or
+    hydrolysis that regulates adaptor interactions, not whether HSPA12A should be
+    annotated to ATP-dependent folding chaperone activity.
+  gap_kind:
+  - BIOLOGY
+  - CURATION
+  dark_aspect: RESIDUAL_SUBGAP
+  status: NARROWING
+  significance: >-
+    Resolving this would determine whether ATP-binding or ATPase-related
+    annotations are appropriate as narrow mechanistic qualifiers, while avoiding
+    over-propagation of canonical HSP70 chaperone terms from family membership.
+  resolution: >-
+    Purified HSPA12A ATP/ADP binding measurements, basal and cofactor-stimulated
+    ATPase assays, and nucleotide-dependent SorLA-binding/conformation assays
+    should be compared directly with canonical HSP70 controls.
+  provenance:
+  - reference_id: file:human/HSPA12A/HSPA12A-deep-research-falcon.md
+    supporting_text: Current evidence in retrieved primary literature is insufficient to support canonical HSP70 chaperone/protein-folding activity for HSPA12A.
+  - reference_id: file:human/HSPA12A/HSPA12A-hypotheses/hsp70-folding-machinery-check/openscientist.md
+    supporting_text: ATP hydrolysis rate unknown | No published ATPase kinetics for HSPA12A
+  - reference_id: file:human/HSPA12A/HSPA12A-hypotheses/hsp70-folding-machinery-check/openscientist.md
+    supporting_text: ATP binding unconfirmed experimentally | Only IEA annotation exists
+- gap_statement: >-
+    The endogenous mechanism by which HSPA12A changes SorLA/SORL1 internalization
+    and trafficking remains underdefined. SorLA-tail binding and delayed
+    internalization are supported, but it is not clear whether HSPA12A acts by
+    competing with GGA/AP adaptor machinery, by altering vesicle identity, by
+    nucleotide-regulated tail binding, or by another receptor-scaffold mechanism.
+  boundary: >-
+    The review supports negative regulation of receptor internalization for SorLA
+    and proposes a more specific sorting-receptor cytoplasmic-tail binding term.
+    The gap is the mechanistic bridge from tail binding to trafficking outcome,
+    especially in endogenous neuronal or glial systems.
+  gap_kind:
+  - BIOLOGY
+  - ONTOLOGY
+  - CURATION
+  dark_aspect: BP_DARK
+  status: OPEN
+  significance: >-
+    This gap determines how specific HSPA12A's process annotations should be, and
+    whether a new molecular-function term should represent simple receptor-tail
+    binding, cargo-adaptor competition, or a more specific trafficking-adaptor
+    activity.
+  resolution: >-
+    Endogenous knock-in/co-IP or proximity-labeling in neuronal and glial models,
+    SorLA-tail motif mutants, GGA/AP adaptor competition assays, and vesicle
+    identity markers would define the direct trafficking mechanism.
+  provenance:
+  - reference_id: file:human/HSPA12A/HSPA12A-deep-research-falcon.md
+    supporting_text: The D47D48 motif overlaps a reported GGA2 binding site, raising a mechanistic possibility of adaptor competition
+  - reference_id: file:human/HSPA12A/HSPA12A-deep-research-falcon.md
+    supporting_text: Many trafficking/localization effects were measured in HEK293 transfectants, and localization includes tagged HSPA12A constructs; these are strong for mechanistic hypotheses but should be curated with appropriate evidence codes and caution
+  - reference_id: file:human/HSPA12A/HSPA12A-deep-research-falcon.md
+    supporting_text: direct effects on APP processing/amyloid output were not required to support the GO-relevant trafficking statements
+- gap_statement: >-
+    HSPA12A's broader adaptor/regulatory interaction network outside SorLA is not
+    settled. Disease-context studies report signaling or scaffold-like effects,
+    but it is unclear which partners are direct endogenous HSPA12A clients and
+    which phenotypes are downstream consequences of stress, metabolic, or
+    tissue-specific contexts.
+  boundary: >-
+    The review keeps the core function narrow around SorLA cytosolic-tail binding
+    and receptor internalization. It does not convert PCNA, Smurf1/HIF1alpha,
+    PGC-1alpha/AOAH, PKM2, or other disease-context reports into broad core
+    proteostasis or signaling annotations.
+  gap_kind:
+  - BIOLOGY
+  - CURATION
+  dark_aspect: MF_DARK
+  status: OPEN
+  significance: >-
+    A resolved endogenous interaction network would show whether HSPA12A is a
+    mostly SorLA-selective trafficking adaptor or a broader regulatory scaffold
+    with additional curated molecular functions and biological-process roles.
+  resolution: >-
+    AP-MS/BioID/TurboID in relevant primary cell types, endogenous rescue with
+    interaction-defective HSPA12A mutants, and direct partner-binding assays should
+    separate direct adaptor interactions from downstream disease phenotypes.
+  provenance:
+  - reference_id: file:human/HSPA12A/HSPA12A-hypotheses/hsp70-folding-machinery-check/openscientist.md
+    supporting_text: Complete interaction network | SORL1 adapter function established; other partners unknown
+  - reference_id: file:human/HSPA12A/HSPA12A-hypotheses/hsp70-folding-machinery-check/openscientist.md
+    supporting_text: Several published phenotypes associated with HSPA12A — cardioprotection during ischemia/reperfusion, attenuation of septic liver injury, neuroprotection after seizures, roles in NASH and diabetes — are downstream consequences of its adapter/regulatory functions, not evidence of chaperone activity.
+  - reference_id: file:human/HSPA12A/HSPA12A-hypotheses/hsp70-folding-machinery-check/openscientist.md
+    supporting_text: Additional adapter/regulatory functions may exist


### PR DESCRIPTION
## Summary
- add structured HSPA12A knowledge gaps for unresolved nucleotide/ATPase behavior, SorLA trafficking mechanism, and broader adaptor/regulatory interaction network
- render the updated HSPA12A review HTML

## Validation
- `just validate human HSPA12A`
- `just render human HSPA12A`
- `git diff --check`