### PR TITLE
Update BioReason manuscript and yegV source

### DIFF
--- a/genes/ECOLI/yegV/yegV-deep-research-falcon.md
+++ b/genes/ECOLI/yegV/yegV-deep-research-falcon.md
@@ -1,3 +1,4 @@
+
 ---
 provider: falcon
 model: Edison Scientific Literature

--- a/projects/BIOREASON_COMPARISON/article/manuscript.tex
+++ b/projects/BIOREASON_COMPARISON/article/manuscript.tex
@@ -119,9 +119,7 @@ TODO
 \hypertarget{introduction}{%
 \section{Introduction}\label{introduction}}
 
-Functional annotation of gene products --- determining, recording, and
-structuring what a protein does, where in the cell it does it, and in
-what biological process it participates --- is one of the central
+Functional annotation of gene products is one of the central
 tasks of modern molecular biology, underpinning high-throughput
 analyses of molecular data. The Gene Ontology (GO) project organizes
 these annotations, and coordinated both manual curation efforts and
@@ -129,32 +127,30 @@ the assessment and application of annotation
 pipelines\cite{goconsortium2023}.
 
 Annotations in GO can be classified in two categories: \textbf{(i)
-literature-based expert curation}, in which professional curators read
-papers on experimentally tractable model systems and encode the
-findings as structured, evidence-coded annotations; and \textbf{(ii)
-computational inference}, which propagates function across the long tail of
-uncharacterised proteins.
+literature-based expert curation}, in which expert curators and encode
+findings from papers as structured, evidence-coded annotations;
+and \textbf{(ii) computational inference}, which propagates function
+from literature-based knowledge across the tree of life.
 
-Traditional production pipelines such as InterPro2GO, PANTHER/PAINT,
-and orthology transfer are attractive because their inferences are
-transparent: annotations can be traced back to a family, domain
-signature, phylogenetic node, or orthology assertion. Over-prediction
-can usually be easily corrected, for example by weaking a mapping
-between a domain/family and a GO term. Newer
-machine-learning predictors and protein language-model systems are
-less rule-like. They may consume sequence, structure, organism
-context, or model-derived embeddings directly, and some now emit
-free-text rationales or functional summaries alongside term
+Traditional computational pipelines such as InterPro2GO,
+PANTHER/PAINT, and orthology transfer are attractive because their
+inferences are transparent: annotations can be traced back to a
+family, domain signature, phylogenetic node, or orthology
+assertion. Over-prediction can usually be easily corrected, for
+example by weaking a mapping between a domain/family and a GO
+term. Newer machine-learning predictors and protein language-model
+systems are less rule-like. They may consume sequence, structure,
+organism context, or model-derived embeddings directly, and some now
+emit free-text rationales or functional summaries alongside term
 lists. This makes evaluation harder: the prediction is no longer only
 a set of GO terms, and the provenance chain is often less explicit.
 
 This presents a challenge for assessing whether predictions should be
 included alongside trusted methods in the main annotation corpus. The
-community's standard yardstick for answering this question has been
-the Critical Assessment of Functional Annotation (CAFA)
-series \cite{radivojac2013,jiang2016,zhou2019}, which applies temporal
-holdout against GOA snapshots and reports aggregate GOA-agreement
-scores.
+Critical Assessment of Functional Annotation (CAFA)
+project \cite{radivojac2013,jiang2016,zhou2019} evaluates function
+annotation pipelines,using temporal holdout against GO database
+snapshots and reports aggregate agreement scores.
 
 CAFA has been indispensable for tracking aggregate progress of the
 field, but two challenges limit its use as a deployment decision-support


### PR DESCRIPTION
## Summary
- update the BioReason comparison manuscript text
- update the yegV Falcon deep-research source note

## Files changed
- `projects/BIOREASON_COMPARISON/article/manuscript.tex`
- `genes/ECOLI/yegV/yegV-deep-research-falcon.md`

## Tests
- not run; text/source updates only