### PR TITLE
Add VOPP1 knowledge gaps

### DIFF
--- a/genes/human/VOPP1/VOPP1-ai-review.html
+++ b/genes/human/VOPP1/VOPP1-ai-review.html
@@ -2458,6 +2458,8 @@
             <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
             <ul style="margin-top: 0.2rem;">
 
+                <li><em>"These findings throw into doubt the hypothesis that VOPP1 interacts directly with cytoplasmic mediators of the NF kappa B pathway, and suggest that the prosurvival phenotype conferred by this gene product is mediated by other mechanisms."</em> — PMID:20571887</li>
+
                 <li><em>"Foundational work in glioma identifies ECOP/VOPP1 as a modulator of NF‑κB transcriptional activity that promotes cell survival"</em> — file:human/VOPP1/VOPP1-deep-research-falcon.md</li>
 
                 <li><em>"Together, these sources support a model in which VOPP1 functions as a vesicle‑associated adaptor that tunes NF‑κB and growth‑factor–adjacent pathways across tumor contexts"</em> — file:human/VOPP1/VOPP1-deep-research-falcon.md</li>
@@ -3540,6 +3542,12 @@ knowledge_gaps:
       compartment- or motif-defective VOPP1 mutants, would define the direct
       signaling route.
     provenance:
+    - reference_id: PMID:20571887
+      supporting_text: &gt;-
+        These findings throw into doubt the hypothesis that VOPP1 interacts
+        directly with cytoplasmic mediators of the NF kappa B pathway, and
+        suggest that the prosurvival phenotype conferred by this gene product is
+        mediated by other mechanisms.
     - reference_id: file:human/VOPP1/VOPP1-deep-research-falcon.md
       supporting_text: Foundational work in glioma identifies ECOP/VOPP1 as a modulator of NF‑κB transcriptional activity that promotes cell survival
     - reference_id: file:human/VOPP1/VOPP1-deep-research-falcon.md

--- a/genes/human/VOPP1/VOPP1-ai-review.html
+++ b/genes/human/VOPP1/VOPP1-ai-review.html
@@ -2431,6 +2431,108 @@
 
 
 
+    <div class="section">
+        <h2 class="section-title">Knowledge Gaps</h2>
+        <p style="color: #555; font-size: 0.92rem; margin-top: -0.3rem;">
+            What is <em>not</em> known — curated, literature-grounded statements of the open
+            unknowns (the inverse of core functions).
+        </p>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The mechanism connecting vesicle-associated VOPP1 to NF-kappaB-dependent transcription and survival signaling remains unresolved. VOPP1/ECOP can modulate NF-kappaB activity in glioma models, but the direct molecular path from endolysosomal WW-domain-binding/scaffold activity to nuclear NF-kappaB target transcription is not defined.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span><span class="badge">CURATION</span>
+                <span class="badge">BP_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> The review accepts WWOX sequestration in late endosomes/lysosomes as the core molecular function. It treats the general DNA-templated transcription annotation as over-annotated because VOPP1 is not itself a transcription factor.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Resolving this gap would determine whether VOPP1 should receive any specific NF-kappaB signaling or apoptotic-process annotations beyond the direct WWOX-sequestering activity, and would prevent broad transcription annotations from standing in for an unknown upstream mechanism.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Epistasis experiments linking VOPP1 localization, WWOX binding, IkappaB/NF- kappaB pathway components, and transcriptional reporters, ideally with compartment- or motif-defective VOPP1 mutants, would define the direct signaling route.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"Foundational work in glioma identifies ECOP/VOPP1 as a modulator of NF‑κB transcriptional activity that promotes cell survival"</em> — file:human/VOPP1/VOPP1-deep-research-falcon.md</li>
+
+                <li><em>"Together, these sources support a model in which VOPP1 functions as a vesicle‑associated adaptor that tunes NF‑κB and growth‑factor–adjacent pathways across tumor contexts"</em> — file:human/VOPP1/VOPP1-deep-research-falcon.md</li>
+
+                <li><em>"Direct, VOPP1‑focused mechanistic papers from 2023–2024 are limited in the retrieved evidence."</em> — file:human/VOPP1/VOPP1-deep-research-falcon.md</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The compartment-specific architecture of VOPP1 scaffolding remains incompletely defined. VOPP1 is clearly vesicular/endolysosomal and binds WWOX through a PPPY-WW interface, but the structural features beyond the PPPY motif, the high-resolution active compartments, and the composition of VOPP1 signaling complexes are still unclear.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span><span class="badge">CURATION</span>
+                <span class="badge">CC_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> The review accepts lysosome, late endosome, endosome, and cytoplasmic vesicle membrane annotations. The gap is not whether VOPP1 is intracellular and vesicle-associated, but how its membrane topology and compartmentalized complexes specify WWOX sequestration versus other signaling outputs.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Better structural and compartmental detail would sharpen cellular-component annotations and help distinguish WWOX sequestration, NF-kappaB modulation, and MAPK/mTOR-adjacent effects as one vesicular scaffold mechanism or separate context-dependent activities.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> High-resolution endogenous localization, topology mapping, proximity labeling of compartment-specific VOPP1 complexes, and mutational analysis of the transmembrane/cytoplasmic/PPPY regions would define the active molecular architecture.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"Evidence for perinuclear ER/Golgi/late endosome/lysosome association comes from WWOX interactome localization and partner enrichment analyses"</em> — file:human/VOPP1/VOPP1-deep-research-falcon.md</li>
+
+                <li><em>"Structural definition (domains beyond a PPPY motif), high‑resolution localization, and unbiased dependency screens in modern multi‑omic cohorts remain areas for future research"</em> — file:human/VOPP1/VOPP1-deep-research-falcon.md</li>
+
+                <li><em>"markers of endocytosis and autophagy show partial perinuclear co-localization, suggesting that VOPP1-containing vesicles enter final common pathways of the lysosomal system"</em> — PMID:20571887</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The extent to which VOPP1&#39;s cancer-associated expression and pathway dependencies represent generalizable human disease mechanisms remains open. Glioma, breast cancer, and HCC studies support pro-survival/tumorigenic roles, but the validated biomarkers, responsive tumor subsets, and therapeutically targetable mechanism are not yet established.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span><span class="badge">CURATION</span>
+                <span class="badge">BP_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> The review keeps the core function anchored to WWOX sequestration and endolysosomal localization. Broader cancer-process annotations are not automatically inferred from overexpression, amplification, knockdown phenotypes, or preclinical pathway links.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Resolving this gap would determine whether VOPP1 should be annotated to specific cancer-relevant survival, growth-factor, MAPK/mTOR, or apoptosis processes, or whether these remain tumor-context phenotypes downstream of a narrower sequestration/scaffold function.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Prospective tumor cohorts, standardized VOPP1 assays, dependency screens, rescue with mechanism-separating VOPP1 mutants, and therapeutic perturbation of the VOPP1-WWOX/NF-kappaB/MAPK-mTOR axes would define which disease mechanisms are direct and reproducible.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"The HCC preclinical study links VOPP1 to MAPK14 (p38) and RPS6KB1 (S6K) abundance and pathway activity after VOPP1 knockdown"</em> — file:human/VOPP1/VOPP1-deep-research-falcon.md</li>
+
+                <li><em>"standardized assays and prospective validation are needed"</em> — file:human/VOPP1/VOPP1-deep-research-falcon.md</li>
+
+                <li><em>"plausible strategies suggested by preclinical data and warrant medicinal chemistry and delivery exploration"</em> — file:human/VOPP1/VOPP1-deep-research-falcon.md</li>
+
+            </ul>
+
+
+        </div>
+
+    </div>
+
 
 
 
@@ -3410,6 +3512,106 @@ core_functions:
         supporting_text: &#34;In breast cancer cells, VOPP1 sequestrates WWOX in lysosomes,
           impairs its ability to associate with p73alpha, and inhibits WWOX-dependent
           apoptosis.&#34;
+knowledge_gaps:
+  - gap_statement: &gt;-
+      The mechanism connecting vesicle-associated VOPP1 to NF-kappaB-dependent
+      transcription and survival signaling remains unresolved. VOPP1/ECOP can
+      modulate NF-kappaB activity in glioma models, but the direct molecular path
+      from endolysosomal WW-domain-binding/scaffold activity to nuclear NF-kappaB
+      target transcription is not defined.
+    boundary: &gt;-
+      The review accepts WWOX sequestration in late endosomes/lysosomes as the
+      core molecular function. It treats the general DNA-templated transcription
+      annotation as over-annotated because VOPP1 is not itself a transcription
+      factor.
+    gap_kind:
+    - BIOLOGY
+    - CURATION
+    dark_aspect: BP_DARK
+    status: OPEN
+    significance: &gt;-
+      Resolving this gap would determine whether VOPP1 should receive any
+      specific NF-kappaB signaling or apoptotic-process annotations beyond the
+      direct WWOX-sequestering activity, and would prevent broad transcription
+      annotations from standing in for an unknown upstream mechanism.
+    resolution: &gt;-
+      Epistasis experiments linking VOPP1 localization, WWOX binding, IkappaB/NF-
+      kappaB pathway components, and transcriptional reporters, ideally with
+      compartment- or motif-defective VOPP1 mutants, would define the direct
+      signaling route.
+    provenance:
+    - reference_id: file:human/VOPP1/VOPP1-deep-research-falcon.md
+      supporting_text: Foundational work in glioma identifies ECOP/VOPP1 as a modulator of NF‑κB transcriptional activity that promotes cell survival
+    - reference_id: file:human/VOPP1/VOPP1-deep-research-falcon.md
+      supporting_text: Together, these sources support a model in which VOPP1 functions as a vesicle‑associated adaptor that tunes NF‑κB and growth‑factor–adjacent pathways across tumor contexts
+    - reference_id: file:human/VOPP1/VOPP1-deep-research-falcon.md
+      supporting_text: Direct, VOPP1‑focused mechanistic papers from 2023–2024 are limited in the retrieved evidence.
+  - gap_statement: &gt;-
+      The compartment-specific architecture of VOPP1 scaffolding remains
+      incompletely defined. VOPP1 is clearly vesicular/endolysosomal and binds
+      WWOX through a PPPY-WW interface, but the structural features beyond the
+      PPPY motif, the high-resolution active compartments, and the composition of
+      VOPP1 signaling complexes are still unclear.
+    boundary: &gt;-
+      The review accepts lysosome, late endosome, endosome, and cytoplasmic
+      vesicle membrane annotations. The gap is not whether VOPP1 is intracellular
+      and vesicle-associated, but how its membrane topology and compartmentalized
+      complexes specify WWOX sequestration versus other signaling outputs.
+    gap_kind:
+    - BIOLOGY
+    - CURATION
+    dark_aspect: CC_DARK
+    status: OPEN
+    significance: &gt;-
+      Better structural and compartmental detail would sharpen cellular-component
+      annotations and help distinguish WWOX sequestration, NF-kappaB modulation,
+      and MAPK/mTOR-adjacent effects as one vesicular scaffold mechanism or
+      separate context-dependent activities.
+    resolution: &gt;-
+      High-resolution endogenous localization, topology mapping, proximity
+      labeling of compartment-specific VOPP1 complexes, and mutational analysis
+      of the transmembrane/cytoplasmic/PPPY regions would define the active
+      molecular architecture.
+    provenance:
+    - reference_id: file:human/VOPP1/VOPP1-deep-research-falcon.md
+      supporting_text: Evidence for perinuclear ER/Golgi/late endosome/lysosome association comes from WWOX interactome localization and partner enrichment analyses
+    - reference_id: file:human/VOPP1/VOPP1-deep-research-falcon.md
+      supporting_text: Structural definition (domains beyond a PPPY motif), high‑resolution localization, and unbiased dependency screens in modern multi‑omic cohorts remain areas for future research
+    - reference_id: PMID:20571887
+      supporting_text: markers of endocytosis and autophagy show partial perinuclear co-localization, suggesting that VOPP1-containing vesicles enter final common pathways of the lysosomal system
+  - gap_statement: &gt;-
+      The extent to which VOPP1&#39;s cancer-associated expression and pathway
+      dependencies represent generalizable human disease mechanisms remains open.
+      Glioma, breast cancer, and HCC studies support pro-survival/tumorigenic
+      roles, but the validated biomarkers, responsive tumor subsets, and
+      therapeutically targetable mechanism are not yet established.
+    boundary: &gt;-
+      The review keeps the core function anchored to WWOX sequestration and
+      endolysosomal localization. Broader cancer-process annotations are not
+      automatically inferred from overexpression, amplification, knockdown
+      phenotypes, or preclinical pathway links.
+    gap_kind:
+    - BIOLOGY
+    - CURATION
+    dark_aspect: BP_DARK
+    status: OPEN
+    significance: &gt;-
+      Resolving this gap would determine whether VOPP1 should be annotated to
+      specific cancer-relevant survival, growth-factor, MAPK/mTOR, or apoptosis
+      processes, or whether these remain tumor-context phenotypes downstream of a
+      narrower sequestration/scaffold function.
+    resolution: &gt;-
+      Prospective tumor cohorts, standardized VOPP1 assays, dependency screens,
+      rescue with mechanism-separating VOPP1 mutants, and therapeutic perturbation
+      of the VOPP1-WWOX/NF-kappaB/MAPK-mTOR axes would define which disease
+      mechanisms are direct and reproducible.
+    provenance:
+    - reference_id: file:human/VOPP1/VOPP1-deep-research-falcon.md
+      supporting_text: The HCC preclinical study links VOPP1 to MAPK14 (p38) and RPS6KB1 (S6K) abundance and pathway activity after VOPP1 knockdown
+    - reference_id: file:human/VOPP1/VOPP1-deep-research-falcon.md
+      supporting_text: standardized assays and prospective validation are needed
+    - reference_id: file:human/VOPP1/VOPP1-deep-research-falcon.md
+      supporting_text: plausible strategies suggested by preclinical data and warrant medicinal chemistry and delivery exploration
 </code></pre>
             </div>
         </details>

--- a/genes/human/VOPP1/VOPP1-ai-review.yaml
+++ b/genes/human/VOPP1/VOPP1-ai-review.yaml
@@ -451,6 +451,12 @@ knowledge_gaps:
       compartment- or motif-defective VOPP1 mutants, would define the direct
       signaling route.
     provenance:
+    - reference_id: PMID:20571887
+      supporting_text: >-
+        These findings throw into doubt the hypothesis that VOPP1 interacts
+        directly with cytoplasmic mediators of the NF kappa B pathway, and
+        suggest that the prosurvival phenotype conferred by this gene product is
+        mediated by other mechanisms.
     - reference_id: file:human/VOPP1/VOPP1-deep-research-falcon.md
       supporting_text: Foundational work in glioma identifies ECOP/VOPP1 as a modulator of NF‑κB transcriptional activity that promotes cell survival
     - reference_id: file:human/VOPP1/VOPP1-deep-research-falcon.md

--- a/genes/human/VOPP1/VOPP1-ai-review.yaml
+++ b/genes/human/VOPP1/VOPP1-ai-review.yaml
@@ -423,3 +423,103 @@ core_functions:
         supporting_text: "In breast cancer cells, VOPP1 sequestrates WWOX in lysosomes,
           impairs its ability to associate with p73alpha, and inhibits WWOX-dependent
           apoptosis."
+knowledge_gaps:
+  - gap_statement: >-
+      The mechanism connecting vesicle-associated VOPP1 to NF-kappaB-dependent
+      transcription and survival signaling remains unresolved. VOPP1/ECOP can
+      modulate NF-kappaB activity in glioma models, but the direct molecular path
+      from endolysosomal WW-domain-binding/scaffold activity to nuclear NF-kappaB
+      target transcription is not defined.
+    boundary: >-
+      The review accepts WWOX sequestration in late endosomes/lysosomes as the
+      core molecular function. It treats the general DNA-templated transcription
+      annotation as over-annotated because VOPP1 is not itself a transcription
+      factor.
+    gap_kind:
+    - BIOLOGY
+    - CURATION
+    dark_aspect: BP_DARK
+    status: OPEN
+    significance: >-
+      Resolving this gap would determine whether VOPP1 should receive any
+      specific NF-kappaB signaling or apoptotic-process annotations beyond the
+      direct WWOX-sequestering activity, and would prevent broad transcription
+      annotations from standing in for an unknown upstream mechanism.
+    resolution: >-
+      Epistasis experiments linking VOPP1 localization, WWOX binding, IkappaB/NF-
+      kappaB pathway components, and transcriptional reporters, ideally with
+      compartment- or motif-defective VOPP1 mutants, would define the direct
+      signaling route.
+    provenance:
+    - reference_id: file:human/VOPP1/VOPP1-deep-research-falcon.md
+      supporting_text: Foundational work in glioma identifies ECOP/VOPP1 as a modulator of NF‑κB transcriptional activity that promotes cell survival
+    - reference_id: file:human/VOPP1/VOPP1-deep-research-falcon.md
+      supporting_text: Together, these sources support a model in which VOPP1 functions as a vesicle‑associated adaptor that tunes NF‑κB and growth‑factor–adjacent pathways across tumor contexts
+    - reference_id: file:human/VOPP1/VOPP1-deep-research-falcon.md
+      supporting_text: Direct, VOPP1‑focused mechanistic papers from 2023–2024 are limited in the retrieved evidence.
+  - gap_statement: >-
+      The compartment-specific architecture of VOPP1 scaffolding remains
+      incompletely defined. VOPP1 is clearly vesicular/endolysosomal and binds
+      WWOX through a PPPY-WW interface, but the structural features beyond the
+      PPPY motif, the high-resolution active compartments, and the composition of
+      VOPP1 signaling complexes are still unclear.
+    boundary: >-
+      The review accepts lysosome, late endosome, endosome, and cytoplasmic
+      vesicle membrane annotations. The gap is not whether VOPP1 is intracellular
+      and vesicle-associated, but how its membrane topology and compartmentalized
+      complexes specify WWOX sequestration versus other signaling outputs.
+    gap_kind:
+    - BIOLOGY
+    - CURATION
+    dark_aspect: CC_DARK
+    status: OPEN
+    significance: >-
+      Better structural and compartmental detail would sharpen cellular-component
+      annotations and help distinguish WWOX sequestration, NF-kappaB modulation,
+      and MAPK/mTOR-adjacent effects as one vesicular scaffold mechanism or
+      separate context-dependent activities.
+    resolution: >-
+      High-resolution endogenous localization, topology mapping, proximity
+      labeling of compartment-specific VOPP1 complexes, and mutational analysis
+      of the transmembrane/cytoplasmic/PPPY regions would define the active
+      molecular architecture.
+    provenance:
+    - reference_id: file:human/VOPP1/VOPP1-deep-research-falcon.md
+      supporting_text: Evidence for perinuclear ER/Golgi/late endosome/lysosome association comes from WWOX interactome localization and partner enrichment analyses
+    - reference_id: file:human/VOPP1/VOPP1-deep-research-falcon.md
+      supporting_text: Structural definition (domains beyond a PPPY motif), high‑resolution localization, and unbiased dependency screens in modern multi‑omic cohorts remain areas for future research
+    - reference_id: PMID:20571887
+      supporting_text: markers of endocytosis and autophagy show partial perinuclear co-localization, suggesting that VOPP1-containing vesicles enter final common pathways of the lysosomal system
+  - gap_statement: >-
+      The extent to which VOPP1's cancer-associated expression and pathway
+      dependencies represent generalizable human disease mechanisms remains open.
+      Glioma, breast cancer, and HCC studies support pro-survival/tumorigenic
+      roles, but the validated biomarkers, responsive tumor subsets, and
+      therapeutically targetable mechanism are not yet established.
+    boundary: >-
+      The review keeps the core function anchored to WWOX sequestration and
+      endolysosomal localization. Broader cancer-process annotations are not
+      automatically inferred from overexpression, amplification, knockdown
+      phenotypes, or preclinical pathway links.
+    gap_kind:
+    - BIOLOGY
+    - CURATION
+    dark_aspect: BP_DARK
+    status: OPEN
+    significance: >-
+      Resolving this gap would determine whether VOPP1 should be annotated to
+      specific cancer-relevant survival, growth-factor, MAPK/mTOR, or apoptosis
+      processes, or whether these remain tumor-context phenotypes downstream of a
+      narrower sequestration/scaffold function.
+    resolution: >-
+      Prospective tumor cohorts, standardized VOPP1 assays, dependency screens,
+      rescue with mechanism-separating VOPP1 mutants, and therapeutic perturbation
+      of the VOPP1-WWOX/NF-kappaB/MAPK-mTOR axes would define which disease
+      mechanisms are direct and reproducible.
+    provenance:
+    - reference_id: file:human/VOPP1/VOPP1-deep-research-falcon.md
+      supporting_text: The HCC preclinical study links VOPP1 to MAPK14 (p38) and RPS6KB1 (S6K) abundance and pathway activity after VOPP1 knockdown
+    - reference_id: file:human/VOPP1/VOPP1-deep-research-falcon.md
+      supporting_text: standardized assays and prospective validation are needed
+    - reference_id: file:human/VOPP1/VOPP1-deep-research-falcon.md
+      supporting_text: plausible strategies suggested by preclinical data and warrant medicinal chemistry and delivery exploration


### PR DESCRIPTION
## Summary
- add structured VOPP1 knowledge gaps for NF-kappaB pathway mechanism, compartment-specific scaffolding/localization, and cancer-context validation
- render the updated VOPP1 review HTML

## Validation
- `just validate human VOPP1`
- `just render human VOPP1`
- `git diff --check`