### PR TITLE
Add SCGB1C1 knowledge gaps

### DIFF
--- a/genes/human/SCGB1C1/SCGB1C1-ai-review.html
+++ b/genes/human/SCGB1C1/SCGB1C1-ai-review.html
@@ -1480,7 +1480,7 @@ downstream signaling for secretoglobins remain poorly characterized.</div>
 
                 <li><em>"SCGB1C1 treatment notably increased the populations of CD4+CD25+Foxp3+ regulatory T cells (Tregs) in asthmatic mice."</em> — PMID:38892470</li>
 
-                <li><em>"Receptor-mediated signaling pathway for SCGB1C1 is not defined in the retrieved evidence"</em> — file:human/SCGB1C1/SCGB1C1-deep-research-falcon.md</li>
+                <li><em>"**Receptor-mediated signaling pathway** for SCGB1C1 is not defined in the retrieved evidence"</em> — file:human/SCGB1C1/SCGB1C1-deep-research-falcon.md</li>
 
                 <li><em>"IFN-γ down-regulated and IL-4 and IL-13 up-regulated its expression; however, no significant effect was observed for IL-1β and TNF-α"</em> — PMID:21385388</li>
 
@@ -2546,7 +2546,7 @@ knowledge_gaps:
   - reference_id: PMID:38892470
     supporting_text: SCGB1C1 treatment notably increased the populations of CD4+CD25+Foxp3+ regulatory T cells (Tregs) in asthmatic mice.
   - reference_id: file:human/SCGB1C1/SCGB1C1-deep-research-falcon.md
-    supporting_text: Receptor-mediated signaling pathway for SCGB1C1 is not defined in the retrieved evidence
+    supporting_text: &#34;**Receptor-mediated signaling pathway** for SCGB1C1 is not defined in the retrieved evidence&#34;
   - reference_id: PMID:21385388
     supporting_text: IFN-γ down-regulated and IL-4 and IL-13 up-regulated its expression; however, no significant effect was observed for IL-1β and TNF-α
 - gap_statement: &gt;-

--- a/genes/human/SCGB1C1/SCGB1C1-ai-review.html
+++ b/genes/human/SCGB1C1/SCGB1C1-ai-review.html
@@ -1420,6 +1420,108 @@ downstream signaling for secretoglobins remain poorly characterized.</div>
 
 
 
+    <div class="section">
+        <h2 class="section-title">Knowledge Gaps</h2>
+        <p style="color: #555; font-size: 0.92rem; margin-top: -0.3rem;">
+            What is <em>not</em> known — curated, literature-grounded statements of the open
+            unknowns (the inverse of core functions).
+        </p>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The direct ligand-binding specificity of human SCGB1C1 is unresolved. GOA now carries odorant binding based on olfactory/Bowman&#39;s gland localization and secretoglobin-family inference, but the actual human ligands, binding affinities, and structural determinants have not been directly established.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span><span class="badge">CURATION</span>
+                <span class="badge">MF_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> The review accepts secreted extracellular localization and records odorant binding as a putative core function. The gap is the biochemical identity of the hydrophobic ligand(s), not whether SCGB1C1 is a secreted secretoglobin.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Direct ligand evidence would determine whether odorant binding is the right molecular-function annotation, whether a broader lipid/small-molecule binding term is more appropriate, and whether SCGB1C1 has distinct ligand preferences compared with other secretoglobins.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Purified human SCGB1C1 ligand screens, direct binding assays with candidate odorants/lipids/steroids, and structural studies of ligand-bound protein would define the molecular-function annotation more precisely.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"Direct odorant-binding mechanism in humans"</em> — file:human/SCGB1C1/SCGB1C1-deep-research-falcon.md</li>
+
+                <li><em>"explicit ligand identity and affinity constants"</em> — file:human/SCGB1C1/SCGB1C1-deep-research-falcon.md</li>
+
+                <li><em>"functional inference based on localization and family properties rather than direct human binding measurements in the excerpt"</em> — file:human/SCGB1C1/SCGB1C1-deep-research-falcon.md</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The receptor or signaling mechanism behind SCGB1C1 immunomodulation is unknown. Mouse asthma experiments support an anti-inflammatory/Treg-expanding phenotype, and human airway tissue shows cytokine-responsive SCGB1C1 expression, but the direct human receptor, target cell, and downstream pathway are not defined.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span><span class="badge">CURATION</span>
+                <span class="badge">BP_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> The review treats mouse asthma suppression and human cytokine-regulated expression as strong leads for immunomodulatory biology, while avoiding a definitive human immune-process annotation beyond the current putative ligand-binding function.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Resolving this gap would determine whether SCGB1C1 should be annotated to allergic airway inflammation suppression, regulatory T cell expansion, cytokine modulation, or a more general epithelial innate-immune process in humans.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Human airway epithelial and immune-cell assays with recombinant SCGB1C1, receptor/cell-surface binding screens, pathway phosphoproteomics or transcriptomics, and loss/rescue studies in human tissue models would identify the direct immunomodulatory mechanism.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"SCGB1C1 treatment notably increased the populations of CD4+CD25+Foxp3+ regulatory T cells (Tregs) in asthmatic mice."</em> — PMID:38892470</li>
+
+                <li><em>"Receptor-mediated signaling pathway for SCGB1C1 is not defined in the retrieved evidence"</em> — file:human/SCGB1C1/SCGB1C1-deep-research-falcon.md</li>
+
+                <li><em>"IFN-γ down-regulated and IL-4 and IL-13 up-regulated its expression; however, no significant effect was observed for IL-1β and TNF-α"</em> — PMID:21385388</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> Human disease-context roles for SCGB1C1 remain mostly expression-level or biomarker-level. SCGB1C1 is altered in chronic rhinosinusitis with nasal polyps, upper-respiratory infection susceptibility studies, ovarian carcinoma expression surveys, and low-evidence knowledgebase disease links, but these associations do not yet define a direct protective, inflammatory, or disease mechanism.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span><span class="badge">CURATION</span>
+                <span class="badge">BP_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> The review uses human expression and disease-association evidence to frame plausible mucosal/epithelial biology, but not to assign disease-specific GO biological processes or broad immune functions.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> This distinction prevents over-annotation from expression changes while preserving the disease-context leads that could identify the human tissues, stimuli, and pathways where SCGB1C1 is functional.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Mechanistic perturbation studies in human nasal, airway, and other epithelial disease models should test whether SCGB1C1 changes inflammatory phenotypes, barrier responses, pathogen handling, or ligand availability rather than simply marking disease state.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"SCGB1C1 (RYD5) was only increased, whereas the expression of SCGB3A1 (UGRP2) was only decreased, in CRSwNP, and there was a significant difference between CRSsNP and CRSwNP"</em> — PMID:21385388</li>
+
+                <li><em>"Open Targets lists low-evidence associations between SCGB1C1 and several diseases"</em> — file:human/SCGB1C1/SCGB1C1-deep-research-falcon.md</li>
+
+                <li><em>"these should be treated as hypothesis-generating rather than definitive SCGB1C1 disease mechanisms"</em> — file:human/SCGB1C1/SCGB1C1-deep-research-falcon.md</li>
+
+            </ul>
+
+
+        </div>
+
+    </div>
+
 
 
 
@@ -2383,6 +2485,102 @@ suggested_experiments:
 - description: Evaluate recombinant SCGB1C1 effects on cytokines and regulatory T cell markers in human airway epithelial or immune cell co-culture systems.
   experiment_type: cell culture assay
   hypothesis: SCGB1C1 promotes anti-inflammatory cytokine profiles and regulatory T cell markers in human cells.
+knowledge_gaps:
+- gap_statement: &gt;-
+    The direct ligand-binding specificity of human SCGB1C1 is unresolved. GOA now
+    carries odorant binding based on olfactory/Bowman&#39;s gland localization and
+    secretoglobin-family inference, but the actual human ligands, binding
+    affinities, and structural determinants have not been directly established.
+  boundary: &gt;-
+    The review accepts secreted extracellular localization and records odorant
+    binding as a putative core function. The gap is the biochemical identity of
+    the hydrophobic ligand(s), not whether SCGB1C1 is a secreted secretoglobin.
+  gap_kind:
+  - BIOLOGY
+  - CURATION
+  dark_aspect: MF_DARK
+  status: OPEN
+  significance: &gt;-
+    Direct ligand evidence would determine whether odorant binding is the right
+    molecular-function annotation, whether a broader lipid/small-molecule binding
+    term is more appropriate, and whether SCGB1C1 has distinct ligand preferences
+    compared with other secretoglobins.
+  resolution: &gt;-
+    Purified human SCGB1C1 ligand screens, direct binding assays with candidate
+    odorants/lipids/steroids, and structural studies of ligand-bound protein would
+    define the molecular-function annotation more precisely.
+  provenance:
+  - reference_id: file:human/SCGB1C1/SCGB1C1-deep-research-falcon.md
+    supporting_text: Direct odorant-binding mechanism in humans
+  - reference_id: file:human/SCGB1C1/SCGB1C1-deep-research-falcon.md
+    supporting_text: explicit ligand identity and affinity constants
+  - reference_id: file:human/SCGB1C1/SCGB1C1-deep-research-falcon.md
+    supporting_text: functional inference based on localization and family properties rather than direct human binding measurements in the excerpt
+- gap_statement: &gt;-
+    The receptor or signaling mechanism behind SCGB1C1 immunomodulation is
+    unknown. Mouse asthma experiments support an anti-inflammatory/Treg-expanding
+    phenotype, and human airway tissue shows cytokine-responsive SCGB1C1
+    expression, but the direct human receptor, target cell, and downstream
+    pathway are not defined.
+  boundary: &gt;-
+    The review treats mouse asthma suppression and human cytokine-regulated
+    expression as strong leads for immunomodulatory biology, while avoiding a
+    definitive human immune-process annotation beyond the current putative
+    ligand-binding function.
+  gap_kind:
+  - BIOLOGY
+  - CURATION
+  dark_aspect: BP_DARK
+  status: OPEN
+  significance: &gt;-
+    Resolving this gap would determine whether SCGB1C1 should be annotated to
+    allergic airway inflammation suppression, regulatory T cell expansion,
+    cytokine modulation, or a more general epithelial innate-immune process in
+    humans.
+  resolution: &gt;-
+    Human airway epithelial and immune-cell assays with recombinant SCGB1C1,
+    receptor/cell-surface binding screens, pathway phosphoproteomics or
+    transcriptomics, and loss/rescue studies in human tissue models would identify
+    the direct immunomodulatory mechanism.
+  provenance:
+  - reference_id: PMID:38892470
+    supporting_text: SCGB1C1 treatment notably increased the populations of CD4+CD25+Foxp3+ regulatory T cells (Tregs) in asthmatic mice.
+  - reference_id: file:human/SCGB1C1/SCGB1C1-deep-research-falcon.md
+    supporting_text: Receptor-mediated signaling pathway for SCGB1C1 is not defined in the retrieved evidence
+  - reference_id: PMID:21385388
+    supporting_text: IFN-γ down-regulated and IL-4 and IL-13 up-regulated its expression; however, no significant effect was observed for IL-1β and TNF-α
+- gap_statement: &gt;-
+    Human disease-context roles for SCGB1C1 remain mostly expression-level or
+    biomarker-level. SCGB1C1 is altered in chronic rhinosinusitis with nasal
+    polyps, upper-respiratory infection susceptibility studies, ovarian carcinoma
+    expression surveys, and low-evidence knowledgebase disease links, but these
+    associations do not yet define a direct protective, inflammatory, or disease
+    mechanism.
+  boundary: &gt;-
+    The review uses human expression and disease-association evidence to frame
+    plausible mucosal/epithelial biology, but not to assign disease-specific GO
+    biological processes or broad immune functions.
+  gap_kind:
+  - BIOLOGY
+  - CURATION
+  dark_aspect: BP_DARK
+  status: OPEN
+  significance: &gt;-
+    This distinction prevents over-annotation from expression changes while
+    preserving the disease-context leads that could identify the human tissues,
+    stimuli, and pathways where SCGB1C1 is functional.
+  resolution: &gt;-
+    Mechanistic perturbation studies in human nasal, airway, and other epithelial
+    disease models should test whether SCGB1C1 changes inflammatory phenotypes,
+    barrier responses, pathogen handling, or ligand availability rather than
+    simply marking disease state.
+  provenance:
+  - reference_id: PMID:21385388
+    supporting_text: SCGB1C1 (RYD5) was only increased, whereas the expression of SCGB3A1 (UGRP2) was only decreased, in CRSwNP, and there was a significant difference between CRSsNP and CRSwNP
+  - reference_id: file:human/SCGB1C1/SCGB1C1-deep-research-falcon.md
+    supporting_text: Open Targets lists low-evidence associations between SCGB1C1 and several diseases
+  - reference_id: file:human/SCGB1C1/SCGB1C1-deep-research-falcon.md
+    supporting_text: these should be treated as hypothesis-generating rather than definitive SCGB1C1 disease mechanisms
 status: COMPLETE
 </code></pre>
             </div>

--- a/genes/human/SCGB1C1/SCGB1C1-ai-review.yaml
+++ b/genes/human/SCGB1C1/SCGB1C1-ai-review.yaml
@@ -151,4 +151,100 @@ suggested_experiments:
 - description: Evaluate recombinant SCGB1C1 effects on cytokines and regulatory T cell markers in human airway epithelial or immune cell co-culture systems.
   experiment_type: cell culture assay
   hypothesis: SCGB1C1 promotes anti-inflammatory cytokine profiles and regulatory T cell markers in human cells.
+knowledge_gaps:
+- gap_statement: >-
+    The direct ligand-binding specificity of human SCGB1C1 is unresolved. GOA now
+    carries odorant binding based on olfactory/Bowman's gland localization and
+    secretoglobin-family inference, but the actual human ligands, binding
+    affinities, and structural determinants have not been directly established.
+  boundary: >-
+    The review accepts secreted extracellular localization and records odorant
+    binding as a putative core function. The gap is the biochemical identity of
+    the hydrophobic ligand(s), not whether SCGB1C1 is a secreted secretoglobin.
+  gap_kind:
+  - BIOLOGY
+  - CURATION
+  dark_aspect: MF_DARK
+  status: OPEN
+  significance: >-
+    Direct ligand evidence would determine whether odorant binding is the right
+    molecular-function annotation, whether a broader lipid/small-molecule binding
+    term is more appropriate, and whether SCGB1C1 has distinct ligand preferences
+    compared with other secretoglobins.
+  resolution: >-
+    Purified human SCGB1C1 ligand screens, direct binding assays with candidate
+    odorants/lipids/steroids, and structural studies of ligand-bound protein would
+    define the molecular-function annotation more precisely.
+  provenance:
+  - reference_id: file:human/SCGB1C1/SCGB1C1-deep-research-falcon.md
+    supporting_text: Direct odorant-binding mechanism in humans
+  - reference_id: file:human/SCGB1C1/SCGB1C1-deep-research-falcon.md
+    supporting_text: explicit ligand identity and affinity constants
+  - reference_id: file:human/SCGB1C1/SCGB1C1-deep-research-falcon.md
+    supporting_text: functional inference based on localization and family properties rather than direct human binding measurements in the excerpt
+- gap_statement: >-
+    The receptor or signaling mechanism behind SCGB1C1 immunomodulation is
+    unknown. Mouse asthma experiments support an anti-inflammatory/Treg-expanding
+    phenotype, and human airway tissue shows cytokine-responsive SCGB1C1
+    expression, but the direct human receptor, target cell, and downstream
+    pathway are not defined.
+  boundary: >-
+    The review treats mouse asthma suppression and human cytokine-regulated
+    expression as strong leads for immunomodulatory biology, while avoiding a
+    definitive human immune-process annotation beyond the current putative
+    ligand-binding function.
+  gap_kind:
+  - BIOLOGY
+  - CURATION
+  dark_aspect: BP_DARK
+  status: OPEN
+  significance: >-
+    Resolving this gap would determine whether SCGB1C1 should be annotated to
+    allergic airway inflammation suppression, regulatory T cell expansion,
+    cytokine modulation, or a more general epithelial innate-immune process in
+    humans.
+  resolution: >-
+    Human airway epithelial and immune-cell assays with recombinant SCGB1C1,
+    receptor/cell-surface binding screens, pathway phosphoproteomics or
+    transcriptomics, and loss/rescue studies in human tissue models would identify
+    the direct immunomodulatory mechanism.
+  provenance:
+  - reference_id: PMID:38892470
+    supporting_text: SCGB1C1 treatment notably increased the populations of CD4+CD25+Foxp3+ regulatory T cells (Tregs) in asthmatic mice.
+  - reference_id: file:human/SCGB1C1/SCGB1C1-deep-research-falcon.md
+    supporting_text: Receptor-mediated signaling pathway for SCGB1C1 is not defined in the retrieved evidence
+  - reference_id: PMID:21385388
+    supporting_text: IFN-γ down-regulated and IL-4 and IL-13 up-regulated its expression; however, no significant effect was observed for IL-1β and TNF-α
+- gap_statement: >-
+    Human disease-context roles for SCGB1C1 remain mostly expression-level or
+    biomarker-level. SCGB1C1 is altered in chronic rhinosinusitis with nasal
+    polyps, upper-respiratory infection susceptibility studies, ovarian carcinoma
+    expression surveys, and low-evidence knowledgebase disease links, but these
+    associations do not yet define a direct protective, inflammatory, or disease
+    mechanism.
+  boundary: >-
+    The review uses human expression and disease-association evidence to frame
+    plausible mucosal/epithelial biology, but not to assign disease-specific GO
+    biological processes or broad immune functions.
+  gap_kind:
+  - BIOLOGY
+  - CURATION
+  dark_aspect: BP_DARK
+  status: OPEN
+  significance: >-
+    This distinction prevents over-annotation from expression changes while
+    preserving the disease-context leads that could identify the human tissues,
+    stimuli, and pathways where SCGB1C1 is functional.
+  resolution: >-
+    Mechanistic perturbation studies in human nasal, airway, and other epithelial
+    disease models should test whether SCGB1C1 changes inflammatory phenotypes,
+    barrier responses, pathogen handling, or ligand availability rather than
+    simply marking disease state.
+  provenance:
+  - reference_id: PMID:21385388
+    supporting_text: SCGB1C1 (RYD5) was only increased, whereas the expression of SCGB3A1 (UGRP2) was only decreased, in CRSwNP, and there was a significant difference between CRSsNP and CRSwNP
+  - reference_id: file:human/SCGB1C1/SCGB1C1-deep-research-falcon.md
+    supporting_text: Open Targets lists low-evidence associations between SCGB1C1 and several diseases
+  - reference_id: file:human/SCGB1C1/SCGB1C1-deep-research-falcon.md
+    supporting_text: these should be treated as hypothesis-generating rather than definitive SCGB1C1 disease mechanisms
 status: COMPLETE

--- a/genes/human/SCGB1C1/SCGB1C1-ai-review.yaml
+++ b/genes/human/SCGB1C1/SCGB1C1-ai-review.yaml
@@ -212,7 +212,7 @@ knowledge_gaps:
   - reference_id: PMID:38892470
     supporting_text: SCGB1C1 treatment notably increased the populations of CD4+CD25+Foxp3+ regulatory T cells (Tregs) in asthmatic mice.
   - reference_id: file:human/SCGB1C1/SCGB1C1-deep-research-falcon.md
-    supporting_text: Receptor-mediated signaling pathway for SCGB1C1 is not defined in the retrieved evidence
+    supporting_text: "**Receptor-mediated signaling pathway** for SCGB1C1 is not defined in the retrieved evidence"
   - reference_id: PMID:21385388
     supporting_text: IFN-γ down-regulated and IL-4 and IL-13 up-regulated its expression; however, no significant effect was observed for IL-1β and TNF-α
 - gap_statement: >-


### PR DESCRIPTION
## Summary
- add structured SCGB1C1 knowledge gaps for unresolved ligand specificity, immunomodulatory receptor/signaling mechanism, and disease-context expression versus function
- render the updated SCGB1C1 review HTML

## Validation
- `just validate human SCGB1C1`
- `just render human SCGB1C1`
- `git diff --check`