### PR TITLE
Regenerate pages and browser app

### DIFF
--- a/genes/worm/che-13/che-13-ai-review.html
+++ b/genes/worm/che-13/che-13-ai-review.html
@@ -1,0 +1,5018 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>che-13 - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        .propagation-review {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f8fafc;
+            border-left: 3px solid #64748b;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .propagation-title {
+            font-weight: 600;
+            color: #334155;
+            margin-bottom: 0.25rem;
+        }
+
+        .propagation-row {
+            margin-top: 0.25rem;
+        }
+
+        .propagation-source {
+            margin-top: 0.5rem;
+            padding-top: 0.5rem;
+            border-top: 1px solid #e5e7eb;
+        }
+
+        .propagation-source-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #1d4ed8;
+        }
+
+        .propagation-comment {
+            color: #4b5563;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>che-13</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/Q93833" target="_blank" class="term-link">
+                        Q93833
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Caenorhabditis elegans</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-complete">
+                    COMPLETE
+                </span>
+            </div>
+
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "che-13";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="Q93833" data-a="DESCRIPTION: CHE-13 is the Caenorhabditis elegans ortholog of h..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>CHE-13 is the Caenorhabditis elegans ortholog of human IFT57 (also called HIPPI; Chlamydomonas IFT57) and is a structural subunit of the intraflagellar transport complex B (IFT-B). Intraflagellar transport is the bidirectional, microtubule-motor-driven movement of large multiprotein particles that build and maintain cilia: kinesin-2 motors carry IFT-B particles and their ciliary-precursor cargo anterogradely from the ciliary base to the tip, and cytoplasmic dynein-2 returns them retrogradely. CHE-13/IFT57 is itself a component (and moving cargo) of the IFT-B particle rather than an enzyme; it has no known catalytic activity and contributes to assembly and integrity of the IFT-B complex, in part through a C-terminal coiled-coil. In C. elegans, che-13 is expressed in ciliated sensory neurons under control of the RFX transcription factor DAF-19, and the protein concentrates at the ciliary base (basal body, transition zone) and moves along the sensory (non-motile) ciliary axoneme, as expected for an IFT protein. CHE-13 is required to build the ciliary axoneme: loss-of-function mutants retain normal transition zones but have severely truncated axonemes with ectopically assembled doublet microtubules, and they mislocalize other IFT-B proteins such as OSM-5 and OSM-6. Because the 60 ciliated sensory neurons mediate chemosensation, osmotic avoidance and dauer-pathway signaling, che-13 mutants are broadly defective in these sensory behaviors as a downstream consequence of lacking functional cilia, and are dye-filling defective. IFT57 is conserved from algae to humans, and the IFT pathway it serves is central to the biology of ciliopathies.</p>
+    </div>
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Proposed New Ontology Terms</h2>
+
+        <div class="proposed-term">
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>structural constituent of intraflagellar transport particle</h3>
+                <span class="vote-buttons" data-g="Q93833" data-a="structural constituent of intraflagellar transport particle" data-r="" data-act="NEW">
+                    <button class="vote-btn" data-v="up" title="Agree this term should be created">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with creating this term">👎</button>
+                </span>
+            </div>
+
+
+            <p><strong>Definition:</strong> A structural molecule activity in which a protein acts as a structural subunit of an intraflagellar transport (IFT) particle (IFT-A or IFT-B), contributing to the assembly and integrity of the particle that is trafficked along the ciliary axoneme by kinesin-2 and dynein-2 motors.</p>
+
+
+
+            <p><strong>Justification:</strong> CHE-13/IFT57 and its IFT-B/IFT-A paralogs act as structural subunits of the IFT particle, a role currently expressible only as the generic GO:0005198 structural molecule activity. A dedicated MF term would capture the shared function of IFT structural subunits.</p>
+
+
+
+
+
+
+
+            <p><strong>Supporting Evidence:</strong></p>
+            <ul style="margin-left: 1rem;">
+
+                <li>
+
+                    <a href="https://pubmed.ncbi.nlm.nih.gov/12651157" target="_blank" class="term-link">
+                        PMID:12651157
+                    </a>
+
+
+                    : loss of che-13 differentially affects the localization of two known IFT complex B proteins, OSM-5 and OSM-6, implying that CHE-13 functions as part of this complex.
+
+                </li>
+
+            </ul>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030992" target="_blank" class="term-link">
+                                    GO:0030992
+                                </a>
+                            </span>
+                            <span class="term-label">intraciliary transport particle B</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q93833" data-a="GO:0030992" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> CHE-13/IFT57 is a structural subunit of the IFT-B particle; this is the single most important annotation for the gene, supported by orthology to IFT57 and by ComplexPortal (CPX-1290).
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Core molecular role. CHE-13 is the C. elegans IFT57 ortholog and a member of Intraflagellar transport complex B; phylogenetic inference agrees with the direct C. elegans data.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12651157" target="_blank" class="term-link">
+                                        PMID:12651157
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">loss of che-13 differentially affects the localization of two known IFT complex B proteins, OSM-5 and OSM-6, implying that CHE-13 functions as part of this complex.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042073" target="_blank" class="term-link">
+                                    GO:0042073
+                                </a>
+                            </span>
+                            <span class="term-label">intraciliary transport</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q93833" data-a="GO:0042073" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> As an IFT-B subunit and moving IFT cargo, CHE-13 is directly involved in intraciliary transport.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Core biological process. Fluorescent CHE-13 moves along the axoneme as an IFT protein and is part of the transported IFT-B particle.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12651157" target="_blank" class="term-link">
+                                        PMID:12651157
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">concentrates at the base of cilia and moves along the axoneme as expected for an IFT protein</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005929" target="_blank" class="term-link">
+                                    GO:0005929
+                                </a>
+                            </span>
+                            <span class="term-label">cilium</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q93833" data-a="GO:0005929" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> CHE-13 localizes to and functions within the cilium; phylogenetic inference agrees with direct C. elegans localization data.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Cilium localization is directly supported (CHE-13 concentrates at the ciliary base and moves along the axoneme) and is a core aspect of che-13 function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12651157" target="_blank" class="term-link">
+                                        PMID:12651157
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">concentrates at the base of cilia and moves along the axoneme as expected for an IFT protein</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005815" target="_blank" class="term-link">
+                                    GO:0005815
+                                </a>
+                            </span>
+                            <span class="term-label">microtubule organizing center</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q93833" data-a="GO:0005815" data-r="GO_REF:0000033" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetically propagated MTOC localization. In C. elegans the directly demonstrated site is the ciliary basal body, which is a specialized (docked, modified centriole) microtubule organizing center.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Not wrong but generic; the experimentally supported location is the more specific ciliary basal body (GO:0036064). Retained as a non-core, orthology-based location rather than removed.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1905515" target="_blank" class="term-link">
+                                    GO:1905515
+                                </a>
+                            </span>
+                            <span class="term-label">non-motile cilium assembly</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q93833" data-a="GO:1905515" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> CHE-13 is required to build the sensory (non-motile) ciliary axoneme; phylogenetic inference is corroborated by the loss-of-function ultrastructural phenotype.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Core process, appropriately specific (C. elegans sensory cilia are non-motile). che-13 mutants have severely truncated axonemes.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/2428682" target="_blank" class="term-link">
+                                        PMID:2428682
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The cilia in che-13 (e1805), osm-1 (p808), osm-5 (p813), and osm-6 (p811) mutants have normal transition zones and severely shortened axonemes.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005794" target="_blank" class="term-link">
+                                    GO:0005794
+                                </a>
+                            </span>
+                            <span class="term-label">Golgi apparatus</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q93833" data-a="GO:0005794" data-r="GO_REF:0000033" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetically propagated Golgi localization from the IFT57/HIPPI family. There is no experimental support for a Golgi pool of CHE-13 in C. elegans; the protein&#39;s demonstrated sites are the ciliary base, basal body, transition zone and axoneme.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Over-propagated IBA. IFT57/HIPPI family members have varied non-ciliary associations, but CHE-13&#39;s directly observed localization is entirely ciliary. No C. elegans evidence places CHE-13 in the Golgi.
+                        </div>
+
+
+
+                        <div class="propagation-review">
+                            <div class="propagation-title">Propagation Review</div>
+                            <div class="propagation-row">
+                                <strong>Root cause:</strong>
+                                <span class="badge">PROPAGATION BAD</span>
+                            </div>
+
+                            <div class="propagation-row">
+                                <strong>Failure modes:</strong>
+
+                                <span class="badge">COMPARTMENT OR COMPLEX MISMATCH</span>
+
+                            </div>
+
+
+                            <div class="propagation-source">
+                                <strong>Sources checked:</strong>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">PANTHER:PTN000410691</span>
+
+                                    &middot; IFT57/HIPPI family node
+
+
+                                    <span class="badge">SUPPORTS SOURCE BUT NOT TARGET</span>
+
+
+                                </div>
+
+                            </div>
+
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12651157" target="_blank" class="term-link">
+                                        PMID:12651157
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">concentrates at the base of cilia and moves along the axoneme as expected for an IFT protein</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005930" target="_blank" class="term-link">
+                                    GO:0005930
+                                </a>
+                            </span>
+                            <span class="term-label">axoneme</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000044
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q93833" data-a="GO:0005930" data-r="GO_REF:0000044" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> UniProt SubCell mapping to axoneme, consistent with the direct C. elegans IDA localization data.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Core ciliary localization; CHE-13 moves along the axoneme and is directly observed there (corroborated by IDA in PMID:12651157/18337471).
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12651157" target="_blank" class="term-link">
+                                        PMID:12651157
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">concentrates at the base of cilia and moves along the axoneme as expected for an IFT protein</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005929" target="_blank" class="term-link">
+                                    GO:0005929
+                                </a>
+                            </span>
+                            <span class="term-label">cilium</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">NAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/28479320" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:28479320
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Dynein-Driven Retrograde Intraflagellar Transport Is Triphas...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q93833" data-a="GO:0005929" data-r="PMID:28479320" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> ComplexPortal (CPX-1290) statement that CHE-13 localizes to the cilium, consistent with direct experimental data.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Core ciliary localization; corroborated by IDA/IBA evidence.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/28479320" target="_blank" class="term-link">
+                                        PMID:28479320
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Disruption of the dynein-2 tail domain, light intermediate chain, or intraflagellar transport (IFT)-B complex abolishes dynein-2&#39;s ciliary localization</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030992" target="_blank" class="term-link">
+                                    GO:0030992
+                                </a>
+                            </span>
+                            <span class="term-label">intraciliary transport particle B</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">NAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/28479320" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:28479320
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Dynein-Driven Retrograde Intraflagellar Transport Is Triphas...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q93833" data-a="GO:0030992" data-r="PMID:28479320" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> ComplexPortal assertion of CHE-13 membership in IFT particle B, the core structural annotation, based on the C. elegans IFT-B complex identified by mass spectrometry.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Core molecular role, redundant with and reinforcing the IBA/IDA IFT-B membership annotations.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/28479320" target="_blank" class="term-link">
+                                        PMID:28479320
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Disruption of the dynein-2 tail domain, light intermediate chain, or intraflagellar transport (IFT)-B complex abolishes dynein-2&#39;s ciliary localization</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042073" target="_blank" class="term-link">
+                                    GO:0042073
+                                </a>
+                            </span>
+                            <span class="term-label">intraciliary transport</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">NAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/28479320" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:28479320
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Dynein-Driven Retrograde Intraflagellar Transport Is Triphas...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q93833" data-a="GO:0042073" data-r="PMID:28479320" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> ComplexPortal statement of IFT-B involvement in intraciliary transport.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Core process consistent with CHE-13 being a transported IFT-B subunit.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/28479320" target="_blank" class="term-link">
+                                        PMID:28479320
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Disruption of the dynein-2 tail domain, light intermediate chain, or intraflagellar transport (IFT)-B complex abolishes dynein-2&#39;s ciliary localization</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0060271" target="_blank" class="term-link">
+                                    GO:0060271
+                                </a>
+                            </span>
+                            <span class="term-label">cilium assembly</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">NAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/28479320" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:28479320
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Dynein-Driven Retrograde Intraflagellar Transport Is Triphas...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q93833" data-a="GO:0060271" data-r="PMID:28479320" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> ComplexPortal statement of IFT-B involvement in cilium assembly.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Core process; redundant with the IMP/IGI cilium-assembly annotations. The non-motile cilium assembly child term (GO:1905515) is the most specific form for C. elegans.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/2428682" target="_blank" class="term-link">
+                                        PMID:2428682
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The cilia in che-13 (e1805), osm-1 (p808), osm-5 (p813), and osm-6 (p811) mutants have normal transition zones and severely shortened axonemes.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0060271" target="_blank" class="term-link">
+                                    GO:0060271
+                                </a>
+                            </span>
+                            <span class="term-label">cilium assembly</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IGI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/1732156" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:1732156
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Genetic analysis of chemosensory control of dauer formation ...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q93833" data-a="GO:0060271" data-r="PMID:1732156" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Genetic-interaction evidence placing che-13 among cilium-structure genes required for chemosensory cilium function in the dauer pathway.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Core process; che-13 is one of the cilium-structure genes whose mutation gives structurally defective chemosensory cilia.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/1732156" target="_blank" class="term-link">
+                                        PMID:1732156
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Dauer-defective mutations in nine genes cause structurally defective chemosensory cilia, thereby blocking chemosensation.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003674" target="_blank" class="term-link">
+                                    GO:0003674
+                                </a>
+                            </span>
+                            <span class="term-label">molecular_function</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ND</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000015
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q93833" data-a="GO:0003674" data-r="GO_REF:0000015" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Root-level placeholder recording that no specific molecular function had been assigned at the time of annotation.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Retained as the standard ND placeholder. A subunit-specific molecular function (structural molecule activity within IFT-B) is now proposed as a NEW annotation and in core_functions; no catalytic activity is known or expected for this scaffolding subunit.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005198" target="_blank" class="term-link">
+                                    GO:0005198
+                                </a>
+                            </span>
+                            <span class="term-label">structural molecule activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-new">
+                            NEW
+                        </span>
+                        <span class="vote-buttons" data-g="Q93833" data-a="GO:0005198" data-r="GO_REF:0000033" data-act="NEW">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> CHE-13/IFT57 has no catalytic activity; as an IFT-B subunit its molecular function is best captured as a subunit-specific structural molecule activity.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Proposed new molecular-function annotation reflecting CHE-13&#39;s role as a structural subunit of the IFT-B particle (the current GOA carries only the ND root MF for this gene). This IBA/GO_REF:0000033 evidence pairing does NOT currently exist in the GOA export; it is the expected phylogenetic evidence basis if the annotation were made (IFT57 orthologues across species are IFT-B structural subunits). Ideally a more specific &#39;structural constituent of intraflagellar transport particle&#39; term (see proposed_new_terms) would be used.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12651157" target="_blank" class="term-link">
+                                        PMID:12651157
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">loss of che-13 differentially affects the localization of two known IFT complex B proteins, OSM-5 and OSM-6, implying that CHE-13 functions as part of this complex.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005930" target="_blank" class="term-link">
+                                    GO:0005930
+                                </a>
+                            </span>
+                            <span class="term-label">axoneme</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/12651157" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:12651157
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Identification of CHE-13, a novel intraflagellar transport p...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q93833" data-a="GO:0005930" data-r="PMID:12651157" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> CHE-13 is directly observed moving along the ciliary axoneme.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Core ciliary localization directly demonstrated by fluorescent-tagged CHE-13.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12651157" target="_blank" class="term-link">
+                                        PMID:12651157
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">concentrates at the base of cilia and moves along the axoneme as expected for an IFT protein</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030992" target="_blank" class="term-link">
+                                    GO:0030992
+                                </a>
+                            </span>
+                            <span class="term-label">intraciliary transport particle B</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/17314406" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:17314406
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Sensory ciliogenesis in Caenorhabditis elegans: assignment o...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q93833" data-a="GO:0030992" data-r="PMID:17314406" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> che-13 is assigned to the IFT subcomplex B module based on in vivo transport and phenotypic profiling.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Core molecular role; direct assignment of che-13 to the IFT-B module.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/17314406" target="_blank" class="term-link">
+                                        PMID:17314406
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">the C. elegans IFT machinery has a modular design, consisting of modules IFT-subcomplex A, IFT-subcomplex B, and a BBS protein complex</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0035720" target="_blank" class="term-link">
+                                    GO:0035720
+                                </a>
+                            </span>
+                            <span class="term-label">intraciliary anterograde transport</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/12651157" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:12651157
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Identification of CHE-13, a novel intraflagellar transport p...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q93833" data-a="GO:0035720" data-r="PMID:12651157" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> CHE-13 moves anterogradely along the axoneme as an IFT-B particle component.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Core process. Directly reflects the observed IFT movement of tagged CHE-13 from the ciliary base toward the tip.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12651157" target="_blank" class="term-link">
+                                        PMID:12651157
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">concentrates at the base of cilia and moves along the axoneme as expected for an IFT protein</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0035721" target="_blank" class="term-link">
+                                    GO:0035721
+                                </a>
+                            </span>
+                            <span class="term-label">intraciliary retrograde transport</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/12651157" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:12651157
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Identification of CHE-13, a novel intraflagellar transport p...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q93833" data-a="GO:0035721" data-r="PMID:12651157" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> As an IFT-B particle component, CHE-13 is also recycled retrogradely along the axoneme.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Core process. IFT-B particles (including CHE-13) are carried bidirectionally; retrograde recycling is part of the IFT cycle.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12651157" target="_blank" class="term-link">
+                                        PMID:12651157
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">concentrates at the base of cilia and moves along the axoneme as expected for an IFT protein</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1905515" target="_blank" class="term-link">
+                                    GO:1905515
+                                </a>
+                            </span>
+                            <span class="term-label">non-motile cilium assembly</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/2428682" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:2428682
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Mutant sensory cilia in the nematode Caenorhabditis elegans.
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q93833" data-a="GO:1905515" data-r="PMID:2428682" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> che-13 mutants fail to build full sensory (non-motile) cilia; this is the most precise cilium-assembly term for the worm&#39;s sensory cilia.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Core process, and appropriately specific. Directly supported by the ultrastructural phenotype (severely shortened axonemes).
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/2428682" target="_blank" class="term-link">
+                                        PMID:2428682
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The cilia in che-13 (e1805), osm-1 (p808), osm-5 (p813), and osm-6 (p811) mutants have normal transition zones and severely shortened axonemes.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0035869" target="_blank" class="term-link">
+                                    GO:0035869
+                                </a>
+                            </span>
+                            <span class="term-label">ciliary transition zone</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/12651157" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:12651157
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Identification of CHE-13, a novel intraflagellar transport p...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q93833" data-a="GO:0035869" data-r="PMID:12651157" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> CHE-13 is directly localized at/through the ciliary transition zone as it moves between the ciliary base and the axoneme.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Core localization consistent with IFT trafficking through the transition zone.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12651157" target="_blank" class="term-link">
+                                        PMID:12651157
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">concentrates at the base of cilia and moves along the axoneme as expected for an IFT protein</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0036064" target="_blank" class="term-link">
+                                    GO:0036064
+                                </a>
+                            </span>
+                            <span class="term-label">ciliary basal body</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/22922713" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:22922713
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The BBSome controls IFT assembly and turnaround in cilia.
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q93833" data-a="GO:0036064" data-r="PMID:22922713" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> CHE-13 localizes to the ciliary basal body, where IFT particles assemble before entering the cilium.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Core localization at the site of IFT assembly; consistent with CHE-13 concentrating at the ciliary base. The MGI reference (PMID:22922713) is a DYF-2/BBSome paper that does not name che-13, but basal-body localization is independently established for CHE-13 and the experimental annotation is not overruled.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12651157" target="_blank" class="term-link">
+                                        PMID:12651157
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">concentrates at the base of cilia and moves along the axoneme as expected for an IFT protein</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005930" target="_blank" class="term-link">
+                                    GO:0005930
+                                </a>
+                            </span>
+                            <span class="term-label">axoneme</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/18337471" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:18337471
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Functional redundancy of the B9 proteins and nephrocystins i...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q93833" data-a="GO:0005930" data-r="PMID:18337471" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> A second WormBase IDA supporting CHE-13 axoneme localization.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Core ciliary localization; redundant with the PMID:12651157 axoneme IDA. The cited B9/nephrocystin paper does not foreground che-13, but axoneme localization is well established and the annotation is not overruled.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12651157" target="_blank" class="term-link">
+                                        PMID:12651157
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">concentrates at the base of cilia and moves along the axoneme as expected for an IFT protein</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008104" target="_blank" class="term-link">
+                                    GO:0008104
+                                </a>
+                            </span>
+                            <span class="term-label">intracellular protein localization</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/16957054" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:16957054
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Caenorhabditis elegans DYF-2, an orthologue of human WDR19, ...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-modify">
+                            MODIFY
+                        </span>
+                        <span class="vote-buttons" data-g="Q93833" data-a="GO:0008104" data-r="PMID:16957054" data-act="MODIFY">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> che-13 loss-of-function mislocalizes the IFT-B proteins OSM-5 and OSM-6, i.e. CHE-13 is required for delivering/localizing ciliary proteins. The generic &#34;intracellular protein localization&#34; term understates this; the specific process is protein localization to the cilium.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The evidence (che-13 mutant mislocalizes IFT-B proteins into cilia) supports a more specific and informative term. Replace the generic GO:0008104 with GO:0061512 protein localization to cilium.
+                        </div>
+
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0061512" target="_blank" class="term-link">
+                                    protein localization to cilium
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12651157" target="_blank" class="term-link">
+                                        PMID:12651157
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">loss of che-13 differentially affects the localization of two known IFT complex B proteins, OSM-5 and OSM-6, implying that CHE-13 functions as part of this complex.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0036064" target="_blank" class="term-link">
+                                    GO:0036064
+                                </a>
+                            </span>
+                            <span class="term-label">ciliary basal body</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ISS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000024
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q93833" data-a="GO:0036064" data-r="GO_REF:0000024" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Sequence-similarity transfer of basal-body localization from the mouse IFT57 ortholog (UniProtKB:Q8BXG3), consistent with the direct C. elegans data.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Core localization; redundant with the IDA basal-body annotation and consistent with CHE-13 concentrating at the ciliary base.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12651157" target="_blank" class="term-link">
+                                        PMID:12651157
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">concentrates at the base of cilia and moves along the axoneme as expected for an IFT protein</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0007635" target="_blank" class="term-link">
+                                    GO:0007635
+                                </a>
+                            </span>
+                            <span class="term-label">chemosensory behavior</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/2428682" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:2428682
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Mutant sensory cilia in the nematode Caenorhabditis elegans.
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q93833" data-a="GO:0007635" data-r="PMID:2428682" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> che-13 mutants are chemosensory-defective (dye-filling defective) because their chemosensory cilia are truncated; this is a downstream consequence of defective cilia, not a direct signalling role of CHE-13.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Indirect, downstream sensory phenotype of ciliary loss rather than a core molecular/biological function of CHE-13. Retained (curator IMP) but marked non-core.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/2428682" target="_blank" class="term-link">
+                                        PMID:2428682
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Mutations in 14 genes prevent dye uptake and disrupt chemosensory behaviors.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>CHE-13/IFT57 is a structural subunit of the intraflagellar transport complex B (IFT-B), the anterograde IFT particle that is itself carried as cargo by kinesin-2 and returned by dynein-2. It scaffolds the IFT-B particle (it has no independent catalytic activity) and is required to build and maintain the sensory ciliary axoneme in C. elegans ciliated neurons.</h3>
+                <span class="vote-buttons" data-g="Q93833" data-a="FUNCTION: CHE-13/IFT57 is a structural subunit of the intraf..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005198" target="_blank" class="term-link">
+                            structural molecule activity
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042073" target="_blank" class="term-link">
+                                intraciliary transport
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1905515" target="_blank" class="term-link">
+                                non-motile cilium assembly
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005930" target="_blank" class="term-link">
+                                axoneme
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0036064" target="_blank" class="term-link">
+                                ciliary basal body
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0035869" target="_blank" class="term-link">
+                                ciliary transition zone
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">In Complex:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030992" target="_blank" class="term-link">
+                            intraciliary transport particle B
+                        </a>
+                    </span>
+                </div>
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/12651157" target="_blank" class="term-link">
+                                PMID:12651157
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">loss of che-13 differentially affects the localization of two known IFT complex B proteins, OSM-5 and OSM-6, implying that CHE-13 functions as part of this complex.</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/2428682" target="_blank" class="term-link">
+                                PMID:2428682
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">The cilia in che-13 (e1805), osm-1 (p808), osm-5 (p813), and osm-6 (p811) mutants have normal transition zones and severely shortened axonemes.</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000015.md" target="_blank" class="term-link">
+                            GO_REF:0000015
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Use of the ND evidence code for Gene Ontology (GO) terms</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000024.md" target="_blank" class="term-link">
+                            GO_REF:0000024
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Manual transfer of experimentally-verified manual GO annotation data to orthologs by curator judgment of sequence similarity</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
+                            GO_REF:0000033
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Annotation inferences using phylogenetic trees</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
+                            GO_REF:0000044
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/12651157" target="_blank" class="term-link">
+                            PMID:12651157
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Identification of CHE-13, a novel intraflagellar transport protein required for cilia formation.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">CHE-13 (F59C6.7) is required for cilia assembly and its function is disrupted in che-13 ciliogenic mutants; fluorescent-tagged CHE-13 concentrates at the ciliary base and moves along the axoneme like an IFT protein, and loss of che-13 mislocalizes the IFT-B proteins OSM-5 and OSM-6, placing CHE-13 in IFT complex B.</div>
+
+                        <div class="finding-text">"loss of che-13 differentially affects the localization of two known IFT complex B proteins, OSM-5 and OSM-6, implying that CHE-13 functions as part of this complex."</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <div class="finding-statement">che-13 expression is controlled by the RFX transcription factor DAF-19, like other IFT-B genes.</div>
+
+                        <div class="finding-text">"expression of che-13 (F59C6.7/9) is regulated by the RFX-type transcription factor DAF-19"</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/16957054" target="_blank" class="term-link">
+                            PMID:16957054
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Caenorhabditis elegans DYF-2, an orthologue of human WDR19, is a component of the intraflagellar transport machinery in sensory cilia.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Study of the IFT machinery in which che-13 mutant analysis contributed to the WormBase IMP that che-13 is required for proper localization of IFT proteins.</div>
+
+                        <div class="finding-text">"The intraflagellar transport (IFT) machinery required to build functional cilia consists of a multisubunit complex"</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/17314406" target="_blank" class="term-link">
+                            PMID:17314406
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Sensory ciliogenesis in Caenorhabditis elegans: assignment of IFT components into distinct modules based on transport and phenotypic profiles.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">The C. elegans IFT machinery is organized into modules, including an IFT subcomplex B module to which che-13 belongs, based on in vivo transport and phenotypic profiles.</div>
+
+                        <div class="finding-text">"the C. elegans IFT machinery has a modular design, consisting of modules IFT-subcomplex A, IFT-subcomplex B, and a BBS protein complex"</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/1732156" target="_blank" class="term-link">
+                            PMID:1732156
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Genetic analysis of chemosensory control of dauer formation in Caenorhabditis elegans.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">che-13 is among the cilium-structure genes whose mutation causes structurally defective chemosensory cilia, placing it at a single step in the dauer-formation epistasis pathway.</div>
+
+                        <div class="finding-text">"Dauer-defective mutations in nine genes cause structurally defective chemosensory cilia, thereby blocking chemosensation."</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/18337471" target="_blank" class="term-link">
+                            PMID:18337471
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Functional redundancy of the B9 proteins and nephrocystins in Caenorhabditis elegans ciliogenesis.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Study of B9/nephrocystin ciliogenesis in which che-13 was used as an IFT/ciliary reference; source of a WormBase axoneme IDA for che-13.</div>
+
+                        <div class="finding-text">"the C. elegans B9 proteins form a complex that localizes to the base of cilia"</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/22922713" target="_blank" class="term-link">
+                            PMID:22922713
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">The BBSome controls IFT assembly and turnaround in cilia.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Establishes that the IFT particle (including IFT-B) is assembled at the ciliary base before entering the cilium; used here as the MGI reference for che-13 ciliary basal body localization.</div>
+
+                        <div class="finding-text">"the BBSome (refs 3, 4), a group of conserved proteins affected in human Bardet-Biedl syndrome"</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/2428682" target="_blank" class="term-link">
+                            PMID:2428682
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Mutant sensory cilia in the nematode Caenorhabditis elegans.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">che-13(e1805) mutants have normal ciliary transition zones but severely shortened axonemes with ectopic doublet microtubules, establishing CHE-13 as required for axoneme (cilium) assembly rather than transition-zone formation, and they are dye-filling / chemosensory defective.</div>
+
+                        <div class="finding-text">"The cilia in che-13 (e1805), osm-1 (p808), osm-5 (p813), and osm-6 (p811) mutants have normal transition zones and severely shortened axonemes."</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/28479320" target="_blank" class="term-link">
+                            PMID:28479320
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Dynein-Driven Retrograde Intraflagellar Transport Is Triphasic in C. elegans Sensory Cilia.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Ciliary entry of dynein-2 requires an intact IFT-B complex (of which CHE-13 is a component); this study is the ComplexPortal source (CPX-1290) for che-13 IFT-B/IFT particle B membership, intraciliary transport, cilium assembly and ciliary localization.</div>
+
+                        <div class="finding-text">"Disruption of the dynein-2 tail domain, light intermediate chain, or intraflagellar transport (IFT)-B complex abolishes dynein-2&#39;s ciliary localization"</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Questions for Experts</h2>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Which IFT-B subunits does CHE-13/IFT57 directly contact in C. elegans, and is the C-terminal coiled-coil required for those contacts?</p>
+
+                    <p style="margin-top: 0.5rem;"><em>Suggested experts: Oliver E. Blacque</em></p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q93833" data-a="Q: Which IFT-B subunits does CHE-13/IFT57 directly co..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Do the two che-13 splice isoforms (a/b) have distinct expression or function in ciliated sensory neurons?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q93833" data-a="Q: Do the two che-13 splice isoforms (a/b) have disti..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Experiments</h2>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Perform in vivo proximity labeling (TurboID) with full-length and coiled-coil-deleted CHE-13 expressed in ciliated neurons, followed by mass spectrometry, to map region-specific IFT-B interaction partners.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: CHE-13/IFT57 bridges specific IFT-B subunits via its C-terminal coiled-coil, and disrupting this region selectively destabilizes part of IFT-B.</em></p>
+
+
+                    <p style="margin-top: 0.5rem;">Type: proximity labeling / interaction mapping</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q93833" data-a="EXPERIMENT: Perform in vivo proximity labeling (TurboID) with ..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Use live imaging of tagged tubulin and IFT-B markers (e.g. OSM-6) in che-13 partial loss-of-function backgrounds to quantify anterograde cargo delivery versus transition-zone integrity.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: The truncated axoneme of che-13 mutants reflects failure to deliver axonemal cargo by IFT-B rather than a transition-zone defect.</em></p>
+
+
+                    <p style="margin-top: 0.5rem;">Type: live-cell imaging</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q93833" data-a="EXPERIMENT: Use live imaging of tagged tubulin and IFT-B marke..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Knowledge Gaps</h2>
+        <p style="color: #555; font-size: 0.92rem; margin-top: -0.3rem;">
+            What is <em>not</em> known — curated, literature-grounded statements of the open
+            unknowns (the inverse of core functions).
+        </p>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The specific intra-complex protein contacts of CHE-13/IFT57 within the C. elegans IFT-B particle have not been experimentally mapped. In vertebrates IFT57 sits in the peripheral IFT-B1 region and helps couple IFT-B to the IFT-A/dynein-2 machinery, but which IFT-B subunits CHE-13 directly contacts in the worm, and whether its C-terminal coiled-coil versus its disordered N-terminal/central segments mediate these contacts, is undetermined.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span><span class="badge">ONTOLOGY</span>
+                <span class="badge">MF_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> It is firmly established that CHE-13 is an IFT-B/IFT57 structural subunit that concentrates at the ciliary base, moves bidirectionally by IFT along the axoneme, is required for axoneme assembly, and is needed for proper localization of other IFT-B proteins (OSM-5, OSM-6).</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Defining CHE-13&#39;s specific IFT-B contacts would explain how the IFT-B particle is built in vivo and how the IFT57 orthologue contributes to IFT-B integrity and ciliopathy-relevant IFT defects.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> In vivo proximity labeling (BioID/TurboID) or cross-linking mass spectrometry of tagged CHE-13 in ciliated neurons, plus structure determination of the C. elegans IFT-B subcomplex, paired with an ontology term for structural constituent of the IFT particle.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"loss of che-13 differentially affects the localization of two known IFT complex B proteins, OSM-5 and OSM-6, implying that CHE-13 functions as part of this complex."</em> — PMID:12651157</li>
+
+            </ul>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Proposed term (ontology gap):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><strong>structural constituent of intraflagellar transport particle</strong> — GO currently expresses this role only as the generic &#39;structural molecule activity&#39; (GO:0005198).</li>
+
+            </ul>
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> It is not resolved whether the severely truncated axoneme of che-13 mutants reflects failure to deliver specific axonemal cargo (e.g. tubulin or motility- related proteins) versus a general loss of IFT-B particle integrity that mislocalizes the whole complex. The che-13 mutant phenotype (short axonemes; OSM-5/OSM-6 mislocalization) is consistent with either mechanism.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">MF_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> che-13 is required for axoneme assembly and for proper localization of other IFT-B proteins; UniProt notes a possible role in ciliary entrance/transport of specific cargo, but no direct CHE-13 cargo-selection activity has been demonstrated.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Distinguishing a cargo-delivery role from a particle-integrity role would clarify whether IFT57/CHE-13 has any cargo-specific function beyond scaffolding IFT-B.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Separation-of-function alleles or domain deletions of che-13 with live imaging of tagged axonemal cargo (tubulin) and IFT-B markers to test whether specific cargo delivery can be uncoupled from IFT-B assembly.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"The cilia in che-13 (e1805), osm-1 (p808), osm-5 (p813), and osm-6 (p811) mutants have normal transition zones and severely shortened axonemes."</em> — PMID:2428682</li>
+
+                <li><em>"loss of che-13 differentially affects the localization of two known IFT complex B proteins, OSM-5 and OSM-6, implying that CHE-13 functions as part of this complex."</em> — PMID:12651157</li>
+
+            </ul>
+
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Tags</h2>
+        <div class="aliases">
+
+            <span class="badge">caeel-ciliopathy</span>
+
+        </div>
+    </div>
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Deep Research Sections -->
+
+    <div class="section">
+        <h2 class="section-title">Deep Research</h2>
+
+        <details class="deep-research-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; gap: 1rem;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Falcon</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(che-13-deep-research-falcon.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="Q93833" data-a="DEEP_RESEARCH: Falcon" data-r="" data-act="DEEP_RESEARCH" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This deep research is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This deep research needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+
+                <div class="report-meta">
+
+                    <span class="report-meta-text">Comprehensive Research Report: CHE-13/IFT57 in *Caenorhabditis elegans*</span>
+
+
+                    <span class="report-badge">Falcon</span>
+
+
+                    <span class="report-badge">Edison Scientific Literature</span>
+
+
+                    <span class="report-badge">33 citations</span>
+
+
+                    <span class="report-badge">2 artifacts</span>
+
+
+                    <span class="report-meta-text">2026-07-04T19:17:57.367710</span>
+
+
+
+                </div>
+
+
+                <div class="artifact-list">
+
+
+
+                    <div class="artifact-link">
+                        <a href="che-13-deep-research-falcon_artifacts/artifact-00.md" class="term-link">Edison artifact artifact-00</a>
+                        <span>(text/markdown)</span>
+                    </div>
+
+
+
+
+                    <div class="artifact-link">
+                        <a href="che-13-deep-research-falcon_artifacts/artifact-01.md" class="term-link">Edison artifact artifact-01</a>
+                        <span>(text/markdown)</span>
+                    </div>
+
+
+                </div>
+
+                <p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h1 id="comprehensive-research-report-che-13ift57-in-caenorhabditis-elegans">Comprehensive Research Report: CHE-13/IFT57 in <em>Caenorhabditis elegans</em></h1>
+<h2 id="1-gene-and-protein-identity">1. Gene and Protein Identity</h2>
+<p>CHE-13 (Chemotaxis abnormal protein 13; gene locus F59C6.7) is the <em>C. elegans</em> ortholog of vertebrate Intraflagellar Transport protein 57 (IFT57), also known as HIPPI (Huntingtin-Interacting Protein 1 Protein Interactor) in mammals (taschner2016intraflagellartransportproteins pages 1-2). The protein belongs to the IFT57 family and is a structural/adaptor component of the intraflagellar transport (IFT) machinery rather than an enzyme or classical transporter. Its key structural features include an N-terminal calponin homology (CH) domain (IPR019530/PF10498) and a C-terminal coiled-coil region, both of which mediate critical protein-protein interactions within the IFT-B complex (taschner2016intraflagellartransportproteins pages 3-4, taschner2016intraflagellartransportproteins pages 1-2).</p>
+<p>The following table summarizes the key properties and annotations for CHE-13/IFT57:</p>
+<table>
+<thead>
+<tr>
+<th>Property</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Gene name</td>
+<td><strong>che-13</strong>; also described as <em>Chemotaxis abnormal protein 13</em> in <em>C. elegans</em> literature and UniProt; corresponds to the IFT57 family member in worm (efimenko2006caenorhabditiselegansdyf2an pages 1-2, taschner2016intraflagellartransportproteins pages 1-2)</td>
+</tr>
+<tr>
+<td>Protein name</td>
+<td><strong>Intraflagellar transport protein CHE-13 / IFT57</strong>; a non-enzymatic structural/adaptor component of the intraflagellar transport machinery rather than a catalyst or transporter with a discrete small-molecule substrate (efimenko2006caenorhabditiselegansdyf2an pages 1-2, taschner2016intraflagellartransportproteins pages 3-4)</td>
+</tr>
+<tr>
+<td>Organism</td>
+<td><strong>Caenorhabditis elegans</strong> (worm), the specific target organism verified from UniProt and supported by the cited cilia literature (efimenko2006caenorhabditiselegansdyf2an pages 1-2, kaplan1993adualmechanosensory pages 3-4)</td>
+</tr>
+<tr>
+<td>UniProt accession</td>
+<td><strong>Q93833</strong> (user-supplied UniProt record for <em>C. elegans</em> CHE-13)</td>
+</tr>
+<tr>
+<td>Protein family</td>
+<td><strong>IFT57 family</strong>; conserved component of the <strong>IFT-B</strong> machinery required for cilia/flagella assembly and transport, with CHE-13 representing the worm ortholog (taschner2016intraflagellartransportproteins pages 1-2, houde2006hippiisessential pages 6-8)</td>
+</tr>
+<tr>
+<td>Key domain</td>
+<td>Contains an <strong>N-terminal calponin-homology (CH) domain</strong> and a <strong>C-terminal coiled-coil region</strong>; the CH domain mediates interaction with IFT172, whereas the coiled-coil region supports association with IFT38 (taschner2016intraflagellartransportproteins pages 3-4, taschner2016intraflagellartransportproteins pages 5-5, taschner2016intraflagellartransportproteins pages 1-2)</td>
+</tr>
+<tr>
+<td>Subcellular localization</td>
+<td>Localizes to the <strong>ciliary base/basal body region</strong> in <em>C. elegans</em> sensory neurons and functions within sensory cilia; CHE-13 has also been observed as an IFT-B component entering residual cilia in mutant backgrounds (cevik2013activetransportand pages 3-5, efimenko2006caenorhabditiselegansdyf2an pages 6-8)</td>
+</tr>
+<tr>
+<td>IFT complex membership (IFT-B2)</td>
+<td>CHE-13/IFT57 is a member of the <strong>IFT-B2 (peripheral) subcomplex</strong> of IFT-B, together with IFT172, IFT80, IFT54, IFT38, and IFT20; this subcomplex can assemble stably apart from the IFT-B1 core (taschner2016intraflagellartransportproteins pages 5-5, taschner2016intraflagellartransportproteins pages 1-2, taschner2016theintraflagellartransport pages 6-8)</td>
+</tr>
+<tr>
+<td>Direct protein interactions</td>
+<td><strong>IFT172:</strong> bound by the IFT57 CH domain; <strong>IFT38:</strong> forms a stable heterodimer/coiled-coil pair with IFT57; <strong>IFT88/IFT52:</strong> part of the bridging interface linking IFT-B2 to IFT-B1 via IFT57/38 and IFT88/52N; <strong>IFT20:</strong> interacts with IFT57 within IFT-B and has been pulled down with it; <strong>KIF3B/kinesin-2:</strong> vertebrate studies implicate IFT57 and IFT20 in association with KIF3B; <strong>dynein-2/WDR34 and related dynein-2 subunits:</strong> IFT57 contributes to dynein-2–IFT-B interactions important for effective IFT (taschner2016intraflagellartransportproteins pages 5-5, taschner2016intraflagellartransportproteins pages 8-9, taschner2016intraflagellartransportproteins pages 5-7, follit2006theintraflagellartransport pages 4-6, bhogaraju2013intraflagellartransportcomplex pages 5-6, hiyamizu2023multipleinteractionsof pages 1-2)</td>
+</tr>
+<tr>
+<td>Biological function</td>
+<td>CHE-13 is a <strong>structural/adaptor component of anterograde intraflagellar transport</strong> needed for <strong>sensory cilium assembly and maintenance</strong>. Its main role is to help organize the IFT-B train architecture, connect IFT-B2 to IFT-B1, and support transport of ciliary cargoes rather than directly binding tubulin as the main cargo receptor. In <em>C. elegans</em>, complex B defects including CHE-13 loss cause severe shortening of cilia and impaired forward IFT (efimenko2006caenorhabditiselegansdyf2an pages 1-2, taschner2016intraflagellartransportproteins pages 3-4, taschner2016intraflagellartransportproteins pages 8-9)</td>
+</tr>
+<tr>
+<td>Mutant phenotype in <em>C. elegans</em></td>
+<td><strong>che-13 mutants</strong> show <strong>severe ultrastructural defects in ciliated sensory endings</strong>, markedly impaired sensory cilium formation/length, and <strong>chemotaxis abnormalities</strong>; they also show reduced <strong>nose-touch avoidance</strong>, consistent with dysfunction of ciliated sensory neurons such as ASH/FLP/OLQ-linked pathways (kaplan1993adualmechanosensory pages 3-4, efimenko2006caenorhabditiselegansdyf2an pages 1-2)</td>
+</tr>
+<tr>
+<td>Mammalian ortholog</td>
+<td>The mammalian ortholog is <strong>IFT57/HIPPI</strong>. In mouse, loss of Hippi/IFT57 eliminates <strong>nodal monocilia</strong>, disrupts <strong>left-right patterning</strong>, and impairs <strong>Sonic hedgehog signaling</strong> in the neural tube, showing strong evolutionary conservation of ciliary function (houde2006hippiisessential pages 6-8, houde2006hippiisessential pages 5-6, houde2006hippiisessential pages 2-3)</td>
+</tr>
+<tr>
+<td>Disease associations in humans</td>
+<td>Human <strong>IFT57</strong> is associated in current datasets with <strong>Bardet-Biedl syndrome</strong>, <strong>orofaciodigital syndrome / OFD18</strong>, and <strong>hypothyroidism</strong> signals in Open Targets; more broadly, its conserved ciliary role supports classification as a <strong>ciliopathy-related gene</strong>. A 2025 study also reported defective IFT57 as a novel cause of Bardet-Biedl syndrome, though that primary paper was not directly retrievable here (OpenTargets Search: -IFT57)</td>
+</tr>
+</tbody>
+</table>
+<p><em>Table: This table summarizes the identity, localization, molecular interactions, and biological roles of C. elegans CHE-13/IFT57, along with conserved mammalian and disease-relevant information. It is useful as a compact reference for the gene’s functional annotation.</em></p>
+<h2 id="2-primary-molecular-function-structural-adaptor-in-intraflagellar-transport">2. Primary Molecular Function: Structural Adaptor in Intraflagellar Transport</h2>
+<p>CHE-13 is not an enzyme, transporter, or signaling receptor. Rather, it functions as a <strong>structural scaffolding and adaptor protein</strong> within the IFT-B complex, which is essential for the bidirectional transport of cargo molecules along the axonemal microtubules of cilia. The IFT-B complex is subdivided into two stable subcomplexes: the IFT-B1 (core) and IFT-B2 (peripheral) subcomplexes. CHE-13/IFT57 is a member of the <strong>IFT-B2 subcomplex</strong>, together with IFT172, IFT80, IFT54, IFT38, and IFT20 (taschner2016intraflagellartransportproteins pages 1-2, taschner2016intraflagellartransportproteins pages 5-5). This IFT-B2 subcomplex can assemble independently of the IFT-B1 core, forming a stable six-subunit complex (taschner2016intraflagellartransportproteins pages 1-2).</p>
+<h3 id="21-domain-mediated-interactions-within-ift-b2">2.1 Domain-Mediated Interactions within IFT-B2</h3>
+<p>Biochemical and structural studies, primarily using recombinant <em>Chlamydomonas reinhardtii</em> proteins, have defined the molecular interactions through which IFT57 organizes the IFT-B2 complex architecture. The <strong>calponin homology (CH) domain</strong> of IFT57 directly mediates the interaction with IFT172, forming a strong association that helps stabilize IFT172 positioning within the complex (taschner2016intraflagellartransportproteins pages 3-4, taschner2016intraflagellartransportproteins pages 5-5, corbo2024newevidenceon pages 33-39). Notably, among the three CH domain-containing proteins in IFT-B2 (IFT57, IFT54, and IFT38), only IFT54 binds αβ-tubulin as cargo; the CH domains of IFT57 and IFT38 instead mediate protein-protein interactions—IFT57's CH domain with IFT172, and IFT38's CH domain with IFT80 (taschner2016intraflagellartransportproteins pages 1-2).</p>
+<p>The <strong>C-terminal coiled-coil region</strong> of IFT57 mediates interaction with the coiled-coil region of IFT38, forming a stable heterodimer (taschner2016intraflagellartransportproteins pages 3-4, taschner2016intraflagellartransportproteins pages 5-5). This IFT57/IFT38 pair is critical for the overall architecture and integrity of the IFT-B2 subcomplex.</p>
+<h3 id="22-bridging-ift-b2-to-ift-b1">2.2 Bridging IFT-B2 to IFT-B1</h3>
+<p>A key structural role of CHE-13/IFT57 is its participation in bridging the IFT-B2 peripheral subcomplex to the IFT-B1 core. The IFT57/38 complex on the IFT-B2 side directly contacts the preformed IFT88/IFT52N subcomplex on the IFT-B1 side, forming a salt-stable interaction that links the two major subcomplexes into the IFT-B holocomplex (taschner2016theintraflagellartransport pages 6-8, taschner2016intraflagellartransportproteins pages 8-9, taschner2016intraflagellartransportproteins pages 5-7). GST pull-down experiments demonstrated that both IFT88 and IFT52N are required for this bridging interaction, and that the IFT-B2 complex is efficiently pulled down by IFT88/IFT52N when IFT57/38 are present (taschner2016intraflagellartransportproteins pages 8-9). Mutations altering IFT52 conformation at this interface are associated with ciliopathy in humans, underscoring the functional significance of this bridging architecture (liu2025structuremakesa pages 2-3).</p>
+<h3 id="23-motor-protein-interactions">2.3 Motor Protein Interactions</h3>
+<p>IFT57 participates in coupling the IFT-B complex to both anterograde and retrograde molecular motors. Co-immunoprecipitation experiments in vertebrate cells and yeast two-hybrid analyses have implicated IFT57 and IFT20 in binding to <strong>KIF3B</strong>, the motor subunit of the heterotrimeric kinesin-2 complex that powers anterograde IFT (bhogaraju2013intraflagellartransportcomplex pages 5-6, follit2006theintraflagellartransport pages 4-6). IFT20 strongly interacts with both IFT57 and KIF3B, suggesting that the IFT20-IFT57 module may serve as an interface for anterograde motor coupling (bhogaraju2013intraflagellartransportcomplex pages 5-6).</p>
+<p>On the retrograde side, a systematic interaction screen identified that IFT57 also contributes to interactions with dynein-2 subunits, including WDR34, which interacts with IFT57 via its C-terminal WD40 repeat domain (hiyamizu2023multipleinteractionsof pages 1-2). These multiple interactions between IFT-B and dynein-2 are required for effective bidirectional intraflagellar transport.</p>
+<p>The complete set of known IFT57 protein interactions is summarized below:</p>
+<table>
+<thead>
+<tr>
+<th>Interaction Partner</th>
+<th>Complex/Context</th>
+<th>Domain Involved in IFT57</th>
+<th>Evidence Type</th>
+<th>Functional Significance</th>
+<th>Reference</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>IFT172</td>
+<td>IFT-B2 subcomplex</td>
+<td>CH domain</td>
+<td>Crystal structure / pulldown</td>
+<td>Stabilizes and positions IFT172 within IFT-B2 architecture (taschner2016intraflagellartransportproteins pages 5-5, taschner2016intraflagellartransportproteins pages 3-4, taschner2016intraflagellartransportproteins pages 1-2)</td>
+<td>Taschner 2016</td>
+</tr>
+<tr>
+<td>IFT38</td>
+<td>IFT-B2 subcomplex</td>
+<td>Coiled-coil domain</td>
+<td>Copurification</td>
+<td>Forms a stable IFT57–IFT38 heterodimer that supports IFT-B2 assembly (taschner2016intraflagellartransportproteins pages 5-5, taschner2016intraflagellartransportproteins pages 3-4, taschner2016intraflagellartransportproteins pages 1-2)</td>
+<td>Taschner 2016</td>
+</tr>
+<tr>
+<td>IFT88/IFT52N</td>
+<td>IFT-B1/B2 bridge</td>
+<td>IFT57/38 complex</td>
+<td>GST pulldown</td>
+<td>Bridges IFT-B2 to the IFT-B1 core to form the IFT-B holocomplex (taschner2016theintraflagellartransport pages 6-8, taschner2016intraflagellartransportproteins pages 8-9, taschner2016intraflagellartransportproteins pages 5-7)</td>
+<td>Taschner 2016</td>
+</tr>
+<tr>
+<td>IFT20</td>
+<td>IFT-B2 subcomplex</td>
+<td>Not specified</td>
+<td>GST pulldown</td>
+<td>Supports shared IFT-B subcomplex organization and likely contributes to kinesin-2 coupling through the IFT20–IFT57 module (bhogaraju2013intraflagellartransportcomplex pages 5-6, follit2006theintraflagellartransport pages 4-6)</td>
+<td>Follit 2006</td>
+</tr>
+<tr>
+<td>KIF3B (kinesin-2)</td>
+<td>Motor-IFT interaction</td>
+<td>Not specified</td>
+<td>Co-IP / Y2H</td>
+<td>Implicates IFT57 in anterograde motor coupling of IFT particles (bhogaraju2013intraflagellartransportcomplex pages 5-6)</td>
+<td>Bhogaraju 2013</td>
+</tr>
+<tr>
+<td>Dynein-2 (WDR34)</td>
+<td>Motor-IFT interaction</td>
+<td>Not specified</td>
+<td>Interaction screen</td>
+<td>Supports retrograde motor coupling and effective bidirectional IFT coordination (hiyamizu2023multipleinteractionsof pages 1-2)</td>
+<td>Hiyamizu 2023</td>
+</tr>
+<tr>
+<td>IFT80</td>
+<td>IFT-B2 subcomplex</td>
+<td>Via IFT172 association</td>
+<td>Copurification</td>
+<td>Contributes to higher-order IFT-B2 architecture together with the IFT57–IFT172 module (taschner2016intraflagellartransportproteins pages 5-5, taschner2016intraflagellartransportproteins pages 3-4)</td>
+<td>Taschner 2016</td>
+</tr>
+<tr>
+<td>SANS/USH1G</td>
+<td>Ciliary USH network</td>
+<td>N-terminal region</td>
+<td>Y2H / co-localization</td>
+<td>Links the Usher syndrome protein network to IFT-B proteins including IFT57 (OpenTargets Search: -IFT57)</td>
+<td>Sorusch 2019</td>
+</tr>
+</tbody>
+</table>
+<p><em>Table: This table summarizes experimentally supported protein-protein interactions involving C. elegans CHE-13/IFT57 and conserved orthologous IFT57 complexes. It is useful for linking domain-level interactions to IFT-B assembly, motor coupling, and ciliary disease-related networks.</em></p>
+<h2 id="3-subcellular-localization">3. Subcellular Localization</h2>
+<p>In <em>C. elegans</em> sensory neurons, CHE-13/IFT57 localizes prominently to the <strong>ciliary base/basal body region</strong>. Fluorescence microscopy studies using CHE-13::mCherry or CHE-13::YFP fusion constructs have demonstrated that CHE-13 concentrates at the basal body, with a gap of approximately 1 μm between CHE-13 signal and the proximal ciliary membrane marker ARL-13, corresponding to the transition zone (cevik2013activetransportand pages 3-5). CHE-13 has been used as a basal body marker in localization studies of other ciliary proteins.</p>
+<p>As a component of IFT-B, CHE-13 also undergoes bidirectional motility along the ciliary axoneme as part of IFT trains. In <em>dyf-2</em> mutant backgrounds (which disrupt the IFT-A component), CHE-13::YFP can still enter and accumulate in residual cilia, distinguishing it from some other IFT-B proteins (such as OSM-5) that are more dependent on DYF-2 for ciliary entry (efimenko2006caenorhabditiselegansdyf2an pages 6-8). This observation positions CHE-13 in a hierarchy of IFT particle assembly, with some degree of independence from IFT-A components for ciliary localization.</p>
+<h2 id="4-biological-processes-and-mutant-phenotypes-in-c-elegans">4. Biological Processes and Mutant Phenotypes in <em>C. elegans</em></h2>
+<h3 id="41-sensory-cilia-assembly">4.1 Sensory Cilia Assembly</h3>
+<p>CHE-13 is essential for the formation and maintenance of sensory cilia in <em>C. elegans</em>. Loss-of-function mutations in <em>che-13</em> result in <strong>drastically reduced cilia length</strong> and severe ultrastructural defects affecting all ciliated sensory endings (efimenko2006caenorhabditiselegansdyf2an pages 1-2, kaplan1993adualmechanosensory pages 3-4). These phenotypes are characteristic of IFT complex B deficiency, reflecting a requirement for CHE-13 in anterograde IFT—the kinesin-powered movement of IFT particles and associated cargoes from the ciliary base toward the tip (efimenko2006caenorhabditiselegansdyf2an pages 1-2).</p>
+<h3 id="42-chemotaxis-and-sensory-behavior">4.2 Chemotaxis and Sensory Behavior</h3>
+<p><em>che-13</em> mutants exhibit profound <strong>chemotaxis defects</strong>, which is the basis for the gene's name. They display severely impaired responses to chemical attractants and repellents, consistent with the disruption of sensory receptor-bearing ciliated endings in amphid and phasmid neurons. <em>che-13</em> mutants are among the most severely affected chemotaxis-defective mutants in <em>C. elegans</em>, because the ultrastructural defects extend to all ciliated sensory endings, unlike mutants affecting only specific subsets of cilia (kaplan1993adualmechanosensory pages 3-4).</p>
+<h3 id="43-mechanosensation-and-touch-avoidance">4.3 Mechanosensation and Touch Avoidance</h3>
+<p>Beyond chemotaxis, <em>che-13</em> mutants show significantly <strong>reduced nose-touch avoidance</strong>—a mechanosensory behavior mediated by ciliated neurons including ASH, FLP, and OLQ. The severity of touch sensitivity defects correlates with the extent of ciliary ultrastructural defects; <em>che-13</em> mutants have more severe structural damage and correspondingly greater behavioral impairment than mutants such as <em>osm-6</em> (kaplan1993adualmechanosensory pages 3-4).</p>
+<h3 id="44-dye-filling-defects">4.4 Dye-Filling Defects</h3>
+<p>As with other IFT-B mutants, <em>che-13</em> animals are expected to show dye-filling defects (Dyf phenotype), reflecting the inability of fluorescent dyes to access the environmentally exposed sensory cilia due to structural abnormalities. This phenotype is commonly used as a diagnostic marker for cilia defects in <em>C. elegans</em> (efimenko2006caenorhabditiselegansdyf2an pages 1-2).</p>
+<h3 id="45-glial-responses-to-cilia-disruption">4.5 Glial Responses to Cilia Disruption</h3>
+<p>Recent work has shown that disruption of sensory neuron cilia (as occurs in <em>che-13</em> and other IFT mutants) elicits acute responses from associated glial cells (amphid sheath glia). These responses include increased extracellular matrix accumulation around cilia and changes in glial gene expression and secretory activity, representing a homeostatic mechanism by which glia monitor and respond to dendrite substructure integrity (varandas2025gliadetectand pages 1-2).</p>
+<h2 id="5-evolutionary-conservation-and-mammalian-ortholog">5. Evolutionary Conservation and Mammalian Ortholog</h2>
+<h3 id="51-ift57hippi-in-mammals">5.1 IFT57/HIPPI in Mammals</h3>
+<p>The mammalian ortholog of CHE-13, known as <strong>IFT57 or HIPPI</strong>, has been extensively characterized. In mouse, Hippi knockout results in the complete absence of motile monocilia on embryonic node cells, leading to loss of leftward nodal flow and severe <strong>left-right axis patterning defects</strong>, including randomized expression of normally asymmetric genes (Nodal, Lefty-2, Pitx2) (houde2006hippiisessential pages 6-8, houde2006hippiisessential pages 5-6). Hippi-null embryos also display neural tube closure defects, exencephaly, hypotelorism, and polydactyly, reflecting impaired <strong>Sonic hedgehog (Shh) signaling</strong> in the neural tube (houde2006hippiisessential pages 5-6). The mutant embryos are lethal before E10.5 (houde2006hippiisessential pages 2-3).</p>
+<p>In adult ciliated cells, Hippi interacts with other IFT proteins including Ift88 and KIF3A, confirming its conserved role in ciliary protein complexes (houde2006hippiisessential pages 6-8).</p>
+<h3 id="52-dual-role-of-ift57hippi">5.2 Dual Role of IFT57/HIPPI</h3>
+<p>A distinctive feature of mammalian IFT57/HIPPI is its <strong>dual cellular function</strong>. In addition to its ciliary role, HIPPI was independently identified as an adaptor protein that mediates pro-apoptotic signaling from polyglutamine-expanded huntingtin through the HIP1-HIPPI complex, activating caspase-8 to trigger cell death in Huntington's disease pathology (houde2006hippiisessential pages 1-2). The ciliary function operates primarily during development, while the apoptosis signaling function has been implicated in adult brain pathology under pathogenic stress conditions (houde2006hippiisessential pages 8-9). Some neuronal degenerative phenotypes in ciliopathy patients may involve IFT57's non-ciliary functions, complicating interpretation of disease mechanisms (gerdes2009thevertebrateprimary pages 8-9).</p>
+<h2 id="6-disease-associations-of-the-human-ortholog">6. Disease Associations of the Human Ortholog</h2>
+<p>OpenTargets data indicate that human IFT57 is associated with several ciliopathy-related conditions, including <strong>Bardet-Biedl syndrome</strong>, <strong>orofaciodigital syndrome type 18 (OFD18)</strong>, and <strong>hypothyroidism</strong> (OpenTargets Search: -IFT57). A 2025 study by Nitoiu et al. identified defective IFT57 as a novel cause of Bardet-Biedl syndrome in a human patient, further confirming the clinical relevance of this gene's ciliary function. These associations are consistent with the essential role of IFT57 in cilia assembly and function, as ciliopathies commonly arise from mutations in IFT components.</p>
+<h2 id="7-summary">7. Summary</h2>
+<p>CHE-13 (IFT57) in <em>C. elegans</em> is a non-enzymatic structural adaptor protein of the IFT-B2 subcomplex that is essential for intraflagellar transport and sensory cilia biogenesis. Its primary molecular role is to organize the IFT-B train architecture through specific domain-mediated interactions: the N-terminal calponin homology domain binds IFT172, the C-terminal coiled-coil mediates heterodimerization with IFT38, and the IFT57/38 module bridges the IFT-B2 peripheral subcomplex to the IFT-B1 core via contacts with IFT88/IFT52. CHE-13 localizes to the basal body region and undergoes IFT-dependent motility within sensory cilia. Loss of CHE-13 causes severe cilia structural defects across all ciliated sensory neurons, resulting in chemotaxis abnormalities, touch avoidance deficits, and dye-filling failure. The protein's function is deeply conserved across evolution, with the mammalian ortholog IFT57/HIPPI being essential for node cilia assembly, left-right patterning, and Hedgehog signaling, and mutations in human IFT57 being linked to Bardet-Biedl syndrome and orofaciodigital syndrome.</p>
+<p>References</p>
+<ol>
+<li>
+<p>(taschner2016intraflagellartransportproteins pages 1-2): Michael Taschner, Kristina Weber, André Mourão, Melanie Vetter, Mayanka Awasthi, Marc Stiegler, Sagar Bhogaraju, and Esben Lorentzen. Intraflagellar transport proteins 172, 80, 57, 54, 38, and 20 form a stable tubulin‐binding ift‐b2 complex. The EMBO Journal, 35:773-790, Feb 2016. URL: https://doi.org/10.15252/embj.201593164, doi:10.15252/embj.201593164. This article has 224 citations.</p>
+</li>
+<li>
+<p>(taschner2016intraflagellartransportproteins pages 3-4): Michael Taschner, Kristina Weber, André Mourão, Melanie Vetter, Mayanka Awasthi, Marc Stiegler, Sagar Bhogaraju, and Esben Lorentzen. Intraflagellar transport proteins 172, 80, 57, 54, 38, and 20 form a stable tubulin‐binding ift‐b2 complex. The EMBO Journal, 35:773-790, Feb 2016. URL: https://doi.org/10.15252/embj.201593164, doi:10.15252/embj.201593164. This article has 224 citations.</p>
+</li>
+<li>
+<p>(efimenko2006caenorhabditiselegansdyf2an pages 1-2): Evgeni Efimenko, Oliver E. Blacque, Guangshuo Ou, Courtney J. Haycraft, Bradley K. Yoder, Jonathan M. Scholey, Michel R. Leroux, and Peter Swoboda. <i>caenorhabditis elegans</i>dyf-2, an orthologue of human wdr19, is a component of the intraflagellar transport machinery in sensory cilia. Nov 2006. URL: https://doi.org/10.1091/mbc.e06-04-0260, doi:10.1091/mbc.e06-04-0260. This article has 98 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(kaplan1993adualmechanosensory pages 3-4): J. M. Kaplan and H. Horvitz. A dual mechanosensory and chemosensory neuron in caenorhabditis elegans. Proceedings of the National Academy of Sciences of the United States of America, 90:2227-2231, Mar 1993. URL: https://doi.org/10.1073/pnas.90.6.2227, doi:10.1073/pnas.90.6.2227. This article has 677 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(houde2006hippiisessential pages 6-8): Caroline Houde, Robin J. Dickinson, Vicky M. Houtzager, Rebecca Cullum, Rachel Montpetit, Martina Metzler, Elizabeth M. Simpson, Sophie Roy, Michael R. Hayden, Pamela A. Hoodless, and Donald W. Nicholson. Hippi is essential for node cilia assembly and sonic hedgehog signaling. Developmental biology, 300 2:523-33, Dec 2006. URL: https://doi.org/10.1016/j.ydbio.2006.09.001, doi:10.1016/j.ydbio.2006.09.001. This article has 123 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(taschner2016intraflagellartransportproteins pages 5-5): Michael Taschner, Kristina Weber, André Mourão, Melanie Vetter, Mayanka Awasthi, Marc Stiegler, Sagar Bhogaraju, and Esben Lorentzen. Intraflagellar transport proteins 172, 80, 57, 54, 38, and 20 form a stable tubulin‐binding ift‐b2 complex. The EMBO Journal, 35:773-790, Feb 2016. URL: https://doi.org/10.15252/embj.201593164, doi:10.15252/embj.201593164. This article has 224 citations.</p>
+</li>
+<li>
+<p>(cevik2013activetransportand pages 3-5): Sebiha Cevik, Anna A. W. M. Sanders, Erwin Van Wijk, Karsten Boldt, Lara Clarke, Jeroen van Reeuwijk, Yuji Hori, Nicola Horn, Lisette Hetterschijt, Anita Wdowicz, Andrea Mullins, Katarzyna Kida, Oktay I. Kaplan, Sylvia E. C. van Beersum, Ka Man Wu, Stef J. F. Letteboer, Dorus A. Mans, Toshiaki Katada, Kenji Kontani, Marius Ueffing, Ronald Roepman, Hannie Kremer, and Oliver E. Blacque. Active transport and diffusion barriers restrict joubert syndrome-associated arl13b/arl-13 to an inv-like ciliary membrane subdomain. PLoS Genetics, 9:e1003977, Dec 2013. URL: https://doi.org/10.1371/journal.pgen.1003977, doi:10.1371/journal.pgen.1003977. This article has 115 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(efimenko2006caenorhabditiselegansdyf2an pages 6-8): Evgeni Efimenko, Oliver E. Blacque, Guangshuo Ou, Courtney J. Haycraft, Bradley K. Yoder, Jonathan M. Scholey, Michel R. Leroux, and Peter Swoboda. <i>caenorhabditis elegans</i>dyf-2, an orthologue of human wdr19, is a component of the intraflagellar transport machinery in sensory cilia. Nov 2006. URL: https://doi.org/10.1091/mbc.e06-04-0260, doi:10.1091/mbc.e06-04-0260. This article has 98 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(taschner2016theintraflagellartransport pages 6-8): Michael Taschner and Esben Lorentzen. The intraflagellar transport machinery. Cold Spring Harbor perspectives in biology, 8 10:a028092, Oct 2016. URL: https://doi.org/10.1101/cshperspect.a028092, doi:10.1101/cshperspect.a028092. This article has 419 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(taschner2016intraflagellartransportproteins pages 8-9): Michael Taschner, Kristina Weber, André Mourão, Melanie Vetter, Mayanka Awasthi, Marc Stiegler, Sagar Bhogaraju, and Esben Lorentzen. Intraflagellar transport proteins 172, 80, 57, 54, 38, and 20 form a stable tubulin‐binding ift‐b2 complex. The EMBO Journal, 35:773-790, Feb 2016. URL: https://doi.org/10.15252/embj.201593164, doi:10.15252/embj.201593164. This article has 224 citations.</p>
+</li>
+<li>
+<p>(taschner2016intraflagellartransportproteins pages 5-7): Michael Taschner, Kristina Weber, André Mourão, Melanie Vetter, Mayanka Awasthi, Marc Stiegler, Sagar Bhogaraju, and Esben Lorentzen. Intraflagellar transport proteins 172, 80, 57, 54, 38, and 20 form a stable tubulin‐binding ift‐b2 complex. The EMBO Journal, 35:773-790, Feb 2016. URL: https://doi.org/10.15252/embj.201593164, doi:10.15252/embj.201593164. This article has 224 citations.</p>
+</li>
+<li>
+<p>(follit2006theintraflagellartransport pages 4-6): John A. Follit, Richard A. Tuft, Kevin E. Fogarty, and Gregory J. Pazour. The intraflagellar transport protein ift20 is associated with the golgi complex and is required for cilia assembly. Molecular biology of the cell, 17 9:3781-92, Sep 2006. URL: https://doi.org/10.1091/mbc.e06-02-0133, doi:10.1091/mbc.e06-02-0133. This article has 620 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(bhogaraju2013intraflagellartransportcomplex pages 5-6): Sagar Bhogaraju, Benjamin D Engel, and Esben Lorentzen. Intraflagellar transport complex structure and cargo interactions. Cilia, 2:10-10, Aug 2013. URL: https://doi.org/10.1186/2046-2530-2-10, doi:10.1186/2046-2530-2-10. This article has 125 citations.</p>
+</li>
+<li>
+<p>(hiyamizu2023multipleinteractionsof pages 1-2): Shunya Hiyamizu, Hantian Qiu, Laura Vuolo, Nicola L. Stevenson, Caroline Shak, Kate J. Heesom, Yuki Hamada, Yuta Tsurumi, Shuhei Chiba, Yohei Katoh, David J. Stephens, and Kazuhisa Nakayama. Multiple interactions of the dynein-2 complex with the ift-b complex are required for effective intraflagellar transport. Journal of Cell Science, Feb 2023. URL: https://doi.org/10.1242/jcs.260462, doi:10.1242/jcs.260462. This article has 18 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(houde2006hippiisessential pages 5-6): Caroline Houde, Robin J. Dickinson, Vicky M. Houtzager, Rebecca Cullum, Rachel Montpetit, Martina Metzler, Elizabeth M. Simpson, Sophie Roy, Michael R. Hayden, Pamela A. Hoodless, and Donald W. Nicholson. Hippi is essential for node cilia assembly and sonic hedgehog signaling. Developmental biology, 300 2:523-33, Dec 2006. URL: https://doi.org/10.1016/j.ydbio.2006.09.001, doi:10.1016/j.ydbio.2006.09.001. This article has 123 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(houde2006hippiisessential pages 2-3): Caroline Houde, Robin J. Dickinson, Vicky M. Houtzager, Rebecca Cullum, Rachel Montpetit, Martina Metzler, Elizabeth M. Simpson, Sophie Roy, Michael R. Hayden, Pamela A. Hoodless, and Donald W. Nicholson. Hippi is essential for node cilia assembly and sonic hedgehog signaling. Developmental biology, 300 2:523-33, Dec 2006. URL: https://doi.org/10.1016/j.ydbio.2006.09.001, doi:10.1016/j.ydbio.2006.09.001. This article has 123 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(OpenTargets Search: -IFT57): Open Targets Query (-IFT57, 5 results). Buniello, A. et al. (2025). Open Targets Platform: facilitating therapeutic hypotheses building in drug discovery. Nucleic Acids Research.</p>
+</li>
+<li>
+<p>(corbo2024newevidenceon pages 33-39): Dalia Corbo, Caterina Mencarelli, and Pietro Lupetti. New evidence on ift turnaround at the flagellar tip and the association of ift trains with the flagellar membrane in the model organism chlamydomonas reinhardtii. Jul 2024. URL: https://doi.org/10.25434/dalia-corbo_phd2024-07-12, doi:10.25434/dalia-corbo_phd2024-07-12. This article has 0 citations.</p>
+</li>
+<li>
+<p>(liu2025structuremakesa pages 2-3): Ying Liu, Yong Zhang, Hua Ni, and Peiwei Liu. Structure makes a difference: <scp>ift</scp> complex in ciliary function and ciliopathy. Cytoskeleton, Sep 2025. URL: https://doi.org/10.1002/cm.70033, doi:10.1002/cm.70033. This article has 1 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(varandas2025gliadetectand pages 1-2): Katherine C. Varandas, Brianna M. Hodges, Lauren Lubeck, Amelia Farinas, Yupu Liang, Yun Lu, and Shai Shaham. Glia detect and transiently protect against dendrite substructure disruption in c. elegans. Nature Communications, Jan 2025. URL: https://doi.org/10.1038/s41467-024-55674-0, doi:10.1038/s41467-024-55674-0. This article has 7 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(houde2006hippiisessential pages 1-2): Caroline Houde, Robin J. Dickinson, Vicky M. Houtzager, Rebecca Cullum, Rachel Montpetit, Martina Metzler, Elizabeth M. Simpson, Sophie Roy, Michael R. Hayden, Pamela A. Hoodless, and Donald W. Nicholson. Hippi is essential for node cilia assembly and sonic hedgehog signaling. Developmental biology, 300 2:523-33, Dec 2006. URL: https://doi.org/10.1016/j.ydbio.2006.09.001, doi:10.1016/j.ydbio.2006.09.001. This article has 123 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(houde2006hippiisessential pages 8-9): Caroline Houde, Robin J. Dickinson, Vicky M. Houtzager, Rebecca Cullum, Rachel Montpetit, Martina Metzler, Elizabeth M. Simpson, Sophie Roy, Michael R. Hayden, Pamela A. Hoodless, and Donald W. Nicholson. Hippi is essential for node cilia assembly and sonic hedgehog signaling. Developmental biology, 300 2:523-33, Dec 2006. URL: https://doi.org/10.1016/j.ydbio.2006.09.001, doi:10.1016/j.ydbio.2006.09.001. This article has 123 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(gerdes2009thevertebrateprimary pages 8-9): Jantje M. Gerdes, Erica E. Davis, and Nicholas Katsanis. The vertebrate primary cilium in development, homeostasis, and disease. Cell, 137:32-45, Apr 2009. URL: https://doi.org/10.1016/j.cell.2009.03.023, doi:10.1016/j.cell.2009.03.023. This article has 900 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+</ol>
+<h2 id="artifacts">Artifacts</h2>
+<ul>
+<li><a href="che-13-deep-research-falcon_artifacts/artifact-00.md">Edison artifact artifact-00</a></li>
+<li><a href="che-13-deep-research-falcon_artifacts/artifact-01.md">Edison artifact artifact-01</a></li>
+</ul>
+<h2 id="citations">Citations</h2>
+<ol>
+<li>taschner2016intraflagellartransportproteins pages 1-2</li>
+<li>taschner2016intraflagellartransportproteins pages 8-9</li>
+<li>liu2025structuremakesa pages 2-3</li>
+<li>bhogaraju2013intraflagellartransportcomplex pages 5-6</li>
+<li>hiyamizu2023multipleinteractionsof pages 1-2</li>
+<li>cevik2013activetransportand pages 3-5</li>
+<li>kaplan1993adualmechanosensory pages 3-4</li>
+<li>varandas2025gliadetectand pages 1-2</li>
+<li>houde2006hippiisessential pages 5-6</li>
+<li>houde2006hippiisessential pages 2-3</li>
+<li>houde2006hippiisessential pages 6-8</li>
+<li>houde2006hippiisessential pages 1-2</li>
+<li>houde2006hippiisessential pages 8-9</li>
+<li>gerdes2009thevertebrateprimary pages 8-9</li>
+<li>taschner2016intraflagellartransportproteins pages 3-4</li>
+<li>taschner2016intraflagellartransportproteins pages 5-5</li>
+<li>taschner2016theintraflagellartransport pages 6-8</li>
+<li>taschner2016intraflagellartransportproteins pages 5-7</li>
+<li>follit2006theintraflagellartransport pages 4-6</li>
+<li>corbo2024newevidenceon pages 33-39</li>
+<li>https://doi.org/10.15252/embj.201593164,</li>
+<li>https://doi.org/10.1091/mbc.e06-04-0260,</li>
+<li>https://doi.org/10.1073/pnas.90.6.2227,</li>
+<li>https://doi.org/10.1016/j.ydbio.2006.09.001,</li>
+<li>https://doi.org/10.1371/journal.pgen.1003977,</li>
+<li>https://doi.org/10.1101/cshperspect.a028092,</li>
+<li>https://doi.org/10.1091/mbc.e06-02-0133,</li>
+<li>https://doi.org/10.1186/2046-2530-2-10,</li>
+<li>https://doi.org/10.1242/jcs.260462,</li>
+<li>https://doi.org/10.25434/dalia-corbo_phd2024-07-12,</li>
+<li>https://doi.org/10.1002/cm.70033,</li>
+<li>https://doi.org/10.1038/s41467-024-55674-0,</li>
+<li>https://doi.org/10.1016/j.cell.2009.03.023,</li>
+</ol>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(che-13-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="Q93833" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="che-13-q93833-che13_caeel-research-notes">che-13 (Q93833, CHE13_CAEEL) research notes</h1>
+<p>Research journal for the AI GO-annotation review of <em>C. elegans</em> <strong>che-13</strong><br />
+(WormBase WBGene00000492; ORF F59C6.7; UniProt Q93833).</p>
+<h2 id="identity-ortholog-assignment-verified">Identity / ortholog assignment (VERIFIED)</h2>
+<ul>
+<li>che-13 = "Chemotaxis abnormal protein 13" / "Intraflagellar transport protein che-13".</li>
+<li><strong>IFT57 ortholog.</strong> UniProt: <code>SIMILARITY: Belongs to the IFT57 family</code> (ECO:0000305).<br />
+  PANTHER family <strong>PTHR16011 = IFT57/HIPPI</strong> (subfamily PTHR16011:SF0 =<br />
+  "INTRAFLAGELLAR TRANSPORT PROTEIN 57 HOMOLOG"); Pfam <strong>PF10498 (IFT57)</strong>; InterPro<br />
+<strong>IPR019530 (Intra-flagellar_transport_57)</strong>. So che-13 is the <em>C. elegans</em> ortholog<br />
+  of human <strong>IFT57</strong> (a.k.a. HIPPI/ESRRBL1). Confirms the task's stated assignment.</li>
+<li>Member of <strong>IFT complex B (IFT-B)</strong>: ComplexPortal <strong>CPX-1290</strong> "Intraflagellar<br />
+  transport complex B"; Reactome R-CEL-5620924 "Intraflagellar transport".</li>
+<li>412 aa, one predicted C-terminal coiled-coil (302-393), N-terminal + central<br />
+  disordered/acidic regions. Two alternatively spliced isoforms (Q93833-1 "a" displayed;<br />
+  Q93833-2 "b"). No catalytic motif — a <strong>structural/scaffolding subunit</strong>, not an enzyme.</li>
+</ul>
+<h2 id="what-is-known-with-provenance">What is KNOWN (with provenance)</h2>
+<h3 id="molecular-role-structural-subunit-of-the-ift-b-particle">Molecular role: structural subunit of the IFT-B particle</h3>
+<ul>
+<li>che-13 is a component of IFT complex B, the anterograde IFT particle.<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/12651157" title="loss of che-13 differentially affects the localization of two known IFT complex B proteins, OSM-5 and OSM-6, implying that CHE-13 functions as part of this complex">PMID:12651157</a></li>
+<li>IFT-B membership confirmed biochemically / by mass-spec identification in the IFT-B<br />
+  complex. [PMID:28479320 abstract establishes IFT-B complex; UniProt SUBUNIT: "Component of the<br />
+  IFT complex B composed of at least che-2, che-13, dyf-1, dyf-3, dyf-6, dyf-11, dyf-13,<br />
+  ift-20, ift-74, ift-81, ifta-2, osm-1, osm-5 and osm-6" ECO:0000269|PubMed:28479320]</li>
+<li>Modular assignment placed che-13 in the IFT-B subcomplex module (Ou et al. 2007).<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/17314406" title="the C. elegans IFT machinery has a modular design, consisting of modules IFT-subcomplex A, IFT-subcomplex B, and a BBS protein complex">PMID:17314406</a></li>
+</ul>
+<h3 id="behaves-as-an-ift-protein-moves-along-the-axoneme">Behaves as an IFT protein (moves along the axoneme)</h3>
+<ul>
+<li>CHE-13::GFP concentrates at the ciliary base and moves along the axoneme, i.e. it is a<br />
+  moving IFT-B particle component carried bidirectionally (anterograde + retrograde).<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/12651157" title="Fluorescent-tagged CHE-13 protein concentrates at the base of cilia and moves along the axoneme as expected for an IFT protein">PMID:12651157</a></li>
+<li>IEP annotations to intraciliary anterograde (GO:0035720) and retrograde (GO:0035721)<br />
+  transport derive from this movement (PMID:12651157).</li>
+</ul>
+<h3 id="required-for-building-the-ciliary-axoneme-ciliogenesis">Required for building the ciliary axoneme (ciliogenesis)</h3>
+<ul>
+<li>che-13(e1805) mutants: <strong>normal transition zones but severely shortened axonemes</strong>, with<br />
+  ectopic doublet microtubules — a cilium-assembly (not transition-zone) defect.<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/2428682" title="The cilia in che-13 (e1805), osm-1 (p808), osm-5 (p813), and osm-6 (p811) mutants have normal transition zones and severely shortened axonemes. Doublet-microtubules, attached to the membrane by Y links, assemble ectopically proximal to the cilia in these mutants">PMID:2428682</a></li>
+<li>che-13 is "required for cilia assembly and whose function is disrupted in che-13<br />
+  ciliogenic mutants". <a href="https://pubmed.ncbi.nlm.nih.gov/12651157" title="a novel C. elegans gene, F59C6.7/9, that is required for cilia assembly and whose function is disrupted in che-13 ciliogenic mutants">PMID:12651157</a></li>
+<li>IGI cilium-assembly annotation from the dauer-pathway genetics: che-13 is one of the<br />
+  cilium-structure genes whose mutation gives structurally defective chemosensory cilia.<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/1732156" title="Dauer-defective mutations in nine genes cause structurally defective chemosensory cilia, thereby blocking chemosensation">PMID:1732156</a></li>
+<li><em>C. elegans</em> sensory cilia are <strong>non-motile</strong> — hence "non-motile cilium assembly"<br />
+  (GO:1905515) is the appropriately specific cilium-assembly term.</li>
+</ul>
+<h3 id="localization-cc">Localization (CC)</h3>
+<ul>
+<li>Base of cilia / basal body, transition zone, along the axoneme.<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/12651157" title="concentrates at the base of cilia and moves along the axoneme">PMID:12651157</a> and<br />
+  UniProt SUBCELLULAR LOCATION: "Cytoplasm, cytoskeleton, cilium axoneme ... Moves along the axoneme".</li>
+<li>IDA localizations in GOA: axoneme (GO:0005930, PMID:12651157/18337471), ciliary<br />
+  transition zone (GO:0035869, PMID:12651157), ciliary basal body (GO:0036064,<br />
+  PMID:22922713/ISS). ComplexPortal NAS cilium (GO:0005929).</li>
+</ul>
+<h3 id="required-for-localizing-other-ift-proteins-into-cilia">Required for localizing other IFT proteins into cilia</h3>
+<ul>
+<li>Loss of che-13 mislocalizes IFT-B proteins OSM-5 and OSM-6 → basis of the "protein<br />
+  localization" IMP (GO:0008104). More precisely this is protein localization <em>to cilium</em>.<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/12651157" title="loss of che-13 differentially affects the localization of two known IFT complex B proteins, OSM-5 and OSM-6">PMID:12651157</a></li>
+</ul>
+<h3 id="regulation-expression">Regulation / expression</h3>
+<ul>
+<li>Expressed in ciliated sensory neurons; transcription controlled by the RFX factor<br />
+<strong>DAF-19</strong> (X-box), like other IFT-B genes.<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/12651157" title="expression of che-13 (F59C6.7/9) is regulated by the RFX-type transcription factor DAF-19, suggesting a conserved transcriptional pathway in ciliogenesis">PMID:12651157</a></li>
+</ul>
+<h3 id="downstream-non-core-phenotypes">Downstream (non-core) phenotypes</h3>
+<ul>
+<li>che-13 mutants are <strong>dye-filling / chemosensory defective</strong> and fail osmotic avoidance;<br />
+  these are <em>downstream consequences</em> of defective sensory cilia, not a direct signalling<br />
+  activity of CHE-13. <a href="https://pubmed.ncbi.nlm.nih.gov/2428682" title="Mutations in 14 genes prevent dye uptake and disrupt chemosensory behaviors">PMID:2428682</a></li>
+<li>UniProt DISRUPTION PHENOTYPE: "defects in ciliary structure resulting in defects in ...<br />
+  osmotic avoidance behavior ... affects the localization of IFT complex B proteins,<br />
+  osm-5 and osm-6 ... Shortened axonemes of all classes of sensory cilia in the head.<br />
+  Required for mating." (ECO:0000269|PubMed:12651157, PubMed:2428682).</li>
+</ul>
+<h2 id="what-is-not-known-candidate-knowledge-gaps">What is NOT known (candidate knowledge gaps)</h2>
+<ol>
+<li><strong>Intra-complex contacts of CHE-13/IFT57 in the worm are not mapped.</strong> In vertebrates<br />
+   IFT57 sits in the IFT-B1 peripheral region and helps bridge IFT-B to the IFT-A/dynein-2<br />
+   handoff (and IFT57 loss destabilizes IFT-B), but which IFT-B subunits CHE-13 directly<br />
+   contacts in <em>C. elegans</em>, and via which region (the coiled-coil vs the disordered N/central<br />
+   segments), is undetermined. GOA carries only the generic root MF (GO:0003674, ND) —<br />
+   no subunit-level MF term exists.</li>
+<li><strong>No independent biochemical/enzymatic activity</strong> is known or expected for CHE-13;<br />
+   whether the che-3/motility-cargo "entrance" role suggested by UniProt reflects a<br />
+   direct CHE-13 cargo-selection activity vs a general IFT-B requirement is unresolved.<br />
+   [UniProt FUNCTION "May be required for ciliary entrance and transport of specific<br />
+   ciliary cargo proteins such as che-3 which are related to motility (PubMed:28479320)"]</li>
+<li><strong>Isoform-specific function.</strong> Two splice isoforms (a/b differ in the first ~119 aa);<br />
+   whether the two isoforms have distinct roles/expression is unstudied.</li>
+</ol>
+<h2 id="annotation-review-plan-summary">Annotation-review plan (summary)</h2>
+<ul>
+<li>Keep as <strong>core</strong>: IFT-B membership (GO:0030992, part_of), intraciliary transport<br />
+  (GO:0042073), cilium assembly (GO:0060271) + non-motile cilium assembly (GO:1905515),<br />
+  anterograde/retrograde intraciliary transport (GO:0035720/0035721), and the ciliary<br />
+  localizations (axoneme, transition zone, basal body, cilium).</li>
+<li><strong>MODIFY</strong> GO:0008104 intracellular protein localization → GO:0061512 protein<br />
+  localization to cilium (more specific; supported by OSM-5/OSM-6 mislocalization).</li>
+<li><strong>KEEP_AS_NON_CORE</strong>: microtubule organizing center (GO:0005815, IBA; generic parent of<br />
+  the experimentally supported ciliary basal body), chemosensory behavior (GO:0007635,<br />
+  downstream sensory phenotype), ND root MF (GO:0003674).</li>
+<li><strong>MARK_AS_OVER_ANNOTATED</strong>: Golgi apparatus (GO:0005794, IBA) — no experimental support<br />
+  in worm; over-propagated from the IFT57/HIPPI family; CHE-13 is a ciliary/basal-body<br />
+  protein.</li>
+<li>Add a <strong>NEW</strong> structural-molecule-activity MF (GO:0005198) as the subunit-level MF, per<br />
+  the osm-6 precedent, and propose a dedicated "structural constituent of IFT particle" term.</li>
+</ul>
+<h2 id="provenance-cache-status">Provenance / cache status</h2>
+<ul>
+<li>All 8 cited PMIDs cached in <code>publications/</code>. Only PMID:22922713 has full text; the rest<br />
+  are abstract-only (verified <code>full_text_available:</code> flags). Experimental IDA/IMP/IGI/IEP<br />
+  annotations citing abstract-only papers are NOT overruled on cached-text grounds<br />
+  (curator read full text), per repo guidance.<br />
+</content><br />
+</invoke></li>
+</ul>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: Q93833
+gene_symbol: che-13
+product_type: PROTEIN
+status: COMPLETE
+taxon:
+  id: NCBITaxon:6239
+  label: Caenorhabditis elegans
+description: &gt;-
+  CHE-13 is the Caenorhabditis elegans ortholog of human IFT57 (also called HIPPI;
+  Chlamydomonas IFT57) and is a structural subunit of the intraflagellar transport
+  complex B (IFT-B). Intraflagellar transport is the bidirectional, microtubule-motor-driven
+  movement of large multiprotein particles that build and maintain cilia: kinesin-2 motors
+  carry IFT-B particles and their ciliary-precursor cargo anterogradely from the ciliary
+  base to the tip, and cytoplasmic dynein-2 returns them retrogradely. CHE-13/IFT57 is
+  itself a component (and moving cargo) of the IFT-B particle rather than an enzyme; it
+  has no known catalytic activity and contributes to assembly and integrity of the IFT-B
+  complex, in part through a C-terminal coiled-coil. In C. elegans, che-13 is expressed in
+  ciliated sensory neurons under control of the RFX transcription factor DAF-19, and the
+  protein concentrates at the ciliary base (basal body, transition zone) and moves along
+  the sensory (non-motile) ciliary axoneme, as expected for an IFT protein. CHE-13 is
+  required to build the ciliary axoneme: loss-of-function mutants retain normal transition
+  zones but have severely truncated axonemes with ectopically assembled doublet
+  microtubules, and they mislocalize other IFT-B proteins such as OSM-5 and OSM-6. Because
+  the 60 ciliated sensory neurons mediate chemosensation, osmotic avoidance and
+  dauer-pathway signaling, che-13 mutants are broadly defective in these sensory behaviors
+  as a downstream consequence of lacking functional cilia, and are dye-filling defective.
+  IFT57 is conserved from algae to humans, and the IFT pathway it serves is central to the
+  biology of ciliopathies.
+alternative_products:
+- name: a
+  id: Q93833-1
+- name: b
+  id: Q93833-2
+  sequence_note: VSP_043944, VSP_043945
+references:
+- id: GO_REF:0000015
+  title: Use of the ND evidence code for Gene Ontology (GO) terms
+  findings: []
+- id: GO_REF:0000024
+  title: Manual transfer of experimentally-verified manual GO annotation data to orthologs
+    by curator judgment of sequence similarity
+  findings: []
+- id: GO_REF:0000033
+  title: Annotation inferences using phylogenetic trees
+  findings: []
+- id: GO_REF:0000044
+  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location
+    vocabulary mapping, accompanied by conservative changes to GO terms applied by
+    UniProt
+  findings: []
+- id: PMID:12651157
+  title: Identification of CHE-13, a novel intraflagellar transport protein required
+    for cilia formation.
+  findings:
+  - statement: CHE-13 (F59C6.7) is required for cilia assembly and its function is
+      disrupted in che-13 ciliogenic mutants; fluorescent-tagged CHE-13 concentrates at
+      the ciliary base and moves along the axoneme like an IFT protein, and loss of che-13
+      mislocalizes the IFT-B proteins OSM-5 and OSM-6, placing CHE-13 in IFT complex B.
+    supporting_text: loss of che-13 differentially affects the localization of two known
+      IFT complex B proteins, OSM-5 and OSM-6, implying that CHE-13 functions as part of
+      this complex.
+  - statement: che-13 expression is controlled by the RFX transcription factor DAF-19,
+      like other IFT-B genes.
+    supporting_text: expression of che-13 (F59C6.7/9) is regulated by the RFX-type
+      transcription factor DAF-19
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: Haycraft et al. 2003 (Exp Cell Res); abstract-only in cache. The
+      defining che-13 cloning/characterization paper. Source of IFT-B membership, ciliary
+      base/axoneme localization, DAF-19-dependent expression, the anterograde/retrograde
+      IEP annotations and the OSM-5/OSM-6 mislocalization (protein-localization) evidence.
+- id: PMID:16957054
+  title: Caenorhabditis elegans DYF-2, an orthologue of human WDR19, is a component
+    of the intraflagellar transport machinery in sensory cilia.
+  findings:
+  - statement: Study of the IFT machinery in which che-13 mutant analysis contributed to
+      the WormBase IMP that che-13 is required for proper localization of IFT proteins.
+    supporting_text: The intraflagellar transport (IFT) machinery required to build
+      functional cilia consists of a multisubunit complex
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: Efimenko et al. 2006; abstract-only. Primarily a DYF-2/WDR19 paper that
+      does not foreground che-13; it is the GOA reference for the che-13(WBVar00144317) IMP
+      to intracellular protein localization. Not overruled (curator full-text evidence).
+- id: PMID:17314406
+  title: &#39;Sensory ciliogenesis in Caenorhabditis elegans: assignment of IFT components
+    into distinct modules based on transport and phenotypic profiles.&#39;
+  findings:
+  - statement: The C. elegans IFT machinery is organized into modules, including an IFT
+      subcomplex B module to which che-13 belongs, based on in vivo transport and
+      phenotypic profiles.
+    supporting_text: the C. elegans IFT machinery has a modular design, consisting of
+      modules IFT-subcomplex A, IFT-subcomplex B, and a BBS protein complex
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: Ou et al. 2007 (Mol Biol Cell); abstract-only. Source of the IDA IFT
+      particle B membership annotation for che-13.
+- id: PMID:1732156
+  title: Genetic analysis of chemosensory control of dauer formation in Caenorhabditis
+    elegans.
+  findings:
+  - statement: che-13 is among the cilium-structure genes whose mutation causes
+      structurally defective chemosensory cilia, placing it at a single step in the
+      dauer-formation epistasis pathway.
+    supporting_text: Dauer-defective mutations in nine genes cause structurally defective
+      chemosensory cilia, thereby blocking chemosensation.
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: Vowels &amp; Thomas 1992; abstract-only. Basis for the che-13 cilium-assembly
+      IGI as a genetic requirement for functional chemosensory cilia in the dauer pathway.
+- id: PMID:18337471
+  title: Functional redundancy of the B9 proteins and nephrocystins in Caenorhabditis
+    elegans ciliogenesis.
+  findings:
+  - statement: Study of B9/nephrocystin ciliogenesis in which che-13 was used as an
+      IFT/ciliary reference; source of a WormBase axoneme IDA for che-13.
+    supporting_text: the C. elegans B9 proteins form a complex that localizes to the base
+      of cilia
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: Williams et al. 2008; abstract-only. Primarily a B9/nephrocystin paper
+      that does not foreground che-13; it is the GOA reference for one of the che-13
+      axoneme IDA annotations. Not overruled (curator full-text evidence).
+- id: PMID:22922713
+  title: The BBSome controls IFT assembly and turnaround in cilia.
+  findings:
+  - statement: Establishes that the IFT particle (including IFT-B) is assembled at the
+      ciliary base before entering the cilium; used here as the MGI reference for che-13
+      ciliary basal body localization.
+    supporting_text: the BBSome (refs 3, 4), a group of conserved proteins affected in
+      human Bardet-Biedl syndrome
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: Wei et al. 2012 (Nat Cell Biol); full text available. The paper is about
+      DYF-2 and the BBSome and does not name che-13; it is the MGI reference for the che-13
+      ciliary basal body IDA. Basal-body localization is independently established for
+      che-13 (concentrates at the ciliary base, PMID:12651157), so the annotation is not
+      overruled.
+- id: PMID:2428682
+  title: Mutant sensory cilia in the nematode Caenorhabditis elegans.
+  findings:
+  - statement: che-13(e1805) mutants have normal ciliary transition zones but severely
+      shortened axonemes with ectopic doublet microtubules, establishing CHE-13 as
+      required for axoneme (cilium) assembly rather than transition-zone formation, and
+      they are dye-filling / chemosensory defective.
+    supporting_text: The cilia in che-13 (e1805), osm-1 (p808), osm-5 (p813), and osm-6
+      (p811) mutants have normal transition zones and severely shortened axonemes.
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: Perkins et al. 1986 (Dev Biol); abstract-only. Foundational
+      ultrastructural characterization of the che-13 ciliary phenotype and its
+      dye-filling/chemosensory defects.
+- id: PMID:28479320
+  title: Dynein-Driven Retrograde Intraflagellar Transport Is Triphasic in C. elegans
+    Sensory Cilia.
+  findings:
+  - statement: Ciliary entry of dynein-2 requires an intact IFT-B complex (of which
+      CHE-13 is a component); this study is the ComplexPortal source (CPX-1290) for
+      che-13 IFT-B/IFT particle B membership, intraciliary transport, cilium assembly
+      and ciliary localization.
+    supporting_text: Disruption of the dynein-2 tail domain, light intermediate chain,
+      or intraflagellar transport (IFT)-B complex abolishes dynein-2&#39;s ciliary
+      localization
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: Yi et al. 2017 (Curr Biol); abstract-only. Identifies che-13 in IFT
+      complex B by mass spectrometry (UniProt SUBUNIT) and underlies the ComplexPortal NAS
+      annotations for IFT particle B membership, intraciliary transport, cilium assembly
+      and cilium.
+existing_annotations:
+- term:
+    id: GO:0030992
+    label: intraciliary transport particle B
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: part_of
+  review:
+    summary: CHE-13/IFT57 is a structural subunit of the IFT-B particle; this is the single
+      most important annotation for the gene, supported by orthology to IFT57 and by
+      ComplexPortal (CPX-1290).
+    action: ACCEPT
+    reason: Core molecular role. CHE-13 is the C. elegans IFT57 ortholog and a member of
+      Intraflagellar transport complex B; phylogenetic inference agrees with the direct
+      C. elegans data.
+    supported_by:
+    - reference_id: PMID:12651157
+      supporting_text: loss of che-13 differentially affects the localization of two known
+        IFT complex B proteins, OSM-5 and OSM-6, implying that CHE-13 functions as part of
+        this complex.
+- term:
+    id: GO:0042073
+    label: intraciliary transport
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: involved_in
+  review:
+    summary: As an IFT-B subunit and moving IFT cargo, CHE-13 is directly involved in
+      intraciliary transport.
+    action: ACCEPT
+    reason: Core biological process. Fluorescent CHE-13 moves along the axoneme as an IFT
+      protein and is part of the transported IFT-B particle.
+    supported_by:
+    - reference_id: PMID:12651157
+      supporting_text: concentrates at the base of cilia and moves along the axoneme as
+        expected for an IFT protein
+- term:
+    id: GO:0005929
+    label: cilium
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: is_active_in
+  review:
+    summary: CHE-13 localizes to and functions within the cilium; phylogenetic inference
+      agrees with direct C. elegans localization data.
+    action: ACCEPT
+    reason: Cilium localization is directly supported (CHE-13 concentrates at the ciliary
+      base and moves along the axoneme) and is a core aspect of che-13 function.
+    supported_by:
+    - reference_id: PMID:12651157
+      supporting_text: concentrates at the base of cilia and moves along the axoneme as
+        expected for an IFT protein
+- term:
+    id: GO:0005815
+    label: microtubule organizing center
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: is_active_in
+  review:
+    summary: Phylogenetically propagated MTOC localization. In C. elegans the directly
+      demonstrated site is the ciliary basal body, which is a specialized (docked, modified
+      centriole) microtubule organizing center.
+    action: KEEP_AS_NON_CORE
+    reason: Not wrong but generic; the experimentally supported location is the more
+      specific ciliary basal body (GO:0036064). Retained as a non-core, orthology-based
+      location rather than removed.
+- term:
+    id: GO:1905515
+    label: non-motile cilium assembly
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: involved_in
+  review:
+    summary: CHE-13 is required to build the sensory (non-motile) ciliary axoneme;
+      phylogenetic inference is corroborated by the loss-of-function ultrastructural
+      phenotype.
+    action: ACCEPT
+    reason: Core process, appropriately specific (C. elegans sensory cilia are non-motile).
+      che-13 mutants have severely truncated axonemes.
+    supported_by:
+    - reference_id: PMID:2428682
+      supporting_text: The cilia in che-13 (e1805), osm-1 (p808), osm-5 (p813), and osm-6
+        (p811) mutants have normal transition zones and severely shortened axonemes.
+- term:
+    id: GO:0005794
+    label: Golgi apparatus
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: is_active_in
+  review:
+    summary: Phylogenetically propagated Golgi localization from the IFT57/HIPPI family.
+      There is no experimental support for a Golgi pool of CHE-13 in C. elegans; the
+      protein&#39;s demonstrated sites are the ciliary base, basal body, transition zone and
+      axoneme.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Over-propagated IBA. IFT57/HIPPI family members have varied non-ciliary
+      associations, but CHE-13&#39;s directly observed localization is entirely ciliary. No
+      C. elegans evidence places CHE-13 in the Golgi.
+    propagation_review:
+      root_cause: PROPAGATION_BAD
+      failure_modes:
+      - COMPARTMENT_OR_COMPLEX_MISMATCH
+      source_entities:
+      - source_id: PANTHER:PTN000410691
+        source_label: IFT57/HIPPI family node
+        source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
+    supported_by:
+    - reference_id: PMID:12651157
+      supporting_text: concentrates at the base of cilia and moves along the axoneme as
+        expected for an IFT protein
+- term:
+    id: GO:0005930
+    label: axoneme
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000044
+  qualifier: located_in
+  review:
+    summary: UniProt SubCell mapping to axoneme, consistent with the direct C. elegans
+      IDA localization data.
+    action: ACCEPT
+    reason: Core ciliary localization; CHE-13 moves along the axoneme and is directly
+      observed there (corroborated by IDA in PMID:12651157/18337471).
+    supported_by:
+    - reference_id: PMID:12651157
+      supporting_text: concentrates at the base of cilia and moves along the axoneme as
+        expected for an IFT protein
+- term:
+    id: GO:0005929
+    label: cilium
+  evidence_type: NAS
+  original_reference_id: PMID:28479320
+  qualifier: located_in
+  review:
+    summary: ComplexPortal (CPX-1290) statement that CHE-13 localizes to the cilium,
+      consistent with direct experimental data.
+    action: ACCEPT
+    reason: Core ciliary localization; corroborated by IDA/IBA evidence.
+    supported_by:
+    - reference_id: PMID:28479320
+      supporting_text: Disruption of the dynein-2 tail domain, light intermediate chain,
+        or intraflagellar transport (IFT)-B complex abolishes dynein-2&#39;s ciliary
+        localization
+- term:
+    id: GO:0030992
+    label: intraciliary transport particle B
+  evidence_type: NAS
+  original_reference_id: PMID:28479320
+  qualifier: part_of
+  review:
+    summary: ComplexPortal assertion of CHE-13 membership in IFT particle B, the core
+      structural annotation, based on the C. elegans IFT-B complex identified by mass
+      spectrometry.
+    action: ACCEPT
+    reason: Core molecular role, redundant with and reinforcing the IBA/IDA IFT-B
+      membership annotations.
+    supported_by:
+    - reference_id: PMID:28479320
+      supporting_text: Disruption of the dynein-2 tail domain, light intermediate chain,
+        or intraflagellar transport (IFT)-B complex abolishes dynein-2&#39;s ciliary
+        localization
+- term:
+    id: GO:0042073
+    label: intraciliary transport
+  evidence_type: NAS
+  original_reference_id: PMID:28479320
+  qualifier: involved_in
+  review:
+    summary: ComplexPortal statement of IFT-B involvement in intraciliary transport.
+    action: ACCEPT
+    reason: Core process consistent with CHE-13 being a transported IFT-B subunit.
+    supported_by:
+    - reference_id: PMID:28479320
+      supporting_text: Disruption of the dynein-2 tail domain, light intermediate chain,
+        or intraflagellar transport (IFT)-B complex abolishes dynein-2&#39;s ciliary
+        localization
+- term:
+    id: GO:0060271
+    label: cilium assembly
+  evidence_type: NAS
+  original_reference_id: PMID:28479320
+  qualifier: involved_in
+  review:
+    summary: ComplexPortal statement of IFT-B involvement in cilium assembly.
+    action: ACCEPT
+    reason: Core process; redundant with the IMP/IGI cilium-assembly annotations. The
+      non-motile cilium assembly child term (GO:1905515) is the most specific form for
+      C. elegans.
+    supported_by:
+    - reference_id: PMID:2428682
+      supporting_text: The cilia in che-13 (e1805), osm-1 (p808), osm-5 (p813), and osm-6
+        (p811) mutants have normal transition zones and severely shortened axonemes.
+- term:
+    id: GO:0060271
+    label: cilium assembly
+  evidence_type: IGI
+  original_reference_id: PMID:1732156
+  qualifier: involved_in
+  review:
+    summary: Genetic-interaction evidence placing che-13 among cilium-structure genes
+      required for chemosensory cilium function in the dauer pathway.
+    action: ACCEPT
+    reason: Core process; che-13 is one of the cilium-structure genes whose mutation gives
+      structurally defective chemosensory cilia.
+    supported_by:
+    - reference_id: PMID:1732156
+      supporting_text: Dauer-defective mutations in nine genes cause structurally defective
+        chemosensory cilia, thereby blocking chemosensation.
+- term:
+    id: GO:0003674
+    label: molecular_function
+  evidence_type: ND
+  original_reference_id: GO_REF:0000015
+  qualifier: enables
+  review:
+    summary: Root-level placeholder recording that no specific molecular function had been
+      assigned at the time of annotation.
+    action: KEEP_AS_NON_CORE
+    reason: Retained as the standard ND placeholder. A subunit-specific molecular function
+      (structural molecule activity within IFT-B) is now proposed as a NEW annotation and
+      in core_functions; no catalytic activity is known or expected for this scaffolding
+      subunit.
+- term:
+    id: GO:0005198
+    label: structural molecule activity
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: enables
+  review:
+    summary: CHE-13/IFT57 has no catalytic activity; as an IFT-B subunit its molecular
+      function is best captured as a subunit-specific structural molecule activity.
+    action: NEW
+    reason: Proposed new molecular-function annotation reflecting CHE-13&#39;s role as a
+      structural subunit of the IFT-B particle (the current GOA carries only the ND root
+      MF for this gene). This IBA/GO_REF:0000033 evidence pairing does NOT currently exist
+      in the GOA export; it is the expected phylogenetic evidence basis if the annotation
+      were made (IFT57 orthologues across species are IFT-B structural subunits). Ideally a
+      more specific &#39;structural constituent of intraflagellar transport particle&#39; term (see
+      proposed_new_terms) would be used.
+    supported_by:
+    - reference_id: PMID:12651157
+      supporting_text: loss of che-13 differentially affects the localization of two known
+        IFT complex B proteins, OSM-5 and OSM-6, implying that CHE-13 functions as part of
+        this complex.
+- term:
+    id: GO:0005930
+    label: axoneme
+  evidence_type: IDA
+  original_reference_id: PMID:12651157
+  qualifier: located_in
+  review:
+    summary: CHE-13 is directly observed moving along the ciliary axoneme.
+    action: ACCEPT
+    reason: Core ciliary localization directly demonstrated by fluorescent-tagged CHE-13.
+    supported_by:
+    - reference_id: PMID:12651157
+      supporting_text: concentrates at the base of cilia and moves along the axoneme as
+        expected for an IFT protein
+- term:
+    id: GO:0030992
+    label: intraciliary transport particle B
+  evidence_type: IDA
+  original_reference_id: PMID:17314406
+  qualifier: part_of
+  review:
+    summary: che-13 is assigned to the IFT subcomplex B module based on in vivo transport
+      and phenotypic profiling.
+    action: ACCEPT
+    reason: Core molecular role; direct assignment of che-13 to the IFT-B module.
+    supported_by:
+    - reference_id: PMID:17314406
+      supporting_text: the C. elegans IFT machinery has a modular design, consisting of
+        modules IFT-subcomplex A, IFT-subcomplex B, and a BBS protein complex
+- term:
+    id: GO:0035720
+    label: intraciliary anterograde transport
+  evidence_type: IEP
+  original_reference_id: PMID:12651157
+  qualifier: involved_in
+  review:
+    summary: CHE-13 moves anterogradely along the axoneme as an IFT-B particle component.
+    action: ACCEPT
+    reason: Core process. Directly reflects the observed IFT movement of tagged CHE-13
+      from the ciliary base toward the tip.
+    supported_by:
+    - reference_id: PMID:12651157
+      supporting_text: concentrates at the base of cilia and moves along the axoneme as
+        expected for an IFT protein
+- term:
+    id: GO:0035721
+    label: intraciliary retrograde transport
+  evidence_type: IEP
+  original_reference_id: PMID:12651157
+  qualifier: involved_in
+  review:
+    summary: As an IFT-B particle component, CHE-13 is also recycled retrogradely along
+      the axoneme.
+    action: ACCEPT
+    reason: Core process. IFT-B particles (including CHE-13) are carried bidirectionally;
+      retrograde recycling is part of the IFT cycle.
+    supported_by:
+    - reference_id: PMID:12651157
+      supporting_text: concentrates at the base of cilia and moves along the axoneme as
+        expected for an IFT protein
+- term:
+    id: GO:1905515
+    label: non-motile cilium assembly
+  evidence_type: IMP
+  original_reference_id: PMID:2428682
+  qualifier: involved_in
+  review:
+    summary: che-13 mutants fail to build full sensory (non-motile) cilia; this is the most
+      precise cilium-assembly term for the worm&#39;s sensory cilia.
+    action: ACCEPT
+    reason: Core process, and appropriately specific. Directly supported by the
+      ultrastructural phenotype (severely shortened axonemes).
+    supported_by:
+    - reference_id: PMID:2428682
+      supporting_text: The cilia in che-13 (e1805), osm-1 (p808), osm-5 (p813), and osm-6
+        (p811) mutants have normal transition zones and severely shortened axonemes.
+- term:
+    id: GO:0035869
+    label: ciliary transition zone
+  evidence_type: IDA
+  original_reference_id: PMID:12651157
+  qualifier: located_in
+  review:
+    summary: CHE-13 is directly localized at/through the ciliary transition zone as it
+      moves between the ciliary base and the axoneme.
+    action: ACCEPT
+    reason: Core localization consistent with IFT trafficking through the transition zone.
+    supported_by:
+    - reference_id: PMID:12651157
+      supporting_text: concentrates at the base of cilia and moves along the axoneme as
+        expected for an IFT protein
+- term:
+    id: GO:0036064
+    label: ciliary basal body
+  evidence_type: IDA
+  original_reference_id: PMID:22922713
+  qualifier: located_in
+  review:
+    summary: CHE-13 localizes to the ciliary basal body, where IFT particles assemble
+      before entering the cilium.
+    action: ACCEPT
+    reason: Core localization at the site of IFT assembly; consistent with CHE-13
+      concentrating at the ciliary base. The MGI reference (PMID:22922713) is a
+      DYF-2/BBSome paper that does not name che-13, but basal-body localization is
+      independently established for CHE-13 and the experimental annotation is not overruled.
+    supported_by:
+    - reference_id: PMID:12651157
+      supporting_text: concentrates at the base of cilia and moves along the axoneme as
+        expected for an IFT protein
+- term:
+    id: GO:0005930
+    label: axoneme
+  evidence_type: IDA
+  original_reference_id: PMID:18337471
+  qualifier: located_in
+  review:
+    summary: A second WormBase IDA supporting CHE-13 axoneme localization.
+    action: ACCEPT
+    reason: Core ciliary localization; redundant with the PMID:12651157 axoneme IDA. The
+      cited B9/nephrocystin paper does not foreground che-13, but axoneme localization is
+      well established and the annotation is not overruled.
+    supported_by:
+    - reference_id: PMID:12651157
+      supporting_text: concentrates at the base of cilia and moves along the axoneme as
+        expected for an IFT protein
+- term:
+    id: GO:0008104
+    label: intracellular protein localization
+  evidence_type: IMP
+  original_reference_id: PMID:16957054
+  qualifier: involved_in
+  review:
+    summary: che-13 loss-of-function mislocalizes the IFT-B proteins OSM-5 and OSM-6,
+      i.e. CHE-13 is required for delivering/localizing ciliary proteins. The generic
+      &#34;intracellular protein localization&#34; term understates this; the specific process is
+      protein localization to the cilium.
+    action: MODIFY
+    reason: The evidence (che-13 mutant mislocalizes IFT-B proteins into cilia) supports a
+      more specific and informative term. Replace the generic GO:0008104 with GO:0061512
+      protein localization to cilium.
+    proposed_replacement_terms:
+    - id: GO:0061512
+      label: protein localization to cilium
+    supported_by:
+    - reference_id: PMID:12651157
+      supporting_text: loss of che-13 differentially affects the localization of two known
+        IFT complex B proteins, OSM-5 and OSM-6, implying that CHE-13 functions as part of
+        this complex.
+- term:
+    id: GO:0036064
+    label: ciliary basal body
+  evidence_type: ISS
+  original_reference_id: GO_REF:0000024
+  qualifier: located_in
+  review:
+    summary: Sequence-similarity transfer of basal-body localization from the mouse IFT57
+      ortholog (UniProtKB:Q8BXG3), consistent with the direct C. elegans data.
+    action: ACCEPT
+    reason: Core localization; redundant with the IDA basal-body annotation and consistent
+      with CHE-13 concentrating at the ciliary base.
+    supported_by:
+    - reference_id: PMID:12651157
+      supporting_text: concentrates at the base of cilia and moves along the axoneme as
+        expected for an IFT protein
+- term:
+    id: GO:0007635
+    label: chemosensory behavior
+  evidence_type: IMP
+  original_reference_id: PMID:2428682
+  qualifier: involved_in
+  review:
+    summary: che-13 mutants are chemosensory-defective (dye-filling defective) because
+      their chemosensory cilia are truncated; this is a downstream consequence of defective
+      cilia, not a direct signalling role of CHE-13.
+    action: KEEP_AS_NON_CORE
+    reason: Indirect, downstream sensory phenotype of ciliary loss rather than a core
+      molecular/biological function of CHE-13. Retained (curator IMP) but marked non-core.
+    supported_by:
+    - reference_id: PMID:2428682
+      supporting_text: Mutations in 14 genes prevent dye uptake and disrupt chemosensory
+        behaviors.
+core_functions:
+- description: CHE-13/IFT57 is a structural subunit of the intraflagellar transport complex
+    B (IFT-B), the anterograde IFT particle that is itself carried as cargo by kinesin-2
+    and returned by dynein-2. It scaffolds the IFT-B particle (it has no independent
+    catalytic activity) and is required to build and maintain the sensory ciliary axoneme
+    in C. elegans ciliated neurons.
+  supported_by:
+  - reference_id: PMID:12651157
+    supporting_text: loss of che-13 differentially affects the localization of two known
+      IFT complex B proteins, OSM-5 and OSM-6, implying that CHE-13 functions as part of
+      this complex.
+  - reference_id: PMID:2428682
+    supporting_text: The cilia in che-13 (e1805), osm-1 (p808), osm-5 (p813), and osm-6
+      (p811) mutants have normal transition zones and severely shortened axonemes.
+  molecular_function:
+    id: GO:0005198
+    label: structural molecule activity
+  directly_involved_in:
+  - id: GO:0042073
+    label: intraciliary transport
+  - id: GO:1905515
+    label: non-motile cilium assembly
+  locations:
+  - id: GO:0005930
+    label: axoneme
+  - id: GO:0036064
+    label: ciliary basal body
+  - id: GO:0035869
+    label: ciliary transition zone
+  in_complex:
+    id: GO:0030992
+    label: intraciliary transport particle B
+proposed_new_terms:
+- proposed_name: structural constituent of intraflagellar transport particle
+  proposed_definition: A structural molecule activity in which a protein acts as a
+    structural subunit of an intraflagellar transport (IFT) particle (IFT-A or IFT-B),
+    contributing to the assembly and integrity of the particle that is trafficked along
+    the ciliary axoneme by kinesin-2 and dynein-2 motors.
+  justification: CHE-13/IFT57 and its IFT-B/IFT-A paralogs act as structural subunits of
+    the IFT particle, a role currently expressible only as the generic GO:0005198
+    structural molecule activity. A dedicated MF term would capture the shared function of
+    IFT structural subunits.
+  supported_by:
+  - reference_id: PMID:12651157
+    supporting_text: loss of che-13 differentially affects the localization of two known
+      IFT complex B proteins, OSM-5 and OSM-6, implying that CHE-13 functions as part of
+      this complex.
+knowledge_gaps:
+- gap_statement: The specific intra-complex protein contacts of CHE-13/IFT57 within the
+    C. elegans IFT-B particle have not been experimentally mapped. In vertebrates IFT57
+    sits in the peripheral IFT-B1 region and helps couple IFT-B to the IFT-A/dynein-2
+    machinery, but which IFT-B subunits CHE-13 directly contacts in the worm, and whether
+    its C-terminal coiled-coil versus its disordered N-terminal/central segments mediate
+    these contacts, is undetermined.
+  boundary: It is firmly established that CHE-13 is an IFT-B/IFT57 structural subunit that
+    concentrates at the ciliary base, moves bidirectionally by IFT along the axoneme, is
+    required for axoneme assembly, and is needed for proper localization of other IFT-B
+    proteins (OSM-5, OSM-6).
+  gap_kind:
+  - BIOLOGY
+  - ONTOLOGY
+  dark_aspect: MF_DARK
+  status: OPEN
+  significance: Defining CHE-13&#39;s specific IFT-B contacts would explain how the IFT-B
+    particle is built in vivo and how the IFT57 orthologue contributes to IFT-B integrity
+    and ciliopathy-relevant IFT defects.
+  resolution: In vivo proximity labeling (BioID/TurboID) or cross-linking mass spectrometry
+    of tagged CHE-13 in ciliated neurons, plus structure determination of the C. elegans
+    IFT-B subcomplex, paired with an ontology term for structural constituent of the IFT
+    particle.
+  provenance:
+  - reference_id: PMID:12651157
+    supporting_text: loss of che-13 differentially affects the localization of two known
+      IFT complex B proteins, OSM-5 and OSM-6, implying that CHE-13 functions as part of
+      this complex.
+  proposed_terms:
+  - proposed_name: structural constituent of intraflagellar transport particle
+    proposed_definition: A structural molecule activity in which a protein acts as a
+      structural subunit of an intraflagellar transport (IFT) particle (IFT-A or IFT-B),
+      contributing to assembly and integrity of the particle trafficked along the ciliary
+      axoneme.
+    justification: GO currently expresses this role only as the generic &#39;structural
+      molecule activity&#39; (GO:0005198).
+- gap_statement: It is not resolved whether the severely truncated axoneme of che-13
+    mutants reflects failure to deliver specific axonemal cargo (e.g. tubulin or motility-
+    related proteins) versus a general loss of IFT-B particle integrity that mislocalizes
+    the whole complex. The che-13 mutant phenotype (short axonemes; OSM-5/OSM-6
+    mislocalization) is consistent with either mechanism.
+  boundary: che-13 is required for axoneme assembly and for proper localization of other
+    IFT-B proteins; UniProt notes a possible role in ciliary entrance/transport of specific
+    cargo, but no direct CHE-13 cargo-selection activity has been demonstrated.
+  gap_kind:
+  - BIOLOGY
+  dark_aspect: MF_DARK
+  status: OPEN
+  significance: Distinguishing a cargo-delivery role from a particle-integrity role would
+    clarify whether IFT57/CHE-13 has any cargo-specific function beyond scaffolding IFT-B.
+  resolution: Separation-of-function alleles or domain deletions of che-13 with live
+    imaging of tagged axonemal cargo (tubulin) and IFT-B markers to test whether specific
+    cargo delivery can be uncoupled from IFT-B assembly.
+  provenance:
+  - reference_id: PMID:2428682
+    supporting_text: The cilia in che-13 (e1805), osm-1 (p808), osm-5 (p813), and osm-6
+      (p811) mutants have normal transition zones and severely shortened axonemes.
+  - reference_id: PMID:12651157
+    supporting_text: loss of che-13 differentially affects the localization of two known
+      IFT complex B proteins, OSM-5 and OSM-6, implying that CHE-13 functions as part of
+      this complex.
+suggested_questions:
+- question: Which IFT-B subunits does CHE-13/IFT57 directly contact in C. elegans, and is
+    the C-terminal coiled-coil required for those contacts?
+  experts:
+  - Oliver E. Blacque
+- question: Do the two che-13 splice isoforms (a/b) have distinct expression or function in
+    ciliated sensory neurons?
+  experts: []
+suggested_experiments:
+- hypothesis: CHE-13/IFT57 bridges specific IFT-B subunits via its C-terminal coiled-coil,
+    and disrupting this region selectively destabilizes part of IFT-B.
+  description: Perform in vivo proximity labeling (TurboID) with full-length and
+    coiled-coil-deleted CHE-13 expressed in ciliated neurons, followed by mass spectrometry,
+    to map region-specific IFT-B interaction partners.
+  experiment_type: proximity labeling / interaction mapping
+- hypothesis: The truncated axoneme of che-13 mutants reflects failure to deliver axonemal
+    cargo by IFT-B rather than a transition-zone defect.
+  description: Use live imaging of tagged tubulin and IFT-B markers (e.g. OSM-6) in che-13
+    partial loss-of-function backgrounds to quantify anterograde cargo delivery versus
+    transition-zone integrity.
+  experiment_type: live-cell imaging
+tags:
+- caeel-ciliopathy
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/genes/worm/clk-1/clk-1-ai-review.html
+++ b/genes/worm/clk-1/clk-1-ai-review.html
@@ -1,0 +1,6544 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>clk-1 - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        .propagation-review {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f8fafc;
+            border-left: 3px solid #64748b;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .propagation-title {
+            font-weight: 600;
+            color: #334155;
+            margin-bottom: 0.25rem;
+        }
+
+        .propagation-row {
+            margin-top: 0.25rem;
+        }
+
+        .propagation-source {
+            margin-top: 0.5rem;
+            padding-top: 0.5rem;
+            border-top: 1px solid #e5e7eb;
+        }
+
+        .propagation-source-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #1d4ed8;
+        }
+
+        .propagation-comment {
+            color: #4b5563;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>clk-1</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/P48376" target="_blank" class="term-link">
+                        P48376
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Caenorhabditis elegans</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-draft">
+                    DRAFT
+                </span>
+            </div>
+
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "clk-1";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="P48376" data-a="DESCRIPTION: clk-1 encodes the C. elegans ortholog of COQ7 (hum..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>clk-1 encodes the C. elegans ortholog of COQ7 (human COQ7), a mitochondrial carboxylate-bridged di-iron monooxygenase (hydroxylase) that catalyzes the penultimate step of ubiquinone (coenzyme Q) biosynthesis: hydroxylation of 5-demethoxyubiquinone (DMQ) to 3-demethylubiquinone, using NAD(P)H and molecular oxygen (EC 1.14.13.253). The mature protein is a peripheral protein of the inner mitochondrial membrane on the matrix side and acts within the multi-subunit CoQ biosynthetic (COQ) machinery. Loss of clk-1 abolishes synthesis of ubiquinone (UQ9) and causes accumulation of the DMQ9 precursor, which can partially substitute as a respiratory-chain electron carrier. clk-1 is the founding &#34;Clk&#34; (clock) longevity gene: reduction-of-function mutants show an average slowing of developmental, behavioral, respiratory and metabolic rates and a markedly extended lifespan; these organismal phenotypes arise downstream of altered quinone content and mitochondrial reactive-oxygen-species output rather than from the hydroxylation step itself. A distinct, debated nuclear pool of CLK-1/COQ7 has additionally been reported to modulate mitochondrial retrograde stress signalling (the mitochondrial unfolded protein response), ROS-responsive gene expression, and longevity independently of ubiquinone biosynthesis.</p>
+    </div>
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Proposed New Ontology Terms</h2>
+
+        <div class="proposed-term">
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>coenzyme Q biosynthesis complex</h3>
+                <span class="vote-buttons" data-g="P48376" data-a="coenzyme Q biosynthesis complex" data-r="" data-act="NEW">
+                    <button class="vote-btn" data-v="up" title="Agree this term should be created">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with creating this term">👎</button>
+                </span>
+            </div>
+
+
+            <p><strong>Definition:</strong> A protein-containing complex, located at the matrix face of the inner mitochondrial membrane, that carries out the later membrane-associated steps of ubiquinone (coenzyme Q) biosynthesis; in eukaryotes it comprises multiple COQ polypeptides (including the COQ7/CLK-1 hydroxylase) that are mutually stabilizing.</p>
+
+
+
+            <p><strong>Justification:</strong> CLK-1/COQ7 and its orthologs function within, and structurally stabilize, a multi-subunit CoQ biosynthetic complex, but GO has no cellular-component term for this complex.</p>
+
+
+
+            <p><strong>Parent term:</strong>
+                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0032991" target="_blank" class="term-link">
+                    protein-containing complex
+                </a>
+            </p>
+
+
+
+
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005743" target="_blank" class="term-link">
+                                    GO:0005743
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial inner membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P48376" data-a="GO:0005743" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Core localization. CLK-1 is a peripheral inner-mitochondrial-membrane protein (matrix side) where it catalyzes DMQ hydroxylation in CoQ biosynthesis.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Phylogenetic (IBA) placement in the inner mitochondrial membrane is consistent with direct experimental evidence that active CLK-1-GFP is found in worm mitochondria and with UniProt&#39;s peripheral/matrix-side membrane assignment.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/10202142" target="_blank" class="term-link">
+                                        PMID:10202142
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">CLK-1 is fully active when fused to green fluorescent protein and is found in the mitochondria of all somatic cells.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0160224" target="_blank" class="term-link">
+                                    GO:0160224
+                                </a>
+                            </span>
+                            <span class="term-label">3-demethoxyubiquinone 3-hydroxylase (NADH) activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P48376" data-a="GO:0160224" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Core molecular function: the di-iron ubiquinone/CoQ biosynthetic monooxygenase catalyzing the DMQ to demethylubiquinone hydroxylation.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> This is the direct, evolutionarily conserved molecular function of clk-1/COQ7, matching EC 1.14.13.253 and supported experimentally in the worm.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/14517217" target="_blank" class="term-link">
+                                        PMID:14517217
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">clk-1 encodes a hydroxylase involved in the biosynthesis of the redox-active lipid ubiquinone (co-enzyme Q), and in clk-1 mutants, ubiquinone is replaced by its biosynthetic precursor demethoxyubiquinone.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006744" target="_blank" class="term-link">
+                                    GO:0006744
+                                </a>
+                            </span>
+                            <span class="term-label">ubiquinone biosynthetic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P48376" data-a="GO:0006744" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Core biological process; the pathway in which the clk-1 hydroxylase acts.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> clk-1 is required for ubiquinone biosynthesis; loss abolishes UQ9 and leads to accumulation of the DMQ9 intermediate.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/11244089" target="_blank" class="term-link">
+                                        PMID:11244089
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">This result demonstrates that CLK-1 is absolutely required for the biosynthesis of UQ(9) in C. elegans.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:2000377" target="_blank" class="term-link">
+                                    GO:2000377
+                                </a>
+                            </span>
+                            <span class="term-label">regulation of reactive oxygen species metabolic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P48376" data-a="GO:2000377" data-r="GO_REF:0000033" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Non-core regulatory role tied to the debated nuclear function; clk-1 mutants have altered ROS and a ROS-responsive gene-expression program.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> This IBA propagation reflects the reported nuclear CLK-1/COQ7 role in ROS metabolism rather than the direct hydroxylase activity; retain as a non-core downstream/moonlighting function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/25961505" target="_blank" class="term-link">
+                                        PMID:25961505
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">the pathway regulates both mitochondrial reactive oxygen species metabolism and the mitochondrial unfolded protein response.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005634" target="_blank" class="term-link">
+                                    GO:0005634
+                                </a>
+                            </span>
+                            <span class="term-label">nucleus</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P48376" data-a="GO:0005634" data-r="GO_REF:0000033" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Debated secondary nuclear localization propagated by phylogeny; treat as non-core.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> A nuclear pool of CLK-1/COQ7 has been reported (GFP in both compartments), but this localization and its functional significance remain debated; it is not the core mitochondrial site of the enzyme.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/25961505" target="_blank" class="term-link">
+                                        PMID:25961505
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">adult transgenic worms expressing CLK-1 fused to green fluorescent protein (GFP) also display fluorescence in both compartments</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008340" target="_blank" class="term-link">
+                                    GO:0008340
+                                </a>
+                            </span>
+                            <span class="term-label">determination of adult lifespan</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P48376" data-a="GO:0008340" data-r="GO_REF:0000033" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Classic longevity phenotype; a downstream organismal consequence of altered quinone content, not the core molecular function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> clk-1 loss extends lifespan, but this is a pleiotropic downstream effect of reduced ubiquinone/altered mitochondrial metabolism; keep as non-core.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/10202142" target="_blank" class="term-link">
+                                        PMID:10202142
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">the reduced respiration of the long-lived clk-1 mutants suggests that longevity is promoted by the age-dependent decrease in mitochondrial function</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004497" target="_blank" class="term-link">
+                                    GO:0004497
+                                </a>
+                            </span>
+                            <span class="term-label">monooxygenase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P48376" data-a="GO:0004497" data-r="GO_REF:0000002" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct but general parent of the specific 3-demethoxyubiquinone 3-hydroxylase activity; captures the core monooxygenase function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> InterPro2GO assigns the general monooxygenase parent; it is accurate for the di-iron hydroxylase but less informative than GO:0160224, which is also annotated.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/14517217" target="_blank" class="term-link">
+                                        PMID:14517217
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">clk-1 encodes a hydroxylase involved in the biosynthesis of the redox-active lipid ubiquinone (co-enzyme Q)</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005634" target="_blank" class="term-link">
+                                    GO:0005634
+                                </a>
+                            </span>
+                            <span class="term-label">nucleus</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000044
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P48376" data-a="GO:0005634" data-r="GO_REF:0000044" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Debated nuclear localization propagated from the UniProt subcellular vocabulary.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> This IEA derives from the UniProt Nucleus subcellular-location term, which is itself based on the single (debated) report of nuclear CLK-1/COQ7; retain as non-core.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/25961505" target="_blank" class="term-link">
+                                        PMID:25961505
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">We have uncovered a distinct nuclear form of CLK-1 that independently regulates lifespan.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005739" target="_blank" class="term-link">
+                                    GO:0005739
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrion</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000044
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P48376" data-a="GO:0005739" data-r="GO_REF:0000044" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Core localization; the enzyme&#39;s primary compartment.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Mitochondrial localization is strongly established experimentally for CLK-1.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/10202142" target="_blank" class="term-link">
+                                        PMID:10202142
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">CLK-1 is fully active when fused to green fluorescent protein and is found in the mitochondria of all somatic cells.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005743" target="_blank" class="term-link">
+                                    GO:0005743
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial inner membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000044
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P48376" data-a="GO:0005743" data-r="GO_REF:0000044" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Core localization; peripheral inner-membrane, matrix side.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Consistent with UniProt&#39;s inner-membrane (peripheral, matrix-side) assignment and the phylogenetic annotation.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006744" target="_blank" class="term-link">
+                                    GO:0006744
+                                </a>
+                            </span>
+                            <span class="term-label">ubiquinone biosynthetic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000120
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P48376" data-a="GO:0006744" data-r="GO_REF:0000120" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Core biological process (electronic support for the pathway role).
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Automated multi-method IEA correctly assigns the ubiquinone biosynthetic process, consistent with experimental evidence.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/11244089" target="_blank" class="term-link">
+                                        PMID:11244089
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">This result demonstrates that CLK-1 is absolutely required for the biosynthesis of UQ(9) in C. elegans.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016709" target="_blank" class="term-link">
+                                    GO:0016709
+                                </a>
+                            </span>
+                            <span class="term-label">oxidoreductase activity, acting on paired donors, with incorporation or reduction of molecular oxygen, NAD(P)H as one donor, and incorporation of one atom of oxygen</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000104
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P48376" data-a="GO:0016709" data-r="GO_REF:0000104" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct general MF parent corresponding to the EC 1.14.13 mechanism (NAD(P)H, one oxygen atom incorporated).
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Accurately describes the mechanistic class of the clk-1 hydroxylation reaction; less specific than GO:0160224 but not incorrect.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031314" target="_blank" class="term-link">
+                                    GO:0031314
+                                </a>
+                            </span>
+                            <span class="term-label">extrinsic component of mitochondrial inner membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000104
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P48376" data-a="GO:0031314" data-r="GO_REF:0000104" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Accurate refinement of the localization: CLK-1 is a peripheral (extrinsic) inner-membrane protein on the matrix face.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Matches UniProt&#39;s &#34;Peripheral membrane protein; Matrix side&#34; assignment and is more precise than the plain inner-membrane term.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0160224" target="_blank" class="term-link">
+                                    GO:0160224
+                                </a>
+                            </span>
+                            <span class="term-label">3-demethoxyubiquinone 3-hydroxylase (NADH) activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000120
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P48376" data-a="GO:0160224" data-r="GO_REF:0000120" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Core molecular function (electronic/RHEA-EC support).
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Automated RHEA/EC-based assignment of the specific hydroxylase activity, the direct molecular function of clk-1.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/11244089" target="_blank" class="term-link">
+                                        PMID:11244089
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">clk-1 mutants mitochondria do not contain detectable levels of UQ(9). Instead, the UQ(9) biosynthesis intermediate, demethoxyubiquinone (DMQ(9)), is present at high levels.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000122" target="_blank" class="term-link">
+                                    GO:0000122
+                                </a>
+                            </span>
+                            <span class="term-label">negative regulation of transcription by RNA polymerase II</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/25961505" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:25961505
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    A nuclear role for the respiratory enzyme CLK-1 in regulatin...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P48376" data-a="GO:0000122" data-r="PMID:25961505" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Non-core, debated nuclear moonlighting function; nuclear CLK-1 suppresses a subset of ROS/UPRmt genes.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Based on the reported nuclear role in which CLK-1 abrogates the elevated transcript levels of stress genes in clk-1 null worms. This is an experimental IMP but reflects a debated non-mitochondrial activity; retain as non-core.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/25961505" target="_blank" class="term-link">
+                                        PMID:25961505
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The expression of nuclear CLK-1 in clk-1 null worms abrogated the increased transcript levels of these genes</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0045944" target="_blank" class="term-link">
+                                    GO:0045944
+                                </a>
+                            </span>
+                            <span class="term-label">positive regulation of transcription by RNA polymerase II</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/25961505" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:25961505
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    A nuclear role for the respiratory enzyme CLK-1 in regulatin...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P48376" data-a="GO:0045944" data-r="PMID:25961505" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Non-core, debated nuclear moonlighting function; nuclear CLK-1 promotes expression of some target genes (e.g. glna-1/GLS2).
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Same nuclear study: loss of nuclear CLK-1/COQ7 decreases glna-1/GLS2 expression, which is rescued by nuclear CLK-1. Experimental IMP but a debated non-core function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/25961505" target="_blank" class="term-link">
+                                        PMID:25961505
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">glna-1 transcript levels were decreased compared to wild type animals, an effect that was rescued in the presence of CLK-1nuc(+)</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008340" target="_blank" class="term-link">
+                                    GO:0008340
+                                </a>
+                            </span>
+                            <span class="term-label">determination of adult lifespan</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/17277769" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:17277769
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    eIF4E function in somatic cells modulates ageing in Caenorha...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P48376" data-a="GO:0008340" data-r="PMID:17277769" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Longevity phenotype; clk mutants used in a genetic study of translation and ageing. Downstream/non-core.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Supports clk-1&#39;s role in lifespan determination as a pleiotropic downstream effect. The cached abstract names &#34;clk&#34; mutants; the curator read the full text.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/17277769" target="_blank" class="term-link">
+                                        PMID:17277769
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">lack of IFE-2 enhances the long-lived phenotype of clk and dietary-restricted eat mutant animals.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008340" target="_blank" class="term-link">
+                                    GO:0008340
+                                </a>
+                            </span>
+                            <span class="term-label">determination of adult lifespan</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IGI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/17277769" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:17277769
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    eIF4E function in somatic cells modulates ageing in Caenorha...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P48376" data-a="GO:0008340" data-r="PMID:17277769" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Genetic-interaction evidence for the longevity phenotype (with ife-2). Downstream/non-core.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> IGI supporting the pleiotropic lifespan role; a non-core organismal phenotype.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/17277769" target="_blank" class="term-link">
+                                        PMID:17277769
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">lack of IFE-2 enhances the long-lived phenotype of clk and dietary-restricted eat mutant animals.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008340" target="_blank" class="term-link">
+                                    GO:0008340
+                                </a>
+                            </span>
+                            <span class="term-label">determination of adult lifespan</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IGI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/19783783" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:19783783
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Life-span extension by dietary restriction is mediated by NL...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P48376" data-a="GO:0008340" data-r="PMID:19783783" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Genetic-interaction lifespan evidence (electron-transport-chain longevity pathway). Downstream/non-core.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The cached abstract discusses long-lived electron-transport-chain mutants rather than naming clk-1 explicitly; the full-text curator classed clk-1 in this group. clk-1&#39;s lifespan role is well established, so retain as non-core rather than remove.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/19783783" target="_blank" class="term-link">
+                                        PMID:19783783
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">has no effect on the life span of long-lived mutants resulting from reduced insulin/IGF-1 signaling or dysfunction of the mitochondrial electron transport chain.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008340" target="_blank" class="term-link">
+                                    GO:0008340
+                                </a>
+                            </span>
+                            <span class="term-label">determination of adult lifespan</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/19783783" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:19783783
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Life-span extension by dietary restriction is mediated by NL...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P48376" data-a="GO:0008340" data-r="PMID:19783783" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Longevity phenotype (mutant); downstream/non-core.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> IMP for the pleiotropic lifespan phenotype; retain as a non-core downstream effect of altered mitochondrial quinone metabolism.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/19783783" target="_blank" class="term-link">
+                                        PMID:19783783
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">has no effect on the life span of long-lived mutants resulting from reduced insulin/IGF-1 signaling or dysfunction of the mitochondrial electron transport chain.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005634" target="_blank" class="term-link">
+                                    GO:0005634
+                                </a>
+                            </span>
+                            <span class="term-label">nucleus</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/25961505" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:25961505
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    A nuclear role for the respiratory enzyme CLK-1 in regulatin...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P48376" data-a="GO:0005634" data-r="PMID:25961505" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct (GFP/immunostaining) evidence for a nuclear pool of CLK-1/COQ7; a debated secondary localization, kept as non-core.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Genuine experimental IDA (CLK-1-GFP in both compartments; endogenous COQ7 in nuclei), but the endogenous, physiologically significant nuclear pool remains debated and is not the core enzymatic site. Per curation guidance the experimental annotation is retained (not removed), marked non-core.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/25961505" target="_blank" class="term-link">
+                                        PMID:25961505
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">adult transgenic worms expressing CLK-1 fused to green fluorescent protein (GFP) also display fluorescence in both compartments</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005739" target="_blank" class="term-link">
+                                    GO:0005739
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrion</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/25961505" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:25961505
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    A nuclear role for the respiratory enzyme CLK-1 in regulatin...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P48376" data-a="GO:0005739" data-r="PMID:25961505" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Core localization; direct evidence for mitochondrial CLK-1.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Direct imaging shows CLK-1-GFP in mitochondria (and nucleus); mitochondrion is the primary/core site of the enzyme.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/25961505" target="_blank" class="term-link">
+                                        PMID:25961505
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">adult transgenic worms expressing CLK-1 fused to green fluorescent protein (GFP) also display fluorescence in both compartments</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006744" target="_blank" class="term-link">
+                                    GO:0006744
+                                </a>
+                            </span>
+                            <span class="term-label">ubiquinone biosynthetic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/25961505" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:25961505
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    A nuclear role for the respiratory enzyme CLK-1 in regulatin...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P48376" data-a="GO:0006744" data-r="PMID:25961505" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Core biological process; full-length CLK-1 rescues UQ biosynthesis.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> This study confirms the mitochondrial CLK-1 requirement for ubiquinone biosynthesis (full-length, but not nuclear-only, CLK-1 rescues UQ).
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/25961505" target="_blank" class="term-link">
+                                        PMID:25961505
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">full length CLK-1 was able to rescue ubiquinone biosynthesis in these worms, however, CLK-1nuc(+) could not</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008340" target="_blank" class="term-link">
+                                    GO:0008340
+                                </a>
+                            </span>
+                            <span class="term-label">determination of adult lifespan</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/25961505" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:25961505
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    A nuclear role for the respiratory enzyme CLK-1 in regulatin...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P48376" data-a="GO:0008340" data-r="PMID:25961505" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Longevity phenotype; here attributed partly to the debated nuclear CLK-1 pool. Downstream/non-core.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> clk-1 modulates lifespan; this study assigns part of that effect to nuclear CLK-1 independent of ubiquinone. A non-core downstream/moonlighting phenotype.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/25961505" target="_blank" class="term-link">
+                                        PMID:25961505
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">the expression of CLK-1nuc(+) in clk-1 null worms caused a decrease in their enhanced longevity phenotype</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:2000377" target="_blank" class="term-link">
+                                    GO:2000377
+                                </a>
+                            </span>
+                            <span class="term-label">regulation of reactive oxygen species metabolic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/25961505" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:25961505
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    A nuclear role for the respiratory enzyme CLK-1 in regulatin...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P48376" data-a="GO:2000377" data-r="PMID:25961505" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Non-core regulatory role; nuclear CLK-1 modulates cellular ROS levels and ROS-responsive gene expression.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Experimental IMP for ROS regulation via the debated nuclear pathway; a downstream/moonlighting function rather than the direct hydroxylase activity.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/25961505" target="_blank" class="term-link">
+                                        PMID:25961505
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Expression of CLK-1nuc(+) in clk-1 null worms partially rescued the increased ROS levels observed in these animals</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000976" target="_blank" class="term-link">
+                                    GO:0000976
+                                </a>
+                            </span>
+                            <span class="term-label">transcription cis-regulatory region binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/11959146" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:11959146
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    CLK-1 protein has DNA binding activity specific to O(L) regi...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P48376" data-a="GO:0000976" data-r="PMID:11959146" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Isolated in-vitro report that CLK-1 binds the O_L region of mitochondrial DNA; a debated possible moonlighting activity, kept as non-core.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The single (2002) in-vitro study shows sequence-specific binding to the mitochondrial-DNA O_L region, not a nuclear cis-regulatory region; it is not widely replicated and is unrelated to the core hydroxylase function. As an experimental IDA it is retained rather than removed, but flagged as a debated, possibly over-annotated moonlighting activity.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/11959146" target="_blank" class="term-link">
+                                        PMID:11959146
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">C. elegans CLK-1 as well as its mouse homologue have DNA binding activity that is specific to the O(L) region of mitochondrial DNA.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005739" target="_blank" class="term-link">
+                                    GO:0005739
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrion</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/17189267" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:17189267
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Knockdown of mitochondrial heat shock protein 70 promotes pr...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P48376" data-a="GO:0005739" data-r="PMID:17189267" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Core localization; CLK-1 treated as a mitochondrial protein.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> This study monitors CLK-1 as a mitochondrial protein whose levels drop upon hsp-6 (mtHSP70) knockdown, consistent with mitochondrial localization.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/17189267" target="_blank" class="term-link">
+                                        PMID:17189267
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Knockdown of HSP-6 by RNA interference in young adult nematodes caused a reduction in the levels of ATP-2, HSP-60 and CLK-1</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006744" target="_blank" class="term-link">
+                                    GO:0006744
+                                </a>
+                            </span>
+                            <span class="term-label">ubiquinone biosynthetic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/14517217" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:14517217
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Molecular mechanism of maternal rescue in the clk-1 mutants ...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P48376" data-a="GO:0006744" data-r="PMID:14517217" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Core biological process; clk-1 hydroxylase required for UQ, replaced by DMQ in mutants.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Directly supports the ubiquinone biosynthetic role; in clk-1 mutants UQ is replaced by the DMQ precursor.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/14517217" target="_blank" class="term-link">
+                                        PMID:14517217
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">clk-1 encodes a hydroxylase involved in the biosynthesis of the redox-active lipid ubiquinone (co-enzyme Q), and in clk-1 mutants, ubiquinone is replaced by its biosynthetic precursor demethoxyubiquinone.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008340" target="_blank" class="term-link">
+                                    GO:0008340
+                                </a>
+                            </span>
+                            <span class="term-label">determination of adult lifespan</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/14517217" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:14517217
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Molecular mechanism of maternal rescue in the clk-1 mutants ...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P48376" data-a="GO:0008340" data-r="PMID:14517217" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Longevity/developmental-timing phenotype; downstream/non-core.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Supports the pleiotropic ageing phenotype; a downstream consequence of altered quinone metabolism, not the core function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/14517217" target="_blank" class="term-link">
+                                        PMID:14517217
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The clk-1 mutants of Caenorhabditis elegans display an average slowing down of physiological rates, including those of development, various behaviors, and aging.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008340" target="_blank" class="term-link">
+                                    GO:0008340
+                                </a>
+                            </span>
+                            <span class="term-label">determination of adult lifespan</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IGI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/14517217" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:14517217
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Molecular mechanism of maternal rescue in the clk-1 mutants ...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P48376" data-a="GO:0008340" data-r="PMID:14517217" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Genetic interaction with daf-2 for lifespan; downstream/non-core longevity phenotype.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The daf-2 clk-1 double-mutant synergy underlies this IGI; a non-core organismal longevity phenotype.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/14517217" target="_blank" class="term-link">
+                                        PMID:14517217
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">the very long lifespan observed in daf-2 clk-1 double mutants is not abolished by the maternal effect</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0040010" target="_blank" class="term-link">
+                                    GO:0040010
+                                </a>
+                            </span>
+                            <span class="term-label">positive regulation of growth rate</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/14517217" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:14517217
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Molecular mechanism of maternal rescue in the clk-1 mutants ...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P48376" data-a="GO:0040010" data-r="PMID:14517217" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Developmental-timing/growth-rate phenotype (the &#34;Clk&#34; slowing); downstream and non-core.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> clk-1 loss slows post-embryonic growth and development; a pleiotropic timing phenotype rather than the direct molecular function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/14517217" target="_blank" class="term-link">
+                                        PMID:14517217
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The clk-1 mutants of Caenorhabditis elegans display an average slowing down of physiological rates, including those of development, various behaviors, and aging.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0048520" target="_blank" class="term-link">
+                                    GO:0048520
+                                </a>
+                            </span>
+                            <span class="term-label">positive regulation of behavior</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/14517217" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:14517217
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Molecular mechanism of maternal rescue in the clk-1 mutants ...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P48376" data-a="GO:0048520" data-r="PMID:14517217" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Behavioral-rate (&#34;clock&#34;) phenotype (e.g. defecation/pumping rhythms); downstream/non-core.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Slowed rhythmic behaviors are a hallmark Clk phenotype but a downstream consequence of altered mitochondrial metabolism.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/14517217" target="_blank" class="term-link">
+                                        PMID:14517217
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The clk-1 mutants of Caenorhabditis elegans display an average slowing down of physiological rates, including those of development, various behaviors, and aging.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051094" target="_blank" class="term-link">
+                                    GO:0051094
+                                </a>
+                            </span>
+                            <span class="term-label">positive regulation of developmental process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/14517217" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:14517217
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Molecular mechanism of maternal rescue in the clk-1 mutants ...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P48376" data-a="GO:0051094" data-r="PMID:14517217" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Developmental-timing phenotype; downstream/non-core.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> clk-1 loss slows embryonic and post-embryonic development; a pleiotropic timing phenotype, not the core function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/14517217" target="_blank" class="term-link">
+                                        PMID:14517217
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The clk-1 mutants of Caenorhabditis elegans display an average slowing down of physiological rates, including those of development, various behaviors, and aging.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006119" target="_blank" class="term-link">
+                                    GO:0006119
+                                </a>
+                            </span>
+                            <span class="term-label">oxidative phosphorylation</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/16920626" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:16920626
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Mitochondrial complex I function modulates volatile anesthet...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P48376" data-a="GO:0006119" data-r="PMID:16920626" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Non-core; clk-1 mutation alters respiratory-chain (OXPHOS) function via changed quinone content.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> OXPHOS effects are a downstream consequence of DMQ-for-UQ substitution at the respiratory chain, not a direct clk-1 molecular function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/16920626" target="_blank" class="term-link">
+                                        PMID:16920626
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">a clear correlation between complex I-dependent oxidative phosphorylation capacity and volatile anesthetic sensitivity.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0009410" target="_blank" class="term-link">
+                                    GO:0009410
+                                </a>
+                            </span>
+                            <span class="term-label">response to xenobiotic stimulus</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/16920626" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:16920626
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Mitochondrial complex I function modulates volatile anesthet...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P48376" data-a="GO:0009410" data-r="PMID:16920626" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Altered volatile-anesthetic (xenobiotic) sensitivity of the mutant; an indirect downstream phenotype, non-core.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The anesthetic-sensitivity phenotype arises indirectly from altered complex-I/ OXPHOS function in quinone-pathway mutants; a distal phenotype rather than a direct clk-1 function (borderline over-annotation), kept as non-core.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/16920626" target="_blank" class="term-link">
+                                        PMID:16920626
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">a clear correlation between complex I-dependent oxidative phosphorylation capacity and volatile anesthetic sensitivity.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005739" target="_blank" class="term-link">
+                                    GO:0005739
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrion</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/10202142" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:10202142
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    CLK-1 controls respiration, behavior and aging in the nemato...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P48376" data-a="GO:0005739" data-r="PMID:10202142" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Core localization; direct evidence that active CLK-1-GFP is mitochondrial.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Foundational direct evidence for mitochondrial localization of functional CLK-1.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/10202142" target="_blank" class="term-link">
+                                        PMID:10202142
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">CLK-1 is fully active when fused to green fluorescent protein and is found in the mitochondria of all somatic cells.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006744" target="_blank" class="term-link">
+                                    GO:0006744
+                                </a>
+                            </span>
+                            <span class="term-label">ubiquinone biosynthetic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/11244089" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:11244089
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Altered quinone biosynthesis in the long-lived clk-1 mutants...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P48376" data-a="GO:0006744" data-r="PMID:11244089" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Core biological process; biochemical demonstration that CLK-1 is required for UQ9 synthesis (DMQ9 accumulates in mutants).
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Strong direct biochemical evidence for the ubiquinone biosynthetic role.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/11244089" target="_blank" class="term-link">
+                                        PMID:11244089
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">clk-1 mutants mitochondria do not contain detectable levels of UQ(9). Instead, the UQ(9) biosynthesis intermediate, demethoxyubiquinone (DMQ(9)), is present at high levels.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006744" target="_blank" class="term-link">
+                                    GO:0006744
+                                </a>
+                            </span>
+                            <span class="term-label">ubiquinone biosynthetic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/12709403" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:12709403
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Silencing of ubiquinone biosynthesis genes extends life span...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P48376" data-a="GO:0006744" data-r="PMID:12709403" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Core biological process; RNAi of clk-1 (with other COQ genes) reduces Q and extends lifespan.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> RNAi phenotype confirms clk-1&#39;s role in ubiquinone biosynthesis.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12709403" target="_blank" class="term-link">
+                                        PMID:12709403
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">We have identified by RNA interference (RNAi) eight genes, including clk-1, involved in ubiquinone biosynthesis in C. elegans</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008340" target="_blank" class="term-link">
+                                    GO:0008340
+                                </a>
+                            </span>
+                            <span class="term-label">determination of adult lifespan</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/10202142" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:10202142
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    CLK-1 controls respiration, behavior and aging in the nemato...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P48376" data-a="GO:0008340" data-r="PMID:10202142" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Longevity phenotype (foundational); downstream/non-core.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Foundational demonstration that clk-1 controls aging; a pleiotropic downstream phenotype rather than the core molecular function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/10202142" target="_blank" class="term-link">
+                                        PMID:10202142
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Overexpression of CLK-1 activity in wild-type worms can increase mitochondrial activity, accelerate behavioral rates during aging and shorten life span</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030534" target="_blank" class="term-link">
+                                    GO:0030534
+                                </a>
+                            </span>
+                            <span class="term-label">adult behavior</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/10202142" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:10202142
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    CLK-1 controls respiration, behavior and aging in the nemato...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P48376" data-a="GO:0030534" data-r="PMID:10202142" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Rhythmic adult-behavior (&#34;clock&#34;) phenotype; downstream/non-core.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The slowed rhythmic behaviors of clk-1 mutants are a downstream Clk phenotype, not the direct function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/10202142" target="_blank" class="term-link">
+                                        PMID:10202142
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Mutations in the clk-1 gene of the nematode Caenorhabditis elegans result in an average slowing of a variety of developmental and physiological processes, including the cell cycle, embryogenesis, post-embryonic growth, rhythmic behaviors and aging.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0045333" target="_blank" class="term-link">
+                                    GO:0045333
+                                </a>
+                            </span>
+                            <span class="term-label">cellular respiration</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/10202142" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:10202142
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    CLK-1 controls respiration, behavior and aging in the nemato...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P48376" data-a="GO:0045333" data-r="PMID:10202142" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> clk-1 controls respiration via its role in ubiquinone supply; a closely-linked but downstream process, non-core.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Respiration is affected because ubiquinone (or the DMQ surrogate) feeds the electron transport chain; this is a consequence of the biosynthetic function rather than the molecular function itself.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/10202142" target="_blank" class="term-link">
+                                        PMID:10202142
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">the reduced respiration of the long-lived clk-1 mutants</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>Mitochondrial di-iron ubiquinone (coenzyme Q) biosynthetic monooxygenase. CLK-1 (COQ7 ortholog) uses a carboxylate-bridged di-iron center and NAD(P)H to hydroxylate 5-demethoxyubiquinone (DMQ) to 3-demethylubiquinone, the penultimate step of ubiquinone biosynthesis, acting as a peripheral protein on the matrix face of the inner mitochondrial membrane. Loss of this activity abolishes UQ9 and causes DMQ9 accumulation.</h3>
+                <span class="vote-buttons" data-g="P48376" data-a="FUNCTION: Mitochondrial di-iron ubiquinone (coenzyme Q) bios..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0160224" target="_blank" class="term-link">
+                            3-demethoxyubiquinone 3-hydroxylase (NADH) activity
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006744" target="_blank" class="term-link">
+                                ubiquinone biosynthetic process
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005743" target="_blank" class="term-link">
+                                mitochondrial inner membrane
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005739" target="_blank" class="term-link">
+                                mitochondrion
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/11244089" target="_blank" class="term-link">
+                                PMID:11244089
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">This result demonstrates that CLK-1 is absolutely required for the biosynthesis of UQ(9) in C. elegans.</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/14517217" target="_blank" class="term-link">
+                                PMID:14517217
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">clk-1 encodes a hydroxylase involved in the biosynthesis of the redox-active lipid ubiquinone (co-enzyme Q), and in clk-1 mutants, ubiquinone is replaced by its biosynthetic precursor demethoxyubiquinone.</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/9020081" target="_blank" class="term-link">
+                                PMID:9020081
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">clk-1 complemented the phenotype of cat5/coq7 null mutants, demonstrating that clk-1 and CAT5/COQ7 share biochemical function</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:worm/clk-1/clk-1-deep-research-falcon.md
+
+                        </span>
+
+                        <div class="finding-text">CLK-1 (UniProt P48376) is a mitochondrial diiron carboxylate hydroxylase that catalyzes the C5 hydroxylation of DMQ9 to produce UQ9, the penultimate step in coenzyme Q biosynthesis.</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000002.md" target="_blank" class="term-link">
+                            GO_REF:0000002
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation through association of InterPro records with GO terms</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
+                            GO_REF:0000033
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Annotation inferences using phylogenetic trees</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
+                            GO_REF:0000044
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000104.md" target="_blank" class="term-link">
+                            GO_REF:0000104
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Electronic Gene Ontology annotations created by transferring manual GO annotations between related proteins based on shared sequence features</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000120.md" target="_blank" class="term-link">
+                            GO_REF:0000120
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Combined Automated Annotation using Multiple IEA Methods</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/9020081" target="_blank" class="term-link">
+                            PMID:9020081
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Structural and functional conservation of the Caenorhabditis elegans timing gene clk-1.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/10202142" target="_blank" class="term-link">
+                            PMID:10202142
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">CLK-1 controls respiration, behavior and aging in the nematode Caenorhabditis elegans.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/11244089" target="_blank" class="term-link">
+                            PMID:11244089
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Altered quinone biosynthesis in the long-lived clk-1 mutants of Caenorhabditis elegans.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/11959146" target="_blank" class="term-link">
+                            PMID:11959146
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">CLK-1 protein has DNA binding activity specific to O(L) region of mitochondrial DNA.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/12709403" target="_blank" class="term-link">
+                            PMID:12709403
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Silencing of ubiquinone biosynthesis genes extends life span in Caenorhabditis elegans.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/14517217" target="_blank" class="term-link">
+                            PMID:14517217
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Molecular mechanism of maternal rescue in the clk-1 mutants of Caenorhabditis elegans.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/16920626" target="_blank" class="term-link">
+                            PMID:16920626
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Mitochondrial complex I function modulates volatile anesthetic sensitivity in C. elegans.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/17189267" target="_blank" class="term-link">
+                            PMID:17189267
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Knockdown of mitochondrial heat shock protein 70 promotes progeria-like phenotypes in caenorhabditis elegans.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/17277769" target="_blank" class="term-link">
+                            PMID:17277769
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">eIF4E function in somatic cells modulates ageing in Caenorhabditis elegans.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/19783783" target="_blank" class="term-link">
+                            PMID:19783783
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Life-span extension by dietary restriction is mediated by NLP-7 signaling and coelomocyte endocytosis in C. elegans.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/25961505" target="_blank" class="term-link">
+                            PMID:25961505
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">A nuclear role for the respiratory enzyme CLK-1 in regulating mitochondrial stress responses and longevity.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        file:worm/clk-1/clk-1-deep-research-falcon.md
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Deep research report (Edison/falcon): C. elegans CLK-1 (COQ7)</div>
+
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Questions for Experts</h2>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Is the pro-longevity signal in clk-1 mutants driven by the accumulated DMQ species, by lowered ubiquinone, or by an altered ROS output, and are these separable?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P48376" data-a="Q: Is the pro-longevity signal in clk-1 mutants drive..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Does an endogenous nuclear pool of CLK-1 exist at physiologically relevant levels in C. elegans, and if so how is it targeted given the non-conserved N-terminus?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P48376" data-a="Q: Does an endogenous nuclear pool of CLK-1 exist at ..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Experiments</h2>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Rescue clk-1 nulls with graded dietary ubiquinone versus DMQ analogs while measuring quinone pools, mitochondrial ROS, respiration, and lifespan, to determine which change is causal for lifespan extension.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: The longevity of clk-1 mutants is set by the quinone species/ROS output rather than by ATP-level respiratory deficiency.</em></p>
+
+
+                    <p style="margin-top: 0.5rem;">Type: metabolite-rescue and phenotype assay</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P48376" data-a="EXPERIMENT: Rescue clk-1 nulls with graded dietary ubiquinone ..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Use endogenously tagged CLK-1 and separation-of-function alleles (nuclear- targeting-impaired vs catalytically-dead) with imaging, subcellular fractionation, and ChIP to test for a reproducible, sequence-specific nuclear/ chromatin role in the worm.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: CLK-1 has a separable nuclear function distinct from its mitochondrial hydroxylase activity.</em></p>
+
+
+                    <p style="margin-top: 0.5rem;">Type: genetics and localization</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P48376" data-a="EXPERIMENT: Use endogenously tagged CLK-1 and separation-of-fu..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Knowledge Gaps</h2>
+        <p style="color: #555; font-size: 0.92rem; margin-top: -0.3rem;">
+            What is <em>not</em> known — curated, literature-grounded statements of the open
+            unknowns (the inverse of core functions).
+        </p>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> How the quinone change in clk-1 mutants (loss of ubiquinone UQ9, accumulation of the DMQ9 precursor) is transduced into the pro-longevity signal is undetermined: it is unclear whether the signal comes from DMQ itself, from altered respiratory-chain electron flow, from changed mitochondrial ROS output, or from a ubiquinone-independent route, and which of these is causal for lifespan extension.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">BP_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> It is firmly established that CLK-1 catalyzes DMQ hydroxylation in ubiquinone biosynthesis, that clk-1 nulls lack UQ9 and accumulate DMQ9, that DMQ9 can partially substitute as a respiratory-chain electron carrier, and that clk-1 loss extends lifespan. The mechanistic link between the specific quinone species and the longevity output is what remains open.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> clk-1 is a flagship mitochondrial-longevity (&#34;Clk&#34;) gene; resolving how quinone identity sets lifespan would clarify a central, conserved model of how mitochondrial metabolism controls ageing.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Uncouple the candidate signals experimentally (e.g. dietary UQ rescue vs DMQ supplementation; quinone-pool and ROS measurements combined with lifespan) to establish which change is causal.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"it has not been possible to identify biochemical changes that might underlie the extension of life span observed in clk-1 mutants, and therefore the function of CLK-1 in C. elegans remains unknown."</em> — PMID:11244089</li>
+
+                <li><em>"extended lifespans through a pathway that appears to be independent of ubiquinone biosynthesis and ATP production"</em> — PMID:25961505</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> Whether CLK-1 has a genuine, physiologically significant non-mitochondrial (nuclear) function in C. elegans is unresolved: how a nuclear pool is targeted (the worm N-terminus lacks the COQ7 nuclear-targeting residues), whether it binds DNA sequence-specifically, and whether its effect on transcription of ROS/UPRmt genes is a direct molecular activity or an indirect consequence, remain open and debated.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">MF_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> A nuclear pool of CLK-1/COQ7 and a ubiquinone-independent effect on ROS metabolism, the mitochondrial unfolded protein response, and longevity have been reported (Nat Cell Biol 2015), and an older in-vitro study reports CLK-1 binding the O_L region of mitochondrial DNA. What is unresolved is the mechanism, endogenous relevance, and reproducibility of a nuclear/DNA-associated role.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> If real, a moonlighting nuclear/retrograde-signalling function would redefine CLK-1/COQ7 beyond a metabolic enzyme; if not, several transcription/ROS annotations rest on a contested model.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Independent replication with endogenous, tagged CLK-1 (localization, ChIP, and separation-of-function alleles that disable nuclear but not mitochondrial CLK-1) in the worm.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"the N-terminal residues we identified as being critical for nuclear localisation of COQ7 do not appear to be conserved in CLK-1"</em> — PMID:25961505</li>
+
+                <li><em>"in addition to its enzymatic function in ubiquinone biosynthesis, CLK-1 is involved in the regulation of mtDNA replication or transcription."</em> — PMID:11959146</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> There is no Gene Ontology cellular-component term for the multi-subunit ubiquinone-biosynthetic (COQ) complex (&#34;CoQ synthome&#34;) of which CLK-1/COQ7 is a component and which it is proposed to structurally stabilize, so this membership cannot be expressed as a GO annotation.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">ONTOLOGY</span>
+                <span class="badge">CC_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> CLK-1/COQ7 is described (by similarity to characterized orthologs) as part of a multi-subunit COQ enzyme complex with a structural stabilizing role, but GO provides only the ubiquinone biosynthetic process and membrane-location terms, not a complex term.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Capturing COQ-complex membership would let curation record the structural role of COQ7 family members alongside their catalytic activity.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Add a &#34;coenzyme Q biosynthesis complex&#34; (or &#34;CoQ synthome&#34;) cellular-component term to GO.</p>
+
+
+
+            <p style="margin-top: 0.5rem;"><strong>Proposed term (ontology gap):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><strong>coenzyme Q biosynthesis complex</strong></li>
+
+            </ul>
+
+        </div>
+
+    </div>
+
+
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Deep Research Sections -->
+
+    <div class="section">
+        <h2 class="section-title">Deep Research</h2>
+
+        <details class="deep-research-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; gap: 1rem;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Falcon</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(clk-1-deep-research-falcon.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="P48376" data-a="DEEP_RESEARCH: Falcon" data-r="" data-act="DEEP_RESEARCH" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This deep research is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This deep research needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+
+                <div class="report-meta">
+
+                    <span class="report-meta-text">Comprehensive Research Report: *C. elegans* CLK-1 (COQ7) — Gene ID: clk-1, UniProt: P48376</span>
+
+
+                    <span class="report-badge">Falcon</span>
+
+
+                    <span class="report-badge">Edison Scientific Literature</span>
+
+
+                    <span class="report-badge">40 citations</span>
+
+
+                    <span class="report-badge">1 artifacts</span>
+
+
+                    <span class="report-meta-text">2026-07-04T15:46:09.357765</span>
+
+
+
+                </div>
+
+
+                <div class="artifact-list">
+
+
+
+                    <div class="artifact-link">
+                        <a href="clk-1-deep-research-falcon_artifacts/artifact-00.md" class="term-link">Edison artifact artifact-00</a>
+                        <span>(text/markdown)</span>
+                    </div>
+
+
+                </div>
+
+                <p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h1 id="comprehensive-research-report-c-elegans-clk-1-coq7-gene-id-clk-1-uniprot-p48376">Comprehensive Research Report: <em>C. elegans</em> CLK-1 (COQ7) — Gene ID: clk-1, UniProt: P48376</h1>
+<h2 id="gene-identity-verification">Gene Identity Verification</h2>
+<p>The gene symbol <strong>clk-1</strong> unambiguously corresponds to the <em>Caenorhabditis elegans</em> <strong>Clock abnormal protein 1</strong>, also known as <strong>ubiquinone biosynthesis monooxygenase COQ7</strong> (UniProt: P48376). This protein belongs to the <strong>COQ7 family</strong> of diiron carboxylate hydroxylases and contains the expected Ferritin-like superfamily fold (IPR009078) and the Ubq_synth_Coq7 domain (IPR011566; PF03232). The gene is encoded at locus ZC395.2 and is orthologous to yeast <em>COQ7/CAT5</em>, mouse <em>Mclk1</em>, and human <em>COQ7</em> (wang2013moleculargeneticsof pages 4-6, jonassen1998yeastclk1homologue pages 1-1).</p>
+<p>The following table summarizes the core properties of CLK-1:</p>
+<table>
+<thead>
+<tr>
+<th>Property</th>
+<th>Details/Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Gene name</td>
+<td><strong>clk-1</strong> (C. elegans clock abnormal protein 1 / COQ7 ortholog) (wang2013moleculargeneticsof pages 4-6, jonassen1998yeastclk1homologue pages 1-1)</td>
+</tr>
+<tr>
+<td>UniProt accession</td>
+<td><strong>P48376</strong></td>
+</tr>
+<tr>
+<td>Protein name</td>
+<td><strong>NADPH-dependent 3-demethoxyubiquinone 3-hydroxylase, mitochondrial</strong>; also called <strong>protein CLK-1</strong> or <strong>ubiquinone biosynthesis monooxygenase COQ7</strong> (wang2013moleculargeneticsof pages 6-7, stefely2017biochemistryofmitochondrial pages 21-22)</td>
+</tr>
+<tr>
+<td>Enzymatic function</td>
+<td>Catalyzes hydroxylation of demethoxyubiquinone during coenzyme Q biosynthesis; in C. elegans, loss of clk-1 prevents endogenous UQ9 production and causes DMQ9 accumulation, establishing CLK-1 as the DMQ hydroxylase step in the pathway (wang2013moleculargeneticsof pages 6-7, haynes2022mitochondrialdysfunctionaging pages 1-2, haynes2022mitochondrialdysfunctionaging pages 12-12)</td>
+</tr>
+<tr>
+<td>EC number</td>
+<td><strong>EC 1.14.13.253</strong></td>
+</tr>
+<tr>
+<td>Substrate</td>
+<td><strong>DMQ9 / 5-demethoxyubiquinone-9</strong> (demethoxyubiquinone precursor of ubiquinone-9) (wang2013moleculargeneticsof pages 6-7, haynes2022mitochondrialdysfunctionaging pages 1-2, wang2013moleculargeneticsof pages 12-14)</td>
+</tr>
+<tr>
+<td>Product</td>
+<td><strong>UQ9 / ubiquinone-9 (coenzyme Q9)</strong>; some descriptions also refer to formation of the hydroxylated intermediate en route to mature ubiquinone (haynes2022mitochondrialdysfunctionaging pages 1-2, haynes2022mitochondrialdysfunctionaging pages 12-12)</td>
+</tr>
+<tr>
+<td>Cofactor / active site</td>
+<td><strong>Carboxylate-bridged diiron center</strong> that activates dioxygen for aromatic ring hydroxylation; catalytic activity is iron-sensitive and disrupted by manganese mismetallation (wang2013moleculargeneticsof pages 6-7, diessl2022manganesedrivencoqdeficiency pages 3-5, diessl2022manganesedrivencoqdeficiency pages 1-2)</td>
+</tr>
+<tr>
+<td>Protein family</td>
+<td><strong>COQ7 family</strong>; conserved eukaryotic ubiquinone-biosynthetic hydroxylase family (wang2013moleculargeneticsof pages 4-6, jonassen1998yeastclk1homologue pages 1-1)</td>
+</tr>
+<tr>
+<td>Structural features</td>
+<td>Predicted/characterized <strong>four-helix bundle</strong> diiron protein with an additional <strong>membrane-associating helix</strong>; membrane-bound or peripherally membrane-associated hydroxylase (wang2022predictingandunderstanding pages 34-38, awad2018coenzymeq10deficiencies pages 7-8)</td>
+</tr>
+<tr>
+<td>Subcellular localization</td>
+<td>Primarily <strong>mitochondrial</strong>, associated with the <strong>inner mitochondrial membrane on the matrix side</strong> for CoQ biosynthesis; evidence also supports <strong>nuclear localization under stress/ROS conditions</strong>, where CLK-1/COQ7 may regulate gene expression (awad2018coenzymeq10deficiencies pages 7-8, lionaki2016differentialproteindistribution pages 8-9, jonassen2001adietarysource pages 5-6)</td>
+</tr>
+<tr>
+<td>Pathway</td>
+<td><strong>Coenzyme Q (ubiquinone) biosynthesis</strong>; CLK-1/COQ7 functions in the late aromatic ring-modification steps and participates with COQ3/4/5/6/7/9 in the <strong>COQ metabolon / CoQ synthome</strong> (awad2018coenzymeq10deficiencies pages 8-10, nicoll2024invitroconstruction pages 1-2)</td>
+</tr>
+<tr>
+<td>Organism</td>
+<td><strong>Caenorhabditis elegans</strong> (worm)</td>
+</tr>
+<tr>
+<td>Orthologs</td>
+<td>Conserved across eukaryotes: <strong>yeast Coq7p/Cat5p</strong>, <strong>mouse MCLK1</strong>, <strong>human COQ7</strong>; functional complementation data support strong conservation (haynes2022mitochondrialdysfunctionaging pages 12-12, wang2013moleculargeneticsof pages 4-6, diazcasado2019theparadoxof pages 7-9, jonassen1998yeastclk1homologue pages 1-1)</td>
+</tr>
+</tbody>
+</table>
+<p><em>Table: This table summarizes the core identity, enzymatic role, localization, structure, and pathway context of C. elegans CLK-1/COQ7. It is useful as a compact reference for functional annotation and for distinguishing clk-1 from unrelated similarly named genes.</em></p>
+<hr />
+<h2 id="1-enzymatic-function-and-catalytic-mechanism">1. Enzymatic Function and Catalytic Mechanism</h2>
+<h3 id="11-primary-reaction">1.1 Primary Reaction</h3>
+<p>CLK-1 is an NADH-dependent hydroxylase (EC 1.14.13.253) that catalyzes the <strong>hydroxylation of 5-demethoxyubiquinone-9 (DMQ9) to produce ubiquinone-9 (UQ9/coenzyme Q9)</strong> in <em>C. elegans</em>. This reaction represents the <strong>penultimate step</strong> in the coenzyme Q biosynthetic pathway, specifically the C5 hydroxylation of the quinone ring (wang2013moleculargeneticsof pages 6-7, stefely2017biochemistryofmitochondrial pages 21-22, haynes2022mitochondrialdysfunctionaging pages 1-2, haynes2022mitochondrialdysfunctionaging pages 12-12). Loss-of-function mutations in <em>clk-1</em> (such as the <em>qm30</em> null allele) abolish endogenous UQ9 production and lead to accumulation of DMQ9, the direct substrate of CLK-1, firmly establishing this enzymatic assignment (haynes2022mitochondrialdysfunctionaging pages 1-2, wang2013moleculargeneticsof pages 12-14, wang2013moleculargeneticsof pages 4-6).</p>
+<h3 id="12-active-site-and-cofactor">1.2 Active Site and Cofactor</h3>
+<p>CLK-1/COQ7 is a member of the <strong>carboxylate-bridged diiron protein family</strong>, which also includes methane monooxygenase, ribonucleotide reductase, and phenol hydroxylase (awad2018coenzymeq10deficiencies pages 7-8). The protein employs a <strong>diiron center</strong> to activate molecular oxygen (O₂) for the aromatic ring hydroxylation reaction. Spectroscopic characterization of the purified mouse ortholog MCLK1 confirmed the presence of this diiron center, which serves as the catalytic active site for dioxygen activation and subsequent demethoxyubiquinone hydroxylation (wang2013moleculargeneticsof pages 6-7). The enzymatic activity is sensitive to iron availability, and the diiron center can be reduced by substrate-mediated processes in the presence of NADH and oxygen. In vitro assays using substrate analogs DMQ0 and DMQ2 demonstrated binding to the diiron site and NADH-mediated reduction (stefely2017biochemistryofmitochondrial pages 21-22, awad2018coenzymeq10deficiencies pages 8-10).</p>
+<h3 id="13-structural-features">1.3 Structural Features</h3>
+<p>COQ7 is predicted—and partially confirmed experimentally—to adopt a <strong>four-helix bundle</strong> architecture, with an additional α-helix mediating peripheral association with the mitochondrial inner membrane (wang2022predictingandunderstanding pages 34-38, awad2018coenzymeq10deficiencies pages 7-8). The iron-liganding motif has been refined as <strong>E–X₆–Y–X₂₂–E–X₂–H–X₄₈–E–X₆–Y–X₂₈–E–X₂–H</strong>, with key residues (E60, Y67, E90, H93, E142, Y149, E178, H181 in human COQ7 numbering) predicted to coordinate the two Fe(II) atoms within the bundle. However, experimentally determined structures have not yet captured metals in the active site, so the metal-liganding assignments remain based on structural analogy to other diiron proteins (wang2022predictingandunderstanding pages 34-38, wang2022predictingandunderstanding pages 38-41).</p>
+<p>A particularly notable finding is that the diiron center of Coq7 is <strong>uniquely sensitive to manganese mismetallation</strong>. Under conditions of manganese overload, Mn²⁺ ions erroneously occupy the diiron binding sites, inactivating the enzyme and triggering its proteolytic degradation. This mismetallation selectively disrupts CoQ biosynthesis while leaving respiratory chain complexes intact, establishing Coq7 as the molecular target of manganese-induced bioenergetic failure (diessl2022manganesedrivencoqdeficiency pages 3-5, diessl2022manganesedrivencoqdeficiency pages 5-6, diessl2022manganesedrivencoqdeficiency pages 1-2, diessl2022manganesedrivencoqdeficiency pages 2-3).</p>
+<hr />
+<h2 id="2-subcellular-localization">2. Subcellular Localization</h2>
+<h3 id="21-mitochondrial-localization">2.1 Mitochondrial Localization</h3>
+<p>The primary site of CLK-1 function is the <strong>mitochondria</strong>. CLK-1 contains a mitochondrial targeting sequence (MTS) and is <strong>peripherally associated with the inner mitochondrial membrane on the matrix side</strong> (awad2018coenzymeq10deficiencies pages 7-8, jonassen2001adietarysource pages 5-6). This localization is consistent with the established site of coenzyme Q biosynthesis in eukaryotic cells and with the mitochondrial localization of the yeast homolog Coq7p (jonassen2001adietarysource pages 5-6, jonassen1998yeastclk1homologue pages 1-1). CLK-1 is expressed ubiquitously throughout the worm, consistent with the observation that Q biosynthesis occurs in essentially all tissues (jonassen2001adietarysource pages 5-6).</p>
+<h3 id="22-dual-localization-to-the-nucleus">2.2 Dual Localization to the Nucleus</h3>
+<p>Evidence supports a <strong>dual mitochondrial-nuclear distribution</strong> for CLK-1/COQ7. The protein contains nuclear localization signals in addition to its MTS, and nuclear accumulation has been observed under conditions of <strong>mitochondrial stress and elevated reactive oxygen species (ROS)</strong> (lionaki2016differentialproteindistribution pages 8-9, lionaki2016differentialproteindistribution pages 7-8). In the nucleus, CLK-1/COQ7 has been reported to bind chromatin and regulate oxidative stress response genes while suppressing genes associated with the mitochondrial unfolded protein response (UPRmt). Importantly, restricting CLK-1 exclusively to the nucleus inhibits ubiquinone biosynthesis, demonstrating that its nuclear role is distinct from its enzymatic function in the mitochondria (lionaki2016differentialproteindistribution pages 8-9). However, these nuclear "moonlighting" functions remain an area of active investigation and require further confirmation (haynes2022mitochondrialdysfunctionaging pages 12-13).</p>
+<hr />
+<h2 id="3-pathway-context-the-coq-biosynthetic-pathway-and-the-coq-metabolon">3. Pathway Context: The CoQ Biosynthetic Pathway and the COQ Metabolon</h2>
+<h3 id="31-coq-biosynthesis">3.1 CoQ Biosynthesis</h3>
+<p>Coenzyme Q (ubiquinone) is an essential redox-active lipid composed of a benzoquinone ring and a polyisoprenyl tail. It functions primarily as a mobile electron carrier in the mitochondrial electron transport chain and as a membrane-soluble antioxidant (guerra2023coenzymeqbiochemistry pages 1-3). The biosynthesis of CoQ involves multiple enzymatic modifications of the aromatic ring, including decarboxylation, hydroxylation, and methylation reactions. CLK-1/COQ7 catalyzes the <strong>late-stage C5 hydroxylation</strong> that converts DMQ to UQ (haynes2022mitochondrialdysfunctionaging pages 12-12, guerra2023coenzymeqbiochemistry pages 3-4).</p>
+<h3 id="32-the-coq-metabolon-coq-synthome">3.2 The COQ Metabolon (CoQ Synthome)</h3>
+<p>CLK-1/COQ7 does not function in isolation but rather as part of a <strong>multi-protein complex called the COQ metabolon</strong> (also termed the CoQ synthome or Complex Q). This complex comprises at least six core proteins: <strong>COQ3, COQ4, COQ5, COQ6, COQ7, and COQ9</strong>, all located at the matrix side of the inner mitochondrial membrane (awad2018coenzymeq10deficiencies pages 8-10, nicoll2024invitroconstruction pages 1-2). The metabolon coordinates sequential ring-modification reactions, facilitating substrate channeling among its component enzymes.</p>
+<p>A landmark 2024 study by Nicoll et al. in <em>Nature Catalysis</em> achieved the first <strong>in vitro reconstitution of the complete COQ metabolon</strong> using ancestral sequence reconstruction, capturing the entire biosynthetic pathway in vitro and revealing enzymes responsible for previously uncharacterized steps (nicoll2024invitroconstruction pages 1-2, mattevi2023invitroconstruction pages 1-4). This work also demonstrated that <strong>COQ8, a kinase</strong>, increases and streamlines coenzyme Q production by phosphorylating metabolon components such as COQ3, thereby regulating metabolon assembly and disassembly (nicoll2024invitroconstruction pages 1-2, nicoll2024invitroconstruction pages 8-8).</p>
+<h3 id="33-the-coq7coq9-interaction">3.3 The COQ7–COQ9 Interaction</h3>
+<p>A particularly well-characterized interaction within the metabolon is the <strong>COQ7:COQ9 complex</strong>. COQ9 is a lipid-binding auxiliary protein that physically associates with COQ7 and is essential for both the stability and catalytic activity of COQ7 (diazcasado2019theparadoxof pages 3-5, staiano2023biosynthesisdeficiencyand pages 4-5). The two proteins form a <strong>double heterodimer</strong> that reshapes the mitochondrial inner membrane to allow substrate accessibility to their lipid-binding sites (staiano2023biosynthesisdeficiencyand pages 4-5). COQ9 binds aromatic isoprene intermediates and is proposed to present these directly to COQ7 for hydroxylation (diazcasado2019theparadoxof pages 3-5). In COQ9-deficient cells and mice, COQ7 levels decrease and the COQ7 substrate DMQ accumulates, confirming the functional coupling of these two proteins (diazcasado2019theparadoxof pages 3-5).</p>
+<hr />
+<h2 id="4-phenotypes-of-clk-1-mutants-and-relationship-to-aging">4. Phenotypes of <em>clk-1</em> Mutants and Relationship to Aging</h2>
+<h3 id="41-pleiotropic-phenotypes">4.1 Pleiotropic Phenotypes</h3>
+<p><em>clk-1</em> loss-of-function mutants in <em>C. elegans</em> display a constellation of <strong>pleiotropic phenotypes</strong> collectively described as the "Clock" (Clk) phenotype: <strong>slowed development, reduced rates of pharyngeal pumping, defecation, and swimming</strong>, as well as <strong>increased UV stress resistance and extended adult lifespan</strong> (jonassen2001adietarysource pages 5-6, jonassen1998yeastclk1homologue pages 1-1). The <em>clk-1</em> mutant was among the first genetic demonstrations that <strong>mitochondrial dysfunction can paradoxically extend lifespan</strong> (haynes2022mitochondrialdysfunctionaging pages 1-1, haynes2022mitochondrialdysfunctionaging pages 12-12).</p>
+<h3 id="42-dmq9-accumulation-and-uq9-deficiency">4.2 DMQ9 Accumulation and UQ9 Deficiency</h3>
+<p><em>clk-1</em> null mutants lack endogenous UQ9 and instead accumulate its biosynthetic precursor DMQ9 (haynes2022mitochondrialdysfunctionaging pages 1-2, wang2013moleculargeneticsof pages 12-14). DMQ9 differs from UQ9 by lacking one methoxy group and appears to act as a <strong>non-functional competitor at CoQ-binding sites</strong> in mitochondrial respiratory complexes, particularly at Complex I, further reducing electron transport chain efficiency (diazcasado2019theparadoxof pages 7-9, wang2013moleculargeneticsof pages 12-14). Despite lacking endogenous UQ9, <em>clk-1</em> mutants survive because they can absorb <strong>bacterial UQ8 from their <em>E. coli</em> food source</strong>, which partially substitutes for endogenous UQ9 but does not fully restore wild-type phenotypes (haynes2022mitochondrialdysfunctionaging pages 1-1, haynes2022mitochondrialdysfunctionaging pages 1-2). Critically, <em>clk-1</em> mutant larvae die on CoQ-deficient diets, indicating that a minimum level of dietary CoQ is essential for development and fertility (diazcasado2019theparadoxof pages 7-9).</p>
+<h3 id="43-mechanism-of-lifespan-extension">4.3 Mechanism of Lifespan Extension</h3>
+<p>The lifespan extension in <em>clk-1</em> mutants is intimately tied to deficient UQ synthesis. Treatment with <strong>2,4-dihydroxybenzoic acid (2,4-DHB)</strong>, a biosynthetic intermediate that bypasses the CLK-1 enzymatic step, rescues all <em>clk-1</em> mutant phenotypes including the aging effect, even without any CLK-1 protein present (haynes2022mitochondrialdysfunctionaging pages 1-2, haynes2022mitochondrialdysfunctionaging pages 12-12). This demonstrates that all phenotypes result from the lack of UQ9 rather than from loss of any alternative CLK-1 function. The precise mechanism by which reduced UQ biosynthesis extends lifespan remains under investigation, but it is proposed to involve <strong>reduced electron flow through the respiratory chain, altered ROS production, and adaptive mitohormetic responses</strong> (diazcasado2019theparadoxof pages 7-9, haynes2022mitochondrialdysfunctionaging pages 12-12). Notably, the lifespan extension in <em>clk-1</em> mutants is not suppressed by loss of the apoptotic pathway component CED-4, and in fact CED-4 loss further extends <em>clk-1</em> mutant lifespan, distinguishing the <em>clk-1</em> longevity mechanism from those of other mitochondrial mutants such as <em>isp-1</em> and <em>nuo-6</em> (haynes2022mitochondrialdysfunctionaging pages 12-13).</p>
+<hr />
+<h2 id="5-evolutionary-conservation">5. Evolutionary Conservation</h2>
+<p>CLK-1/COQ7 is <strong>highly conserved across eukaryotes</strong>, from <em>Saccharomyces cerevisiae</em> (yeast Coq7p/Cat5p) to <em>C. elegans</em> (CLK-1), mouse (MCLK1), and human (COQ7) (wang2013moleculargeneticsof pages 4-6, diazcasado2019theparadoxof pages 7-9, jonassen1998yeastclk1homologue pages 1-1). Functional conservation has been demonstrated through <strong>cross-species complementation experiments</strong>: the rat and <em>C. elegans</em> CLK-1 homologs can rescue yeast <em>coq7/cat5</em> mutants, restoring growth on nonfermentable carbon sources (jonassen1998yeastclk1homologue pages 1-1). Similarly, mammalian COQ7 cDNA can partially complement yeast <em>coq7</em> mutations (wang2013moleculargeneticsof pages 4-6). Both yeast <em>coq7</em> and <em>C. elegans clk-1</em> mutants accumulate the same class of biosynthetic intermediate (DMQ6 and DMQ9, respectively), and heterozygous <em>Mclk1</em> mice also display extended lifespan, paralleling the <em>C. elegans</em> phenotype (wang2013moleculargeneticsof pages 4-6, diazcasado2019theparadoxof pages 7-9). Treatment with 2,4-DHB restores UQ biosynthesis in CLK-1-deficient mouse cells and <em>Mclk1</em> knockout mice, confirming conservation of the bypass mechanism (haynes2022mitochondrialdysfunctionaging pages 12-12).</p>
+<hr />
+<h2 id="6-recent-developments-20222024">6. Recent Developments (2022–2024)</h2>
+<p>Several important advances have furthered our understanding of COQ7/CLK-1:</p>
+<ul>
+<li>
+<p><strong>In vitro reconstitution of the COQ metabolon (2024):</strong> Nicoll et al. used ancestral sequence reconstruction to create stable, experimentally tractable COQ proteins and achieved the first complete in vitro reconstitution of the CoQ biosynthetic metabolon, revealing the determinants of substrate channeling and the regulatory role of COQ8 kinase (nicoll2024invitroconstruction pages 1-2, mattevi2023invitroconstruction pages 1-4, nicoll2024invitroconstruction pages 8-8).</p>
+</li>
+<li>
+<p><strong>Manganese mismetallation of Coq7 (2022):</strong> Diessl et al. demonstrated that manganese overload selectively inactivates Coq7 through mismetallation of its diiron center, revealing a conserved molecular mechanism for manganese-induced bioenergetic failure (diessl2022manganesedrivencoqdeficiency pages 3-5, diessl2022manganesedrivencoqdeficiency pages 5-6, diessl2022manganesedrivencoqdeficiency pages 1-2).</p>
+</li>
+<li>
+<p><strong>COQ7:COQ9 double heterodimer characterization (2023):</strong> Staiano et al. described the COQ7–COQ9 complex as a double heterodimer that reshapes the mitochondrial inner membrane for substrate accessibility, advancing understanding of the lipid-binding and substrate delivery mechanisms (staiano2023biosynthesisdeficiencyand pages 4-5).</p>
+</li>
+<li>
+<p><strong>CoQ biochemistry review (2023):</strong> Guerra and Pagliarini provided a comprehensive review highlighting persisting knowledge gaps in CoQ biosynthesis, distribution, and transport, while emphasizing the central role of the COQ metabolon in which COQ7 participates (guerra2023coenzymeqbiochemistry pages 12-14, guerra2023coenzymeqbiochemistry pages 1-3).</p>
+</li>
+</ul>
+<hr />
+<h2 id="summary">Summary</h2>
+<p><em>C. elegans</em> CLK-1 (UniProt P48376) is a mitochondrial diiron carboxylate hydroxylase that catalyzes the C5 hydroxylation of DMQ9 to produce UQ9, the penultimate step in coenzyme Q biosynthesis. It functions at the matrix face of the inner mitochondrial membrane as part of the COQ metabolon, in close partnership with the lipid-binding protein COQ9. Loss of CLK-1 abolishes endogenous UQ9 production, leading to pleiotropic phenotypes including slowed development and extended lifespan—effects that are entirely attributable to UQ deficiency and can be rescued by biosynthetic bypass compounds. CLK-1 is highly conserved across eukaryotes, and its diiron active site is uniquely vulnerable to manganese mismetallation. Evidence also supports a secondary, stress-responsive nuclear localization where CLK-1 may modulate gene expression, though this function requires further confirmation.</p>
+<p>References</p>
+<ol>
+<li>
+<p>(wang2013moleculargeneticsof pages 4-6): Ying Wang and Siegfried Hekimi. Molecular genetics of ubiquinone biosynthesis in animals. Critical Reviews in Biochemistry and Molecular Biology, 48:69-88, Jan 2013. URL: https://doi.org/10.3109/10409238.2012.741564, doi:10.3109/10409238.2012.741564. This article has 90 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(jonassen1998yeastclk1homologue pages 1-1): Tanya Jonassen, Markus Proft, Francisca Randez-Gil, Jeffery R. Schultz, B. Noelle Marbois, Karl-Dieter Entian, and Catherine F. Clarke. Yeast clk-1 homologue (coq7/cat5) is a mitochondrial protein in coenzyme q synthesis*. The Journal of Biological Chemistry, 273:3351-3357, Feb 1998. URL: https://doi.org/10.1074/jbc.273.6.3351, doi:10.1074/jbc.273.6.3351. This article has 182 citations.</p>
+</li>
+<li>
+<p>(wang2013moleculargeneticsof pages 6-7): Ying Wang and Siegfried Hekimi. Molecular genetics of ubiquinone biosynthesis in animals. Critical Reviews in Biochemistry and Molecular Biology, 48:69-88, Jan 2013. URL: https://doi.org/10.3109/10409238.2012.741564, doi:10.3109/10409238.2012.741564. This article has 90 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(stefely2017biochemistryofmitochondrial pages 21-22): Jonathan A. Stefely and David J. Pagliarini. Biochemistry of mitochondrial coenzyme q biosynthesis. Trends in biochemical sciences, 42 10:824-843, Oct 2017. URL: https://doi.org/10.1016/j.tibs.2017.06.008, doi:10.1016/j.tibs.2017.06.008. This article has 401 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(haynes2022mitochondrialdysfunctionaging pages 1-2): Cole M Haynes and Siegfried Hekimi. Mitochondrial dysfunction, aging, and the mitochondrial unfolded protein response in <i>caenorhabditis elegans</i>. Genetics, Nov 2022. URL: https://doi.org/10.1093/genetics/iyac160, doi:10.1093/genetics/iyac160. This article has 40 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(haynes2022mitochondrialdysfunctionaging pages 12-12): Cole M Haynes and Siegfried Hekimi. Mitochondrial dysfunction, aging, and the mitochondrial unfolded protein response in <i>caenorhabditis elegans</i>. Genetics, Nov 2022. URL: https://doi.org/10.1093/genetics/iyac160, doi:10.1093/genetics/iyac160. This article has 40 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(wang2013moleculargeneticsof pages 12-14): Ying Wang and Siegfried Hekimi. Molecular genetics of ubiquinone biosynthesis in animals. Critical Reviews in Biochemistry and Molecular Biology, 48:69-88, Jan 2013. URL: https://doi.org/10.3109/10409238.2012.741564, doi:10.3109/10409238.2012.741564. This article has 90 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(diessl2022manganesedrivencoqdeficiency pages 3-5): Jutta Diessl, Jens Berndtsson, Filomena Broeskamp, Lukas Habernig, Verena Kohler, Carmela Vazquez-Calvo, Arpita Nandy, Carlotta Peselj, Sofia Drobysheva, Ludovic Pelosi, F.-Nora Vögtle, Fabien Pierrel, Martin Ott, and Sabrina Büttner. Manganese-driven coq deficiency. Nature Communications, Oct 2022. URL: https://doi.org/10.1038/s41467-022-33641-x, doi:10.1038/s41467-022-33641-x. This article has 26 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(diessl2022manganesedrivencoqdeficiency pages 1-2): Jutta Diessl, Jens Berndtsson, Filomena Broeskamp, Lukas Habernig, Verena Kohler, Carmela Vazquez-Calvo, Arpita Nandy, Carlotta Peselj, Sofia Drobysheva, Ludovic Pelosi, F.-Nora Vögtle, Fabien Pierrel, Martin Ott, and Sabrina Büttner. Manganese-driven coq deficiency. Nature Communications, Oct 2022. URL: https://doi.org/10.1038/s41467-022-33641-x, doi:10.1038/s41467-022-33641-x. This article has 26 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(wang2022predictingandunderstanding pages 34-38): Sining Wang, Akash Jain, Noelle Alexa Novales, Audrey N. Nashner, Fiona Tran, and Catherine F. Clarke. Predicting and understanding the pathology of single nucleotide variants in human coq genes. Antioxidants, 11:2308, Nov 2022. URL: https://doi.org/10.3390/antiox11122308, doi:10.3390/antiox11122308. This article has 7 citations.</p>
+</li>
+<li>
+<p>(awad2018coenzymeq10deficiencies pages 7-8): Agape M. Awad, Michelle C. Bradley, Lucía Fernández-del-Río, Anish Nag, Hui S. Tsui, and Catherine F. Clarke. Coenzyme q10 deficiencies: pathways in yeast and humans. Essays in Biochemistry, 62:361-376, Jul 2018. URL: https://doi.org/10.1042/ebc20170106, doi:10.1042/ebc20170106. This article has 185 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(lionaki2016differentialproteindistribution pages 8-9): Eirini Lionaki, Ilias Gkikas, and Nektarios Tavernarakis. Differential protein distribution between the nucleus and mitochondria: implications in aging. Frontiers in Genetics, Sep 2016. URL: https://doi.org/10.3389/fgene.2016.00162, doi:10.3389/fgene.2016.00162. This article has 57 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(jonassen2001adietarysource pages 5-6): Tanya Jonassen, Pamela L. Larsen, and Catherine F. Clarke. A dietary source of coenzyme q is essential for growth of long-lived caenorhabditis elegans clk-1 mutants. Proceedings of the National Academy of Sciences of the United States of America, 98 2:421-6, Jan 2001. URL: https://doi.org/10.1073/pnas.98.2.421, doi:10.1073/pnas.98.2.421. This article has 249 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(awad2018coenzymeq10deficiencies pages 8-10): Agape M. Awad, Michelle C. Bradley, Lucía Fernández-del-Río, Anish Nag, Hui S. Tsui, and Catherine F. Clarke. Coenzyme q10 deficiencies: pathways in yeast and humans. Essays in Biochemistry, 62:361-376, Jul 2018. URL: https://doi.org/10.1042/ebc20170106, doi:10.1042/ebc20170106. This article has 185 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(nicoll2024invitroconstruction pages 1-2): Callum R. Nicoll, Laura Alvigini, Andrea Gottinger, Domiziana Cecchini, Barbara Mannucci, Federica Corana, María Laura Mascotti, and Andrea Mattevi. In vitro construction of the coq metabolon unveils the molecular determinants of coenzyme q biosynthesis. Nature catalysis, 7:148-160, Jan 2024. URL: https://doi.org/10.1038/s41929-023-01087-z, doi:10.1038/s41929-023-01087-z. This article has 27 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(diazcasado2019theparadoxof pages 7-9): M. E. Díaz-Casado, J. Quiles, Eliana Barriocanal-Casado, Pilar González-García, Maurizio Battino, M. Battino, Maurizio Battino, L. López, and A. Varela-López. The paradox of coenzyme q10 in aging. Sep 2019. URL: https://doi.org/10.3390/nu11092221, doi:10.3390/nu11092221. This article has 105 citations.</p>
+</li>
+<li>
+<p>(wang2022predictingandunderstanding pages 38-41): Sining Wang, Akash Jain, Noelle Alexa Novales, Audrey N. Nashner, Fiona Tran, and Catherine F. Clarke. Predicting and understanding the pathology of single nucleotide variants in human coq genes. Antioxidants, 11:2308, Nov 2022. URL: https://doi.org/10.3390/antiox11122308, doi:10.3390/antiox11122308. This article has 7 citations.</p>
+</li>
+<li>
+<p>(diessl2022manganesedrivencoqdeficiency pages 5-6): Jutta Diessl, Jens Berndtsson, Filomena Broeskamp, Lukas Habernig, Verena Kohler, Carmela Vazquez-Calvo, Arpita Nandy, Carlotta Peselj, Sofia Drobysheva, Ludovic Pelosi, F.-Nora Vögtle, Fabien Pierrel, Martin Ott, and Sabrina Büttner. Manganese-driven coq deficiency. Nature Communications, Oct 2022. URL: https://doi.org/10.1038/s41467-022-33641-x, doi:10.1038/s41467-022-33641-x. This article has 26 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(diessl2022manganesedrivencoqdeficiency pages 2-3): Jutta Diessl, Jens Berndtsson, Filomena Broeskamp, Lukas Habernig, Verena Kohler, Carmela Vazquez-Calvo, Arpita Nandy, Carlotta Peselj, Sofia Drobysheva, Ludovic Pelosi, F.-Nora Vögtle, Fabien Pierrel, Martin Ott, and Sabrina Büttner. Manganese-driven coq deficiency. Nature Communications, Oct 2022. URL: https://doi.org/10.1038/s41467-022-33641-x, doi:10.1038/s41467-022-33641-x. This article has 26 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(lionaki2016differentialproteindistribution pages 7-8): Eirini Lionaki, Ilias Gkikas, and Nektarios Tavernarakis. Differential protein distribution between the nucleus and mitochondria: implications in aging. Frontiers in Genetics, Sep 2016. URL: https://doi.org/10.3389/fgene.2016.00162, doi:10.3389/fgene.2016.00162. This article has 57 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(haynes2022mitochondrialdysfunctionaging pages 12-13): Cole M Haynes and Siegfried Hekimi. Mitochondrial dysfunction, aging, and the mitochondrial unfolded protein response in <i>caenorhabditis elegans</i>. Genetics, Nov 2022. URL: https://doi.org/10.1093/genetics/iyac160, doi:10.1093/genetics/iyac160. This article has 40 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(guerra2023coenzymeqbiochemistry pages 1-3): Rachel M. Guerra and David J. Pagliarini. Coenzyme q biochemistry and biosynthesis. Trends in Biochemical Sciences, 48:463-476, May 2023. URL: https://doi.org/10.1016/j.tibs.2022.12.006, doi:10.1016/j.tibs.2022.12.006. This article has 142 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(guerra2023coenzymeqbiochemistry pages 3-4): Rachel M. Guerra and David J. Pagliarini. Coenzyme q biochemistry and biosynthesis. Trends in Biochemical Sciences, 48:463-476, May 2023. URL: https://doi.org/10.1016/j.tibs.2022.12.006, doi:10.1016/j.tibs.2022.12.006. This article has 142 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(mattevi2023invitroconstruction pages 1-4): Andrea Mattevi, Callum Nicoll, Laura Alvigini, Andrea Gottinger, Domiziana Cecchini, Barbara Mannucci, Federica Corana, and Maria Laura Mascotti. In vitro construction of the coq metabolon unveils the molecular determinants of coenzyme q biosynthesis. Nov 2023. URL: https://doi.org/10.21203/rs.3.rs-2845141/v1, doi:10.21203/rs.3.rs-2845141/v1.</p>
+</li>
+<li>
+<p>(nicoll2024invitroconstruction pages 8-8): Callum R. Nicoll, Laura Alvigini, Andrea Gottinger, Domiziana Cecchini, Barbara Mannucci, Federica Corana, María Laura Mascotti, and Andrea Mattevi. In vitro construction of the coq metabolon unveils the molecular determinants of coenzyme q biosynthesis. Nature catalysis, 7:148-160, Jan 2024. URL: https://doi.org/10.1038/s41929-023-01087-z, doi:10.1038/s41929-023-01087-z. This article has 27 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(diazcasado2019theparadoxof pages 3-5): M. E. Díaz-Casado, J. Quiles, Eliana Barriocanal-Casado, Pilar González-García, Maurizio Battino, M. Battino, Maurizio Battino, L. López, and A. Varela-López. The paradox of coenzyme q10 in aging. Sep 2019. URL: https://doi.org/10.3390/nu11092221, doi:10.3390/nu11092221. This article has 105 citations.</p>
+</li>
+<li>
+<p>(staiano2023biosynthesisdeficiencyand pages 4-5): Carmine Staiano, Laura García-Corzo, David Mantle, Nadia Turton, Lauren E. Millichap, Gloria Brea-Calvo, and Iain Hargreaves. Biosynthesis, deficiency, and supplementation of coenzyme q. Antioxidants, 12:1469, Jul 2023. URL: https://doi.org/10.3390/antiox12071469, doi:10.3390/antiox12071469. This article has 25 citations.</p>
+</li>
+<li>
+<p>(haynes2022mitochondrialdysfunctionaging pages 1-1): Cole M Haynes and Siegfried Hekimi. Mitochondrial dysfunction, aging, and the mitochondrial unfolded protein response in <i>caenorhabditis elegans</i>. Genetics, Nov 2022. URL: https://doi.org/10.1093/genetics/iyac160, doi:10.1093/genetics/iyac160. This article has 40 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(guerra2023coenzymeqbiochemistry pages 12-14): Rachel M. Guerra and David J. Pagliarini. Coenzyme q biochemistry and biosynthesis. Trends in Biochemical Sciences, 48:463-476, May 2023. URL: https://doi.org/10.1016/j.tibs.2022.12.006, doi:10.1016/j.tibs.2022.12.006. This article has 142 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+</ol>
+<h2 id="artifacts">Artifacts</h2>
+<ul>
+<li><a href="clk-1-deep-research-falcon_artifacts/artifact-00.md">Edison artifact artifact-00</a></li>
+</ul>
+<h2 id="citations">Citations</h2>
+<ol>
+<li>wang2013moleculargeneticsof pages 6-7</li>
+<li>jonassen2001adietarysource pages 5-6</li>
+<li>lionaki2016differentialproteindistribution pages 8-9</li>
+<li>haynes2022mitochondrialdysfunctionaging pages 12-13</li>
+<li>guerra2023coenzymeqbiochemistry pages 1-3</li>
+<li>staiano2023biosynthesisdeficiencyand pages 4-5</li>
+<li>diazcasado2019theparadoxof pages 3-5</li>
+<li>diazcasado2019theparadoxof pages 7-9</li>
+<li>wang2013moleculargeneticsof pages 4-6</li>
+<li>haynes2022mitochondrialdysfunctionaging pages 12-12</li>
+<li>stefely2017biochemistryofmitochondrial pages 21-22</li>
+<li>haynes2022mitochondrialdysfunctionaging pages 1-2</li>
+<li>wang2013moleculargeneticsof pages 12-14</li>
+<li>diessl2022manganesedrivencoqdeficiency pages 3-5</li>
+<li>diessl2022manganesedrivencoqdeficiency pages 1-2</li>
+<li>wang2022predictingandunderstanding pages 34-38</li>
+<li>nicoll2024invitroconstruction pages 1-2</li>
+<li>wang2022predictingandunderstanding pages 38-41</li>
+<li>diessl2022manganesedrivencoqdeficiency pages 5-6</li>
+<li>diessl2022manganesedrivencoqdeficiency pages 2-3</li>
+<li>lionaki2016differentialproteindistribution pages 7-8</li>
+<li>guerra2023coenzymeqbiochemistry pages 3-4</li>
+<li>mattevi2023invitroconstruction pages 1-4</li>
+<li>nicoll2024invitroconstruction pages 8-8</li>
+<li>haynes2022mitochondrialdysfunctionaging pages 1-1</li>
+<li>guerra2023coenzymeqbiochemistry pages 12-14</li>
+<li>https://doi.org/10.3109/10409238.2012.741564,</li>
+<li>https://doi.org/10.1074/jbc.273.6.3351,</li>
+<li>https://doi.org/10.1016/j.tibs.2017.06.008,</li>
+<li>https://doi.org/10.1093/genetics/iyac160,</li>
+<li>https://doi.org/10.1038/s41467-022-33641-x,</li>
+<li>https://doi.org/10.3390/antiox11122308,</li>
+<li>https://doi.org/10.1042/ebc20170106,</li>
+<li>https://doi.org/10.3389/fgene.2016.00162,</li>
+<li>https://doi.org/10.1073/pnas.98.2.421,</li>
+<li>https://doi.org/10.1038/s41929-023-01087-z,</li>
+<li>https://doi.org/10.3390/nu11092221,</li>
+<li>https://doi.org/10.1016/j.tibs.2022.12.006,</li>
+<li>https://doi.org/10.21203/rs.3.rs-2845141/v1,</li>
+<li>https://doi.org/10.3390/antiox12071469,</li>
+</ol>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(clk-1-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="P48376" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="clk-1-coq7-ortholog-research-notes">clk-1 (COQ7 ortholog) — research notes</h1>
+<p>UniProt: P48376 (COQ7_CAEEL). WormBase: WBGene00000536 / ZC395.2. Gene symbol clk-1<br />
+("clock abnormal / clk"). Human ortholog: COQ7. 187 aa precursor with an N-terminal<br />
+mitochondrial transit peptide (1–8) cleaved to a mature 9–187 chain.</p>
+<h2 id="summary-of-what-is-known-with-provenance">Summary of what is KNOWN (with provenance)</h2>
+<h3 id="direct-molecular-function-di-iron-ubiquinonecoq-biosynthetic-monooxygenase">Direct molecular function: di-iron ubiquinone/CoQ biosynthetic monooxygenase</h3>
+<ul>
+<li>clk-1/COQ7 catalyzes the penultimate step of ubiquinone (coenzyme Q) biosynthesis: the<br />
+  hydroxylation of 5-demethoxyubiquinone (DMQ) at the C6 (C5 in some numbering) position,<br />
+  producing 3-demethylubiquinone. EC 1.14.13.253; RHEA:81211. It uses a carboxylate-bridged<br />
+  di-iron center and NAD(P)H (UniProt P48376 CATALYTIC ACTIVITY / COFACTOR: "Binds 2 iron<br />
+  ions per subunit"; FT BINDING residues 30/60/63/112/148/151 to Fe cation).</li>
+<li>The enzyme belongs to the COQ7 family / ferritin-like di-iron superfamily<br />
+  (Pfam PF03232 COQ7; InterPro IPR011566; PANTHER PTHR11237 "COENZYME Q10 BIOSYNTHESIS<br />
+  PROTEIN 7"; HAMAP MF_01658/MF_03194).</li>
+<li>Founding paper established structural + functional conservation of clk-1 as a "timing gene"<br />
+  and did mutagenesis of the catalytic Glu148: <a href="https://pubmed.ncbi.nlm.nih.gov/9020081" title="Structural and functional   conservation of the Caenorhabditis elegans timing gene clk-1">PMID:9020081</a> (Science 1997). (Not in GOA<br />
+  annotation set but is the founding functional reference; cited in UniProt.)</li>
+<li>Biochemical proof that CLK-1 is required for UQ biosynthesis in the worm:<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/11244089" title="clk-1 mutants mitochondria do not contain detectable levels of UQ(9).   Instead, the UQ(9) biosynthesis intermediate, demethoxyubiquinone (DMQ(9)), is present at   high levels. This result demonstrates that CLK-1 is absolutely required for the biosynthesis   of UQ(9) in C. elegans.">PMID:11244089</a> Also: DMQ9 can substitute as an electron carrier —<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/11244089" title="DMQ(2) can act as an electron acceptor for both complex I and complex II in   clk-1 mutant mitochondria">PMID:11244089</a>.</li>
+<li>clk-1 encodes "a hydroxylase involved in the biosynthesis of the redox-active lipid<br />
+  ubiquinone (co-enzyme Q), and in clk-1 mutants, ubiquinone is replaced by its biosynthetic<br />
+  precursor demethoxyubiquinone" <a href="https://pubmed.ncbi.nlm.nih.gov/14517217">PMID:14517217</a>.</li>
+</ul>
+<h3 id="subcellular-location-mitochondrion-inner-membrane-matrix-face">Subcellular location: mitochondrion (inner membrane, matrix face)</h3>
+<ul>
+<li>UniProt SUBCELLULAR LOCATION: "Mitochondrion inner membrane; Peripheral membrane protein;<br />
+  Matrix side" (so a genuine "extrinsic component of mitochondrial inner membrane",<br />
+  GO:0031314, not an integral membrane protein).</li>
+<li>CLK-1-GFP is fully active and localizes to mitochondria of all somatic cells:<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/10202142" title="CLK-1 is fully active when fused to green fluorescent protein and is found   in the mitochondria of all somatic cells.">PMID:10202142</a></li>
+<li>Mitochondrial localization independently observed: <a href="https://pubmed.ncbi.nlm.nih.gov/25961505" title="adult transgenic worms   expressing CLK-1 fused to green fluorescent protein (GFP) also display fluorescence in both   compartments">PMID:25961505</a> (mitochondria and nucleus).</li>
+</ul>
+<h2 id="downstream-mutant-phenotype-non-core-biology">Downstream / mutant-phenotype (NON-CORE) biology</h2>
+<p>The mutant phenotypes are consequences of altered Q/DMQ, not the direct molecular activity.</p>
+<ul>
+<li>Longevity ("Clk" clock phenotype): clk-1 mutations extend lifespan and slow developmental<br />
+  and behavioral rates. <a href="https://pubmed.ncbi.nlm.nih.gov/10202142" title="Mutations in the clk-1 gene ... result in an average   slowing of a variety of developmental and physiological processes, including the cell cycle,   embryogenesis, post-embryonic growth, rhythmic behaviors and aging.">PMID:10202142</a> Overexpression shortens<br />
+  lifespan and accelerates behavior <a href="https://pubmed.ncbi.nlm.nih.gov/10202142" title="Overexpression of CLK-1 activity in   wild-type worms can increase mitochondrial activity, accelerate behavioral rates during aging   and shorten life span">PMID:10202142</a>.</li>
+<li>Lifespan extension by RNAi of UQ-biosynthesis genes incl. clk-1: <a href="https://pubmed.ncbi.nlm.nih.gov/12709403" title="We have   identified by RNA interference (RNAi) eight genes, including clk-1, involved in ubiquinone   biosynthesis in C. elegans ... and extended life span compared with non-interfered animals.">PMID:12709403</a></li>
+<li>Maternal rescue / developmental-timing: <a href="https://pubmed.ncbi.nlm.nih.gov/14517217" title="homozygous clk-1 mutants display a   wild-type phenotype when issued from a heterozygous mother ... increased adult longevity can   be uncoupled from the early mutant phenotypes">PMID:14517217</a>.</li>
+<li>Genetic-interaction lifespan modulation with translation / DR pathways (clk-1 used as a<br />
+  long-lived ETC/"clk" mutant partner): <a href="https://pubmed.ncbi.nlm.nih.gov/17277769" title="lack of IFE-2 enhances the long-lived   phenotype of clk and dietary-restricted eat mutant animals.">PMID:17277769</a>; <a href="https://pubmed.ncbi.nlm.nih.gov/19783783">PMID:19783783</a> (DR / NLP-7,<br />
+  clk-1 as ETC-mutant control; IGI/IMP determination of adult lifespan).</li>
+<li>Oxidative phosphorylation / anesthetic (xenobiotic) sensitivity: complex I–dependent OXPHOS<br />
+  correlates with volatile-anesthetic sensitivity, tested across ETC/CoQ mutants including<br />
+  clk-1: <a href="https://pubmed.ncbi.nlm.nih.gov/16920626" title="a clear correlation between complex I-dependent oxidative   phosphorylation capacity and volatile anesthetic sensitivity.">PMID:16920626</a></li>
+<li>CLK-1 protein level tracks mitochondrial biogenesis; used as a mito marker reduced on hsp-6<br />
+  knockdown: <a href="https://pubmed.ncbi.nlm.nih.gov/17189267" title="Knockdown of HSP-6 by RNA interference in young adult nematodes   caused a reduction in the levels of ATP-2, HSP-60 and CLK-1">PMID:17189267</a>.</li>
+</ul>
+<h2 id="debated-secondary-nuclear-moonlighting-role-treat-cautiously">DEBATED / secondary nuclear moonlighting role — treat cautiously</h2>
+<ul>
+<li>A distinct <strong>nuclear</strong> pool of CLK-1/COQ7 was reported to regulate mitochondrial stress<br />
+  responses and longevity independently of UQ biosynthesis: <a href="https://pubmed.ncbi.nlm.nih.gov/25961505" title="We have uncovered a   distinct nuclear form of CLK-1 that independently regulates lifespan.">PMID:25961505</a>; the nuclear-only,<br />
+  MTS-deleted CLK-1 "localised predominantly to the nucleus" and "CLK-1nuc(+) could not" rescue<br />
+  UQ biosynthesis <a href="https://pubmed.ncbi.nlm.nih.gov/25961505" title="full length CLK-1 was able to rescue ubiquinone biosynthesis   in these worms, however, CLK-1nuc(+) could not">PMID:25961505</a>, yet partially rescued ROS, UPRmt, and<br />
+  longevity phenotypes. Nuclear COQ7 associates with chromatin <a href="https://pubmed.ncbi.nlm.nih.gov/25961505" title="the uncleaved   form of COQ7, but not the R28A mutant, was enriched in the chromatin fraction">PMID:25961505</a> and modulates<br />
+  transcription of ROS/UPRmt genes (sod-2, skn-1, hsp-6, hsp-60, spg-7; human SOD2/NRF2/HMOX1,<br />
+  HSPA9/HSPD1/AFG3L2 etc.). This underlies the WormBase IMP annotations to<br />
+  negative/positive regulation of transcription by RNA Pol II, regulation of ROS metabolic<br />
+  process, and determination of adult lifespan on PMID:25961505.</li>
+<li>An older, isolated in-vitro report: CLK-1 binds the O_L region of <strong>mitochondrial</strong> DNA:<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/11959146" title="C. elegans CLK-1 as well as its mouse homologue have DNA binding activity   that is specific to the O(L) region of mitochondrial DNA.">PMID:11959146</a> This is the basis of the IDA<br />
+  "transcription cis-regulatory region binding" (GO:0000976) annotation. Note the binding is to<br />
+  mtDNA (a replication/transcription origin), a single in-vitro study, not widely replicated —<br />
+  a possible moonlighting activity, not the core enzymatic function.</li>
+</ul>
+<p>Caveat on the nuclear model: the nuclear localization/role is a genuine experimental report<br />
+(Nat Cell Biol 2015) but remains debated in the field; CLK-1's N-terminus and human COQ7's NTS<br />
+are not conserved (<a href="https://pubmed.ncbi.nlm.nih.gov/25961505" title="the N-terminal residues we identified as being critical for nuclear localisation of COQ7 do not appear to be conserved in CLK-1">PMID:25961505</a>), and independent<br />
+confirmation of an endogenous, functionally significant nuclear pool in the worm is limited.</p>
+<h2 id="what-is-not-known-knowledge-gaps">What is NOT known (knowledge gaps)</h2>
+<ol>
+<li><strong>How DMQ-vs-Q levels produce the longevity signal.</strong> clk-1 mutants accumulate DMQ9 and lack<br />
+   UQ9 yet respire near-normally (DMQ9 substitutes as an electron carrier) <a href="https://pubmed.ncbi.nlm.nih.gov/11244089">PMID:11244089</a>, and<br />
+   lifespan extension appears "independent of ubiquinone biosynthesis and ATP production"<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/25961505">PMID:25961505</a>. The mechanistic chain from the specific quinone species (DMQ vs Q, ROS<br />
+   output) to the pro-longevity signal is not established.</li>
+<li><strong>The disputed nuclear/non-mitochondrial role.</strong> Whether an endogenous nuclear CLK-1 pool of<br />
+   physiological significance exists in the worm, how it is targeted (worm N-terminus lacks the<br />
+   COQ7 NTS), whether it binds DNA sequence-specifically, and whether "transcription regulation"<br />
+   is a direct molecular function or an indirect consequence, are unresolved.</li>
+<li><strong>Ontology gap:</strong> CLK-1/COQ7 is described as a component of a multi-subunit COQ enzyme<br />
+   ("CoQ synthome") complex with a structural stabilizing role (UniProt, By similarity), but GO<br />
+   has no "coenzyme Q biosynthesis complex" cellular-component term to capture this membership.</li>
+</ol>
+<h2 id="provenance-note-on-deep-research">Provenance note on deep research</h2>
+<p>Falcon deep research (<code>just deep-research-falcon worm clk-1 --fallback perplexity-lite</code>) took<br />
+~29 min on the congested shared Edison endpoint and the wrapper recipe ultimately reported a<br />
+timeout, but the Edison run did land a real report at the boundary:<br />
+<code>clk-1-deep-research-falcon.md</code> (provider: falcon, model: Edison Scientific Literature,<br />
+cached: false, 40 cited sources). It was verified as genuine and on-target (di-iron DMQ9-&gt;UQ9<br />
+hydroxylase, COQ metabolon/CoQ-synthome membership, debated nuclear moonlighting "requires<br />
+further confirmation", 2,4-DHB bypass showing phenotypes are attributable to UQ deficiency) and<br />
+is committed as corroborating context. The review itself is grounded in the UniProt record, the<br />
+GOA TSV, and the 11 cached primary publications (PMID_9020081, 10202142, 11244089, 11959146,<br />
+12709403, 14517217, 16920626, 17189267, 17277769, 19783783, 25961505); every <code>supporting_text</code><br />
+is a verbatim PMID quote. The falcon file is cited only once (core_functions corroboration) with<br />
+a verbatim quote from the committed file. There are no UNDECIDED calls.</p>
+<h2 id="annotation-review-plan-core-vs-non-core">Annotation-review plan (core vs non-core)</h2>
+<ul>
+<li>CORE (keep, ACCEPT): 3-demethoxyubiquinone 3-hydroxylase (NADH) activity (GO:0160224);<br />
+  ubiquinone biosynthetic process (GO:0006744); mitochondrion (GO:0005739); mitochondrial inner<br />
+  membrane (GO:0005743); extrinsic component of mitochondrial inner membrane (GO:0031314);<br />
+  general MF parents monooxygenase activity (GO:0004497) and oxidoreductase...NAD(P)H one-oxygen<br />
+  (GO:0016709) are correct but less-informative parents — keep, flag as non-core/general.</li>
+<li>NON-CORE (KEEP_AS_NON_CORE): determination of adult lifespan (all evidence); cellular<br />
+  respiration; oxidative phosphorylation; adult behavior; positive regulation of behavior;<br />
+  positive regulation of growth rate; positive regulation of developmental process; response to<br />
+  xenobiotic stimulus; regulation of ROS metabolic process; nucleus (all); neg/pos regulation<br />
+  of transcription by RNA Pol II; transcription cis-regulatory region binding (debated in-vitro<br />
+  mtDNA-binding moonlighting).</li>
+<li>No REMOVE actions: all experimental annotations are defensible; the debated nuclear/DNA<br />
+  functions are experimental (IDA/IMP) so are retained as non-core with caveats rather than<br />
+  removed.<br />
+</content><br />
+</invoke></li>
+</ul>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: P48376
+gene_symbol: clk-1
+product_type: PROTEIN
+status: DRAFT
+taxon:
+  id: NCBITaxon:6239
+  label: Caenorhabditis elegans
+description: &gt;-
+  clk-1 encodes the C. elegans ortholog of COQ7 (human COQ7), a mitochondrial
+  carboxylate-bridged di-iron monooxygenase (hydroxylase) that catalyzes the
+  penultimate step of ubiquinone (coenzyme Q) biosynthesis: hydroxylation of
+  5-demethoxyubiquinone (DMQ) to 3-demethylubiquinone, using NAD(P)H and molecular
+  oxygen (EC 1.14.13.253). The mature protein is a peripheral protein of the inner
+  mitochondrial membrane on the matrix side and acts within the multi-subunit CoQ
+  biosynthetic (COQ) machinery. Loss of clk-1 abolishes synthesis of ubiquinone
+  (UQ9) and causes accumulation of the DMQ9 precursor, which can partially substitute
+  as a respiratory-chain electron carrier. clk-1 is the founding &#34;Clk&#34; (clock)
+  longevity gene: reduction-of-function mutants show an average slowing of
+  developmental, behavioral, respiratory and metabolic rates and a markedly extended
+  lifespan; these organismal phenotypes arise downstream of altered quinone content
+  and mitochondrial reactive-oxygen-species output rather than from the hydroxylation
+  step itself. A distinct, debated nuclear pool of CLK-1/COQ7 has additionally been
+  reported to modulate mitochondrial retrograde stress signalling (the mitochondrial
+  unfolded protein response), ROS-responsive gene expression, and longevity
+  independently of ubiquinone biosynthesis.
+existing_annotations:
+- term:
+    id: GO:0005743
+    label: mitochondrial inner membrane
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: is_active_in
+  review:
+    summary: &gt;-
+      Core localization. CLK-1 is a peripheral inner-mitochondrial-membrane protein
+      (matrix side) where it catalyzes DMQ hydroxylation in CoQ biosynthesis.
+    action: ACCEPT
+    reason: &gt;-
+      Phylogenetic (IBA) placement in the inner mitochondrial membrane is consistent
+      with direct experimental evidence that active CLK-1-GFP is found in worm
+      mitochondria and with UniProt&#39;s peripheral/matrix-side membrane assignment.
+    supported_by:
+    - reference_id: PMID:10202142
+      supporting_text: &gt;-
+        CLK-1 is fully active when fused to green fluorescent protein and is found in
+        the mitochondria of all somatic cells.
+- term:
+    id: GO:0160224
+    label: 3-demethoxyubiquinone 3-hydroxylase (NADH) activity
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Core molecular function: the di-iron ubiquinone/CoQ biosynthetic monooxygenase
+      catalyzing the DMQ to demethylubiquinone hydroxylation.
+    action: ACCEPT
+    reason: &gt;-
+      This is the direct, evolutionarily conserved molecular function of clk-1/COQ7,
+      matching EC 1.14.13.253 and supported experimentally in the worm.
+    supported_by:
+    - reference_id: PMID:14517217
+      supporting_text: &gt;-
+        clk-1 encodes a hydroxylase involved in the biosynthesis of the redox-active
+        lipid ubiquinone (co-enzyme Q), and in clk-1 mutants, ubiquinone is replaced
+        by its biosynthetic precursor demethoxyubiquinone.
+- term:
+    id: GO:0006744
+    label: ubiquinone biosynthetic process
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: involved_in
+  review:
+    summary: Core biological process; the pathway in which the clk-1 hydroxylase acts.
+    action: ACCEPT
+    reason: &gt;-
+      clk-1 is required for ubiquinone biosynthesis; loss abolishes UQ9 and leads to
+      accumulation of the DMQ9 intermediate.
+    supported_by:
+    - reference_id: PMID:11244089
+      supporting_text: &gt;-
+        This result demonstrates that CLK-1 is absolutely required for the
+        biosynthesis of UQ(9) in C. elegans.
+- term:
+    id: GO:2000377
+    label: regulation of reactive oxygen species metabolic process
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Non-core regulatory role tied to the debated nuclear function; clk-1 mutants
+      have altered ROS and a ROS-responsive gene-expression program.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      This IBA propagation reflects the reported nuclear CLK-1/COQ7 role in ROS
+      metabolism rather than the direct hydroxylase activity; retain as a non-core
+      downstream/moonlighting function.
+    supported_by:
+    - reference_id: PMID:25961505
+      supporting_text: &gt;-
+        the pathway regulates both mitochondrial reactive oxygen species metabolism
+        and the mitochondrial unfolded protein response.
+- term:
+    id: GO:0005634
+    label: nucleus
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: is_active_in
+  review:
+    summary: &gt;-
+      Debated secondary nuclear localization propagated by phylogeny; treat as
+      non-core.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      A nuclear pool of CLK-1/COQ7 has been reported (GFP in both compartments), but
+      this localization and its functional significance remain debated; it is not the
+      core mitochondrial site of the enzyme.
+    supported_by:
+    - reference_id: PMID:25961505
+      supporting_text: &gt;-
+        adult transgenic worms expressing CLK-1 fused to green fluorescent protein
+        (GFP) also display fluorescence in both compartments
+- term:
+    id: GO:0008340
+    label: determination of adult lifespan
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Classic longevity phenotype; a downstream organismal consequence of altered
+      quinone content, not the core molecular function.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      clk-1 loss extends lifespan, but this is a pleiotropic downstream effect of
+      reduced ubiquinone/altered mitochondrial metabolism; keep as non-core.
+    supported_by:
+    - reference_id: PMID:10202142
+      supporting_text: &gt;-
+        the reduced respiration of the long-lived clk-1 mutants suggests that
+        longevity is promoted by the age-dependent decrease in mitochondrial function
+- term:
+    id: GO:0004497
+    label: monooxygenase activity
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Correct but general parent of the specific 3-demethoxyubiquinone 3-hydroxylase
+      activity; captures the core monooxygenase function.
+    action: ACCEPT
+    reason: &gt;-
+      InterPro2GO assigns the general monooxygenase parent; it is accurate for the
+      di-iron hydroxylase but less informative than GO:0160224, which is also
+      annotated.
+    supported_by:
+    - reference_id: PMID:14517217
+      supporting_text: &gt;-
+        clk-1 encodes a hydroxylase involved in the biosynthesis of the redox-active
+        lipid ubiquinone (co-enzyme Q)
+- term:
+    id: GO:0005634
+    label: nucleus
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000044
+  qualifier: located_in
+  review:
+    summary: Debated nuclear localization propagated from the UniProt subcellular vocabulary.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      This IEA derives from the UniProt Nucleus subcellular-location term, which is
+      itself based on the single (debated) report of nuclear CLK-1/COQ7; retain as
+      non-core.
+    supported_by:
+    - reference_id: PMID:25961505
+      supporting_text: &gt;-
+        We have uncovered a distinct nuclear form of CLK-1 that independently
+        regulates lifespan.
+- term:
+    id: GO:0005739
+    label: mitochondrion
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000044
+  qualifier: located_in
+  review:
+    summary: Core localization; the enzyme&#39;s primary compartment.
+    action: ACCEPT
+    reason: &gt;-
+      Mitochondrial localization is strongly established experimentally for CLK-1.
+    supported_by:
+    - reference_id: PMID:10202142
+      supporting_text: &gt;-
+        CLK-1 is fully active when fused to green fluorescent protein and is found in
+        the mitochondria of all somatic cells.
+- term:
+    id: GO:0005743
+    label: mitochondrial inner membrane
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000044
+  qualifier: located_in
+  review:
+    summary: Core localization; peripheral inner-membrane, matrix side.
+    action: ACCEPT
+    reason: &gt;-
+      Consistent with UniProt&#39;s inner-membrane (peripheral, matrix-side) assignment
+      and the phylogenetic annotation.
+- term:
+    id: GO:0006744
+    label: ubiquinone biosynthetic process
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000120
+  qualifier: involved_in
+  review:
+    summary: Core biological process (electronic support for the pathway role).
+    action: ACCEPT
+    reason: &gt;-
+      Automated multi-method IEA correctly assigns the ubiquinone biosynthetic
+      process, consistent with experimental evidence.
+    supported_by:
+    - reference_id: PMID:11244089
+      supporting_text: &gt;-
+        This result demonstrates that CLK-1 is absolutely required for the
+        biosynthesis of UQ(9) in C. elegans.
+- term:
+    id: GO:0016709
+    label: oxidoreductase activity, acting on paired donors, with incorporation or
+      reduction of molecular oxygen, NAD(P)H as one donor, and incorporation of one
+      atom of oxygen
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000104
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Correct general MF parent corresponding to the EC 1.14.13 mechanism (NAD(P)H,
+      one oxygen atom incorporated).
+    action: ACCEPT
+    reason: &gt;-
+      Accurately describes the mechanistic class of the clk-1 hydroxylation reaction;
+      less specific than GO:0160224 but not incorrect.
+- term:
+    id: GO:0031314
+    label: extrinsic component of mitochondrial inner membrane
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000104
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Accurate refinement of the localization: CLK-1 is a peripheral (extrinsic)
+      inner-membrane protein on the matrix face.
+    action: ACCEPT
+    reason: &gt;-
+      Matches UniProt&#39;s &#34;Peripheral membrane protein; Matrix side&#34; assignment and is
+      more precise than the plain inner-membrane term.
+- term:
+    id: GO:0160224
+    label: 3-demethoxyubiquinone 3-hydroxylase (NADH) activity
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000120
+  qualifier: enables
+  review:
+    summary: Core molecular function (electronic/RHEA-EC support).
+    action: ACCEPT
+    reason: &gt;-
+      Automated RHEA/EC-based assignment of the specific hydroxylase activity, the
+      direct molecular function of clk-1.
+    supported_by:
+    - reference_id: PMID:11244089
+      supporting_text: &gt;-
+        clk-1 mutants mitochondria do not contain detectable levels of UQ(9).
+        Instead, the UQ(9) biosynthesis intermediate, demethoxyubiquinone (DMQ(9)),
+        is present at high levels.
+- term:
+    id: GO:0000122
+    label: negative regulation of transcription by RNA polymerase II
+  evidence_type: IMP
+  original_reference_id: PMID:25961505
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Non-core, debated nuclear moonlighting function; nuclear CLK-1 suppresses a
+      subset of ROS/UPRmt genes.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Based on the reported nuclear role in which CLK-1 abrogates the elevated
+      transcript levels of stress genes in clk-1 null worms. This is an experimental
+      IMP but reflects a debated non-mitochondrial activity; retain as non-core.
+    supported_by:
+    - reference_id: PMID:25961505
+      supporting_text: &gt;-
+        The expression of nuclear CLK-1 in clk-1 null worms abrogated the increased
+        transcript levels of these genes
+- term:
+    id: GO:0045944
+    label: positive regulation of transcription by RNA polymerase II
+  evidence_type: IMP
+  original_reference_id: PMID:25961505
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Non-core, debated nuclear moonlighting function; nuclear CLK-1 promotes
+      expression of some target genes (e.g. glna-1/GLS2).
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Same nuclear study: loss of nuclear CLK-1/COQ7 decreases glna-1/GLS2
+      expression, which is rescued by nuclear CLK-1. Experimental IMP but a debated
+      non-core function.
+    supported_by:
+    - reference_id: PMID:25961505
+      supporting_text: &gt;-
+        glna-1 transcript levels were decreased compared to wild type animals, an
+        effect that was rescued in the presence of CLK-1nuc(+)
+- term:
+    id: GO:0008340
+    label: determination of adult lifespan
+  evidence_type: IMP
+  original_reference_id: PMID:17277769
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Longevity phenotype; clk mutants used in a genetic study of translation and
+      ageing. Downstream/non-core.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Supports clk-1&#39;s role in lifespan determination as a pleiotropic downstream
+      effect. The cached abstract names &#34;clk&#34; mutants; the curator read the full text.
+    supported_by:
+    - reference_id: PMID:17277769
+      supporting_text: &gt;-
+        lack of IFE-2 enhances the long-lived phenotype of clk and dietary-restricted
+        eat mutant animals.
+- term:
+    id: GO:0008340
+    label: determination of adult lifespan
+  evidence_type: IGI
+  original_reference_id: PMID:17277769
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Genetic-interaction evidence for the longevity phenotype (with ife-2).
+      Downstream/non-core.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      IGI supporting the pleiotropic lifespan role; a non-core organismal phenotype.
+    supported_by:
+    - reference_id: PMID:17277769
+      supporting_text: &gt;-
+        lack of IFE-2 enhances the long-lived phenotype of clk and dietary-restricted
+        eat mutant animals.
+- term:
+    id: GO:0008340
+    label: determination of adult lifespan
+  evidence_type: IGI
+  original_reference_id: PMID:19783783
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Genetic-interaction lifespan evidence (electron-transport-chain longevity
+      pathway). Downstream/non-core.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      The cached abstract discusses long-lived electron-transport-chain mutants
+      rather than naming clk-1 explicitly; the full-text curator classed clk-1 in
+      this group. clk-1&#39;s lifespan role is well established, so retain as non-core
+      rather than remove.
+    supported_by:
+    - reference_id: PMID:19783783
+      supporting_text: &gt;-
+        has no effect on the life span of long-lived mutants resulting from reduced
+        insulin/IGF-1 signaling or dysfunction of the mitochondrial electron
+        transport chain.
+- term:
+    id: GO:0008340
+    label: determination of adult lifespan
+  evidence_type: IMP
+  original_reference_id: PMID:19783783
+  qualifier: involved_in
+  review:
+    summary: Longevity phenotype (mutant); downstream/non-core.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      IMP for the pleiotropic lifespan phenotype; retain as a non-core downstream
+      effect of altered mitochondrial quinone metabolism.
+    supported_by:
+    - reference_id: PMID:19783783
+      supporting_text: &gt;-
+        has no effect on the life span of long-lived mutants resulting from reduced
+        insulin/IGF-1 signaling or dysfunction of the mitochondrial electron
+        transport chain.
+- term:
+    id: GO:0005634
+    label: nucleus
+  evidence_type: IDA
+  original_reference_id: PMID:25961505
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Direct (GFP/immunostaining) evidence for a nuclear pool of CLK-1/COQ7; a
+      debated secondary localization, kept as non-core.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Genuine experimental IDA (CLK-1-GFP in both compartments; endogenous COQ7 in
+      nuclei), but the endogenous, physiologically significant nuclear pool remains
+      debated and is not the core enzymatic site. Per curation guidance the
+      experimental annotation is retained (not removed), marked non-core.
+    supported_by:
+    - reference_id: PMID:25961505
+      supporting_text: &gt;-
+        adult transgenic worms expressing CLK-1 fused to green fluorescent protein
+        (GFP) also display fluorescence in both compartments
+- term:
+    id: GO:0005739
+    label: mitochondrion
+  evidence_type: IDA
+  original_reference_id: PMID:25961505
+  qualifier: located_in
+  review:
+    summary: Core localization; direct evidence for mitochondrial CLK-1.
+    action: ACCEPT
+    reason: &gt;-
+      Direct imaging shows CLK-1-GFP in mitochondria (and nucleus); mitochondrion is
+      the primary/core site of the enzyme.
+    supported_by:
+    - reference_id: PMID:25961505
+      supporting_text: &gt;-
+        adult transgenic worms expressing CLK-1 fused to green fluorescent protein
+        (GFP) also display fluorescence in both compartments
+- term:
+    id: GO:0006744
+    label: ubiquinone biosynthetic process
+  evidence_type: IMP
+  original_reference_id: PMID:25961505
+  qualifier: involved_in
+  review:
+    summary: Core biological process; full-length CLK-1 rescues UQ biosynthesis.
+    action: ACCEPT
+    reason: &gt;-
+      This study confirms the mitochondrial CLK-1 requirement for ubiquinone
+      biosynthesis (full-length, but not nuclear-only, CLK-1 rescues UQ).
+    supported_by:
+    - reference_id: PMID:25961505
+      supporting_text: &gt;-
+        full length CLK-1 was able to rescue ubiquinone biosynthesis in these worms,
+        however, CLK-1nuc(+) could not
+- term:
+    id: GO:0008340
+    label: determination of adult lifespan
+  evidence_type: IMP
+  original_reference_id: PMID:25961505
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Longevity phenotype; here attributed partly to the debated nuclear CLK-1 pool.
+      Downstream/non-core.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      clk-1 modulates lifespan; this study assigns part of that effect to nuclear
+      CLK-1 independent of ubiquinone. A non-core downstream/moonlighting phenotype.
+    supported_by:
+    - reference_id: PMID:25961505
+      supporting_text: &gt;-
+        the expression of CLK-1nuc(+) in clk-1 null worms caused a decrease in their
+        enhanced longevity phenotype
+- term:
+    id: GO:2000377
+    label: regulation of reactive oxygen species metabolic process
+  evidence_type: IMP
+  original_reference_id: PMID:25961505
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Non-core regulatory role; nuclear CLK-1 modulates cellular ROS levels and
+      ROS-responsive gene expression.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Experimental IMP for ROS regulation via the debated nuclear pathway; a
+      downstream/moonlighting function rather than the direct hydroxylase activity.
+    supported_by:
+    - reference_id: PMID:25961505
+      supporting_text: &gt;-
+        Expression of CLK-1nuc(+) in clk-1 null worms partially rescued the increased
+        ROS levels observed in these animals
+- term:
+    id: GO:0000976
+    label: transcription cis-regulatory region binding
+  evidence_type: IDA
+  original_reference_id: PMID:11959146
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Isolated in-vitro report that CLK-1 binds the O_L region of mitochondrial DNA;
+      a debated possible moonlighting activity, kept as non-core.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      The single (2002) in-vitro study shows sequence-specific binding to the
+      mitochondrial-DNA O_L region, not a nuclear cis-regulatory region; it is not
+      widely replicated and is unrelated to the core hydroxylase function. As an
+      experimental IDA it is retained rather than removed, but flagged as a debated,
+      possibly over-annotated moonlighting activity.
+    supported_by:
+    - reference_id: PMID:11959146
+      supporting_text: &gt;-
+        C. elegans CLK-1 as well as its mouse homologue have DNA binding activity
+        that is specific to the O(L) region of mitochondrial DNA.
+- term:
+    id: GO:0005739
+    label: mitochondrion
+  evidence_type: IDA
+  original_reference_id: PMID:17189267
+  qualifier: located_in
+  review:
+    summary: Core localization; CLK-1 treated as a mitochondrial protein.
+    action: ACCEPT
+    reason: &gt;-
+      This study monitors CLK-1 as a mitochondrial protein whose levels drop upon
+      hsp-6 (mtHSP70) knockdown, consistent with mitochondrial localization.
+    supported_by:
+    - reference_id: PMID:17189267
+      supporting_text: &gt;-
+        Knockdown of HSP-6 by RNA interference in young adult nematodes caused a
+        reduction in the levels of ATP-2, HSP-60 and CLK-1
+- term:
+    id: GO:0006744
+    label: ubiquinone biosynthetic process
+  evidence_type: IMP
+  original_reference_id: PMID:14517217
+  qualifier: involved_in
+  review:
+    summary: Core biological process; clk-1 hydroxylase required for UQ, replaced by DMQ in mutants.
+    action: ACCEPT
+    reason: &gt;-
+      Directly supports the ubiquinone biosynthetic role; in clk-1 mutants UQ is
+      replaced by the DMQ precursor.
+    supported_by:
+    - reference_id: PMID:14517217
+      supporting_text: &gt;-
+        clk-1 encodes a hydroxylase involved in the biosynthesis of the redox-active
+        lipid ubiquinone (co-enzyme Q), and in clk-1 mutants, ubiquinone is replaced
+        by its biosynthetic precursor demethoxyubiquinone.
+- term:
+    id: GO:0008340
+    label: determination of adult lifespan
+  evidence_type: IMP
+  original_reference_id: PMID:14517217
+  qualifier: involved_in
+  review:
+    summary: Longevity/developmental-timing phenotype; downstream/non-core.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Supports the pleiotropic ageing phenotype; a downstream consequence of altered
+      quinone metabolism, not the core function.
+    supported_by:
+    - reference_id: PMID:14517217
+      supporting_text: &gt;-
+        The clk-1 mutants of Caenorhabditis elegans display an average slowing down
+        of physiological rates, including those of development, various behaviors, and
+        aging.
+- term:
+    id: GO:0008340
+    label: determination of adult lifespan
+  evidence_type: IGI
+  original_reference_id: PMID:14517217
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Genetic interaction with daf-2 for lifespan; downstream/non-core longevity
+      phenotype.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      The daf-2 clk-1 double-mutant synergy underlies this IGI; a non-core
+      organismal longevity phenotype.
+    supported_by:
+    - reference_id: PMID:14517217
+      supporting_text: &gt;-
+        the very long lifespan observed in daf-2 clk-1 double mutants is not
+        abolished by the maternal effect
+- term:
+    id: GO:0040010
+    label: positive regulation of growth rate
+  evidence_type: IMP
+  original_reference_id: PMID:14517217
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Developmental-timing/growth-rate phenotype (the &#34;Clk&#34; slowing); downstream and
+      non-core.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      clk-1 loss slows post-embryonic growth and development; a pleiotropic timing
+      phenotype rather than the direct molecular function.
+    supported_by:
+    - reference_id: PMID:14517217
+      supporting_text: &gt;-
+        The clk-1 mutants of Caenorhabditis elegans display an average slowing down
+        of physiological rates, including those of development, various behaviors, and
+        aging.
+- term:
+    id: GO:0048520
+    label: positive regulation of behavior
+  evidence_type: IMP
+  original_reference_id: PMID:14517217
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Behavioral-rate (&#34;clock&#34;) phenotype (e.g. defecation/pumping rhythms);
+      downstream/non-core.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Slowed rhythmic behaviors are a hallmark Clk phenotype but a downstream
+      consequence of altered mitochondrial metabolism.
+    supported_by:
+    - reference_id: PMID:14517217
+      supporting_text: &gt;-
+        The clk-1 mutants of Caenorhabditis elegans display an average slowing down
+        of physiological rates, including those of development, various behaviors, and
+        aging.
+- term:
+    id: GO:0051094
+    label: positive regulation of developmental process
+  evidence_type: IMP
+  original_reference_id: PMID:14517217
+  qualifier: involved_in
+  review:
+    summary: Developmental-timing phenotype; downstream/non-core.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      clk-1 loss slows embryonic and post-embryonic development; a pleiotropic timing
+      phenotype, not the core function.
+    supported_by:
+    - reference_id: PMID:14517217
+      supporting_text: &gt;-
+        The clk-1 mutants of Caenorhabditis elegans display an average slowing down
+        of physiological rates, including those of development, various behaviors, and
+        aging.
+- term:
+    id: GO:0006119
+    label: oxidative phosphorylation
+  evidence_type: IMP
+  original_reference_id: PMID:16920626
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Non-core; clk-1 mutation alters respiratory-chain (OXPHOS) function via changed
+      quinone content.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      OXPHOS effects are a downstream consequence of DMQ-for-UQ substitution at the
+      respiratory chain, not a direct clk-1 molecular function.
+    supported_by:
+    - reference_id: PMID:16920626
+      supporting_text: &gt;-
+        a clear correlation between complex I-dependent oxidative phosphorylation
+        capacity and volatile anesthetic sensitivity.
+- term:
+    id: GO:0009410
+    label: response to xenobiotic stimulus
+  evidence_type: IMP
+  original_reference_id: PMID:16920626
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Altered volatile-anesthetic (xenobiotic) sensitivity of the mutant; an indirect
+      downstream phenotype, non-core.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      The anesthetic-sensitivity phenotype arises indirectly from altered complex-I/
+      OXPHOS function in quinone-pathway mutants; a distal phenotype rather than a
+      direct clk-1 function (borderline over-annotation), kept as non-core.
+    supported_by:
+    - reference_id: PMID:16920626
+      supporting_text: &gt;-
+        a clear correlation between complex I-dependent oxidative phosphorylation
+        capacity and volatile anesthetic sensitivity.
+- term:
+    id: GO:0005739
+    label: mitochondrion
+  evidence_type: IDA
+  original_reference_id: PMID:10202142
+  qualifier: located_in
+  review:
+    summary: Core localization; direct evidence that active CLK-1-GFP is mitochondrial.
+    action: ACCEPT
+    reason: &gt;-
+      Foundational direct evidence for mitochondrial localization of functional CLK-1.
+    supported_by:
+    - reference_id: PMID:10202142
+      supporting_text: &gt;-
+        CLK-1 is fully active when fused to green fluorescent protein and is found in
+        the mitochondria of all somatic cells.
+- term:
+    id: GO:0006744
+    label: ubiquinone biosynthetic process
+  evidence_type: IDA
+  original_reference_id: PMID:11244089
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Core biological process; biochemical demonstration that CLK-1 is required for
+      UQ9 synthesis (DMQ9 accumulates in mutants).
+    action: ACCEPT
+    reason: &gt;-
+      Strong direct biochemical evidence for the ubiquinone biosynthetic role.
+    supported_by:
+    - reference_id: PMID:11244089
+      supporting_text: &gt;-
+        clk-1 mutants mitochondria do not contain detectable levels of UQ(9).
+        Instead, the UQ(9) biosynthesis intermediate, demethoxyubiquinone (DMQ(9)),
+        is present at high levels.
+- term:
+    id: GO:0006744
+    label: ubiquinone biosynthetic process
+  evidence_type: IMP
+  original_reference_id: PMID:12709403
+  qualifier: involved_in
+  review:
+    summary: Core biological process; RNAi of clk-1 (with other COQ genes) reduces Q and extends lifespan.
+    action: ACCEPT
+    reason: &gt;-
+      RNAi phenotype confirms clk-1&#39;s role in ubiquinone biosynthesis.
+    supported_by:
+    - reference_id: PMID:12709403
+      supporting_text: &gt;-
+        We have identified by RNA interference (RNAi) eight genes, including clk-1,
+        involved in ubiquinone biosynthesis in C. elegans
+- term:
+    id: GO:0008340
+    label: determination of adult lifespan
+  evidence_type: IMP
+  original_reference_id: PMID:10202142
+  qualifier: involved_in
+  review:
+    summary: Longevity phenotype (foundational); downstream/non-core.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Foundational demonstration that clk-1 controls aging; a pleiotropic downstream
+      phenotype rather than the core molecular function.
+    supported_by:
+    - reference_id: PMID:10202142
+      supporting_text: &gt;-
+        Overexpression of CLK-1 activity in wild-type worms can increase
+        mitochondrial activity, accelerate behavioral rates during aging and shorten
+        life span
+- term:
+    id: GO:0030534
+    label: adult behavior
+  evidence_type: IMP
+  original_reference_id: PMID:10202142
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Rhythmic adult-behavior (&#34;clock&#34;) phenotype; downstream/non-core.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      The slowed rhythmic behaviors of clk-1 mutants are a downstream Clk phenotype,
+      not the direct function.
+    supported_by:
+    - reference_id: PMID:10202142
+      supporting_text: &gt;-
+        Mutations in the clk-1 gene of the nematode Caenorhabditis elegans result in
+        an average slowing of a variety of developmental and physiological processes,
+        including the cell cycle, embryogenesis, post-embryonic growth, rhythmic
+        behaviors and aging.
+- term:
+    id: GO:0045333
+    label: cellular respiration
+  evidence_type: TAS
+  original_reference_id: PMID:10202142
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      clk-1 controls respiration via its role in ubiquinone supply; a
+      closely-linked but downstream process, non-core.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Respiration is affected because ubiquinone (or the DMQ surrogate) feeds the
+      electron transport chain; this is a consequence of the biosynthetic function
+      rather than the molecular function itself.
+    supported_by:
+    - reference_id: PMID:10202142
+      supporting_text: &gt;-
+        the reduced respiration of the long-lived clk-1 mutants
+core_functions:
+- description: &gt;-
+    Mitochondrial di-iron ubiquinone (coenzyme Q) biosynthetic monooxygenase. CLK-1
+    (COQ7 ortholog) uses a carboxylate-bridged di-iron center and NAD(P)H to
+    hydroxylate 5-demethoxyubiquinone (DMQ) to 3-demethylubiquinone, the penultimate
+    step of ubiquinone biosynthesis, acting as a peripheral protein on the matrix
+    face of the inner mitochondrial membrane. Loss of this activity abolishes UQ9
+    and causes DMQ9 accumulation.
+  molecular_function:
+    id: GO:0160224
+    label: 3-demethoxyubiquinone 3-hydroxylase (NADH) activity
+  directly_involved_in:
+  - id: GO:0006744
+    label: ubiquinone biosynthetic process
+  locations:
+  - id: GO:0005743
+    label: mitochondrial inner membrane
+  - id: GO:0005739
+    label: mitochondrion
+  supported_by:
+  - reference_id: PMID:11244089
+    supporting_text: &gt;-
+      This result demonstrates that CLK-1 is absolutely required for the biosynthesis
+      of UQ(9) in C. elegans.
+  - reference_id: PMID:14517217
+    supporting_text: &gt;-
+      clk-1 encodes a hydroxylase involved in the biosynthesis of the redox-active
+      lipid ubiquinone (co-enzyme Q), and in clk-1 mutants, ubiquinone is replaced by
+      its biosynthetic precursor demethoxyubiquinone.
+  - reference_id: PMID:9020081
+    supporting_text: &gt;-
+      clk-1 complemented the phenotype of cat5/coq7 null mutants, demonstrating that
+      clk-1 and CAT5/COQ7 share biochemical function
+  - reference_id: file:worm/clk-1/clk-1-deep-research-falcon.md
+    supporting_text: &gt;-
+      CLK-1 (UniProt P48376) is a mitochondrial diiron carboxylate hydroxylase that
+      catalyzes the C5 hydroxylation of DMQ9 to produce UQ9, the penultimate step in
+      coenzyme Q biosynthesis.
+knowledge_gaps:
+- gap_statement: &gt;-
+    How the quinone change in clk-1 mutants (loss of ubiquinone UQ9, accumulation of
+    the DMQ9 precursor) is transduced into the pro-longevity signal is undetermined:
+    it is unclear whether the signal comes from DMQ itself, from altered
+    respiratory-chain electron flow, from changed mitochondrial ROS output, or from a
+    ubiquinone-independent route, and which of these is causal for lifespan extension.
+  boundary: &gt;-
+    It is firmly established that CLK-1 catalyzes DMQ hydroxylation in ubiquinone
+    biosynthesis, that clk-1 nulls lack UQ9 and accumulate DMQ9, that DMQ9 can
+    partially substitute as a respiratory-chain electron carrier, and that clk-1 loss
+    extends lifespan. The mechanistic link between the specific quinone species and
+    the longevity output is what remains open.
+  gap_kind:
+  - BIOLOGY
+  dark_aspect: BP_DARK
+  status: OPEN
+  significance: &gt;-
+    clk-1 is a flagship mitochondrial-longevity (&#34;Clk&#34;) gene; resolving how quinone
+    identity sets lifespan would clarify a central, conserved model of how
+    mitochondrial metabolism controls ageing.
+  resolution: &gt;-
+    Uncouple the candidate signals experimentally (e.g. dietary UQ rescue vs DMQ
+    supplementation; quinone-pool and ROS measurements combined with lifespan) to
+    establish which change is causal.
+  provenance:
+  - reference_id: PMID:11244089
+    supporting_text: &gt;-
+      it has not been possible to identify biochemical changes that might underlie
+      the extension of life span observed in clk-1 mutants, and therefore the function
+      of CLK-1 in C. elegans remains unknown.
+  - reference_id: PMID:25961505
+    supporting_text: &gt;-
+      extended lifespans through a pathway that appears to be independent of
+      ubiquinone biosynthesis and ATP production
+- gap_statement: &gt;-
+    Whether CLK-1 has a genuine, physiologically significant non-mitochondrial
+    (nuclear) function in C. elegans is unresolved: how a nuclear pool is targeted
+    (the worm N-terminus lacks the COQ7 nuclear-targeting residues), whether it binds
+    DNA sequence-specifically, and whether its effect on transcription of ROS/UPRmt
+    genes is a direct molecular activity or an indirect consequence, remain open and
+    debated.
+  boundary: &gt;-
+    A nuclear pool of CLK-1/COQ7 and a ubiquinone-independent effect on ROS
+    metabolism, the mitochondrial unfolded protein response, and longevity have been
+    reported (Nat Cell Biol 2015), and an older in-vitro study reports CLK-1 binding
+    the O_L region of mitochondrial DNA. What is unresolved is the mechanism,
+    endogenous relevance, and reproducibility of a nuclear/DNA-associated role.
+  gap_kind:
+  - BIOLOGY
+  dark_aspect: MF_DARK
+  status: OPEN
+  significance: &gt;-
+    If real, a moonlighting nuclear/retrograde-signalling function would redefine
+    CLK-1/COQ7 beyond a metabolic enzyme; if not, several transcription/ROS
+    annotations rest on a contested model.
+  resolution: &gt;-
+    Independent replication with endogenous, tagged CLK-1 (localization, ChIP, and
+    separation-of-function alleles that disable nuclear but not mitochondrial CLK-1)
+    in the worm.
+  provenance:
+  - reference_id: PMID:25961505
+    supporting_text: &gt;-
+      the N-terminal residues we identified as being critical for nuclear
+      localisation of COQ7 do not appear to be conserved in CLK-1
+  - reference_id: PMID:11959146
+    supporting_text: &gt;-
+      in addition to its enzymatic function in ubiquinone biosynthesis, CLK-1 is
+      involved in the regulation of mtDNA replication or transcription.
+- gap_statement: &gt;-
+    There is no Gene Ontology cellular-component term for the multi-subunit
+    ubiquinone-biosynthetic (COQ) complex (&#34;CoQ synthome&#34;) of which CLK-1/COQ7 is a
+    component and which it is proposed to structurally stabilize, so this membership
+    cannot be expressed as a GO annotation.
+  boundary: &gt;-
+    CLK-1/COQ7 is described (by similarity to characterized orthologs) as part of a
+    multi-subunit COQ enzyme complex with a structural stabilizing role, but GO
+    provides only the ubiquinone biosynthetic process and membrane-location terms,
+    not a complex term.
+  gap_kind:
+  - ONTOLOGY
+  dark_aspect: CC_DARK
+  status: OPEN
+  significance: &gt;-
+    Capturing COQ-complex membership would let curation record the structural role of
+    COQ7 family members alongside their catalytic activity.
+  resolution: &gt;-
+    Add a &#34;coenzyme Q biosynthesis complex&#34; (or &#34;CoQ synthome&#34;) cellular-component
+    term to GO.
+  proposed_terms:
+  - proposed_name: coenzyme Q biosynthesis complex
+    proposed_definition: &gt;-
+      A protein-containing complex, located at the matrix face of the inner
+      mitochondrial membrane, that carries out the later membrane-associated steps of
+      ubiquinone (coenzyme Q) biosynthesis; in eukaryotes it comprises multiple COQ
+      polypeptides (including the COQ7/CLK-1 hydroxylase) that are mutually stabilizing.
+    proposed_parent:
+      id: GO:0032991
+      label: protein-containing complex
+proposed_new_terms:
+- proposed_name: coenzyme Q biosynthesis complex
+  proposed_definition: &gt;-
+    A protein-containing complex, located at the matrix face of the inner
+    mitochondrial membrane, that carries out the later membrane-associated steps of
+    ubiquinone (coenzyme Q) biosynthesis; in eukaryotes it comprises multiple COQ
+    polypeptides (including the COQ7/CLK-1 hydroxylase) that are mutually stabilizing.
+  justification: &gt;-
+    CLK-1/COQ7 and its orthologs function within, and structurally stabilize, a
+    multi-subunit CoQ biosynthetic complex, but GO has no cellular-component term for
+    this complex.
+  proposed_parent:
+    id: GO:0032991
+    label: protein-containing complex
+suggested_questions:
+- question: &gt;-
+    Is the pro-longevity signal in clk-1 mutants driven by the accumulated DMQ
+    species, by lowered ubiquinone, or by an altered ROS output, and are these
+    separable?
+- question: &gt;-
+    Does an endogenous nuclear pool of CLK-1 exist at physiologically relevant levels
+    in C. elegans, and if so how is it targeted given the non-conserved N-terminus?
+suggested_experiments:
+- hypothesis: &gt;-
+    The longevity of clk-1 mutants is set by the quinone species/ROS output rather
+    than by ATP-level respiratory deficiency.
+  description: &gt;-
+    Rescue clk-1 nulls with graded dietary ubiquinone versus DMQ analogs while
+    measuring quinone pools, mitochondrial ROS, respiration, and lifespan, to
+    determine which change is causal for lifespan extension.
+  experiment_type: metabolite-rescue and phenotype assay
+- hypothesis: &gt;-
+    CLK-1 has a separable nuclear function distinct from its mitochondrial hydroxylase
+    activity.
+  description: &gt;-
+    Use endogenously tagged CLK-1 and separation-of-function alleles (nuclear-
+    targeting-impaired vs catalytically-dead) with imaging, subcellular
+    fractionation, and ChIP to test for a reproducible, sequence-specific nuclear/
+    chromatin role in the worm.
+  experiment_type: genetics and localization
+references:
+- id: GO_REF:0000002
+  title: Gene Ontology annotation through association of InterPro records with GO
+    terms
+  findings: []
+- id: GO_REF:0000033
+  title: Annotation inferences using phylogenetic trees
+  findings: []
+- id: GO_REF:0000044
+  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location
+    vocabulary mapping, accompanied by conservative changes to GO terms applied by
+    UniProt
+  findings: []
+- id: GO_REF:0000104
+  title: Electronic Gene Ontology annotations created by transferring manual GO annotations
+    between related proteins based on shared sequence features
+  findings: []
+- id: GO_REF:0000120
+  title: Combined Automated Annotation using Multiple IEA Methods
+  findings: []
+- id: PMID:9020081
+  title: Structural and functional conservation of the Caenorhabditis elegans timing
+    gene clk-1.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Founding paper: cloned clk-1, showed conservation to yeast Cat5p/Coq7p, and
+      demonstrated shared biochemical function by cross-complementation. PubMed
+      title-verified; supports the core CoQ7-family molecular function.
+- id: PMID:10202142
+  title: CLK-1 controls respiration, behavior and aging in the nematode Caenorhabditis
+    elegans.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Direct evidence that active CLK-1-GFP localizes to mitochondria; establishes
+      the respiration/behavior/aging phenotypes. Title-verified.
+- id: PMID:11244089
+  title: Altered quinone biosynthesis in the long-lived clk-1 mutants of Caenorhabditis
+    elegans.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Biochemical proof that clk-1 is required for UQ9 synthesis and that DMQ9
+      accumulates and can substitute as an electron carrier; anchors the DMQ-vs-Q
+      knowledge gap. Title-verified.
+- id: PMID:11959146
+  title: CLK-1 protein has DNA binding activity specific to O(L) region of mitochondrial
+    DNA.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: LOW_QUALITY
+    review_notes: &gt;-
+      Correctly cited but an isolated 2002 in-vitro study of mtDNA (O_L) binding, not
+      widely replicated; basis for the debated transcription cis-regulatory region
+      binding annotation. Treated as a possible moonlighting activity, non-core.
+- id: PMID:12709403
+  title: Silencing of ubiquinone biosynthesis genes extends life span in Caenorhabditis
+    elegans.
+  findings: []
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: &gt;-
+      RNAi of clk-1 (among eight CoQ genes) lowers quinone and extends lifespan;
+      supports the ubiquinone biosynthetic role. Title-verified.
+- id: PMID:14517217
+  title: Molecular mechanism of maternal rescue in the clk-1 mutants of Caenorhabditis
+    elegans.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      clk-1 encodes the UQ-biosynthesis hydroxylase; UQ replaced by DMQ in mutants;
+      establishes maternal rescue and uncoupling of longevity from developmental
+      phenotypes. Title-verified.
+- id: PMID:16920626
+  title: Mitochondrial complex I function modulates volatile anesthetic sensitivity
+    in C. elegans.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: &gt;-
+      clk-1 is one of several ETC/CoQ mutants tested; supports the indirect OXPHOS/
+      anesthetic-sensitivity (xenobiotic-response) annotations as downstream effects.
+- id: PMID:17189267
+  title: Knockdown of mitochondrial heat shock protein 70 promotes progeria-like phenotypes
+    in caenorhabditis elegans.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Uses CLK-1 as a mitochondrial protein whose level falls with hsp-6 knockdown;
+      supports mitochondrial localization only.
+- id: PMID:17277769
+  title: eIF4E function in somatic cells modulates ageing in Caenorhabditis elegans.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: &gt;-
+      clk mutants used as long-lived partners in a translation/ageing study; supports
+      the non-core lifespan-determination annotations.
+- id: PMID:19783783
+  title: Life-span extension by dietary restriction is mediated by NLP-7 signaling
+    and coelomocyte endocytosis in C. elegans.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Cached abstract discusses long-lived electron-transport-chain mutants without
+      naming clk-1; full-text curator classed clk-1 in this group. Supports the
+      non-core lifespan annotations; not removed on abstract-only grounds.
+- id: PMID:25961505
+  title: A nuclear role for the respiratory enzyme CLK-1 in regulating mitochondrial
+    stress responses and longevity.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: DISPUTED
+    review_notes: &gt;-
+      Full-text primary paper reporting a distinct nuclear CLK-1/COQ7 pool that
+      regulates ROS metabolism, the UPRmt, transcription, and longevity independently
+      of ubiquinone. The data are genuine but the nuclear/non-mitochondrial model is
+      debated (worm N-terminus lacks the COQ7 NTS; limited independent confirmation).
+      Underlies the nucleus, ROS-regulation, and transcription-regulation annotations,
+      which are retained as non-core.
+- id: file:worm/clk-1/clk-1-deep-research-falcon.md
+  title: &#34;Deep research report (Edison/falcon): C. elegans CLK-1 (COQ7)&#34;
+  reference_review:
+    relevance: MEDIUM
+    correctness: UNVERIFIED
+    review_notes: &gt;-
+      AI-generated Edison/falcon deep-research synthesis (40 cited sources) used only
+      as corroborating context. It independently reproduces the di-iron DMQ9-&gt;UQ9
+      hydroxylase function, the COQ metabolon/CoQ-synthome membership, and the debated
+      (explicitly unconfirmed) nuclear moonlighting role. Its underlying citations were
+      not individually verified, so it is marked UNVERIFIED; every review claim is
+      anchored to cached primary PMIDs, not to this file.
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/genes/worm/tax-2/tax-2-ai-review.html
+++ b/genes/worm/tax-2/tax-2-ai-review.html
@@ -1,0 +1,4961 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>tax-2 - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        .propagation-review {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f8fafc;
+            border-left: 3px solid #64748b;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .propagation-title {
+            font-weight: 600;
+            color: #334155;
+            margin-bottom: 0.25rem;
+        }
+
+        .propagation-row {
+            margin-top: 0.25rem;
+        }
+
+        .propagation-source {
+            margin-top: 0.5rem;
+            padding-top: 0.5rem;
+            border-top: 1px solid #e5e7eb;
+        }
+
+        .propagation-source-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #1d4ed8;
+        }
+
+        .propagation-comment {
+            color: #4b5563;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>tax-2</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/G5EEE2" target="_blank" class="term-link">
+                        G5EEE2
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Caenorhabditis elegans</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-complete">
+                    COMPLETE
+                </span>
+            </div>
+
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "tax-2";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="G5EEE2" data-a="DESCRIPTION: tax-2 encodes the modulatory beta subunit of a cyc..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>tax-2 encodes the modulatory beta subunit of a cyclic nucleotide-gated (CNG) cation channel, the C. elegans ortholog of vertebrate CNGB subunits. TAX-2 cannot form a functional channel on its own; in vivo it co-assembles with the alpha (principal, pore-forming) subunit TAX-4 to build the native sensory CNG channel, a heteromer that is opened directly by intracellular cGMP and conducts Ca2+, Na+ and K+ across the membrane. As a beta subunit TAX-2 tunes rather than solely forms the pore: the TAX-4/TAX-2 heteromer is markedly (about 25-fold) less cGMP-sensitive than the TAX-4 homomer while remaining highly selective for cGMP over cAMP, and the two forms differ in divalent-cation block and single-channel behavior. TAX-2 harbors a pore/ion-transport domain and a C-terminal cyclic-nucleotide-binding domain, and is targeted, together with TAX-4, to the plasma membrane and to specific subcompartments of the non-motile sensory cilia of ciliated neurons, where their ciliary localization is mutually interdependent. As part of the effector channel of cGMP-mediated sensory signal transduction, TAX-2 is required for a broad range of sensory modalities, including chemosensation and chemotaxis, thermosensation, oxygen sensing and aerotaxis, and light responses; channel activity also feeds into downstream outputs such as sensory-neuron gene expression and the maintenance of sensory axon structure.</p>
+    </div>
+
+
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005886" target="_blank" class="term-link">
+                                    GO:0005886
+                                </a>
+                            </span>
+                            <span class="term-label">plasma membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="G5EEE2" data-a="GO:0005886" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> The TAX-2/TAX-4 CNG channel acts at the plasma membrane of ciliated sensory neurons (including the ciliary membrane). Core cellular component.
+                        </div>
+
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/23886944" target="_blank" class="term-link">
+                                        PMID:23886944
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">identify sequences required for efficient ciliary targeting and localization of the TAX-2 CNGB and TAX-4 CNGA subunits.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005222" target="_blank" class="term-link">
+                                    GO:0005222
+                                </a>
+                            </span>
+                            <span class="term-label">intracellularly cAMP-activated cation channel activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="G5EEE2" data-a="GO:0005222" data-r="GO_REF:0000033" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> This IBA term is inherited from the PANTHER CNG family (which includes cAMP-responsive vertebrate CNGA subunits). The native C. elegans TAX-4/TAX-2 heteromer is highly selective for cGMP over cAMP, so cAMP-activated cation channel activity over-states cAMP as a physiological ligand for this channel; cGMP is the relevant activating ligand. Marked as over-annotated rather than removed because CNG channels retain weak cAMP responsiveness in vitro.
+                        </div>
+
+
+
+
+                        <div class="propagation-review">
+                            <div class="propagation-title">Propagation Review</div>
+                            <div class="propagation-row">
+                                <strong>Root cause:</strong>
+                                <span class="badge">TERM SCOPING PROBLEM</span>
+                            </div>
+
+                            <div class="propagation-row">
+                                <strong>Failure modes:</strong>
+
+                                <span class="badge">FUNCTIONAL DIVERGENCE</span>
+
+                            </div>
+
+
+                            <div class="propagation-source">
+                                <strong>Sources checked:</strong>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">PANTHER:PTHR45638</span>
+
+                                    &middot; Cyclic Nucleotide-Gated Cation Channel
+
+
+                                    <span class="badge">SUPPORTS SOURCE BUT NOT TARGET</span>
+
+
+                                    <div class="propagation-comment">Family includes cAMP-responsive vertebrate CNGA subunits, but the C. elegans TAX-4/TAX-2 channel is cGMP-selective, so cAMP-activated activity should not propagate to tax-2.</div>
+
+                                </div>
+
+                            </div>
+
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/10064800" target="_blank" class="term-link">
+                                        PMID:10064800
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">it remains highly selective for cGMP over cAMP.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030553" target="_blank" class="term-link">
+                                    GO:0030553
+                                </a>
+                            </span>
+                            <span class="term-label">cGMP binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="G5EEE2" data-a="GO:0030553" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> TAX-2 contains a C-terminal cyclic-nucleotide-binding domain (CNBD; PROSITE PS50042, residues 538-642) consistent with cyclic-nucleotide sensing by the CNG channel it forms with TAX-4. cGMP is the physiological ligand of the heteromer. Retained as a core-consistent function of the channel, though direct biochemical cGMP binding by the TAX-2 CNBD specifically (as opposed to the TAX-4 alpha subunit) has not been demonstrated (see knowledge gaps).
+                        </div>
+
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/10064800" target="_blank" class="term-link">
+                                        PMID:10064800
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">it remains highly selective for cGMP over cAMP.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0098655" target="_blank" class="term-link">
+                                    GO:0098655
+                                </a>
+                            </span>
+                            <span class="term-label">monoatomic cation transmembrane transport</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="G5EEE2" data-a="GO:0098655" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> The CNG channel conducts cations (Ca2+/Na+/K+) across the membrane; TAX-2 is part of that channel. Core transport process.
+                        </div>
+
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0017071" target="_blank" class="term-link">
+                                    GO:0017071
+                                </a>
+                            </span>
+                            <span class="term-label">intracellular cyclic nucleotide activated cation channel complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="G5EEE2" data-a="GO:0017071" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> TAX-2 is a subunit of the intracellular cyclic-nucleotide-activated cation channel complex (the TAX-4/TAX-2 heteromer). Core cellular component/complex.
+                        </div>
+
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/10064800" target="_blank" class="term-link">
+                                        PMID:10064800
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Here we show that TAX-4 and TAX-2 form a heteromeric channel when expressed in HEK293 cells, but TAX-2 does not form a channel on its own.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005216" target="_blank" class="term-link">
+                                    GO:0005216
+                                </a>
+                            </span>
+                            <span class="term-label">monoatomic ion channel activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="G5EEE2" data-a="GO:0005216" data-r="GO_REF:0000002" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Consistent with TAX-2 being a subunit of an ion channel (Pfam PF00520 ion-transport/pore domain). Accurate but general parent term; the specific channel activity is captured by GO:0005223.
+                        </div>
+
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005221" target="_blank" class="term-link">
+                                    GO:0005221
+                                </a>
+                            </span>
+                            <span class="term-label">intracellularly cyclic nucleotide-activated monoatomic cation channel activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="G5EEE2" data-a="GO:0005221" data-r="GO_REF:0000002" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct at the level of the cyclic-nucleotide-gated channel TAX-2 helps form; the more specific cGMP-activated term (GO:0005223) is the precise function.
+                        </div>
+
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006811" target="_blank" class="term-link">
+                                    GO:0006811
+                                </a>
+                            </span>
+                            <span class="term-label">monoatomic ion transport</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="G5EEE2" data-a="GO:0006811" data-r="GO_REF:0000002" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> General parent of the channel&#39;s cation-transport process. Accurate but broad.
+                        </div>
+
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016020" target="_blank" class="term-link">
+                                    GO:0016020
+                                </a>
+                            </span>
+                            <span class="term-label">membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000120
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="G5EEE2" data-a="GO:0016020" data-r="GO_REF:0000120" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> TAX-2 is a multi-pass membrane protein; correct but less informative than the plasma-membrane/ciliary-membrane localization.
+                        </div>
+
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0055085" target="_blank" class="term-link">
+                                    GO:0055085
+                                </a>
+                            </span>
+                            <span class="term-label">transmembrane transport</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="G5EEE2" data-a="GO:0055085" data-r="GO_REF:0000002" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> General parent of the channel&#39;s transmembrane cation-transport process. Accurate but broad.
+                        </div>
+
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005223" target="_blank" class="term-link">
+                                    GO:0005223
+                                </a>
+                            </span>
+                            <span class="term-label">intracellularly cGMP-activated cation channel activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/10064800" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:10064800
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Functional reconstitution of a heteromeric cyclic nucleotide...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="G5EEE2" data-a="GO:0005223" data-r="PMID:10064800" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Core molecular function. Functional reconstitution in HEK293 cells shows that TAX-2 co-assembles with the alpha subunit TAX-4 into a cGMP-gated cation channel; TAX-2 does not form a channel alone and acts as a modifying beta subunit that lowers the heteromer&#39;s cGMP sensitivity. The &#39;contributes_to&#39; qualifier correctly reflects that TAX-2 participates in, rather than independently enables, this channel activity.
+                        </div>
+
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/10064800" target="_blank" class="term-link">
+                                        PMID:10064800
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">with TAX-4 as the alpha subunit and TAX-2 acting as a modifying beta subunit.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/10064800" target="_blank" class="term-link">
+                                        PMID:10064800
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The heteromeric TAX-4/TAX-2 channel is 25-fold less sensitive to cGMP than the TAX-4 channel, but it remains highly selective for cGMP over cAMP.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0034703" target="_blank" class="term-link">
+                                    GO:0034703
+                                </a>
+                            </span>
+                            <span class="term-label">cation channel complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/10064800" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:10064800
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Functional reconstitution of a heteromeric cyclic nucleotide...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="G5EEE2" data-a="GO:0034703" data-r="PMID:10064800" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> TAX-2 is part of the reconstituted heteromeric cation channel. Core cellular component/complex, directly supported.
+                        </div>
+
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/10064800" target="_blank" class="term-link">
+                                        PMID:10064800
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Here we show that TAX-4 and TAX-2 form a heteromeric channel when expressed in HEK293 cells, but TAX-2 does not form a channel on its own.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0010628" target="_blank" class="term-link">
+                                    GO:0010628
+                                </a>
+                            </span>
+                            <span class="term-label">positive regulation of gene expression</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/25303524" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:25303524
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Chemosensation of bacterial secondary metabolites modulates ...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="G5EEE2" data-a="GO:0010628" data-r="PMID:25303524" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Downstream, activity-dependent output. In the ASJ chemosensory neuron the TAX-2/TAX-4 channel transduces detection of P. aeruginosa secondary metabolites, leading to induced expression of the DAF-7/TGF-beta neuromodulator. This is an indirect consequence of sensory channel activity, not a direct gene-regulatory function of TAX-2. Non-core.
+                        </div>
+
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/25303524" target="_blank" class="term-link">
+                                        PMID:25303524
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">induces expression of the neuromodulator DAF-7/TGF-β</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0007199" target="_blank" class="term-link">
+                                    GO:0007199
+                                </a>
+                            </span>
+                            <span class="term-label">G protein-coupled receptor signaling pathway coupled to cGMP nucleotide second messenger</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/20436480" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:20436480
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    C. elegans phototransduction requires a G protein-dependent ...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="G5EEE2" data-a="GO:0007199" data-r="PMID:20436480" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> In ASJ phototransduction, a G-protein/cGMP cascade opens cGMP-sensitive CNG channels; light-evoked currents are abolished in tax-2 (and tax-4) mutants, placing the channel as the effector downstream of the GPCR-coupled cGMP pathway. Non-core downstream signaling context.
+                        </div>
+
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/20436480" target="_blank" class="term-link">
+                                        PMID:20436480
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">This dark current was apparently carried by CNG channels, as it can be blocked by the CNG channel-specific inhibitor L-cis-diltiazem and was absent in the CNG channel mutants tax-2 and tax-4</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0010754" target="_blank" class="term-link">
+                                    GO:0010754
+                                </a>
+                            </span>
+                            <span class="term-label">negative regulation of receptor guanylyl cyclase signaling pathway</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/23940325" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:23940325
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    In vivo genetic dissection of O2-evoked cGMP dynamics in a C...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="G5EEE2" data-a="GO:0010754" data-r="PMID:23940325" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> In vivo cGMP/Ca2+ imaging of an O2-sensing neuron shows that cGMP-gated channels participate in negative-feedback loops that shape cGMP signaling dynamics. This reflects the channel&#39;s role within feedback regulation of the cGMP pathway rather than a direct enzymatic regulation of guanylyl cyclase. Non-core.
+                        </div>
+
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/23940325" target="_blank" class="term-link">
+                                        PMID:23940325
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Elevated levels of cGMP and Ca(2+) stimulate competing negative feedback loops that shape cGMP dynamics.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0070482" target="_blank" class="term-link">
+                                    GO:0070482
+                                </a>
+                            </span>
+                            <span class="term-label">response to oxygen levels</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/23940325" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:23940325
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    In vivo genetic dissection of O2-evoked cGMP dynamics in a C...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="G5EEE2" data-a="GO:0070482" data-r="PMID:23940325" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> O2-evoked rises in cGMP drive a sustained Ca2+ response that depends on cGMP-gated ion channels (the TAX-2/TAX-4 channel). A downstream sensory response mediated by channel activity. Non-core.
+                        </div>
+
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/23940325" target="_blank" class="term-link">
+                                        PMID:23940325
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Increased cGMP leads to a sustained Ca(2+) response in the neuron that depends on cGMP-gated ion channels.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0040040" target="_blank" class="term-link">
+                                    GO:0040040
+                                </a>
+                            </span>
+                            <span class="term-label">thermosensory behavior</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/7630402" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:7630402
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Neural regulation of thermotaxis in Caenorhabditis elegans.
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="G5EEE2" data-a="GO:0040040" data-r="PMID:7630402" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> tax-2 was isolated as a thermotaxis-abnormal (tax) mutant, and the TAX-2/TAX-4 channel is essential for thermosensation in the AFD thermosensory neuron. This is a downstream sensory behavior mediated by channel activity. Non-core. The cited 1995 thermotaxis paper is the WormBase original reference; its cached record is abstract-only and centers on the AFD/AIY/AIZ circuit, but the tax-2 thermosensory requirement is independently established (PMID:10064800, PMID:9486798); annotation retained (defer to curator full-text) rather than removed.
+                        </div>
+
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9486798" target="_blank" class="term-link">
+                                        PMID:9486798
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The tax-2 and tax-4 genes of C. elegans encode two subunits of a cyclic nucleotide-gated channel that is required for chemosensation, thermosensation and normal axon outgrowth of some sensory neurons.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0098655" target="_blank" class="term-link">
+                                    GO:0098655
+                                </a>
+                            </span>
+                            <span class="term-label">monoatomic cation transmembrane transport</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/10064800" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:10064800
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Functional reconstitution of a heteromeric cyclic nucleotide...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="G5EEE2" data-a="GO:0098655" data-r="PMID:10064800" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Directly supported by functional reconstitution: the heteromeric channel conducts cations across the membrane and differs from the TAX-4 homomer in divalent-cation block and single-channel properties. Core transport process.
+                        </div>
+
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/10064800" target="_blank" class="term-link">
+                                        PMID:10064800
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The heteromeric channel and the TAX-4 homomeric channel differ in their blockage by divalent cations and in their single channel properties.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006935" target="_blank" class="term-link">
+                                    GO:0006935
+                                </a>
+                            </span>
+                            <span class="term-label">chemotaxis</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/9486798" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:9486798
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    A cyclic nucleotide-gated channel inhibits sensory axon outg...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="G5EEE2" data-a="GO:0006935" data-r="PMID:9486798" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> tax-2 activity is required for normal chemotaxis to NaCl and odorants, a downstream sensory behavior mediated by the CNG channel. Non-core.
+                        </div>
+
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9486798" target="_blank" class="term-link">
+                                        PMID:9486798
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">tax-2 activity is required in the adult stage for normal chemotaxis to NaCl and odorants.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030516" target="_blank" class="term-link">
+                                    GO:0030516
+                                </a>
+                            </span>
+                            <span class="term-label">regulation of axon extension</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/9486798" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:9486798
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    A cyclic nucleotide-gated channel inhibits sensory axon outg...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="G5EEE2" data-a="GO:0030516" data-r="PMID:9486798" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> tax-2 (with tax-4) is required to maintain correct sensory axon structure; in mutants, axon outgrowth resumes inappropriately in late larval/adult stages. A distinct, activity-dependent role of the channel in maintaining axon morphology. Non-core.
+                        </div>
+
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9486798" target="_blank" class="term-link">
+                                        PMID:9486798
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">These results indicate that tax-2 and tax-4 are required for the maintenance of correct axon structure</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0009454" target="_blank" class="term-link">
+                                    GO:0009454
+                                </a>
+                            </span>
+                            <span class="term-label">aerotaxis</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/15220933" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:15220933
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Oxygen sensation and social feeding mediated by a C. elegans...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="G5EEE2" data-a="GO:0009454" data-r="PMID:15220933" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Avoidance of high oxygen (aerotaxis) requires the sensory cGMP-gated channel tax-2/tax-4 together with the soluble guanylate cyclase gcy-35. Downstream sensory behavior mediated by channel activity. Non-core.
+                        </div>
+
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/15220933" target="_blank" class="term-link">
+                                        PMID:15220933
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Avoidance of high oxygen levels by C. elegans requires the sensory cGMP-gated channel tax-2/tax-4 and a specific soluble guanylate cyclase homologue, gcy-35.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0055093" target="_blank" class="term-link">
+                                    GO:0055093
+                                </a>
+                            </span>
+                            <span class="term-label">response to hyperoxia</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/15220933" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:15220933
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Oxygen sensation and social feeding mediated by a C. elegans...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="G5EEE2" data-a="GO:0055093" data-r="PMID:15220933" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> The tax-2/tax-4 channel mediates responses that allow avoidance of hyperoxic (high-O2) environments. Downstream sensory response. Non-core.
+                        </div>
+
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/15220933" target="_blank" class="term-link">
+                                        PMID:15220933
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Avoidance of high oxygen levels by C. elegans requires the sensory cGMP-gated channel tax-2/tax-4 and a specific soluble guanylate cyclase homologue, gcy-35.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0045664" target="_blank" class="term-link">
+                                    GO:0045664
+                                </a>
+                            </span>
+                            <span class="term-label">regulation of neuron differentiation</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/14711416" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:14711416
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The CMK-1 CaMKI and the TAX-4 Cyclic nucleotide-gated channe...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="G5EEE2" data-a="GO:0045664" data-r="PMID:14711416" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> An indirect, activity-dependent effect: loss of the TAX-4 channel (which TAX-2 co-forms) alters AFD thermosensory-neuron gene expression and morphology. The cited paper&#39;s abstract foregrounds TAX-4, but TAX-2 is its obligate heteromeric partner; this is a downstream consequence of channel activity rather than a direct differentiation function. Non-core.
+                        </div>
+
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/14711416" target="_blank" class="term-link">
+                                        PMID:14711416
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">the TAX-4 cyclic nucleotide-gated channel regulate gene expression, morphology, and functions of the AFD thermosensory neurons</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0045944" target="_blank" class="term-link">
+                                    GO:0045944
+                                </a>
+                            </span>
+                            <span class="term-label">positive regulation of transcription by RNA polymerase II</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/14711416" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:14711416
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The CMK-1 CaMKI and the TAX-4 Cyclic nucleotide-gated channe...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="G5EEE2" data-a="GO:0045944" data-r="PMID:14711416" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Indirect, activity-dependent regulation of AFD-specific gene expression by the CNG channel; TAX-2 has no direct transcriptional activity. Retained as a downstream effect (abstract foregrounds TAX-4, the obligate partner subunit). Non-core.
+                        </div>
+
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/14711416" target="_blank" class="term-link">
+                                        PMID:14711416
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">the TAX-4 cyclic nucleotide-gated channel regulate gene expression, morphology, and functions of the AFD thermosensory neurons</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0048812" target="_blank" class="term-link">
+                                    GO:0048812
+                                </a>
+                            </span>
+                            <span class="term-label">neuron projection morphogenesis</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/14711416" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:14711416
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The CMK-1 CaMKI and the TAX-4 Cyclic nucleotide-gated channe...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="G5EEE2" data-a="GO:0048812" data-r="PMID:14711416" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Indirect effect on AFD sensory-neuron morphology consequent on loss of CNG channel activity. Downstream/non-core; abstract foregrounds TAX-4, the obligate partner subunit of TAX-2.
+                        </div>
+
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/14711416" target="_blank" class="term-link">
+                                        PMID:14711416
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">the TAX-4 cyclic nucleotide-gated channel regulate gene expression, morphology, and functions of the AFD thermosensory neurons</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0097730" target="_blank" class="term-link">
+                                    GO:0097730
+                                </a>
+                            </span>
+                            <span class="term-label">non-motile cilium</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/23886944" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:23886944
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Cell- and subunit-specific mechanisms of CNG channel ciliary...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-new">
+                            NEW
+                        </span>
+                        <span class="vote-buttons" data-g="G5EEE2" data-a="GO:0097730" data-r="PMID:23886944" data-act="NEW">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Proposed new annotation. The TAX-2 CNGB subunit is targeted to and localized within the non-motile sensory cilia of ciliated neurons; sequences required for ciliary targeting/localization of TAX-2 (and TAX-4) were mapped, and the subunits are relatively immobile in specific ciliary subcompartments. Core cellular component not currently in the GOA set.
+                        </div>
+
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/23886944" target="_blank" class="term-link">
+                                        PMID:23886944
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">identify sequences required for efficient ciliary targeting and localization of the TAX-2 CNGB and TAX-4 CNGA subunits.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0007606" target="_blank" class="term-link">
+                                    GO:0007606
+                                </a>
+                            </span>
+                            <span class="term-label">sensory perception of chemical stimulus</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/9486798" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:9486798
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    A cyclic nucleotide-gated channel inhibits sensory axon outg...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-new">
+                            NEW
+                        </span>
+                        <span class="vote-buttons" data-g="G5EEE2" data-a="GO:0007606" data-r="PMID:9486798" data-act="NEW">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Proposed new annotation summarizing the channel&#39;s core sensory role: tax-2 is required for chemosensation (chemotaxis to NaCl and odorants), a form of sensory perception of chemical stimulus mediated by the CNG channel. Captures the core sensory-transduction process at an appropriate level of generality.
+                        </div>
+
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9486798" target="_blank" class="term-link">
+                                        PMID:9486798
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The tax-2 and tax-4 genes of C. elegans encode two subunits of a cyclic nucleotide-gated channel that is required for chemosensation, thermosensation and normal axon outgrowth of some sensory neurons.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>TAX-2 is the modulatory beta subunit of the sensory cyclic nucleotide-gated (CNG) cation channel. It cannot form a channel on its own; it co-assembles with the alpha (pore-forming) subunit TAX-4 into the native heteromeric channel that is directly opened by intracellular cGMP and conducts cations (Ca2+/Na+/K+) across the plasma/ciliary membrane of ciliated sensory neurons. As a beta subunit TAX-2 contributes ion-channel (pore) structure and tunes the channel: the TAX-4/TAX-2 heteromer is ~25-fold less cGMP-sensitive than the TAX-4 homomer and differs in divalent-cation block and single-channel behavior. This channel is the effector of cGMP-mediated sensory signal transduction.</h3>
+                <span class="vote-buttons" data-g="G5EEE2" data-a="FUNCTION: TAX-2 is the modulatory beta subunit of the sensor..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005216" target="_blank" class="term-link">
+                            monoatomic ion channel activity
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0098655" target="_blank" class="term-link">
+                                monoatomic cation transmembrane transport
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0007606" target="_blank" class="term-link">
+                                sensory perception of chemical stimulus
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005886" target="_blank" class="term-link">
+                                plasma membrane
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0097730" target="_blank" class="term-link">
+                                non-motile cilium
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">In Complex:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0017071" target="_blank" class="term-link">
+                            intracellular cyclic nucleotide activated cation channel complex
+                        </a>
+                    </span>
+                </div>
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/10064800" target="_blank" class="term-link">
+                                PMID:10064800
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">Here we show that TAX-4 and TAX-2 form a heteromeric channel when expressed in HEK293 cells, but TAX-2 does not form a channel on its own.</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/10064800" target="_blank" class="term-link">
+                                PMID:10064800
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">with TAX-4 as the alpha subunit and TAX-2 acting as a modifying beta subunit.</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/23886944" target="_blank" class="term-link">
+                                PMID:23886944
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">identify sequences required for efficient ciliary targeting and localization of the TAX-2 CNGB and TAX-4 CNGA subunits.</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000002.md" target="_blank" class="term-link">
+                            GO_REF:0000002
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation through association of InterPro records with GO terms</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
+                            GO_REF:0000033
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Annotation inferences using phylogenetic trees</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000120.md" target="_blank" class="term-link">
+                            GO_REF:0000120
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Combined Automated Annotation using Multiple IEA Methods</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/10064800" target="_blank" class="term-link">
+                            PMID:10064800
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Functional reconstitution of a heteromeric cyclic nucleotide-gated channel of Caenorhabditis elegans in cultured cells.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/14711416" target="_blank" class="term-link">
+                            PMID:14711416
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">The CMK-1 CaMKI and the TAX-4 Cyclic nucleotide-gated channel regulate thermosensory neuron gene expression and function in C. elegans.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/15220933" target="_blank" class="term-link">
+                            PMID:15220933
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Oxygen sensation and social feeding mediated by a C. elegans guanylate cyclase homologue.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/20436480" target="_blank" class="term-link">
+                            PMID:20436480
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">C. elegans phototransduction requires a G protein-dependent cGMP pathway and a taste receptor homolog.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/23886944" target="_blank" class="term-link">
+                            PMID:23886944
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Cell- and subunit-specific mechanisms of CNG channel ciliary trafficking and localization in C. elegans.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/23940325" target="_blank" class="term-link">
+                            PMID:23940325
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">In vivo genetic dissection of O2-evoked cGMP dynamics in a Caenorhabditis elegans gas sensor.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/25303524" target="_blank" class="term-link">
+                            PMID:25303524
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Chemosensation of bacterial secondary metabolites modulates neuroendocrine signaling and behavior of C. elegans.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/7630402" target="_blank" class="term-link">
+                            PMID:7630402
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Neural regulation of thermotaxis in Caenorhabditis elegans.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/8893027" target="_blank" class="term-link">
+                            PMID:8893027
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Mutations in a cyclic nucleotide-gated channel lead to abnormal thermosensation and chemosensation in C. elegans.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/9486798" target="_blank" class="term-link">
+                            PMID:9486798
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">A cyclic nucleotide-gated channel inhibits sensory axon outgrowth in larval and adult Caenorhabditis elegans: a distinct pathway for maintenance of sensory axon structure.</div>
+
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Questions for Experts</h2>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Does the TAX-2 CNBD bind cGMP, and is that binding required for the beta subunit&#39;s ~25-fold reduction of channel cGMP sensitivity?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="G5EEE2" data-a="Q: Does the TAX-2 CNBD bind cGMP, and is that binding..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> What is the endogenous TAX-4:TAX-2 stoichiometry in native sensory cilia, and does it differ between neuron types or ciliary subcompartments?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="G5EEE2" data-a="Q: What is the endogenous TAX-4:TAX-2 stoichiometry i..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Experiments</h2>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Reconstitute and solve the structure of the TAX-4/TAX-2 heteromer (cryo-EM) and perform side-by-side electrophysiology of TAX-4 homomer versus TAX-4/TAX-2 heteromer with targeted mutations in the TAX-2 CNBD and pore, to define how TAX-2 tunes cGMP sensitivity, ion selectivity and divalent-cation block.</p>
+
+
+
+                </div>
+                <span class="vote-buttons" data-g="G5EEE2" data-a="EXPERIMENT: Reconstitute and solve the structure of the TAX-4/..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Quantify TAX-2 and TAX-4 subunit copy number/ratio in defined sensory cilia in vivo (calibrated fluorescence or single-molecule counting) and correlate with cell-specific cGMP dose-response to map homomeric versus heteromeric channels onto neurons.</p>
+
+
+
+                </div>
+                <span class="vote-buttons" data-g="G5EEE2" data-a="EXPERIMENT: Quantify TAX-2 and TAX-4 subunit copy number/ratio..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Knowledge Gaps</h2>
+        <p style="color: #555; font-size: 0.92rem; margin-top: -0.3rem;">
+            What is <em>not</em> known — curated, literature-grounded statements of the open
+            unknowns (the inverse of core functions).
+        </p>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> How the TAX-2 beta subunit mechanistically modulates the channel — lowering cGMP sensitivity ~25-fold and changing divalent-cation block and single-channel behavior relative to the TAX-4 homomer — and whether this tuning is uniform across neurons, is not defined.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">RESIDUAL_SUBGAP</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> In heterologous cells the TAX-4/TAX-2 heteromer is 25-fold less cGMP-sensitive than the TAX-4 homomer yet stays cGMP-selective, and the two forms differ in divalent-cation block and single-channel properties; the structural/mechanistic basis of this modulation by TAX-2 is not established.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> The beta subunit sets the channel&#39;s cGMP operating range and ion handling, so how TAX-2 tunes gating directly determines each sensory neuron&#39;s stimulus threshold and dynamic range.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Structure/function of the TAX-4/TAX-2 heteromer (cryo-EM and mutagenesis of TAX-2 CNBD/pore residues) with side-by-side homomer-versus-heteromer electrophysiology.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"The heteromeric TAX-4/TAX-2 channel is 25-fold less sensitive to cGMP than the TAX-4 channel, but it remains highly selective for cGMP over cAMP."</em> — PMID:10064800</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> Whether the TAX-2 cyclic-nucleotide-binding domain itself binds cGMP and whether that binding is functional (vs. a modulatory/non-canonical CNBD as in vertebrate CNGB beta subunits) is unknown.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">MF_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> TAX-2 has a predicted CNBD (PROSITE PS50042, residues 538-642) and carries an IBA cGMP-binding annotation, but direct cGMP binding by the TAX-2 CNBD (as opposed to the TAX-4 alpha subunit) has not been demonstrated biochemically.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Whether TAX-2&#39;s CNBD is a functional ligand sensor or a purely structural modulator changes how the heteromer integrates cGMP and how its sensitivity is set.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Direct ligand-binding assays on isolated/mutated TAX-2 CNBD and CNBD-mutant channel electrophysiology.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"it remains highly selective for cGMP over cAMP."</em> — PMID:10064800</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The endogenous TAX-4:TAX-2 subunit stoichiometry and whether channel composition varies between neuron types or between ciliary subcompartments of a single neuron is inferred, not measured.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">RESIDUAL_SUBGAP</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> TAX-4 + TAX-2 co-assemble into a functional heteromer in HEK293 cells while TAX-2 alone cannot form a channel; in vivo, ciliary localization of the two subunits is interdependent and heterogeneous across the cilium, but the native stoichiometry is not quantified.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Subunit composition sets ligand sensitivity, ion handling and localization, so it determines how each sensory neuron converts a cGMP signal into a response.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Quantitative in vivo subunit-copy-number measurement (e.g. calibrated fluorescence or single-molecule counting) per neuron and per ciliary subcompartment.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"CNG channel subunits can be localized to discrete ciliary compartments in individual sensory neurons in C. elegans, suggesting that channel composition is heterogeneous across the cilium."</em> — PMID:23886944</li>
+
+                <li><em>"most of the native channels in C. elegans are likely to be hetero-oligomers of TAX-4 and TAX-2 subunits"</em> — PMID:10064800</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> Whether TAX-2 has roles independent of TAX-4 — for example partnering other CNG alpha subunits, or non-conducting structural/trafficking roles — is unresolved.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">RESIDUAL_SUBGAP</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> TAX-2 forms no channel on its own, so an independent TAX-2 conductance is unlikely; but ciliary localization is subunit-interdependent and TAX-2 is expressed in cells where its full complement of partners and any TAX-4-independent contribution have not been mapped.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Distinguishing an obligate TAX-4 partner from a subunit with broader partnerships or scaffolding roles would clarify which sensory functions strictly require the canonical TAX-4/TAX-2 heteromer.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Interaction proteomics and cell-specific epistasis (tax-2 vs tax-4 vs other CNG subunits) with functional imaging in defined neurons.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"Here we show that TAX-4 and TAX-2 form a heteromeric channel when expressed in HEK293 cells, but TAX-2 does not form a channel on its own."</em> — PMID:10064800</li>
+
+            </ul>
+
+
+        </div>
+
+    </div>
+
+
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Deep Research Sections -->
+
+    <div class="section">
+        <h2 class="section-title">Deep Research</h2>
+
+        <details class="deep-research-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; gap: 1rem;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Falcon</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(tax-2-deep-research-falcon.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="G5EEE2" data-a="DEEP_RESEARCH: Falcon" data-r="" data-act="DEEP_RESEARCH" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This deep research is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This deep research needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+
+                <div class="report-meta">
+
+                    <span class="report-meta-text">Comprehensive Research Report: *tax-2* (UniProt G5EEE2) in *Caenorhabditis elegans*</span>
+
+
+                    <span class="report-badge">Falcon</span>
+
+
+                    <span class="report-badge">Edison Scientific Literature</span>
+
+
+                    <span class="report-badge">27 citations</span>
+
+
+                    <span class="report-badge">2 artifacts</span>
+
+
+                    <span class="report-meta-text">2026-07-04T17:22:13.093109</span>
+
+
+
+                </div>
+
+
+                <div class="artifact-list">
+
+
+
+                    <div class="artifact-link">
+                        <a href="tax-2-deep-research-falcon_artifacts/artifact-00.md" class="term-link">Edison artifact artifact-00</a>
+                        <span>(text/markdown)</span>
+                    </div>
+
+
+
+
+                    <div class="artifact-link">
+                        <a href="tax-2-deep-research-falcon_artifacts/artifact-01.md" class="term-link">Edison artifact artifact-01</a>
+                        <span>(text/markdown)</span>
+                    </div>
+
+
+                </div>
+
+                <p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h1 id="comprehensive-research-report-tax-2-uniprot-g5eee2-in-caenorhabditis-elegans">Comprehensive Research Report: <em>tax-2</em> (UniProt G5EEE2) in <em>Caenorhabditis elegans</em></h1>
+<h2 id="1-gene-identity-and-protein-overview">1. Gene Identity and Protein Overview</h2>
+<p>The <em>tax-2</em> gene (locus F36F2.5, also designated CELE_F36F2.5) in <em>Caenorhabditis elegans</em> encodes the β (B-type) subunit of a cyclic nucleotide-gated (CNG) cation channel (mckemy2007temperaturesensingacross pages 3-4, ferkey2021chemosensorysignaltransduction pages 14-15). This assignment is fully consistent with the UniProt G5EEE2 entry, which lists domains for CNG_cation_channel (IPR050866), cNMP-binding domain (IPR000595), cNMP-binding domain superfamily (IPR018490), cNMP-binding domain signature (IPR018488), and ion transport domain (IPR005821). The gene name <em>tax-2</em> derives from its original identification in screens for mutants with abnormal thermotaxis (thermotaxis abnormal), though the gene has subsequently been shown to play essential roles in multiple sensory modalities.</p>
+<p>TAX-2 partners with TAX-4 (the α subunit) to form the principal heteromeric CNG channel required for sensory transduction across a broad array of <em>C. elegans</em> sensory neurons (bargmann2006chemosensationinc. pages 10-12, ferkey2021chemosensorysignaltransduction pages 14-15). The TAX-2/TAX-4 channel is structurally most similar to vertebrate rod photoreceptor CNG channels (mckemy2007temperaturesensingacross pages 3-4).</p>
+<h2 id="2-molecular-function-and-channel-biophysics">2. Molecular Function and Channel Biophysics</h2>
+<h3 id="21-primary-function">2.1 Primary Function</h3>
+<p>TAX-2 functions as the obligate β subunit of a heteromeric cGMP-gated nonselective cation channel. The channel is directly gated by intracellular cyclic GMP (cGMP), converting changes in intracellular cGMP concentration—produced or consumed by upstream guanylyl cyclases and phosphodiesterases—into ion flux across the plasma membrane, thereby depolarizing sensory neurons and permitting calcium entry (mckemy2007temperaturesensingacross pages 3-4, li2024inhibitionofa pages 6-7, bargmann2006chemosensationinc. pages 10-12).</p>
+<h3 id="22-subunit-composition-and-biophysical-properties">2.2 Subunit Composition and Biophysical Properties</h3>
+<p>Heterologous expression studies (in HEK293 cells) have established the following key biophysical properties:</p>
+<ul>
+<li><strong>TAX-4 homomeric channels</strong> can form functional channels independently, exhibiting high cGMP sensitivity (K_D ≈ 4 × 10⁻⁷ M) with poor sensitivity to cAMP (mckemy2007temperaturesensingacross pages 3-4).</li>
+<li><strong>TAX-2 cannot form functional channels on its own</strong> (mckemy2007temperaturesensingacross pages 3-4).</li>
+<li><strong>TAX-2/TAX-4 heteromeric channels</strong> exhibit approximately 25-fold reduced cGMP sensitivity compared to TAX-4 homomers while maintaining selectivity for cGMP over cAMP (mckemy2007temperaturesensingacross pages 3-4). They are highly permeable to calcium but less sensitive to divalent ion block than TAX-4 homomers (mckemy2007temperaturesensingacross pages 3-4). TAX-4 homomeric channels stay open approximately seven times longer than heteromeric TAX-4/TAX-2 channels, with heteromeric channels having approximately 10-fold lower cGMP affinity (ferkey2021chemosensorysignaltransduction pages 14-15).</li>
+</ul>
+<p>These properties indicate that TAX-2 modulates channel kinetics and sensitivity, likely tuning the dynamic range of sensory responses in vivo. The following table summarizes the biophysical comparison:</p>
+<table>
+<thead>
+<tr>
+<th>Property</th>
+<th>TAX-4 Homomeric Channel</th>
+<th>TAX-2/TAX-4 Heteromeric Channel</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>cGMP sensitivity (KD)</td>
+<td>High sensitivity; KD ≈ 4 × 10⁻⁷ M for cGMP (mckemy2007temperaturesensingacross pages 3-4)</td>
+<td>~25-fold lower cGMP sensitivity than TAX-4 alone; still cGMP-gated (mckemy2007temperaturesensingacross pages 3-4)</td>
+</tr>
+<tr>
+<td>cAMP sensitivity</td>
+<td>Poor sensitivity to cAMP; strongly prefers cGMP (mckemy2007temperaturesensingacross pages 3-4)</td>
+<td>Retains selectivity for cGMP over cAMP (mckemy2007temperaturesensingacross pages 3-4)</td>
+</tr>
+<tr>
+<td>Calcium permeability</td>
+<td>Calcium permeable (mckemy2007temperaturesensingacross pages 3-4)</td>
+<td>Highly calcium permeable; supports Ca²⁺ influx in sensory transduction (mckemy2007temperaturesensingacross pages 3-4)</td>
+</tr>
+<tr>
+<td>Divalent ion block sensitivity</td>
+<td>More sensitive to divalent ion block (mckemy2007temperaturesensingacross pages 3-4)</td>
+<td>Less sensitive to divalent ion block than TAX-4 alone (mckemy2007temperaturesensingacross pages 3-4)</td>
+</tr>
+<tr>
+<td>Ability to form functional channels independently</td>
+<td>Yes; TAX-4 alone can form a functional channel in heterologous expression systems (mckemy2007temperaturesensingacross pages 3-4)</td>
+<td>Yes as a co-expressed heteromer; requires both TAX-2 and TAX-4 for this channel composition (mckemy2007temperaturesensingacross pages 3-4, ferkey2021chemosensorysignaltransduction pages 14-15)</td>
+</tr>
+<tr>
+<td>Open time</td>
+<td>Longer open time; about 7-fold longer than heteromeric TAX-2/TAX-4 channels (ferkey2021chemosensorysignaltransduction pages 14-15)</td>
+<td>Shorter open time than TAX-4 homomers (ferkey2021chemosensorysignaltransduction pages 14-15)</td>
+</tr>
+<tr>
+<td>Structural similarity</td>
+<td>CNG channel α-like subunit; channel complex is structurally similar to rod photoreceptor CNG channels (mckemy2007temperaturesensingacross pages 3-4)</td>
+<td>Heteromeric CNG channel most similar to rod photoreceptor channels; TAX-2 is the β-subunit partner (mckemy2007temperaturesensingacross pages 3-4)</td>
+</tr>
+</tbody>
+</table>
+<p><em>Table: This table compares the key biophysical features of TAX-4 homomeric channels and TAX-2/TAX-4 heteromeric channels in C. elegans. It is useful for distinguishing the specific functional contribution of TAX-2 as the β-subunit in the sensory CNG channel complex.</em></p>
+<h3 id="23-alternative-subunit-partnerships">2.3 Alternative Subunit Partnerships</h3>
+<p>Recent work has revealed that TAX-2 can function either with TAX-4 or with alternative α subunits such as CNG-3. In AFD thermosensory neurons, TAX-2 is required for tactile-dependent locomotion modulation, but TAX-4 is dispensable for this process, suggesting that TAX-2 can pair with CNG-3 or other α subunits to form functionally distinct channel complexes depending on the sensory context (rosero2026afdthermosensoryneurons pages 13-14).</p>
+<h2 id="3-expression-pattern-and-subcellular-localization">3. Expression Pattern and Subcellular Localization</h2>
+<h3 id="31-neuronal-expression">3.1 Neuronal Expression</h3>
+<p>TAX-2 is expressed in a broad set of sensory neurons in the amphid and other sensory organs of <em>C. elegans</em>. These include AWC (olfactory neurons for volatile attractants), ASE (gustatory neurons for water-soluble chemicals and salts), AWB (olfactory avoidance neurons for volatile repellents), AFD (thermosensory neurons), BAG (CO₂-sensing neurons), ASG, ASI, ASJ, ASK (chemosensory and neuroendocrine neurons), and ADE neurons (ferkey2021chemosensorysignaltransduction pages 14-15, mckemy2007temperaturesensingacross pages 3-4, rosero2026afdthermosensoryneurons pages 14-15). TAX-2/TAX-4 channels are also expressed in body cavity neurons AQR, PQR, and URX, which function as oxygen sensors exposed to pseudocoelomic fluid (menini2009theneurobiologyof pages 36-38).</p>
+<h3 id="32-subcellular-localization">3.2 Subcellular Localization</h3>
+<p>TAX-2 protein is localized to <strong>sensory cilia and dendritic structures</strong> of sensory neurons—the precise sites where environmental stimuli are transduced into electrical signals (mckemy2007temperaturesensingacross pages 3-4, bargmann2006chemosensationinc. pages 10-12). The channel is primarily found in cilia rather than in axonal compartments (bargmann2006chemosensationinc. pages 10-12). The specific subdomain localization within cilia is neuron-specific and functionally important (ferkey2021chemosensorysignaltransduction pages 14-15). Notably, <em>tax-2</em> and <em>tax-4</em> mutant cilia retain normal structural morphology, normal dye uptake, and normal intraflagellar transport, demonstrating that the channel functions downstream of ciliary structure rather than being required for cilia formation per se (li2024inhibitionofa pages 7-8).</p>
+<p>The following table summarizes TAX-2 expression across neuron types and the corresponding sensory modalities:</p>
+<table>
+<thead>
+<tr>
+<th>Neuron</th>
+<th>Sensory Modality</th>
+<th>Upstream Guanylyl Cyclase(s)</th>
+<th>Biological Process</th>
+<th>Key Evidence/References</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>AWC</td>
+<td>Olfaction; volatile attractants</td>
+<td>ODR-1, DAF-11</td>
+<td>Odor-evoked cGMP signaling gates TAX-2/TAX-4 to drive chemotaxis; also contributes to activity-dependent gene expression and odor plasticity</td>
+<td>tax-2 expressed in AWC; TAX-2/TAX-4 act downstream of GPCR/G protein signaling with ODR-1 and DAF-11 in AWC olfaction (bargmann2006chemosensationinc. pages 10-12, ferkey2021chemosensorysignaltransduction pages 14-15)</td>
+</tr>
+<tr>
+<td>ASE</td>
+<td>Gustation; water-soluble chemicals, salt, alkalinity</td>
+<td>GCY-14 for alkalinity; other ASE rGCs not fully specified here</td>
+<td>Salt chemotaxis and pH/alkalinity responses require TAX-2/TAX-4-mediated cGMP signaling</td>
+<td>tax-2 expressed in ASE; TAX-2/TAX-4 required for chemotaxis to water-soluble compounds and calcium responses to NaCl/pH changes (bargmann2006chemosensationinc. pages 10-12, ferkey2021chemosensorysignaltransduction pages 14-15, bargmann2006chemosensationinc. pages 1-3)</td>
+</tr>
+<tr>
+<td>AWB</td>
+<td>Olfactory avoidance; volatile repellents</td>
+<td>Not clearly resolved in the retrieved evidence; cGMP pathway upstream likely includes GPCR-regulated GC signaling</td>
+<td>Avoidance of volatile repellents and modulation of odor responses</td>
+<td>tax-2 expressed in AWB; TAX-2/TAX-4 required for AWB-mediated avoidance and localize to sensory cilia; PDE-5 also modulates AWB olfactory signaling (bargmann2006chemosensationinc. pages 10-12, ferkey2021chemosensorysignaltransduction pages 14-15, galande2025rolesofcyclic pages 12-13)</td>
+</tr>
+<tr>
+<td>AFD</td>
+<td>Thermosensation</td>
+<td>GCY-8, GCY-18, GCY-23</td>
+<td>Thermotaxis and thermotransduction through cGMP-triggered opening of TAX-2/TAX-4, causing Ca2+ fluctuations</td>
+<td>tax-2 expressed in AFD; TAX-2/TAX-4 localized to cilia/dendrites; AFD thermosensation uses GCY-8/18/23 upstream of the channel (mckemy2007temperaturesensingacross pages 3-4, galande2025rolesofcyclic pages 15-16)</td>
+</tr>
+<tr>
+<td>BAG</td>
+<td>CO2 sensing; also implicated in O2-related circuit functions</td>
+<td>GCY-9</td>
+<td>CO2-evoked sensory signaling and behavioral plasticity</td>
+<td>tax-2 expressed in BAG; recent pathway summaries place GCY-9 upstream of TAX-2/TAX-4 in BAG CO2 signaling (rosero2026afdthermosensoryneurons pages 14-15, ferkey2021chemosensorysignaltransduction pages 14-15, galande2025rolesofcyclic pages 15-16)</td>
+</tr>
+<tr>
+<td>AQR/PQR/URX</td>
+<td>Oxygen sensing / aerotaxis</td>
+<td>GCY-35, GCY-36</td>
+<td>Body-cavity neuron O2 sensing; cGMP opens TAX-2/TAX-4 to control aerotaxis</td>
+<td>TAX-2/TAX-4 function downstream of soluble guanylyl cyclases GCY-35/36 in AQR/PQR/URX oxygen sensing (menini2009theneurobiologyof pages 36-38, galande2025rolesofcyclic pages 7-9)</td>
+</tr>
+<tr>
+<td>ASG</td>
+<td>Chemosensory / sensory integration</td>
+<td>Not specified in retrieved evidence</td>
+<td>Likely participates in TAX-2/TAX-4-dependent sensory signaling; specific pathway assignment remains limited in the retrieved literature</td>
+<td>tax-2 expression reported in ASG, but neuron-specific upstream GC and process were not defined in the retrieved evidence (ferkey2021chemosensorysignaltransduction pages 14-15)</td>
+</tr>
+<tr>
+<td>ASI</td>
+<td>Neuroendocrine chemosensory signaling</td>
+<td>DAF-11 implicated in dauer/pheromone-related cGMP signaling</td>
+<td>Dauer regulation, sensory integration, and regulation of daf-7 expression</td>
+<td>tax-2 expressed in ASI; TAX-2/TAX-4 contribute to dauer-related cGMP signaling and regulation of sensory gene expression/neuroendocrine outputs (ferkey2021chemosensorysignaltransduction pages 19-20, ferkey2021chemosensorysignaltransduction pages 14-15)</td>
+</tr>
+<tr>
+<td>ASJ</td>
+<td>Sensory/neuroendocrine signaling; thermo/photo-related cGMP pathways in broader literature</td>
+<td>Not clearly specified in retrieved tax-2-centered evidence</td>
+<td>Regulation of daf-7 expression and sensory-state signaling; recent PDE literature implicates ASJ cGMP dynamics</td>
+<td>tax-2 expression reported in ASJ; channel complex regulates gene expression including daf-7 in ASJ/ASI, but specific upstream GC was not resolved in the retrieved evidence (ferkey2021chemosensorysignaltransduction pages 14-15, galande2025rolesofcyclic pages 9-10)</td>
+</tr>
+<tr>
+<td>ASK</td>
+<td>Chemosensory / pheromone-related signaling</td>
+<td>DAF-11 implicated in pheromone/dauer context</td>
+<td>Dauer pheromone signaling and sensory integration</td>
+<td>tax-2 expressed in ASK; DAF-11 and G proteins act in pheromone signaling contexts where TAX-2/TAX-4 function downstream in dauer-related pathways (ferkey2021chemosensorysignaltransduction pages 19-20, ferkey2021chemosensorysignaltransduction pages 14-15)</td>
+</tr>
+<tr>
+<td>ADE</td>
+<td>Sensory neuron; modality not well defined here</td>
+<td>Not specified in retrieved evidence</td>
+<td>tax-2 expression indicates possible CNG-dependent sensory signaling, but a precise TAX-2-specific function in ADE was not resolved in the retrieved sources</td>
+<td>ADE listed among tax-2-expressing neurons; specific upstream GC and function not defined in retrieved evidence (rosero2026afdthermosensoryneurons pages 14-15, ferkey2021chemosensorysignaltransduction pages 14-15)</td>
+</tr>
+</tbody>
+</table>
+<p><em>Table: This table summarizes where TAX-2 is expressed in C. elegans and links each neuron type to its sensory modality, likely upstream guanylyl cyclases, and major biological roles. It is useful for mapping TAX-2 onto specific cGMP-dependent sensory circuits while distinguishing well-supported assignments from areas where evidence remains limited.</em></p>
+<h2 id="4-signaling-pathways">4. Signaling Pathways</h2>
+<p>TAX-2/TAX-4 channels serve as the critical downstream effector in multiple cGMP-dependent sensory transduction cascades. The general signaling logic is conserved across modalities: an environmental stimulus activates guanylyl cyclases (either receptor-type or soluble), elevating intracellular cGMP, which directly gates TAX-2/TAX-4 channels to allow cation influx and neuronal depolarization.</p>
+<h3 id="41-chemosensation-olfaction-and-gustation">4.1 Chemosensation (Olfaction and Gustation)</h3>
+<p>In AWC olfactory neurons, odorants are detected by G protein-coupled receptors (GPCRs) that activate the Gα protein ODR-3. ODR-3 regulates cGMP levels by activating receptor guanylyl cyclases ODR-1 and DAF-11 (which likely function as heterodimers), and/or modulating phosphodiesterases. The resulting increase in cGMP directly opens TAX-2/TAX-4 channels to depolarize the neuron (bargmann2006chemosensationinc. pages 10-12). In ASE gustatory neurons, TAX-2/TAX-4 channels are required for calcium flux responses to NaCl concentration changes and pH stimuli (ferkey2021chemosensorysignaltransduction pages 14-15). <em>tax-2</em> mutants are defective in AWC-mediated chemotaxis to volatile odors, ASE-mediated chemotaxis to water-soluble attractants, and AWB-mediated avoidance of volatile repellents (bargmann2006chemosensationinc. pages 10-12).</p>
+<h3 id="42-thermosensation">4.2 Thermosensation</h3>
+<p>In AFD thermosensory neurons, temperature-responsive receptor guanylyl cyclases GCY-8, GCY-18, and GCY-23 produce cGMP in response to warming, which gates TAX-2/TAX-4 channels and promotes intracellular Ca²⁺ fluctuations necessary for thermotaxis behavior (mckemy2007temperaturesensingacross pages 3-4). <em>tax-2</em> mutants show thermotactic deficits similar to those observed after AFD neuron ablation (mckemy2007temperaturesensingacross pages 3-4).</p>
+<h3 id="43-oxygen-sensing-aerotaxis">4.3 Oxygen Sensing (Aerotaxis)</h3>
+<p>In body cavity neurons AQR, PQR, and URX, dissolved oxygen activates soluble guanylyl cyclases GCY-35 and GCY-36, producing cGMP that opens TAX-2/TAX-4 channels to mediate aerotaxis behavior (menini2009theneurobiologyof pages 36-38, galande2025rolesofcyclic pages 7-9).</p>
+<h3 id="44-co2-sensing">4.4 CO₂ Sensing</h3>
+<p>In BAG neurons, the soluble guanylyl cyclase GCY-9 produces cGMP in response to CO₂, activating TAX-2/TAX-4 channels for CO₂-evoked behavioral responses (galande2025rolesofcyclic pages 15-16).</p>
+<h3 id="45-negative-feedback-by-phosphodiesterases">4.5 Negative Feedback by Phosphodiesterases</h3>
+<p>Cyclic nucleotide phosphodiesterases PDE-1, PDE-2, and PDE-5 hydrolyze cGMP to provide negative feedback regulation of TAX-2/TAX-4 channel activity. In PQR oxygen-sensing neurons, PDE-1 restores cGMP to baseline after oxygen stimulation (galande2025rolesofcyclic pages 7-9). In AFD thermosensory neurons, PDE-1 and PDE-5 regulate cGMP in neuronal receptive endings, while PDE-2 is required for recovery and adaptation phases of thermotransduction (galande2025rolesofcyclic pages 15-16, galande2025rolesofcyclic pages 7-9, galande2025rolesofcyclic pages 12-13). In AWB olfactory neurons, PDE-5 modulates responses to low concentrations of odorants (galande2025rolesofcyclic pages 12-13). Complete disruption of PDE activity (quadruple pde-1:pde-2:pde-3:pde-5 mutants) results in elevated cGMP levels and loss of chemotactic responses to alkaline pH, phenocopying TAX-2/TAX-4 channel defects (galande2025rolesofcyclic pages 13-15).</p>
+<h2 id="5-downstream-physiological-roles">5. Downstream Physiological Roles</h2>
+<h3 id="51-dauer-formation">5.1 Dauer Formation</h3>
+<p><em>tax-2</em> mutants exhibit a weak dauer-constitutive (Daf-c) phenotype, particularly at high temperatures, indicating a role in the cGMP signaling branch of dauer formation (fielenbach2008c.elegansdauer pages 3-5, bargmann2006chemosensationinc. pages 10-12, fielenbach2008c.elegansdauer pages 2-3). This phenotype is less severe than that of <em>daf-11</em> guanylyl cyclase mutants, which produce potent Daf-c phenotypes, placing TAX-2/TAX-4 downstream of DAF-11 in the dauer signaling pathway (fielenbach2008c.elegansdauer pages 2-3). The cGMP pathway intersects with insulin/IGF-1-like signaling (IIS) and TGF-β signaling to control the dauer decision (fielenbach2008c.elegansdauer pages 3-5).</p>
+<h3 id="52-longevity">5.2 Longevity</h3>
+<p>Loss of TAX-2/TAX-4 channel function extends <em>C. elegans</em> lifespan. Mutations in <em>tax-2</em> extend lifespan particularly at low temperatures (lin2017longevitycontrolby pages 1-2). The <em>tax-4(p678)</em> mutation extends mean lifespan from approximately 19 to 30 days (li2024inhibitionofa pages 6-7). Mechanistically, suppressed CNG channel activity on sensory cilia non-cell-autonomously activates the unfolded protein response of the endoplasmic reticulum (UPR^ER) in intestinal cells through the IRE-1–XBP-1 signaling pathway, promoting resistance to age-dependent protein aggregation and extending lifespan (li2024inhibitionofa pages 6-7, li2024inhibitionofa pages 1-2). This establishes a sensory neuron-to-intestine signaling axis mediated by TAX-2/TAX-4 channel activity.</p>
+<h3 id="53-activity-dependent-gene-expression">5.3 Activity-Dependent Gene Expression</h3>
+<p>TAX-2/TAX-4 channels regulate activity-dependent gene expression in sensory neurons. In AWC neurons, channel activity controls expression of the receptor gene <em>str-2</em>, which is important for odor discrimination and olfactory neuron identity specification (ferkey2021chemosensorysignaltransduction pages 14-15, bargmann2006chemosensationinc. pages 10-12). In ASI and ASJ neurons, the channels regulate expression of <em>daf-7</em> (TGF-β), a key neuroendocrine signal for dauer and reproductive growth decisions (ferkey2021chemosensorysignaltransduction pages 14-15).</p>
+<h3 id="54-tactile-dependent-behavioral-modulation">5.4 Tactile-Dependent Behavioral Modulation</h3>
+<p>A recent study has uncovered an unexpected role for TAX-2 in the AFD thermosensory neuron beyond its canonical function in temperature detection: TAX-2 mediates tactile-dependent locomotion modulation. Intriguingly, TAX-4 is dispensable for this process, and TAX-2 may function with alternative α subunits such as CNG-3 in this context (rosero2026afdthermosensoryneurons pages 13-14). This modulation requires electrical synapses (innexins) between AFD and the AIB interneuron, indicating integration of TAX-2-dependent signals into broader circuit-level processing.</p>
+<h2 id="6-genetic-alleles-and-mutant-phenotypes">6. Genetic Alleles and Mutant Phenotypes</h2>
+<p>Several <em>tax-2</em> alleles have been characterized: <em>tax-2(p694)</em> is the canonical loss-of-function allele used in most studies of CNG channel function and sensory signaling (li2024inhibitionofa pages 7-8); <em>tax-2(p691)</em> and <em>tax-2(ot25)</em> are additional alleles (hill2024molecularandneuronal pages 84-89). The engineered phosphomutant <em>tax-2(oy191[S727A])</em> has been investigated in the context of rapid temperature adaptation in AFD neurons, where it does not affect rapid adaptation responses (hill2024molecularandneuronal pages 84-89). This suggests that phosphorylation of Ser727 may regulate other aspects of TAX-2 function or contribute to slower forms of sensory plasticity.</p>
+<h2 id="7-evolutionary-context">7. Evolutionary Context</h2>
+<p>TAX-2 is structurally most similar to β subunits of CNG channels expressed in vertebrate rod photoreceptors (mckemy2007temperaturesensingacross pages 3-4). The TAX-2/TAX-4 heteromeric channel shares homology with human CNG channels (li2024inhibitionofa pages 6-7). The conservation of cGMP-gated channel-dependent sensory transduction from nematodes to vertebrates underscores the ancient evolutionary origin of this signaling mechanism. Orthologs of <em>tax-2</em> and <em>tax-4</em> in parasitic nematodes such as <em>Brugia malayi</em> can partially rescue sensory defects in <em>C. elegans</em> mutants, confirming functional conservation across nematode species (rosero2026afdthermosensoryneurons pages 13-14).</p>
+<h2 id="8-summary">8. Summary</h2>
+<p><em>tax-2</em> encodes the β subunit of the principal cGMP-gated cation channel in <em>C. elegans</em> sensory neurons. Together with the α subunit TAX-4, it forms a heteromeric channel localized to sensory cilia that serves as the critical downstream effector in multiple cGMP-dependent signal transduction pathways. These pathways mediate chemosensation, thermosensation, oxygen sensing, and CO₂ sensing. The channel is gated by cGMP produced by specific guanylyl cyclases (ODR-1/DAF-11 for chemosensation; GCY-8/18/23 for thermosensation; GCY-35/36 for O₂; GCY-9 for CO₂), with signal termination provided by phosphodiesterases PDE-1, PDE-2, and PDE-5. Beyond acute sensory transduction, TAX-2/TAX-4 channel activity influences activity-dependent gene expression, dauer developmental decisions, and organismal lifespan through non-cell-autonomous activation of the UPR^ER in intestinal cells. TAX-2 can also partner with alternative α subunits such as CNG-3 for context-specific functions, revealing a previously unappreciated combinatorial logic in CNG channel function in this organism.</p>
+<p>References</p>
+<ol>
+<li>
+<p>(mckemy2007temperaturesensingacross pages 3-4): David D. McKemy. Temperature sensing across species. Pflügers Archiv - European Journal of Physiology, 454:777-791, Jan 2007. URL: https://doi.org/10.1007/s00424-006-0199-6, doi:10.1007/s00424-006-0199-6. This article has 115 citations.</p>
+</li>
+<li>
+<p>(ferkey2021chemosensorysignaltransduction pages 14-15): Denise M Ferkey, Piali Sengupta, and Noelle D L’Etoile. Chemosensory signal transduction in caenorhabditis elegans. Genetics, Mar 2021. URL: https://doi.org/10.1093/genetics/iyab004, doi:10.1093/genetics/iyab004. This article has 162 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(bargmann2006chemosensationinc. pages 10-12): Cornelia Bargmann. Chemosensation in c. elegans. WormBook : the online review of C. elegans biology, pages 1-29, Oct 2006. URL: https://doi.org/10.1895/wormbook.1.123.1, doi:10.1895/wormbook.1.123.1. This article has 1160 citations.</p>
+</li>
+<li>
+<p>(li2024inhibitionofa pages 6-7): Dongdong Li, Di Chen, Wei Li, and Guangshuo Ou. Inhibition of a cyclic nucleotide-gated channel on neuronal cilia activates unfolded protein response in intestinal cells to promote longevity. Proceedings of the National Academy of Sciences of the United States of America, Jun 2024. URL: https://doi.org/10.1073/pnas.2321228121, doi:10.1073/pnas.2321228121. This article has 3 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(rosero2026afdthermosensoryneurons pages 13-14): Manuel Rosero and Jihong Bai. Afd thermosensory neurons mediate tactile-dependent locomotion modulation in c. elegans. Apr 2026. URL: https://doi.org/10.7554/elife.106496, doi:10.7554/elife.106496. This article has 0 citations.</p>
+</li>
+<li>
+<p>(rosero2026afdthermosensoryneurons pages 14-15): Manuel Rosero and Jihong Bai. Afd thermosensory neurons mediate tactile-dependent locomotion modulation in c. elegans. Apr 2026. URL: https://doi.org/10.7554/elife.106496, doi:10.7554/elife.106496. This article has 0 citations.</p>
+</li>
+<li>
+<p>(menini2009theneurobiologyof pages 36-38): A. Menini. The neurobiology of olfaction. ArXiv, pages 1-418, Nov 2009. URL: https://doi.org/10.1201/9781420071993, doi:10.1201/9781420071993. This article has 142 citations.</p>
+</li>
+<li>
+<p>(li2024inhibitionofa pages 7-8): Dongdong Li, Di Chen, Wei Li, and Guangshuo Ou. Inhibition of a cyclic nucleotide-gated channel on neuronal cilia activates unfolded protein response in intestinal cells to promote longevity. Proceedings of the National Academy of Sciences of the United States of America, Jun 2024. URL: https://doi.org/10.1073/pnas.2321228121, doi:10.1073/pnas.2321228121. This article has 3 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(bargmann2006chemosensationinc. pages 1-3): Cornelia Bargmann. Chemosensation in c. elegans. WormBook : the online review of C. elegans biology, pages 1-29, Oct 2006. URL: https://doi.org/10.1895/wormbook.1.123.1, doi:10.1895/wormbook.1.123.1. This article has 1160 citations.</p>
+</li>
+<li>
+<p>(galande2025rolesofcyclic pages 12-13): Kranti K. Galande and Rick H. Cote. Roles of cyclic nucleotide phosphodiesterases in signal transduction pathways in the nematode caenorhabditis elegans. Cells, 14:1174, Jul 2025. URL: https://doi.org/10.3390/cells14151174, doi:10.3390/cells14151174. This article has 4 citations.</p>
+</li>
+<li>
+<p>(galande2025rolesofcyclic pages 15-16): Kranti K. Galande and Rick H. Cote. Roles of cyclic nucleotide phosphodiesterases in signal transduction pathways in the nematode caenorhabditis elegans. Cells, 14:1174, Jul 2025. URL: https://doi.org/10.3390/cells14151174, doi:10.3390/cells14151174. This article has 4 citations.</p>
+</li>
+<li>
+<p>(galande2025rolesofcyclic pages 7-9): Kranti K. Galande and Rick H. Cote. Roles of cyclic nucleotide phosphodiesterases in signal transduction pathways in the nematode caenorhabditis elegans. Cells, 14:1174, Jul 2025. URL: https://doi.org/10.3390/cells14151174, doi:10.3390/cells14151174. This article has 4 citations.</p>
+</li>
+<li>
+<p>(ferkey2021chemosensorysignaltransduction pages 19-20): Denise M Ferkey, Piali Sengupta, and Noelle D L’Etoile. Chemosensory signal transduction in caenorhabditis elegans. Genetics, Mar 2021. URL: https://doi.org/10.1093/genetics/iyab004, doi:10.1093/genetics/iyab004. This article has 162 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(galande2025rolesofcyclic pages 9-10): Kranti K. Galande and Rick H. Cote. Roles of cyclic nucleotide phosphodiesterases in signal transduction pathways in the nematode caenorhabditis elegans. Cells, 14:1174, Jul 2025. URL: https://doi.org/10.3390/cells14151174, doi:10.3390/cells14151174. This article has 4 citations.</p>
+</li>
+<li>
+<p>(galande2025rolesofcyclic pages 13-15): Kranti K. Galande and Rick H. Cote. Roles of cyclic nucleotide phosphodiesterases in signal transduction pathways in the nematode caenorhabditis elegans. Cells, 14:1174, Jul 2025. URL: https://doi.org/10.3390/cells14151174, doi:10.3390/cells14151174. This article has 4 citations.</p>
+</li>
+<li>
+<p>(fielenbach2008c.elegansdauer pages 3-5): Nicole Fielenbach and Adam Antebi. C. elegans dauer formation and the molecular basis of plasticity. Genes &amp; development, 22 16:2149-65, Aug 2008. URL: https://doi.org/10.1101/gad.1701508, doi:10.1101/gad.1701508. This article has 741 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(fielenbach2008c.elegansdauer pages 2-3): Nicole Fielenbach and Adam Antebi. C. elegans dauer formation and the molecular basis of plasticity. Genes &amp; development, 22 16:2149-65, Aug 2008. URL: https://doi.org/10.1101/gad.1701508, doi:10.1101/gad.1701508. This article has 741 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(lin2017longevitycontrolby pages 1-2): Chih-Ta Lin, Chun-Wei He, Tzu-Ting Huang, and Chun-Liang Pan. Longevity control by the nervous system: sensory perception, stress response and beyond. Translational Medicine of Aging, 1:41-51, Oct 2017. URL: https://doi.org/10.1016/j.tma.2017.07.001, doi:10.1016/j.tma.2017.07.001. This article has 9 citations.</p>
+</li>
+<li>
+<p>(li2024inhibitionofa pages 1-2): Dongdong Li, Di Chen, Wei Li, and Guangshuo Ou. Inhibition of a cyclic nucleotide-gated channel on neuronal cilia activates unfolded protein response in intestinal cells to promote longevity. Proceedings of the National Academy of Sciences of the United States of America, Jun 2024. URL: https://doi.org/10.1073/pnas.2321228121, doi:10.1073/pnas.2321228121. This article has 3 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(hill2024molecularandneuronal pages 84-89): Tyler J Hill. Molecular and neuronal mechanisms underlying rapid experience-dependent plasticity in a single thermosensory neuron. Text, Jan 2024. URL: https://doi.org/10.48617/etd.1088, doi:10.48617/etd.1088. This article has 0 citations and is from a peer-reviewed journal.</p>
+</li>
+</ol>
+<h2 id="artifacts">Artifacts</h2>
+<ul>
+<li><a href="tax-2-deep-research-falcon_artifacts/artifact-00.md">Edison artifact artifact-00</a></li>
+<li><a href="tax-2-deep-research-falcon_artifacts/artifact-01.md">Edison artifact artifact-01</a></li>
+</ul>
+<h2 id="citations">Citations</h2>
+<ol>
+<li>mckemy2007temperaturesensingacross pages 3-4</li>
+<li>ferkey2021chemosensorysignaltransduction pages 14-15</li>
+<li>rosero2026afdthermosensoryneurons pages 13-14</li>
+<li>menini2009theneurobiologyof pages 36-38</li>
+<li>li2024inhibitionofa pages 7-8</li>
+<li>galande2025rolesofcyclic pages 15-16</li>
+<li>galande2025rolesofcyclic pages 7-9</li>
+<li>galande2025rolesofcyclic pages 12-13</li>
+<li>galande2025rolesofcyclic pages 13-15</li>
+<li>lin2017longevitycontrolby pages 1-2</li>
+<li>li2024inhibitionofa pages 6-7</li>
+<li>hill2024molecularandneuronal pages 84-89</li>
+<li>rosero2026afdthermosensoryneurons pages 14-15</li>
+<li>ferkey2021chemosensorysignaltransduction pages 19-20</li>
+<li>galande2025rolesofcyclic pages 9-10</li>
+<li>li2024inhibitionofa pages 1-2</li>
+<li>S727A</li>
+<li>https://doi.org/10.1007/s00424-006-0199-6,</li>
+<li>https://doi.org/10.1093/genetics/iyab004,</li>
+<li>https://doi.org/10.1895/wormbook.1.123.1,</li>
+<li>https://doi.org/10.1073/pnas.2321228121,</li>
+<li>https://doi.org/10.7554/elife.106496,</li>
+<li>https://doi.org/10.1201/9781420071993,</li>
+<li>https://doi.org/10.3390/cells14151174,</li>
+<li>https://doi.org/10.1101/gad.1701508,</li>
+<li>https://doi.org/10.1016/j.tma.2017.07.001,</li>
+<li>https://doi.org/10.48617/etd.1088,</li>
+</ol>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(tax-2-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="G5EEE2" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="tax-2-c-elegans-gene-review-notes">tax-2 (C. elegans) — Gene Review Notes</h1>
+<p>UniProt: G5EEE2 (G5EEE2_CAEEL) | WormBase: WBGene00006525 / F36F2.5 | 800 aa<br />
+Gene name origin: <em>tax</em> = <strong>ta</strong>xis abnormal / thermota<strong>x</strong>is-abnormal (isolated in chemotaxis/thermotaxis screens).</p>
+<h2 id="one-line-summary">One-line summary</h2>
+<p>TAX-2 is the <strong>modulatory beta subunit</strong> of the sensory cyclic-nucleotide-gated (CNG) cation<br />
+channel of <em>C. elegans</em>. It partners with the alpha (pore-forming) subunit <strong>TAX-4</strong> to form the<br />
+native heteromeric cGMP-gated channel in ciliated sensory neurons. TAX-2 <strong>cannot form a channel<br />
+on its own</strong>; it tunes the channel's ligand sensitivity and is required for its correct ciliary<br />
+localization.</p>
+<h2 id="protein-architecture-from-uniprot-g5eee2">Protein architecture (from UniProt G5EEE2)</h2>
+<ul>
+<li>Ion-transport (pore) domain: Pfam PF00520 (Ion_trans); TM helices predicted ~220-242, ~254-274 (Phobius).</li>
+<li>Cyclic-nucleotide-binding domain (CNBD): Pfam PF00027; PROSITE PS50042 at residues 538-642.</li>
+<li>InterPro family IPR050866 CNG_cation_channel; PANTHER PTHR45638 (Cyclic Nucleotide-Gated Cation Channel),<br />
+  subfamily PTHR45638:SF1 "CYCLIC NUCLEOTIDE-GATED ION CHANNEL SUBUNIT B" — i.e. classified as a <strong>CNGB-type (beta)</strong> subunit.</li>
+<li>TCDB 1.A.1.5.19 (voltage-gated ion channel VIC superfamily).</li>
+<li>Long disordered N- and C-terminal regions (21-75; 733-800, acidic).</li>
+</ul>
+<h2 id="known-well-supported">KNOWN (well-supported)</h2>
+<h3 id="molecular-function-complex-core">Molecular function / complex — CORE</h3>
+<ul>
+<li>TAX-4 (alpha) and TAX-2 (beta) form a <strong>heteromeric CNG channel</strong> when co-expressed in HEK293 cells;<br />
+<strong>TAX-2 does not form a channel on its own</strong>. Native channels are likely TAX-4/TAX-2 hetero-oligomers,<br />
+  "with TAX-4 as the alpha subunit and TAX-2 acting as a modifying beta subunit."<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/10064800" title="Here we show that TAX-4 and TAX-2 form a heteromeric channel when expressed in HEK293 cells, but TAX-2 does not form a channel on its own.">PMID:10064800</a><br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/10064800" title="with TAX-4 as the alpha subunit and TAX-2 acting as a modifying beta subunit.">PMID:10064800</a></li>
+<li>TAX-2 is "most closely related to the beta subunits of the rod phototransduction channels."<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/10064800" title="TAX-2 is most closely related to the beta subunits of the rod phototransduction channels.">PMID:10064800</a></li>
+<li>The heteromer <strong>tunes ligand sensitivity</strong>: "The heteromeric TAX-4/TAX-2 channel is 25-fold less sensitive<br />
+  to cGMP than the TAX-4 channel, but it remains highly selective for cGMP over cAMP." The heteromer and TAX-4<br />
+  homomer also differ in divalent-cation block and single-channel properties.<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/10064800" title="The heteromeric TAX-4/TAX-2 channel is 25-fold less sensitive to cGMP than the TAX-4 channel, but it remains highly selective for cGMP over cAMP.">PMID:10064800</a></li>
+<li>Original genetics: "The tax-2 and tax-4 genes of C. elegans encode two subunits of a cyclic nucleotide-gated<br />
+  channel that is required for chemosensation, thermosensation and normal axon outgrowth of some sensory neurons."<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/9486798" title="The tax-2 and tax-4 genes of C. elegans encode two subunits of a cyclic nucleotide-gated channel that is required for chemosensation, thermosensation and normal axon outgrowth of some sensory neurons.">PMID:9486798</a></li>
+</ul>
+<h3 id="localization-core">Localization — CORE</h3>
+<ul>
+<li>Channel acts at the <strong>plasma membrane / sensory cilia</strong> of ciliated neurons. Ciliary targeting is<br />
+  subunit- and cell-specific; sequences required for ciliary targeting/localization of the TAX-2 CNGB and<br />
+  TAX-4 CNGA subunits have been mapped, and ciliary localization of the two subunits is interdependent.<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/23886944" title="identify sequences required for efficient ciliary targeting and localization of the TAX-2 CNGB and TAX-4 CNGA subunits.">PMID:23886944</a><br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/23886944" title="TAX-2 and TAX-4 are relatively immobile in specific sensory cilia subcompartments">PMID:23886944</a></li>
+<li>The alpha subunit TAX-4::GFP is "partly localized at the sensory endings of these neurons."<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/8893027" title="The Tax-4::GFP fusion is partly localized at the sensory endings of these neurons.">PMID:8893027</a> (alpha subunit; supports plasma-membrane/sensory-ending localization of the channel)</li>
+</ul>
+<h3 id="sensory-physiology-behavior-channel-dependent-non-core-downstream-of-channel-activity">Sensory physiology / behavior (channel-dependent) — NON-CORE (downstream of channel activity)</h3>
+<ul>
+<li><strong>Chemotaxis</strong>: "tax-2 activity is required in the adult stage for normal chemotaxis to NaCl and odorants."<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/9486798" title="tax-2 activity is required in the adult stage for normal chemotaxis to NaCl and odorants.">PMID:9486798</a></li>
+<li><strong>Sensory axon maintenance</strong>: "tax-2 and tax-4 are required for the maintenance of correct axon structure";<br />
+  a ts tax-2 allele shows tax-2 activity is required in the adult to preserve axon morphology.<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/9486798" title="these results indicate that tax-2 and tax-4 are required for the maintenance of correct axon structure">PMID:9486798</a></li>
+<li><strong>Oxygen sensing / aerotaxis / hyperoxia</strong>: "Avoidance of high oxygen levels by C. elegans requires the sensory<br />
+  cGMP-gated channel tax-2/tax-4 and a specific soluble guanylate cyclase homologue, gcy-35."<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/15220933" title="Avoidance of high oxygen levels by C. elegans requires the sensory cGMP-gated channel tax-2/tax-4 and a specific soluble guanylate cyclase homologue, gcy-35.">PMID:15220933</a></li>
+<li><strong>O2-evoked cGMP/Ca2+ dynamics &amp; feedback</strong>: "Increased cGMP leads to a sustained Ca(2+) response in the neuron<br />
+  that depends on cGMP-gated ion channels"; "Elevated levels of cGMP and Ca(2+) stimulate competing negative<br />
+  feedback loops that shape cGMP dynamics."<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/23940325" title="Increased cGMP leads to a sustained Ca(2+) response in the neuron that depends on cGMP-gated ion channels.">PMID:23940325</a><br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/23940325" title="Elevated levels of cGMP and Ca(2+) stimulate competing negative feedback loops that shape cGMP dynamics.">PMID:23940325</a></li>
+<li><strong>Phototransduction (G-protein/cGMP pathway)</strong>: light-evoked dark current in ASJ "was absent in the CNG channel<br />
+  mutants tax-2 and tax-4"; LITE-1-dependent photocurrent "also required the GC DAF-11 and the CNG channel TAX-2 and TAX-4."<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/20436480" title="This dark current was apparently carried by CNG channels, as it can be blocked by the CNG channel-specific inhibitor L-cis-diltiazem and was absent in the CNG channel mutants tax-2 and tax-4">PMID:20436480</a><br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/20436480" title="the LITE-1-dependent photocurrent in ASI also required the GC DAF-11 and the CNG channel TAX-2 and TAX-4">PMID:20436480</a></li>
+<li><strong>Thermosensation/thermotaxis</strong>: tax-2/tax-4 essential for thermosensation (PMID:10064800; PMID:9486798).<br />
+  PMID:7630402 (Mori &amp; Ohshima 1995, the WormBase original ref for thermosensory behavior) is the thermotaxis<br />
+  neural-circuit paper; full text not in cache and the abstract centers on AFD/AIY/AIZ, but tax-2 was isolated<br />
+  as a thermotaxis-abnormal (<em>tax</em>) mutant and its thermosensory requirement is independently established.</li>
+<li><strong>Chemosensory control of gene expression / neuroendocrine signaling</strong>: ASJ chemosensation of P. aeruginosa<br />
+  metabolites "induces expression of the neuromodulator DAF-7/TGF-β"; TAX-2/TAX-4 is the ASJ chemosensory channel upstream.<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/25303524" title="induces expression of the neuromodulator DAF-7/TGF-β">PMID:25303524</a></li>
+<li><strong>Thermosensory-neuron gene expression / morphology</strong>: CMK-1 and TAX-4 (the channel TAX-2 co-forms) "regulate<br />
+  gene expression, morphology, and functions of the AFD thermosensory neurons"; TAX-4 activity is required during<br />
+  larval stages to maintain adult gene expression. (Abstract foregrounds TAX-4; TAX-2 is the obligate partner subunit.)<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/14711416" title="the TAX-4 cyclic nucleotide-gated channel regulate gene expression, morphology, and functions of the AFD thermosensory neurons">PMID:14711416</a></li>
+</ul>
+<h2 id="not-known-uncertain-knowledge-gaps">NOT known / uncertain (knowledge gaps)</h2>
+<ol>
+<li><strong>Mechanism of beta-subunit modulation.</strong> How TAX-2 lowers cGMP sensitivity ~25-fold and alters divalent-cation<br />
+   block / single-channel behavior of the heteromer, and whether it does so uniformly across neurons, is not<br />
+   mechanistically defined. <a href="https://pubmed.ncbi.nlm.nih.gov/10064800">PMID:10064800</a></li>
+<li><strong>Does the TAX-2 CNBD bind cGMP?</strong> TAX-2 has a CNBD (PS50042, 538-642) and carries an IBA cGMP-binding annotation,<br />
+   but direct biochemical cGMP binding by the TAX-2 CNBD (vs. a modulatory/non-canonical CNBD as in vertebrate CNGB)<br />
+   has not been demonstrated. Beta-subunit CNBDs are frequently ligand-non-functional or purely modulatory.</li>
+<li><strong>In vivo stoichiometry &amp; composition.</strong> The endogenous TAX-4:TAX-2 ratio and whether composition varies between<br />
+   neurons or ciliary subcompartments is inferred, not measured; ciliary localization is subunit-interdependent<br />
+   and heterogeneous across the cilium. [PMID:23886944, PMID:10064800]</li>
+<li><strong>tax-2 roles independent of tax-4.</strong> Because TAX-2 forms no channel alone, an independent conductance is unlikely,<br />
+   but whether TAX-2 has tax-4-independent roles (e.g. partnering other alpha subunits such as CNG-1/CNG-3, or<br />
+   non-conducting/structural/trafficking roles) is unresolved. [PMID:10064800, PMID:23886944]</li>
+</ol>
+<h2 id="ligand-selectivity-note-affects-camp-annotation">Ligand-selectivity note (affects cAMP annotation)</h2>
+<p>The native worm heteromer "remains highly selective for cGMP over cAMP" <a href="https://pubmed.ncbi.nlm.nih.gov/10064800">PMID:10064800</a>. The GOA IBA term<br />
+GO:0005222 (intracellularly cAMP-activated cation channel activity) is inherited from the PANTHER CNG family<br />
+(which contains cAMP-responsive vertebrate CNGA2) and over-states cAMP as a physiological ligand for the worm<br />
+TAX-2/TAX-4 channel → marked as over-annotated.</p>
+<h2 id="annotation-plan-25-goa-annotations">Annotation plan (25 GOA annotations)</h2>
+<ul>
+<li>CORE channel MF/CC/transport (ACCEPT): plasma membrane (IBA), cGMP binding (IBA), monoatomic cation<br />
+  transmembrane transport (IBA+IDA), intracellular cyclic-nucleotide-activated cation channel complex (IBA),<br />
+  monoatomic ion channel activity (IEA), intracellularly cyclic-nucleotide-activated monoatomic cation channel<br />
+  activity (IEA), monoatomic ion transport (IEA), transmembrane transport (IEA), membrane (IEA),<br />
+<strong>intracellularly cGMP-activated cation channel activity (IDA, contributes_to)</strong>, cation channel complex (IDA, part_of).</li>
+<li>OVER-ANNOTATED: intracellularly cAMP-activated cation channel activity (IBA) — heteromer is cGMP-selective.</li>
+<li>NON-CORE (KEEP): positive regulation of gene expression, GPCR signaling coupled to cGMP, negative regulation of<br />
+  receptor guanylyl cyclase signaling, response to oxygen levels, thermosensory behavior, chemotaxis, regulation of<br />
+  axon extension, aerotaxis, response to hyperoxia, regulation of neuron differentiation, positive regulation of<br />
+  transcription by RNA Pol II, neuron projection morphogenesis. All are downstream sensory outputs of channel activity.</li>
+</ul>
+<h2 id="cross-reference">Cross-reference</h2>
+<p>tax-4 (alpha subunit) review: PR #1716 (branch claude/worm-tax-4-review). Channel-complex modeling kept consistent:<br />
+in_complex = GO:0017071; native channel is TAX-4/TAX-2 heteromer. tax-2 modeled with contributes_to_molecular_function<br />
+to reflect its beta/modulatory (non-pore-forming-alone) role.</p>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: G5EEE2
+gene_symbol: tax-2
+product_type: PROTEIN
+status: COMPLETE
+taxon:
+  id: NCBITaxon:6239
+  label: Caenorhabditis elegans
+description: &gt;-
+  tax-2 encodes the modulatory beta subunit of a cyclic nucleotide-gated (CNG)
+  cation channel, the C. elegans ortholog of vertebrate CNGB subunits. TAX-2
+  cannot form a functional channel on its own; in vivo it co-assembles with the
+  alpha (principal, pore-forming) subunit TAX-4 to build the native sensory CNG
+  channel, a heteromer that is opened directly by intracellular cGMP and conducts
+  Ca2+, Na+ and K+ across the membrane. As a beta subunit TAX-2 tunes rather than
+  solely forms the pore: the TAX-4/TAX-2 heteromer is markedly (about 25-fold)
+  less cGMP-sensitive than the TAX-4 homomer while remaining highly selective for
+  cGMP over cAMP, and the two forms differ in divalent-cation block and
+  single-channel behavior. TAX-2 harbors a pore/ion-transport domain and a
+  C-terminal cyclic-nucleotide-binding domain, and is targeted, together with
+  TAX-4, to the plasma membrane and to specific subcompartments of the non-motile
+  sensory cilia of ciliated neurons, where their ciliary localization is mutually
+  interdependent. As part of the effector channel of cGMP-mediated sensory signal
+  transduction, TAX-2 is required for a broad range of sensory modalities,
+  including chemosensation and chemotaxis, thermosensation, oxygen sensing and
+  aerotaxis, and light responses; channel activity also feeds into downstream
+  outputs such as sensory-neuron gene expression and the maintenance of sensory
+  axon structure.
+existing_annotations:
+- term:
+    id: GO:0005886
+    label: plasma membrane
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: is_active_in
+  review:
+    summary: &gt;-
+      The TAX-2/TAX-4 CNG channel acts at the plasma membrane of ciliated sensory
+      neurons (including the ciliary membrane). Core cellular component.
+    action: ACCEPT
+    supported_by:
+    - reference_id: PMID:23886944
+      supporting_text: &gt;-
+        identify sequences required for efficient ciliary targeting and
+        localization of the TAX-2 CNGB and TAX-4 CNGA subunits.
+- term:
+    id: GO:0005222
+    label: intracellularly cAMP-activated cation channel activity
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: enables
+  review:
+    summary: &gt;-
+      This IBA term is inherited from the PANTHER CNG family (which includes
+      cAMP-responsive vertebrate CNGA subunits). The native C. elegans TAX-4/TAX-2
+      heteromer is highly selective for cGMP over cAMP, so cAMP-activated cation
+      channel activity over-states cAMP as a physiological ligand for this channel;
+      cGMP is the relevant activating ligand. Marked as over-annotated rather than
+      removed because CNG channels retain weak cAMP responsiveness in vitro.
+    action: MARK_AS_OVER_ANNOTATED
+    supported_by:
+    - reference_id: PMID:10064800
+      supporting_text: &gt;-
+        it remains highly selective for cGMP over cAMP.
+    propagation_review:
+      root_cause: TERM_SCOPING_PROBLEM
+      failure_modes:
+      - FUNCTIONAL_DIVERGENCE
+      source_entities:
+      - source_id: PANTHER:PTHR45638
+        source_label: Cyclic Nucleotide-Gated Cation Channel
+        source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
+        comment: &gt;-
+          Family includes cAMP-responsive vertebrate CNGA subunits, but the
+          C. elegans TAX-4/TAX-2 channel is cGMP-selective, so cAMP-activated
+          activity should not propagate to tax-2.
+- term:
+    id: GO:0030553
+    label: cGMP binding
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: enables
+  review:
+    summary: &gt;-
+      TAX-2 contains a C-terminal cyclic-nucleotide-binding domain (CNBD;
+      PROSITE PS50042, residues 538-642) consistent with cyclic-nucleotide sensing
+      by the CNG channel it forms with TAX-4. cGMP is the physiological ligand of
+      the heteromer. Retained as a core-consistent function of the channel, though
+      direct biochemical cGMP binding by the TAX-2 CNBD specifically (as opposed to
+      the TAX-4 alpha subunit) has not been demonstrated (see knowledge gaps).
+    action: ACCEPT
+    supported_by:
+    - reference_id: PMID:10064800
+      supporting_text: &gt;-
+        it remains highly selective for cGMP over cAMP.
+- term:
+    id: GO:0098655
+    label: monoatomic cation transmembrane transport
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      The CNG channel conducts cations (Ca2+/Na+/K+) across the membrane; TAX-2 is
+      part of that channel. Core transport process.
+    action: ACCEPT
+- term:
+    id: GO:0017071
+    label: intracellular cyclic nucleotide activated cation channel complex
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: part_of
+  review:
+    summary: &gt;-
+      TAX-2 is a subunit of the intracellular cyclic-nucleotide-activated cation
+      channel complex (the TAX-4/TAX-2 heteromer). Core cellular component/complex.
+    action: ACCEPT
+    supported_by:
+    - reference_id: PMID:10064800
+      supporting_text: &gt;-
+        Here we show that TAX-4 and TAX-2 form a heteromeric channel when expressed
+        in HEK293 cells, but TAX-2 does not form a channel on its own.
+- term:
+    id: GO:0005216
+    label: monoatomic ion channel activity
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Consistent with TAX-2 being a subunit of an ion channel (Pfam PF00520
+      ion-transport/pore domain). Accurate but general parent term; the specific
+      channel activity is captured by GO:0005223.
+    action: ACCEPT
+- term:
+    id: GO:0005221
+    label: intracellularly cyclic nucleotide-activated monoatomic cation channel activity
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Correct at the level of the cyclic-nucleotide-gated channel TAX-2 helps form;
+      the more specific cGMP-activated term (GO:0005223) is the precise function.
+    action: ACCEPT
+- term:
+    id: GO:0006811
+    label: monoatomic ion transport
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      General parent of the channel&#39;s cation-transport process. Accurate but broad.
+    action: ACCEPT
+- term:
+    id: GO:0016020
+    label: membrane
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000120
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      TAX-2 is a multi-pass membrane protein; correct but less informative than the
+      plasma-membrane/ciliary-membrane localization.
+    action: ACCEPT
+- term:
+    id: GO:0055085
+    label: transmembrane transport
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      General parent of the channel&#39;s transmembrane cation-transport process.
+      Accurate but broad.
+    action: ACCEPT
+- term:
+    id: GO:0005223
+    label: intracellularly cGMP-activated cation channel activity
+  evidence_type: IDA
+  original_reference_id: PMID:10064800
+  qualifier: contributes_to
+  review:
+    summary: &gt;-
+      Core molecular function. Functional reconstitution in HEK293 cells shows that
+      TAX-2 co-assembles with the alpha subunit TAX-4 into a cGMP-gated cation
+      channel; TAX-2 does not form a channel alone and acts as a modifying beta
+      subunit that lowers the heteromer&#39;s cGMP sensitivity. The &#39;contributes_to&#39;
+      qualifier correctly reflects that TAX-2 participates in, rather than
+      independently enables, this channel activity.
+    action: ACCEPT
+    supported_by:
+    - reference_id: PMID:10064800
+      supporting_text: &gt;-
+        with TAX-4 as the alpha subunit and TAX-2 acting as a modifying beta
+        subunit.
+    - reference_id: PMID:10064800
+      supporting_text: &gt;-
+        The heteromeric TAX-4/TAX-2 channel is 25-fold less sensitive to cGMP than
+        the TAX-4 channel, but it remains highly selective for cGMP over cAMP.
+- term:
+    id: GO:0034703
+    label: cation channel complex
+  evidence_type: IDA
+  original_reference_id: PMID:10064800
+  qualifier: part_of
+  review:
+    summary: &gt;-
+      TAX-2 is part of the reconstituted heteromeric cation channel. Core cellular
+      component/complex, directly supported.
+    action: ACCEPT
+    supported_by:
+    - reference_id: PMID:10064800
+      supporting_text: &gt;-
+        Here we show that TAX-4 and TAX-2 form a heteromeric channel when expressed
+        in HEK293 cells, but TAX-2 does not form a channel on its own.
+- term:
+    id: GO:0010628
+    label: positive regulation of gene expression
+  evidence_type: IMP
+  original_reference_id: PMID:25303524
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Downstream, activity-dependent output. In the ASJ chemosensory neuron the
+      TAX-2/TAX-4 channel transduces detection of P. aeruginosa secondary
+      metabolites, leading to induced expression of the DAF-7/TGF-beta
+      neuromodulator. This is an indirect consequence of sensory channel activity,
+      not a direct gene-regulatory function of TAX-2. Non-core.
+    action: KEEP_AS_NON_CORE
+    supported_by:
+    - reference_id: PMID:25303524
+      supporting_text: &gt;-
+        induces expression of the neuromodulator DAF-7/TGF-β
+- term:
+    id: GO:0007199
+    label: G protein-coupled receptor signaling pathway coupled to cGMP nucleotide
+      second messenger
+  evidence_type: IMP
+  original_reference_id: PMID:20436480
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      In ASJ phototransduction, a G-protein/cGMP cascade opens cGMP-sensitive CNG
+      channels; light-evoked currents are abolished in tax-2 (and tax-4) mutants,
+      placing the channel as the effector downstream of the GPCR-coupled cGMP
+      pathway. Non-core downstream signaling context.
+    action: KEEP_AS_NON_CORE
+    supported_by:
+    - reference_id: PMID:20436480
+      supporting_text: &gt;-
+        This dark current was apparently carried by CNG channels, as it can be
+        blocked by the CNG channel-specific inhibitor L-cis-diltiazem and was absent
+        in the CNG channel mutants tax-2 and tax-4
+- term:
+    id: GO:0010754
+    label: negative regulation of receptor guanylyl cyclase signaling pathway
+  evidence_type: IMP
+  original_reference_id: PMID:23940325
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      In vivo cGMP/Ca2+ imaging of an O2-sensing neuron shows that cGMP-gated
+      channels participate in negative-feedback loops that shape cGMP signaling
+      dynamics. This reflects the channel&#39;s role within feedback regulation of the
+      cGMP pathway rather than a direct enzymatic regulation of guanylyl cyclase.
+      Non-core.
+    action: KEEP_AS_NON_CORE
+    supported_by:
+    - reference_id: PMID:23940325
+      supporting_text: &gt;-
+        Elevated levels of cGMP and Ca(2+) stimulate competing negative feedback
+        loops that shape cGMP dynamics.
+- term:
+    id: GO:0070482
+    label: response to oxygen levels
+  evidence_type: IMP
+  original_reference_id: PMID:23940325
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      O2-evoked rises in cGMP drive a sustained Ca2+ response that depends on
+      cGMP-gated ion channels (the TAX-2/TAX-4 channel). A downstream sensory
+      response mediated by channel activity. Non-core.
+    action: KEEP_AS_NON_CORE
+    supported_by:
+    - reference_id: PMID:23940325
+      supporting_text: &gt;-
+        Increased cGMP leads to a sustained Ca(2+) response in the neuron that
+        depends on cGMP-gated ion channels.
+- term:
+    id: GO:0040040
+    label: thermosensory behavior
+  evidence_type: IMP
+  original_reference_id: PMID:7630402
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      tax-2 was isolated as a thermotaxis-abnormal (tax) mutant, and the TAX-2/TAX-4
+      channel is essential for thermosensation in the AFD thermosensory neuron. This
+      is a downstream sensory behavior mediated by channel activity. Non-core. The
+      cited 1995 thermotaxis paper is the WormBase original reference; its cached
+      record is abstract-only and centers on the AFD/AIY/AIZ circuit, but the tax-2
+      thermosensory requirement is independently established (PMID:10064800,
+      PMID:9486798); annotation retained (defer to curator full-text) rather than
+      removed.
+    action: KEEP_AS_NON_CORE
+    supported_by:
+    - reference_id: PMID:9486798
+      supporting_text: &gt;-
+        The tax-2 and tax-4 genes of C. elegans encode two subunits of a cyclic
+        nucleotide-gated channel that is required for chemosensation, thermosensation
+        and normal axon outgrowth of some sensory neurons.
+- term:
+    id: GO:0098655
+    label: monoatomic cation transmembrane transport
+  evidence_type: IDA
+  original_reference_id: PMID:10064800
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Directly supported by functional reconstitution: the heteromeric channel
+      conducts cations across the membrane and differs from the TAX-4 homomer in
+      divalent-cation block and single-channel properties. Core transport process.
+    action: ACCEPT
+    supported_by:
+    - reference_id: PMID:10064800
+      supporting_text: &gt;-
+        The heteromeric channel and the TAX-4 homomeric channel differ in their
+        blockage by divalent cations and in their single channel properties.
+- term:
+    id: GO:0006935
+    label: chemotaxis
+  evidence_type: IMP
+  original_reference_id: PMID:9486798
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      tax-2 activity is required for normal chemotaxis to NaCl and odorants, a
+      downstream sensory behavior mediated by the CNG channel. Non-core.
+    action: KEEP_AS_NON_CORE
+    supported_by:
+    - reference_id: PMID:9486798
+      supporting_text: &gt;-
+        tax-2 activity is required in the adult stage for normal chemotaxis to NaCl
+        and odorants.
+- term:
+    id: GO:0030516
+    label: regulation of axon extension
+  evidence_type: IMP
+  original_reference_id: PMID:9486798
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      tax-2 (with tax-4) is required to maintain correct sensory axon structure;
+      in mutants, axon outgrowth resumes inappropriately in late larval/adult
+      stages. A distinct, activity-dependent role of the channel in maintaining
+      axon morphology. Non-core.
+    action: KEEP_AS_NON_CORE
+    supported_by:
+    - reference_id: PMID:9486798
+      supporting_text: &gt;-
+        These results indicate that tax-2 and tax-4 are required for the maintenance
+        of correct axon structure
+- term:
+    id: GO:0009454
+    label: aerotaxis
+  evidence_type: IMP
+  original_reference_id: PMID:15220933
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Avoidance of high oxygen (aerotaxis) requires the sensory cGMP-gated channel
+      tax-2/tax-4 together with the soluble guanylate cyclase gcy-35. Downstream
+      sensory behavior mediated by channel activity. Non-core.
+    action: KEEP_AS_NON_CORE
+    supported_by:
+    - reference_id: PMID:15220933
+      supporting_text: &gt;-
+        Avoidance of high oxygen levels by C. elegans requires the sensory
+        cGMP-gated channel tax-2/tax-4 and a specific soluble guanylate cyclase
+        homologue, gcy-35.
+- term:
+    id: GO:0055093
+    label: response to hyperoxia
+  evidence_type: IMP
+  original_reference_id: PMID:15220933
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      The tax-2/tax-4 channel mediates responses that allow avoidance of hyperoxic
+      (high-O2) environments. Downstream sensory response. Non-core.
+    action: KEEP_AS_NON_CORE
+    supported_by:
+    - reference_id: PMID:15220933
+      supporting_text: &gt;-
+        Avoidance of high oxygen levels by C. elegans requires the sensory
+        cGMP-gated channel tax-2/tax-4 and a specific soluble guanylate cyclase
+        homologue, gcy-35.
+- term:
+    id: GO:0045664
+    label: regulation of neuron differentiation
+  evidence_type: IMP
+  original_reference_id: PMID:14711416
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      An indirect, activity-dependent effect: loss of the TAX-4 channel (which
+      TAX-2 co-forms) alters AFD thermosensory-neuron gene expression and
+      morphology. The cited paper&#39;s abstract foregrounds TAX-4, but TAX-2 is its
+      obligate heteromeric partner; this is a downstream consequence of channel
+      activity rather than a direct differentiation function. Non-core.
+    action: KEEP_AS_NON_CORE
+    supported_by:
+    - reference_id: PMID:14711416
+      supporting_text: &gt;-
+        the TAX-4 cyclic nucleotide-gated channel regulate gene expression,
+        morphology, and functions of the AFD thermosensory neurons
+- term:
+    id: GO:0045944
+    label: positive regulation of transcription by RNA polymerase II
+  evidence_type: IMP
+  original_reference_id: PMID:14711416
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Indirect, activity-dependent regulation of AFD-specific gene expression by
+      the CNG channel; TAX-2 has no direct transcriptional activity. Retained as a
+      downstream effect (abstract foregrounds TAX-4, the obligate partner subunit).
+      Non-core.
+    action: KEEP_AS_NON_CORE
+    supported_by:
+    - reference_id: PMID:14711416
+      supporting_text: &gt;-
+        the TAX-4 cyclic nucleotide-gated channel regulate gene expression,
+        morphology, and functions of the AFD thermosensory neurons
+- term:
+    id: GO:0048812
+    label: neuron projection morphogenesis
+  evidence_type: IMP
+  original_reference_id: PMID:14711416
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Indirect effect on AFD sensory-neuron morphology consequent on loss of CNG
+      channel activity. Downstream/non-core; abstract foregrounds TAX-4, the
+      obligate partner subunit of TAX-2.
+    action: KEEP_AS_NON_CORE
+    supported_by:
+    - reference_id: PMID:14711416
+      supporting_text: &gt;-
+        the TAX-4 cyclic nucleotide-gated channel regulate gene expression,
+        morphology, and functions of the AFD thermosensory neurons
+- term:
+    id: GO:0097730
+    label: non-motile cilium
+  evidence_type: IDA
+  original_reference_id: PMID:23886944
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Proposed new annotation. The TAX-2 CNGB subunit is targeted to and localized
+      within the non-motile sensory cilia of ciliated neurons; sequences required
+      for ciliary targeting/localization of TAX-2 (and TAX-4) were mapped, and the
+      subunits are relatively immobile in specific ciliary subcompartments. Core
+      cellular component not currently in the GOA set.
+    action: NEW
+    supported_by:
+    - reference_id: PMID:23886944
+      supporting_text: &gt;-
+        identify sequences required for efficient ciliary targeting and
+        localization of the TAX-2 CNGB and TAX-4 CNGA subunits.
+- term:
+    id: GO:0007606
+    label: sensory perception of chemical stimulus
+  evidence_type: IMP
+  original_reference_id: PMID:9486798
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Proposed new annotation summarizing the channel&#39;s core sensory role: tax-2 is
+      required for chemosensation (chemotaxis to NaCl and odorants), a form of
+      sensory perception of chemical stimulus mediated by the CNG channel. Captures
+      the core sensory-transduction process at an appropriate level of generality.
+    action: NEW
+    supported_by:
+    - reference_id: PMID:9486798
+      supporting_text: &gt;-
+        The tax-2 and tax-4 genes of C. elegans encode two subunits of a cyclic
+        nucleotide-gated channel that is required for chemosensation, thermosensation
+        and normal axon outgrowth of some sensory neurons.
+core_functions:
+- description: &gt;-
+    TAX-2 is the modulatory beta subunit of the sensory cyclic nucleotide-gated
+    (CNG) cation channel. It cannot form a channel on its own; it co-assembles with
+    the alpha (pore-forming) subunit TAX-4 into the native heteromeric channel that
+    is directly opened by intracellular cGMP and conducts cations (Ca2+/Na+/K+)
+    across the plasma/ciliary membrane of ciliated sensory neurons. As a beta
+    subunit TAX-2 contributes ion-channel (pore) structure and tunes the channel:
+    the TAX-4/TAX-2 heteromer is ~25-fold less cGMP-sensitive than the TAX-4
+    homomer and differs in divalent-cation block and single-channel behavior. This
+    channel is the effector of cGMP-mediated sensory signal transduction.
+  molecular_function:
+    id: GO:0005216
+    label: monoatomic ion channel activity
+  contributes_to_molecular_function:
+    id: GO:0005223
+    label: intracellularly cGMP-activated cation channel activity
+  directly_involved_in:
+  - id: GO:0098655
+    label: monoatomic cation transmembrane transport
+  - id: GO:0007606
+    label: sensory perception of chemical stimulus
+  locations:
+  - id: GO:0005886
+    label: plasma membrane
+  - id: GO:0097730
+    label: non-motile cilium
+  in_complex:
+    id: GO:0017071
+    label: intracellular cyclic nucleotide activated cation channel complex
+  supported_by:
+  - reference_id: PMID:10064800
+    supporting_text: &gt;-
+      Here we show that TAX-4 and TAX-2 form a heteromeric channel when expressed
+      in HEK293 cells, but TAX-2 does not form a channel on its own.
+  - reference_id: PMID:10064800
+    supporting_text: &gt;-
+      with TAX-4 as the alpha subunit and TAX-2 acting as a modifying beta subunit.
+  - reference_id: PMID:23886944
+    supporting_text: &gt;-
+      identify sequences required for efficient ciliary targeting and localization
+      of the TAX-2 CNGB and TAX-4 CNGA subunits.
+knowledge_gaps:
+- gap_statement: &gt;-
+    How the TAX-2 beta subunit mechanistically modulates the channel — lowering
+    cGMP sensitivity ~25-fold and changing divalent-cation block and single-channel
+    behavior relative to the TAX-4 homomer — and whether this tuning is uniform
+    across neurons, is not defined.
+  boundary: &gt;-
+    In heterologous cells the TAX-4/TAX-2 heteromer is 25-fold less cGMP-sensitive
+    than the TAX-4 homomer yet stays cGMP-selective, and the two forms differ in
+    divalent-cation block and single-channel properties; the structural/mechanistic
+    basis of this modulation by TAX-2 is not established.
+  gap_kind:
+  - BIOLOGY
+  dark_aspect: RESIDUAL_SUBGAP
+  status: OPEN
+  significance: &gt;-
+    The beta subunit sets the channel&#39;s cGMP operating range and ion handling, so
+    how TAX-2 tunes gating directly determines each sensory neuron&#39;s stimulus
+    threshold and dynamic range.
+  resolution: &gt;-
+    Structure/function of the TAX-4/TAX-2 heteromer (cryo-EM and mutagenesis of
+    TAX-2 CNBD/pore residues) with side-by-side homomer-versus-heteromer
+    electrophysiology.
+  provenance:
+  - reference_id: PMID:10064800
+    supporting_text: &gt;-
+      The heteromeric TAX-4/TAX-2 channel is 25-fold less sensitive to cGMP than the
+      TAX-4 channel, but it remains highly selective for cGMP over cAMP.
+- gap_statement: &gt;-
+    Whether the TAX-2 cyclic-nucleotide-binding domain itself binds cGMP and
+    whether that binding is functional (vs. a modulatory/non-canonical CNBD as in
+    vertebrate CNGB beta subunits) is unknown.
+  boundary: &gt;-
+    TAX-2 has a predicted CNBD (PROSITE PS50042, residues 538-642) and carries an
+    IBA cGMP-binding annotation, but direct cGMP binding by the TAX-2 CNBD (as
+    opposed to the TAX-4 alpha subunit) has not been demonstrated biochemically.
+  gap_kind:
+  - BIOLOGY
+  dark_aspect: MF_DARK
+  status: OPEN
+  significance: &gt;-
+    Whether TAX-2&#39;s CNBD is a functional ligand sensor or a purely structural
+    modulator changes how the heteromer integrates cGMP and how its sensitivity is
+    set.
+  resolution: &gt;-
+    Direct ligand-binding assays on isolated/mutated TAX-2 CNBD and CNBD-mutant
+    channel electrophysiology.
+  provenance:
+  - reference_id: PMID:10064800
+    supporting_text: &gt;-
+      it remains highly selective for cGMP over cAMP.
+- gap_statement: &gt;-
+    The endogenous TAX-4:TAX-2 subunit stoichiometry and whether channel
+    composition varies between neuron types or between ciliary subcompartments of a
+    single neuron is inferred, not measured.
+  boundary: &gt;-
+    TAX-4 + TAX-2 co-assemble into a functional heteromer in HEK293 cells while
+    TAX-2 alone cannot form a channel; in vivo, ciliary localization of the two
+    subunits is interdependent and heterogeneous across the cilium, but the native
+    stoichiometry is not quantified.
+  gap_kind:
+  - BIOLOGY
+  dark_aspect: RESIDUAL_SUBGAP
+  status: OPEN
+  significance: &gt;-
+    Subunit composition sets ligand sensitivity, ion handling and localization, so
+    it determines how each sensory neuron converts a cGMP signal into a response.
+  resolution: &gt;-
+    Quantitative in vivo subunit-copy-number measurement (e.g. calibrated
+    fluorescence or single-molecule counting) per neuron and per ciliary
+    subcompartment.
+  provenance:
+  - reference_id: PMID:23886944
+    supporting_text: &gt;-
+      CNG channel subunits can be localized to discrete ciliary compartments in
+      individual sensory neurons in C. elegans, suggesting that channel composition
+      is heterogeneous across the cilium.
+  - reference_id: PMID:10064800
+    supporting_text: &gt;-
+      most of the native channels in C. elegans are likely to be hetero-oligomers of
+      TAX-4 and TAX-2 subunits
+- gap_statement: &gt;-
+    Whether TAX-2 has roles independent of TAX-4 — for example partnering other CNG
+    alpha subunits, or non-conducting structural/trafficking roles — is unresolved.
+  boundary: &gt;-
+    TAX-2 forms no channel on its own, so an independent TAX-2 conductance is
+    unlikely; but ciliary localization is subunit-interdependent and TAX-2 is
+    expressed in cells where its full complement of partners and any TAX-4-independent
+    contribution have not been mapped.
+  gap_kind:
+  - BIOLOGY
+  dark_aspect: RESIDUAL_SUBGAP
+  status: OPEN
+  significance: &gt;-
+    Distinguishing an obligate TAX-4 partner from a subunit with broader partnerships
+    or scaffolding roles would clarify which sensory functions strictly require the
+    canonical TAX-4/TAX-2 heteromer.
+  resolution: &gt;-
+    Interaction proteomics and cell-specific epistasis (tax-2 vs tax-4 vs other CNG
+    subunits) with functional imaging in defined neurons.
+  provenance:
+  - reference_id: PMID:10064800
+    supporting_text: &gt;-
+      Here we show that TAX-4 and TAX-2 form a heteromeric channel when expressed in
+      HEK293 cells, but TAX-2 does not form a channel on its own.
+suggested_questions:
+- question: &gt;-
+    Does the TAX-2 CNBD bind cGMP, and is that binding required for the beta
+    subunit&#39;s ~25-fold reduction of channel cGMP sensitivity?
+- question: &gt;-
+    What is the endogenous TAX-4:TAX-2 stoichiometry in native sensory cilia, and
+    does it differ between neuron types or ciliary subcompartments?
+suggested_experiments:
+- description: &gt;-
+    Reconstitute and solve the structure of the TAX-4/TAX-2 heteromer (cryo-EM) and
+    perform side-by-side electrophysiology of TAX-4 homomer versus TAX-4/TAX-2
+    heteromer with targeted mutations in the TAX-2 CNBD and pore, to define how TAX-2
+    tunes cGMP sensitivity, ion selectivity and divalent-cation block.
+- description: &gt;-
+    Quantify TAX-2 and TAX-4 subunit copy number/ratio in defined sensory cilia in
+    vivo (calibrated fluorescence or single-molecule counting) and correlate with
+    cell-specific cGMP dose-response to map homomeric versus heteromeric channels
+    onto neurons.
+references:
+- id: GO_REF:0000002
+  title: Gene Ontology annotation through association of InterPro records with GO
+    terms
+  findings: []
+- id: GO_REF:0000033
+  title: Annotation inferences using phylogenetic trees
+  findings: []
+- id: GO_REF:0000120
+  title: Combined Automated Annotation using Multiple IEA Methods
+  findings: []
+- id: PMID:10064800
+  title: Functional reconstitution of a heteromeric cyclic nucleotide-gated channel
+    of Caenorhabditis elegans in cultured cells.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PubMed-verified. The definitive TAX-2 paper: TAX-4 and TAX-2 form a heteromeric
+      cGMP-gated channel in HEK293 cells, TAX-2 cannot form a channel alone and acts
+      as a modifying beta subunit, and the heteromer is ~25-fold less cGMP-sensitive
+      than the TAX-4 homomer but stays highly selective for cGMP over cAMP. Grounds the
+      core molecular function/complex, the beta-subunit modulation, and the cAMP
+      over-annotation call.
+- id: PMID:14711416
+  title: The CMK-1 CaMKI and the TAX-4 Cyclic nucleotide-gated channel regulate thermosensory
+    neuron gene expression and function in C. elegans.
+  findings: []
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Assays the AFD CNG channel; loss of channel activity alters AFD-specific gene
+      expression, morphology and function. Abstract foregrounds the TAX-4 alpha
+      subunit, but TAX-2 is its obligate heteromeric partner; supports the indirect,
+      activity-dependent gene-expression / neuron-differentiation / morphology
+      non-core annotations. Cached abstract-only.
+- id: PMID:15220933
+  title: Oxygen sensation and social feeding mediated by a C. elegans guanylate cyclase
+    homologue.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Explicitly names the sensory cGMP-gated channel tax-2/tax-4 as required for
+      high-O2 avoidance, together with the soluble guanylate cyclase gcy-35. Solid
+      support for the aerotaxis and response-to-hyperoxia non-core annotations.
+      Cached abstract-only.
+- id: PMID:20436480
+  title: C. elegans phototransduction requires a G protein-dependent cGMP pathway
+    and a taste receptor homolog.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Full text (PMC) shows ASJ light-evoked currents are abolished in tax-2 and
+      tax-4 mutants and that the LITE-1-dependent photocurrent requires the CNG
+      channel TAX-2 and TAX-4 downstream of a G-protein/cGMP cascade. Supports the
+      GPCR-cGMP-second-messenger non-core annotation.
+- id: PMID:23886944
+  title: Cell- and subunit-specific mechanisms of CNG channel ciliary trafficking
+    and localization in C. elegans.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Directly studies the TAX-2 CNGB (and TAX-4 CNGA) subunit: maps sequences
+      required for ciliary targeting/localization, shows subunit-interdependent and
+      heterogeneous ciliary localization, and that TAX-2/TAX-4 are relatively immobile
+      in cilia subcompartments. Grounds the plasma-membrane/ciliary localization and
+      the in vivo composition/stoichiometry knowledge gap.
+- id: PMID:23940325
+  title: In vivo genetic dissection of O2-evoked cGMP dynamics in a Caenorhabditis
+    elegans gas sensor.
+  findings: []
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: &gt;-
+      In vivo cGMP/Ca2+ imaging showing cGMP-gated channels are required for the
+      sustained O2-evoked Ca2+ response and participate in negative-feedback loops.
+      Supports the response-to-oxygen and negative-regulation-of-rGC-signaling non-core
+      annotations. Cached abstract-only.
+- id: PMID:25303524
+  title: Chemosensation of bacterial secondary metabolites modulates neuroendocrine
+    signaling and behavior of C. elegans.
+  findings: []
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: &gt;-
+      ASJ chemosensory detection of P. aeruginosa metabolites induces DAF-7/TGF-beta
+      expression; the TAX-2/TAX-4 channel is the ASJ chemosensory effector upstream.
+      Supports the positive-regulation-of-gene-expression non-core annotation. Cached
+      abstract-only (does not name tax-2 in the abstract; retained per curator full text).
+- id: PMID:7630402
+  title: Neural regulation of thermotaxis in Caenorhabditis elegans.
+  findings: []
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: &gt;-
+      WormBase original reference for the thermosensory-behavior IMP. The 1995 paper
+      dissects the AFD/AIY/AIZ thermotaxis circuit; its cached record is abstract-only
+      and does not name tax-2, but tax-2 was isolated as a thermotaxis-abnormal mutant
+      and its thermosensory requirement is independently established (PMID:10064800,
+      PMID:9486798). Annotation retained (defer to curator full text) rather than removed.
+- id: PMID:8893027
+  title: Mutations in a cyclic nucleotide-gated channel lead to abnormal thermosensation
+    and chemosensation in C. elegans.
+  findings: []
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Foundational tax-4 paper; TAX-4::GFP localizes to sensory endings of the neurons.
+      Used here as corroboration for the channel&#39;s plasma-membrane/sensory-ending
+      localization (alpha subunit; TAX-2 is the obligate heteromeric partner). Cached
+      abstract-only.
+- id: PMID:9486798
+  title: &#39;A cyclic nucleotide-gated channel inhibits sensory axon outgrowth in larval
+    and adult Caenorhabditis elegans: a distinct pathway for maintenance of sensory
+    axon structure.&#39;
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Directly assays tax-2: a temperature-sensitive tax-2 allele shows tax-2 activity
+      is required in the adult for chemotaxis to NaCl/odorants and for maintenance of
+      correct sensory axon structure. Grounds the chemotaxis and regulation-of-axon-
+      extension non-core annotations and the tax-2/tax-4 channel-subunit framing.
+      Cached abstract-only.
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/genes/worm/xbx-1/xbx-1-ai-review.html
+++ b/genes/worm/xbx-1/xbx-1-ai-review.html
@@ -1,0 +1,4768 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>xbx-1 - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        .propagation-review {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f8fafc;
+            border-left: 3px solid #64748b;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .propagation-title {
+            font-weight: 600;
+            color: #334155;
+            margin-bottom: 0.25rem;
+        }
+
+        .propagation-row {
+            margin-top: 0.25rem;
+        }
+
+        .propagation-source {
+            margin-top: 0.5rem;
+            padding-top: 0.5rem;
+            border-top: 1px solid #e5e7eb;
+        }
+
+        .propagation-source-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #1d4ed8;
+        }
+
+        .propagation-comment {
+            color: #4b5563;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>xbx-1</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/Q19119" target="_blank" class="term-link">
+                        Q19119
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Caenorhabditis elegans</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-complete">
+                    COMPLETE
+                </span>
+            </div>
+
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "xbx-1";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="Q19119" data-a="DESCRIPTION: xbx-1 encodes the Caenorhabditis elegans cytoplasm..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>xbx-1 encodes the Caenorhabditis elegans cytoplasmic dynein-2 light intermediate chain, the ortholog of mammalian DYNC2LI1/D2LIC. It is a non-catalytic subunit of the dynein-2 (IFT-dynein) motor, which also contains the CHE-3 heavy chain. Dynein-2 is the minus-end-directed microtubule motor that powers retrograde intraflagellar transport (IFT), returning IFT trains and turned-over cargo from the ciliary tip back to the base. XBX-1 binds the dynein heavy chain and is required to build and maintain the sensory cilia of C. elegans: it localizes to the ciliary base and basal body and moves bidirectionally along the axoneme (carried anterogradely as inactive cargo by kinesin-2, then powering the retrograde run). Loss of xbx-1 gives short, malformed cilia with a distal bulb in which IFT proteins accumulate, together with the sensory-behaviour defects typical of ciliary mutants. xbx-1 belongs to the DAF-19 (RFX) X-box-regulated ciliary gene battery, from which it takes its name.</p>
+    </div>
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Proposed New Ontology Terms</h2>
+
+        <div class="proposed-term">
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>cytoplasmic dynein 2 complex</h3>
+                <span class="vote-buttons" data-g="Q19119" data-a="cytoplasmic dynein 2 complex" data-r="" data-act="NEW">
+                    <button class="vote-btn" data-v="up" title="Agree this term should be created">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with creating this term">👎</button>
+                </span>
+            </div>
+
+
+            <p><strong>Definition:</strong> A cytoplasmic dynein complex, distinct from the cytoplasmic dynein 1 complex, that is specialized for retrograde intraflagellar transport within cilia and flagella. It is built around the dynein-2 heavy chain (DYNC2H1/CHE-3) together with dynein-2-specific light intermediate (DYNC2LI1/D2LIC/XBX-1), intermediate, light and associated chains, and generates minus-end-directed (tip-to-base) movement along the ciliary axoneme.</p>
+
+
+
+            <p><strong>Justification:</strong> GO has a single cellular-component term GO:0005868 &#34;cytoplasmic dynein complex&#34; that conflates the functionally and compositionally distinct dynein-1 (mitotic/ trafficking) and dynein-2 (ciliary/IFT) motors. A dynein-2-specific term would let XBX-1 and its partners be annotated to their actual complex. This benefits dynein-2 subunit annotation across species, not just XBX-1 — e.g. the heavy chain CHE-3/DYNC2H1, the intermediate chains WDR60/WDR34, and the dynein-2 light chains — and would separate IFT-dynein from dynein-1 in enrichment analyses and GO-CAM models.</p>
+
+
+
+            <p><strong>Parent term:</strong>
+                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005868" target="_blank" class="term-link">
+                    cytoplasmic dynein complex
+                </a>
+            </p>
+
+
+
+
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0036064" target="_blank" class="term-link">
+                                    GO:0036064
+                                </a>
+                            </span>
+                            <span class="term-label">ciliary basal body</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q19119" data-a="GO:0036064" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> XBX-1 localizes to the ciliary base/basal body, where dynein-2 is loaded onto IFT trains. Phylogenetically inferred and corroborated by multiple IDA calls (PMID:33460640, PMID:22922713).
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Consistent with experimentally observed base/basal body localization of XBX-1 and with the known site of dynein-2 loading. A non-core location term but correct.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12802075" target="_blank" class="term-link">
+                                        PMID:12802075
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">XBX-1 localizes to the base of the cilia and undergoes anterograde and retrograde movement along the axoneme</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0045504" target="_blank" class="term-link">
+                                    GO:0045504
+                                </a>
+                            </span>
+                            <span class="term-label">dynein heavy chain binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q19119" data-a="GO:0045504" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Core molecular function: as the dynein-2 light intermediate chain, XBX-1 binds the dynein-2 heavy chain (CHE-3) within the retrograde IFT motor.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> This is the defining, informative molecular function of a dynein light intermediate chain. Supported by orthology to D2LIC and by the functional partnership with CHE-3 in retrograde IFT. Retained as core.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12802075" target="_blank" class="term-link">
+                                        PMID:12802075
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">the DLIC protein XBX-1 functions together with the CHE-3 dynein in retrograde IFT, downstream of the complex A proteins</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005868" target="_blank" class="term-link">
+                                    GO:0005868
+                                </a>
+                            </span>
+                            <span class="term-label">cytoplasmic dynein complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q19119" data-a="GO:0005868" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Core complex membership: XBX-1 is a subunit of the cytoplasmic dynein-2 (IFT-dynein) motor complex.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Well supported; XBX-1 is the light intermediate chain of dynein-2. GO:0005868 is the most specific available term (GO lacks a dedicated &#34;cytoplasmic dynein 2 complex&#34; cellular-component class; see knowledge_gaps). Retained as core.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12802075" target="_blank" class="term-link">
+                                        PMID:12802075
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">the DLIC protein XBX-1 functions together with the CHE-3 dynein in retrograde IFT, downstream of the complex A proteins</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0035721" target="_blank" class="term-link">
+                                    GO:0035721
+                                </a>
+                            </span>
+                            <span class="term-label">intraciliary retrograde transport</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q19119" data-a="GO:0035721" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Core biological process: XBX-1 is part of the dynein-2 motor that drives retrograde IFT (tip-to-base) in cilia.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Directly supported by IMP evidence (PMID:12802075) and orthology; this is the central process for the gene. Retained as core.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12802075" target="_blank" class="term-link">
+                                        PMID:12802075
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">xbx-1, that is required for retrograde IFT and shares homology with a mammalian dynein light intermediate chain (D2LIC)</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0035735" target="_blank" class="term-link">
+                                    GO:0035735
+                                </a>
+                            </span>
+                            <span class="term-label">intraciliary transport involved in cilium assembly</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q19119" data-a="GO:0035735" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IFT (including the retrograde arm powered by dynein-2/XBX-1) is required for cilium assembly and maintenance.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Consistent with the xbx-1 loss-of-function cilium-assembly phenotype and with the established role of IFT in ciliogenesis. Broader BP framing complementary to the more specific retrograde-transport and non-motile-cilium-assembly terms.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12802075" target="_blank" class="term-link">
+                                        PMID:12802075
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">they are shortened and have a bulb like structure in which IFT proteins accumulate</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005930" target="_blank" class="term-link">
+                                    GO:0005930
+                                </a>
+                            </span>
+                            <span class="term-label">axoneme</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q19119" data-a="GO:0005930" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> XBX-1 moves along the ciliary axoneme as part of IFT, where the dynein-2 motor operates during retrograde transport.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Phylogenetically inferred and corroborated by IDA axoneme localization (PMID:12802075, PMID:27930654, PMID:25335890). Correct location.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12802075" target="_blank" class="term-link">
+                                        PMID:12802075
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">XBX-1 localizes to the base of the cilia and undergoes anterograde and retrograde movement along the axoneme</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005813" target="_blank" class="term-link">
+                                    GO:0005813
+                                </a>
+                            </span>
+                            <span class="term-label">centrosome</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000044
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q19119" data-a="GO:0005813" data-r="GO_REF:0000044" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic annotation transferred from the UniProt Subcellular Location &#34;microtubule organizing center, centrosome&#34; mapping. In C. elegans ciliated sensory neurons the relevant MTOC is the centriole-derived ciliary basal body, already captured by IDA basal body annotations.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Dynein-2 is the ciliary/IFT dynein, not the mitotic-spindle dynein; there is no direct evidence for a canonical mitotic centrosome role for XBX-1. The &#34;centrosome&#34; call over-generalizes the basal-body/MTOC localization. Kept (basal bodies are centriole-derived MTOCs) but flagged non-core.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005868" target="_blank" class="term-link">
+                                    GO:0005868
+                                </a>
+                            </span>
+                            <span class="term-label">cytoplasmic dynein complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q19119" data-a="GO:0005868" data-r="GO_REF:0000002" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> InterPro-based electronic support for dynein-2 complex membership, redundant with the IBA part_of annotation.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Consistent electronic corroboration of the experimentally/phylogenetically supported dynein complex membership.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005930" target="_blank" class="term-link">
+                                    GO:0005930
+                                </a>
+                            </span>
+                            <span class="term-label">axoneme</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000044
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q19119" data-a="GO:0005930" data-r="GO_REF:0000044" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic (Subcellular Location) support for axoneme localization, redundant with IDA axoneme annotations.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Consistent with experimentally observed axoneme localization.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0035721" target="_blank" class="term-link">
+                                    GO:0035721
+                                </a>
+                            </span>
+                            <span class="term-label">intraciliary retrograde transport</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q19119" data-a="GO:0035721" data-r="GO_REF:0000002" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> InterPro-based electronic support for the core retrograde IFT process, redundant with IMP/IBA annotations.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Consistent electronic corroboration of the central biological process.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0035735" target="_blank" class="term-link">
+                                    GO:0035735
+                                </a>
+                            </span>
+                            <span class="term-label">intraciliary transport involved in cilium assembly</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q19119" data-a="GO:0035735" data-r="GO_REF:0000002" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> InterPro-based electronic support for the role of IFT in cilium assembly, redundant with the IBA annotation.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Consistent with the gene&#39;s established role in ciliogenesis via IFT.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0036064" target="_blank" class="term-link">
+                                    GO:0036064
+                                </a>
+                            </span>
+                            <span class="term-label">ciliary basal body</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/33460640" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:33460640
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    GRDN-1/Girdin regulates dendrite morphogenesis and cilium po...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q19119" data-a="GO:0036064" data-r="PMID:33460640" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct observation that XBX-1 localizes to the basal body and moves bidirectionally along the axoneme.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Experimentally supported basal body localization (curator read full text); the site where dynein-2 is loaded onto IFT trains. Corroborated by the primary characterization (PMID:12802075). Correct non-core location.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12802075" target="_blank" class="term-link">
+                                        PMID:12802075
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">XBX-1 localizes to the base of the cilia and undergoes anterograde and retrograde movement along the axoneme</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005930" target="_blank" class="term-link">
+                                    GO:0005930
+                                </a>
+                            </span>
+                            <span class="term-label">axoneme</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/27930654" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:27930654
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Whole-Organism Developmental Expression Profiling Identifies...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q19119" data-a="GO:0005930" data-r="PMID:27930654" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> XBX-1::tdTomato was used as an IFT marker localizing to the ciliary base and axoneme.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Experimentally supported axoneme localization (curator read full text), corroborated by the primary characterization (PMID:12802075). Consistent with IFT movement of the dynein-2 motor.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12802075" target="_blank" class="term-link">
+                                        PMID:12802075
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">XBX-1 localizes to the base of the cilia and undergoes anterograde and retrograde movement along the axoneme</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0035869" target="_blank" class="term-link">
+                                    GO:0035869
+                                </a>
+                            </span>
+                            <span class="term-label">ciliary transition zone</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/27930654" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:27930654
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Whole-Organism Developmental Expression Profiling Identifies...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q19119" data-a="GO:0035869" data-r="PMID:27930654" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> XBX-1 traverses the ciliary base/transition zone during IFT, where the dynein-2 motor enters and exits the ciliary compartment.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> IDA annotation from a study using XBX-1 as a ciliary marker; the curator read the full text. XBX-1 passes through the transition zone as part of IFT, so the localization is biologically consistent. Non-core location.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0097546" target="_blank" class="term-link">
+                                    GO:0097546
+                                </a>
+                            </span>
+                            <span class="term-label">ciliary base</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/27930654" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:27930654
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Whole-Organism Developmental Expression Profiling Identifies...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q19119" data-a="GO:0097546" data-r="PMID:27930654" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct observation of XBX-1 at the ciliary base, the site of dynein-2 loading and IFT-train assembly/turnaround.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Experimentally supported and central to dynein-2 function (loading/unloading); corroborated by the primary characterization (PMID:12802075). Correct location.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12802075" target="_blank" class="term-link">
+                                        PMID:12802075
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">XBX-1 localizes to the base of the cilia and undergoes anterograde and retrograde movement along the axoneme</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005929" target="_blank" class="term-link">
+                                    GO:0005929
+                                </a>
+                            </span>
+                            <span class="term-label">cilium</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/27623382" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:27623382
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    A Conserved Role for Girdin in Basal Body Positioning and Ci...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q19119" data-a="GO:0005929" data-r="PMID:27623382" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> XBX-1 localizes to cilia (general ciliary compartment), consistent with its role in IFT.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Experimentally supported general ciliary localization (curator read full text); a parent of the more specific non-motile cilium term also annotated. Corroborated by the primary characterization (PMID:12802075). Correct but non-core.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12802075" target="_blank" class="term-link">
+                                        PMID:12802075
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">XBX-1 localizes to the base of the cilia and undergoes anterograde and retrograde movement along the axoneme</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0097730" target="_blank" class="term-link">
+                                    GO:0097730
+                                </a>
+                            </span>
+                            <span class="term-label">non-motile cilium</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/17420466" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:17420466
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Mutation of the MAP kinase DYF-5 affects docking and undocki...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q19119" data-a="GO:0097730" data-r="PMID:17420466" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> XBX-1 localizes to the non-motile sensory cilia of C. elegans, where it operates in IFT.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> IDA from a study using XBX-1 as a ciliary/IFT marker (curator read full text); C. elegans sensory cilia are non-motile. Corroborated by the primary characterization (PMID:12802075). Correct location for the cell type. Non-core.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12802075" target="_blank" class="term-link">
+                                        PMID:12802075
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">XBX-1 localizes to the base of the cilia and undergoes anterograde and retrograde movement along the axoneme</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005930" target="_blank" class="term-link">
+                                    GO:0005930
+                                </a>
+                            </span>
+                            <span class="term-label">axoneme</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/25335890" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:25335890
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Ciliopathy proteins establish a bipartite signaling compartm...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q19119" data-a="GO:0005930" data-r="PMID:25335890" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> XBX-1 used as an axoneme/ciliary marker in AFD sensory neurons.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Experimentally supported axoneme localization (curator read full text), redundant with other IDA axoneme calls and corroborated by the primary characterization (PMID:12802075). Correct location.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12802075" target="_blank" class="term-link">
+                                        PMID:12802075
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">XBX-1 localizes to the base of the cilia and undergoes anterograde and retrograde movement along the axoneme</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0035721" target="_blank" class="term-link">
+                                    GO:0035721
+                                </a>
+                            </span>
+                            <span class="term-label">intraciliary retrograde transport</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/12802075" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:12802075
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    XBX-1 encodes a dynein light intermediate chain required for...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q19119" data-a="GO:0035721" data-r="PMID:12802075" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Loss of xbx-1 disrupts retrograde IFT, causing IFT proteins to accumulate in a distal ciliary bulb; XBX-1 functions with the CHE-3 dynein downstream of IFT-A.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Primary experimental (IMP) evidence for the gene&#39;s central biological process. Retained as core.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12802075" target="_blank" class="term-link">
+                                        PMID:12802075
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">the DLIC protein XBX-1 functions together with the CHE-3 dynein in retrograde IFT, downstream of the complex A proteins</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12802075" target="_blank" class="term-link">
+                                        PMID:12802075
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">they are shortened and have a bulb like structure in which IFT proteins accumulate</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0045504" target="_blank" class="term-link">
+                                    GO:0045504
+                                </a>
+                            </span>
+                            <span class="term-label">dynein heavy chain binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ISS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/12802075" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:12802075
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    XBX-1 encodes a dynein light intermediate chain required for...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q19119" data-a="GO:0045504" data-r="PMID:12802075" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> By sequence similarity to mammalian D2LIC, XBX-1 binds the dynein-2 heavy chain within the retrograde IFT motor.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Informative, specific molecular function (not generic protein binding). Supported by orthology to D2LIC (with/from rat D2LIC) and by the functional partnership with CHE-3. Retained as core.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12802075" target="_blank" class="term-link">
+                                        PMID:12802075
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">xbx-1, that is required for retrograde IFT and shares homology with a mammalian dynein light intermediate chain (D2LIC)</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0097546" target="_blank" class="term-link">
+                                    GO:0097546
+                                </a>
+                            </span>
+                            <span class="term-label">ciliary base</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/25335890" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:25335890
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Ciliopathy proteins establish a bipartite signaling compartm...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q19119" data-a="GO:0097546" data-r="PMID:25335890" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> XBX-1 localizes to the ciliary base in AFD sensory neurons.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Experimentally supported ciliary base localization (curator read full text), redundant with other IDA base calls and corroborated by the primary characterization (PMID:12802075). Correct location.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12802075" target="_blank" class="term-link">
+                                        PMID:12802075
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">XBX-1 localizes to the base of the cilia and undergoes anterograde and retrograde movement along the axoneme</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1905515" target="_blank" class="term-link">
+                                    GO:1905515
+                                </a>
+                            </span>
+                            <span class="term-label">non-motile cilium assembly</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/12802075" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:12802075
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    XBX-1 encodes a dynein light intermediate chain required for...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q19119" data-a="GO:1905515" data-r="PMID:12802075" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> xbx-1 mutants have short, malformed sensory cilia with a distal IFT-protein bulb, showing XBX-1 is required for assembly of non-motile cilia.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Primary experimental (IMP) evidence for the cilium-assembly requirement; C. elegans sensory cilia are non-motile. Retained as core.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12802075" target="_blank" class="term-link">
+                                        PMID:12802075
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">they are shortened and have a bulb like structure in which IFT proteins accumulate</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0036064" target="_blank" class="term-link">
+                                    GO:0036064
+                                </a>
+                            </span>
+                            <span class="term-label">ciliary basal body</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/22922713" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:22922713
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The BBSome controls IFT assembly and turnaround in cilia.
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q19119" data-a="GO:0036064" data-r="PMID:22922713" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> XBX-1 (dynein-2 light chain, D2LIC ortholog) used as a retrograde IFT motor marker localizing to cilia/basal body.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Experimentally supported basal body localization (curator read full text), redundant with the PMID:33460640 IDA call and corroborated by the primary characterization (PMID:12802075). Correct location.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12802075" target="_blank" class="term-link">
+                                        PMID:12802075
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">XBX-1 localizes to the base of the cilia and undergoes anterograde and retrograde movement along the axoneme</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0097730" target="_blank" class="term-link">
+                                    GO:0097730
+                                </a>
+                            </span>
+                            <span class="term-label">non-motile cilium</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/12802075" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:12802075
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    XBX-1 encodes a dynein light intermediate chain required for...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q19119" data-a="GO:0097730" data-r="PMID:12802075" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> XBX-1 localizes within the non-motile sensory cilia, moving between the base and the axoneme.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Experimentally supported localization to C. elegans (non-motile) sensory cilia. Correct location.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12802075" target="_blank" class="term-link">
+                                        PMID:12802075
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">XBX-1 localizes to the base of the cilia and undergoes anterograde and retrograde movement along the axoneme</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005930" target="_blank" class="term-link">
+                                    GO:0005930
+                                </a>
+                            </span>
+                            <span class="term-label">axoneme</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/12802075" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:12802075
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    XBX-1 encodes a dynein light intermediate chain required for...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q19119" data-a="GO:0005930" data-r="PMID:12802075" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> XBX-1 undergoes bidirectional movement along the ciliary axoneme.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Primary experimental evidence for axoneme localization/movement of the dynein-2 motor. Correct location.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12802075" target="_blank" class="term-link">
+                                        PMID:12802075
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">XBX-1 localizes to the base of the cilia and undergoes anterograde and retrograde movement along the axoneme</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>Cytoplasmic dynein-2 light intermediate chain: a non-catalytic subunit of the dynein-2 (IFT-dynein) motor that binds the CHE-3 dynein heavy chain and contributes to the complex&#39;s minus-end-directed microtubule motor activity, powering retrograde intraflagellar transport required for sensory cilium assembly and maintenance.</h3>
+                <span class="vote-buttons" data-g="Q19119" data-a="FUNCTION: Cytoplasmic dynein-2 light intermediate chain: a n..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0045504" target="_blank" class="term-link">
+                            dynein heavy chain binding
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0035721" target="_blank" class="term-link">
+                                intraciliary retrograde transport
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1905515" target="_blank" class="term-link">
+                                non-motile cilium assembly
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005930" target="_blank" class="term-link">
+                                axoneme
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0097730" target="_blank" class="term-link">
+                                non-motile cilium
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">In Complex:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005868" target="_blank" class="term-link">
+                            cytoplasmic dynein complex
+                        </a>
+                    </span>
+                </div>
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/12802075" target="_blank" class="term-link">
+                                PMID:12802075
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">the DLIC protein XBX-1 functions together with the CHE-3 dynein in retrograde IFT, downstream of the complex A proteins</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/12802075" target="_blank" class="term-link">
+                                PMID:12802075
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">xbx-1, that is required for retrograde IFT and shares homology with a mammalian dynein light intermediate chain (D2LIC)</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000002.md" target="_blank" class="term-link">
+                            GO_REF:0000002
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation through association of InterPro records with GO terms</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
+                            GO_REF:0000033
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Annotation inferences using phylogenetic trees</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
+                            GO_REF:0000044
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/12802075" target="_blank" class="term-link">
+                            PMID:12802075
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">XBX-1 encodes a dynein light intermediate chain required for retrograde intraflagellar transport and cilia assembly in Caenorhabditis elegans.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">xbx-1 is required for retrograde IFT and is homologous to the mammalian dynein light intermediate chain D2LIC.</div>
+
+                        <div class="finding-text">"xbx-1, that is required for retrograde IFT and shares homology with a mammalian dynein light intermediate chain (D2LIC)"</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <div class="finding-statement">XBX-1 functions together with the CHE-3 dynein heavy chain in retrograde IFT, downstream of the IFT-A (complex A) proteins.</div>
+
+                        <div class="finding-text">"the DLIC protein XBX-1 functions together with the CHE-3 dynein in retrograde IFT, downstream of the complex A proteins"</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <div class="finding-statement">XBX-1 localizes to the ciliary base and moves bidirectionally (anterograde and retrograde) along the axoneme.</div>
+
+                        <div class="finding-text">"XBX-1 localizes to the base of the cilia and undergoes anterograde and retrograde movement along the axoneme"</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Loss of xbx-1 produces short cilia with a distal bulb in which IFT proteins accumulate, the hallmark of retrograde IFT failure.</div>
+
+                        <div class="finding-text">"they are shortened and have a bulb like structure in which IFT proteins accumulate"</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/17420466" target="_blank" class="term-link">
+                            PMID:17420466
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Mutation of the MAP kinase DYF-5 affects docking and undocking of kinesin-2 motors and reduces their speed in the cilia of Caenorhabditis elegans.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/22922713" target="_blank" class="term-link">
+                            PMID:22922713
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">The BBSome controls IFT assembly and turnaround in cilia.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/25335890" target="_blank" class="term-link">
+                            PMID:25335890
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Ciliopathy proteins establish a bipartite signaling compartment in a C. elegans thermosensory neuron.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/27623382" target="_blank" class="term-link">
+                            PMID:27623382
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">A Conserved Role for Girdin in Basal Body Positioning and Ciliogenesis.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/27930654" target="_blank" class="term-link">
+                            PMID:27930654
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Whole-Organism Developmental Expression Profiling Identifies RAB-28 as a Novel Ciliary GTPase Associated with the BBSome and Intraflagellar Transport.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/33460640" target="_blank" class="term-link">
+                            PMID:33460640
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">GRDN-1/Girdin regulates dendrite morphogenesis and cilium position in two specialized sensory neuron types in C. elegans.</div>
+
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Questions for Experts</h2>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Does XBX-1 act mainly to stabilize/assemble the dynein-2 motor, to couple it to IFT trains, or to regulate its activation during ciliary turnaround?</p>
+
+                    <p style="margin-top: 0.5rem;"><em>Suggested experts: Intraflagellar transport / dynein-2 motor biologists</em></p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q19119" data-a="Q: Does XBX-1 act mainly to stabilize/assemble the dy..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Does XBX-1 have any dynein-2-independent role at the basal body/centriole?</p>
+
+                    <p style="margin-top: 0.5rem;"><em>Suggested experts: C. elegans ciliary cell biologists</em></p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q19119" data-a="Q: Does XBX-1 have any dynein-2-independent role at t..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Experiments</h2>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Structure-function analysis of XBX-1 (targeted deletions/point mutations of the DLIC fold) combined with co-immunoprecipitation of CHE-3 and live imaging of IFT-train velocities and turnaround in the mutant alleles.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: XBX-1 is required for dynein-2 complex stability and for coupling the motor to IFT trains.</em></p>
+
+
+                    <p style="margin-top: 0.5rem;">Type: structure-function / live imaging</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q19119" data-a="EXPERIMENT: Structure-function analysis of XBX-1 (targeted del..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Dual-color live imaging of anterograde (kinesin-2/IFT-B) and retrograde (XBX-1/CHE-3) markers in xbx-1 mutants to quantify which transport arm and which ciliary segment are affected.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: XBX-1 loss selectively impairs the retrograde (dynein-2) IFT arm.</em></p>
+
+
+                    <p style="margin-top: 0.5rem;">Type: live imaging</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q19119" data-a="EXPERIMENT: Dual-color live imaging of anterograde (kinesin-2/..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Knowledge Gaps</h2>
+        <p style="color: #555; font-size: 0.92rem; margin-top: -0.3rem;">
+            What is <em>not</em> known — curated, literature-grounded statements of the open
+            unknowns (the inverse of core functions).
+        </p>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The specific molecular contribution of the XBX-1 light intermediate chain to dynein-2 function in C. elegans is undetermined: whether it is chiefly required for dynein-2 complex assembly/stability, for coupling the motor to IFT trains as a cargo adaptor, or for regulating motor activation/autoinhibition at the ciliary tip.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">RESIDUAL_SUBGAP</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> It is firmly established that XBX-1 is the dynein-2 LIC (D2LIC ortholog), binds the CHE-3 heavy chain, localizes to the ciliary base/axoneme, and is required for retrograde IFT and cilium assembly. The light intermediate chain itself has no demonstrated enzymatic activity; the ATP-dependent minus-end-directed motor activity is a property of the CHE-3 heavy chain/dynein-2 complex.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> DYNC2LI1 mutations cause skeletal ciliopathies (short-rib thoracic dysplasia); understanding the LIC&#39;s mechanistic role would clarify how dynein-2 assembly and IFT-train coupling are controlled and how they fail in disease.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Structure-function dissection of XBX-1 (domain/point mutants) with biochemical assays of dynein-2 assembly and heavy-chain binding, plus live IFT imaging of train coupling and velocities in xbx-1 alleles.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"the DLIC protein XBX-1 functions together with the CHE-3 dynein in retrograde IFT, downstream of the complex A proteins"</em> — PMID:12802075</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> No GO cellular-component term expresses the cytoplasmic dynein-2 (IFT-dynein) complex distinctly from cytoplasmic dynein-1, so XBX-1&#39;s actual complex membership can only be annotated with the conflated parent term GO:0005868.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">ONTOLOGY</span>
+                <span class="badge">CC_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> XBX-1 is unambiguously a subunit of the ciliary retrograde IFT dynein-2 motor (with CHE-3/DYNC2H1); the only available GO CC term, GO:0005868 &#34;cytoplasmic dynein complex&#34;, also covers dynein-1.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> A dynein-2-specific complex term would let IFT-dynein subunits be annotated to their true complex and separated from dynein-1 in enrichment and model building.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Add a &#34;cytoplasmic dynein 2 complex&#34; cellular-component term as a child of GO:0005868 (see proposed_new_terms).</p>
+
+
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Tags</h2>
+        <div class="aliases">
+
+            <span class="badge">caeel-ciliopathy</span>
+
+        </div>
+    </div>
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Deep Research Sections -->
+
+    <div class="section">
+        <h2 class="section-title">Deep Research</h2>
+
+        <details class="deep-research-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; gap: 1rem;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Falcon</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(xbx-1-deep-research-falcon.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="Q19119" data-a="DEEP_RESEARCH: Falcon" data-r="" data-act="DEEP_RESEARCH" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This deep research is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This deep research needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+
+                <div class="report-meta">
+
+                    <span class="report-meta-text">Comprehensive Research Report: *xbx-1* (F02D8.3) — Cytoplasmic Dynein-2 Light Intermediate Chain 1 in *Caenorhabditis elegans*</span>
+
+
+                    <span class="report-badge">Falcon</span>
+
+
+                    <span class="report-badge">Edison Scientific Literature</span>
+
+
+                    <span class="report-badge">34 citations</span>
+
+
+                    <span class="report-badge">2 artifacts</span>
+
+
+                    <span class="report-meta-text">2026-07-04T19:21:00.927922</span>
+
+
+
+                </div>
+
+
+                <div class="artifact-list">
+
+
+
+                    <div class="artifact-link">
+                        <a href="xbx-1-deep-research-falcon_artifacts/artifact-00.md" class="term-link">Edison artifact artifact-00</a>
+                        <span>(text/markdown)</span>
+                    </div>
+
+
+
+
+                    <div class="artifact-link">
+                        <a href="xbx-1-deep-research-falcon_artifacts/artifact-01.md" class="term-link">Edison artifact artifact-01</a>
+                        <span>(text/markdown)</span>
+                    </div>
+
+
+                </div>
+
+                <p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h1 id="comprehensive-research-report-xbx-1-f02d83-cytoplasmic-dynein-2-light-intermediate-chain-1-in-caenorhabditis-elegans">Comprehensive Research Report: <em>xbx-1</em> (F02D8.3) — Cytoplasmic Dynein-2 Light Intermediate Chain 1 in <em>Caenorhabditis elegans</em></h1>
+<h2 id="1-gene-identity-and-nomenclature">1. Gene Identity and Nomenclature</h2>
+<p>The gene <em>xbx-1</em> (X-box regulated gene 1; systematic name F02D8.3, UniProt Q19119) encodes the cytoplasmic dynein 2 light intermediate chain 1 (DYNC2LI1 ortholog) in <em>Caenorhabditis elegans</em>. The gene name derives from its regulation by the X-box DNA motif, which is recognized by the RFX-family transcription factor DAF-19 (perrone2003anoveldynein pages 1-2, chu2012finetuningof pages 4-5). XBX-1 belongs to the dynein light intermediate chain family and contains a P-loop NTPase domain and a DLIC (dynein light intermediate chain) domain, consistent with its classification as a structural and regulatory subunit of the IFT-dynein (cytoplasmic dynein-2) motor complex (hao2011theretrogradeift pages 5-7, hao2011theretrogradeift pages 1-2).</p>
+<h2 id="2-primary-molecular-function">2. Primary Molecular Function</h2>
+<h3 id="21-role-as-an-essential-ift-dynein-subunit">2.1 Role as an Essential IFT-Dynein Subunit</h3>
+<p>XBX-1 is the light intermediate chain (LIC) of the IFT-dynein complex (also known as cytoplasmic dynein-2), the minus-end-directed microtubule motor responsible for retrograde intraflagellar transport (IFT) within cilia. In <em>C. elegans</em>, the conventional IFT-dynein complex comprises the heavy chain CHE-3 (DYNC2H1 ortholog), the light intermediate chain XBX-1 (DYNC2LI1 ortholog), and several light chains including DYLT-1, DYLT-2 (Tctex-type), and DYRB-1 (Roadblock-type) (hao2011theretrogradeift pages 5-7, hao2011theretrogradeift pages 3-5). XBX-1 is an essential component of this complex: loss-of-function mutations in <em>xbx-1</em> produce short cilia filled with accumulated IFT particle subunits, a hallmark phenotype of retrograde IFT failure (hao2011theretrogradeift pages 1-2, perrone2003anoveldynein pages 1-2).</p>
+<p>The primary function of XBX-1/DYNC2LI1 is not enzymatic per se—it does not catalyze a chemical reaction—but rather structural and regulatory: it is required for the assembly and function of the dynein-2 motor complex that powers the retrograde movement of IFT trains from the ciliary tip back to the ciliary base (hao2011theretrogradeift pages 5-7, hao2011theretrogradeift pages 9-9). Without functional XBX-1, retrograde IFT is disrupted while anterograde transport continues, leading to progressive accumulation of IFT components at the ciliary tip and consequent ciliary structural defects (hao2011theretrogradeift pages 1-2).</p>
+<h3 id="22-structural-role-within-the-dynein-2-holocomplex">2.2 Structural Role within the Dynein-2 Holocomplex</h3>
+<p>Structural studies of the mammalian dynein-2 complex, informed by cryo-electron microscopy, reveal that the holocomplex comprises 11 subunits that can be divided into three subcomplexes: (1) the DYNC2H1–DYNC2LI1 core, (2) the WDR34–DYNLL1/DYNLL2–DYNLRB1/DYNLRB2 module, and (3) the WDR60–TCTEX1D2–DYNLT1/DYNLT3 module (tsurumi2019interactionsofthe pages 1-2). DYNC2LI1 (the XBX-1 ortholog) binds directly to the N-terminal nonmotor tail region of DYNC2H1, and each dynein-2 complex contains two DYNC2H1 molecules that adopt asymmetric conformations, each binding one copy of DYNC2LI1, yielding a 2:2:1:1 stoichiometry for DYNC2H1:DYNC2LI1:WDR60:WDR34 (qiu2022combinationsofdeletion pages 1-2, hiyamizu2023multipleinteractionsof pages 2-3). DYNC2LI1 thus serves as a critical structural bridge between the heavy chain motor and the intermediate/light chain assembly that organizes the tail of the dynein-2 complex (qiu2022combinationsofdeletion pages 1-2, hiyamizu2023multipleinteractionsof pages 3-4).</p>
+<p>The following table summarizes the dynein-2 complex subunit composition:</p>
+<table>
+<thead>
+<tr>
+<th>Subunit type</th>
+<th><em>C. elegans</em> gene name</th>
+<th>Human ortholog</th>
+<th>Role in complex</th>
+<th>Key references</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Heavy chain</td>
+<td><strong>che-3</strong></td>
+<td><strong>DYNC2H1</strong></td>
+<td>Core dynein-2 motor subunit; provides the ATPase/motor domain that powers retrograde intraflagellar transport (IFT) from ciliary tip to base. In <em>C. elegans</em>, CHE-3 is the essential conventional IFT-dynein heavy chain; in human dynein-2, two DYNC2H1 heavy chains form the motor core. (hao2011theretrogradeift pages 5-7, qiu2022combinationsofdeletion pages 1-2, hiyamizu2023multipleinteractionsof pages 2-3)</td>
+<td>Hao et al. 2011; Qiu et al. 2022; Hiyamizu et al. 2023 (hao2011theretrogradeift pages 5-7, qiu2022combinationsofdeletion pages 1-2, hiyamizu2023multipleinteractionsof pages 2-3)</td>
+</tr>
+<tr>
+<td>Light intermediate chain</td>
+<td><strong>xbx-1</strong></td>
+<td><strong>DYNC2LI1</strong></td>
+<td>Dynein-2 light intermediate chain; binds the N-terminal/nonmotor tail of DYNC2H1 and helps bridge the heavy chain to intermediate-chain modules. In <em>C. elegans</em>, XBX-1 is an essential component of IFT-dynein required for retrograde IFT and cilia assembly. In human dynein-2, DYNC2LI1 is part of the DYNC2H1-DYNC2LI1 core subcomplex; the human complex has a reported <strong>2:2:1:1 stoichiometry for DYNC2H1:DYNC2LI1:WDR60:WDR34</strong>. (hao2011theretrogradeift pages 5-7, qiu2022combinationsofdeletion pages 1-2, hiyamizu2023multipleinteractionsof pages 2-3)</td>
+<td>Hao et al. 2011; Qiu et al. 2022; Hiyamizu et al. 2023 (hao2011theretrogradeift pages 5-7, qiu2022combinationsofdeletion pages 1-2, hiyamizu2023multipleinteractionsof pages 2-3)</td>
+</tr>
+<tr>
+<td>Intermediate chain</td>
+<td>No clearly established named equivalent in the retrieved <em>C. elegans</em> xbx-1-focused literature</td>
+<td><strong>WDR60 (DYNC2I1)</strong></td>
+<td>One of the two dynein-2 intermediate chains. Associates with the DYNC2H1-DYNC2LI1 core through WD40-domain interactions and contributes to assembly of the heteromeric dynein-2 tail; also mediates functionally important interactions with IFT-B subunits such as IFT54. (hiyamizu2023multipleinteractionsof pages 2-3, hiyamizu2023multipleinteractionsof pages 1-2, tsurumi2019interactionsofthe pages 1-2, hiyamizu2023multipleinteractionsof pages 3-4)</td>
+<td>Tsurumi et al. 2019; Hiyamizu et al. 2023 (hiyamizu2023multipleinteractionsof pages 2-3, hiyamizu2023multipleinteractionsof pages 1-2, tsurumi2019interactionsofthe pages 1-2, hiyamizu2023multipleinteractionsof pages 3-4)</td>
+</tr>
+<tr>
+<td>Intermediate chain</td>
+<td>No clearly established named equivalent in the retrieved <em>C. elegans</em> xbx-1-focused literature</td>
+<td><strong>WDR34 (DYNC2I2)</strong></td>
+<td>Second dynein-2 intermediate chain. Works with WDR60 to organize the asymmetric tail region of dynein-2; associates with light-chain arrays and is required for proper dynein-2 assembly and retrograde ciliary trafficking. (qiu2022combinationsofdeletion pages 1-2, hiyamizu2023multipleinteractionsof pages 2-3, tsurumi2019interactionsofthe pages 1-2, hiyamizu2023multipleinteractionsof pages 3-4)</td>
+<td>Qiu et al. 2022; Tsurumi et al. 2019; Hiyamizu et al. 2023 (qiu2022combinationsofdeletion pages 1-2, hiyamizu2023multipleinteractionsof pages 2-3, tsurumi2019interactionsofthe pages 1-2, hiyamizu2023multipleinteractionsof pages 3-4)</td>
+</tr>
+<tr>
+<td>Light chain</td>
+<td><strong>dylt-1 / dylt-2</strong></td>
+<td><strong>DYNLT family / TCTEX1D2-associated light-chain module</strong></td>
+<td>Tctex-type light chains associated with the dynein-2 complex in <em>C. elegans</em>; bidirectional IFT behavior supports their participation in the IFT-dynein motor. In vertebrate/human dynein-2, TCTEX1D2 is a dynein-2-specific light chain associated with the WDR60 module. (hao2011theretrogradeift pages 3-5, hiyamizu2023multipleinteractionsof pages 2-3, tsurumi2019interactionsofthe pages 1-2)</td>
+<td>Hao et al. 2011; Tsurumi et al. 2019; Hiyamizu et al. 2023 (hao2011theretrogradeift pages 3-5, hiyamizu2023multipleinteractionsof pages 2-3, tsurumi2019interactionsofthe pages 1-2)</td>
+</tr>
+<tr>
+<td>Light chain</td>
+<td><strong>dyrb-1</strong></td>
+<td><strong>DYNLRB1 / DYNLRB2</strong></td>
+<td>Roadblock-type light chain associated with IFT-dynein in <em>C. elegans</em>; contributes to dynein-2 light-chain architecture. In human dynein-2, roadblock-family dimers are incorporated into the intermediate-chain/light-chain modules. (hao2011theretrogradeift pages 3-5, hiyamizu2023multipleinteractionsof pages 2-3, tsurumi2019interactionsofthe pages 1-2)</td>
+<td>Hao et al. 2011; Tsurumi et al. 2019; Hiyamizu et al. 2023 (hao2011theretrogradeift pages 3-5, hiyamizu2023multipleinteractionsof pages 2-3, tsurumi2019interactionsofthe pages 1-2)</td>
+</tr>
+<tr>
+<td>Light chain</td>
+<td>Various/not clearly resolved in the retrieved <em>C. elegans</em> xbx-1-focused literature</td>
+<td><strong>DYNLL1 / DYNLL2</strong></td>
+<td>LC8-family light chains that help heterodimerize and stabilize intermediate-chain subcomplexes in human dynein-2, especially the WDR34-associated module. Specific <em>C. elegans</em> one-to-one orthology was not clearly established in the retrieved evidence set. (hiyamizu2023multipleinteractionsof pages 2-3, tsurumi2019interactionsofthe pages 1-2)</td>
+<td>Tsurumi et al. 2019; Hiyamizu et al. 2023 (hiyamizu2023multipleinteractionsof pages 2-3, tsurumi2019interactionsofthe pages 1-2)</td>
+</tr>
+</tbody>
+</table>
+<p><em>Table: This table compares the dynein-2 complex across </em>C. elegans<em> and humans, highlighting where xbx-1/DYNC2LI1 fits within the motor. It is useful for linking worm functional genetics to current structural and ciliopathy-focused understanding of human dynein-2.</em></p>
+<h2 id="3-subcellular-localization">3. Subcellular Localization</h2>
+<p>XBX-1 is expressed exclusively in ciliated sensory neurons in <em>C. elegans</em>, consistent with its function as part of the cilium-specific IFT machinery (hao2011theretrogradeift pages 5-7, hao2011theretrogradeift pages 1-2). Using fluorescently tagged reporters (XBX-1::YFP, XBX-1::RFP, XBX-1::tdTomato), the protein has been localized to the ciliary axonemes of both amphid (head) and phasmid (tail) sensory neurons (scheidel2018intraflagellartransportcomplex pages 3-4, hao2011theretrogradeift pages 1-2). XBX-1 is commonly used as a ciliary marker in <em>C. elegans</em> research, demarcating the transition zone and axonemal regions by its characteristic fluorescence pattern (scheidel2018intraflagellartransportcomplex pages 3-4).</p>
+<p>Live imaging of XBX-1::YFP has revealed that the protein undergoes bidirectional transport within cilia, being carried anterogradely as cargo by kinesin-2 motors (kinesin-II and OSM-3) to the distal tip of the cilium, and then powering retrograde transport back toward the base as part of the active dynein-2 motor (hao2011theretrogradeift pages 3-5, hao2011theretrogradeift pages 5-7).</p>
+<h2 id="4-transport-dynamics-and-ift-behavior">4. Transport Dynamics and IFT Behavior</h2>
+<p>A key finding from quantitative IFT studies is that XBX-1 is transported along cilia independently of the IFT particle subcomplexes (IFT-A and IFT-B) and the BBSome. In wild-type amphid cilia, XBX-1::YFP moves anterogradely at approximately 0.776 ± 0.08 µm/s in the middle (doublet microtubule) segment and 1.30 ± 0.18 µm/s in the distal (singlet microtubule) segment (hao2011theretrogradeift pages 5-7). These rates correspond to transport by the coordinated action of kinesin-II and OSM-3 in the middle segment, and by OSM-3 alone in the distal segment, mirroring the behavior of other IFT components (hao2011theretrogradeift pages 3-5, hao2011theretrogradeift pages 5-7). However, unlike IFT-A and IFT-B subunits, XBX-1 transport rates are not affected by loss of BBSome (BBS) subunits, suggesting that IFT-dynein is carried as an independent cargo that binds directly to anterograde motors rather than being coupled through the IFT particle/BBSome complex (hao2011theretrogradeift pages 3-5, hao2011theretrogradeift pages 5-7, wei2012thebbsomecontrols pages 14-16).</p>
+<h2 id="5-loss-of-function-phenotypes">5. Loss-of-Function Phenotypes</h2>
+<p>The <em>xbx-1(ok279)</em> deletion allele disrupts retrograde IFT and produces several well-characterized phenotypes:</p>
+<ul>
+<li><strong>Ciliary structural defects</strong>: <em>xbx-1</em> mutants display highly abnormal phasmid cilia that are short and swollen, filled with accumulated IFT particle subunits, reflecting the failure of retrograde transport to recycle IFT components (hao2011theretrogradeift pages 1-2, hao2011theretrogradeift pages 3-5, perrone2003anoveldynein pages 1-2).</li>
+<li><strong>Dye-filling defects</strong>: <em>xbx-1</em> mutants are dye-filling defective (Dyf), meaning they fail to take up fluorescent hydrophobic dyes (such as DiI) into amphid and phasmid neurons—a standard assay for ciliary integrity in <em>C. elegans</em> (williams2008functionalredundancyof pages 4-6).</li>
+<li><strong>Sensory defects</strong>: Because <em>C. elegans</em> sensory neurons require intact cilia to detect environmental stimuli, <em>xbx-1</em> loss of function is expected to impair chemosensation and other cilium-dependent behaviors, consistent with phenotypes reported for other IFT-dynein subunit mutants (hao2011theretrogradeift pages 1-2, williams2008functionalredundancyof pages 4-6).</li>
+</ul>
+<h2 id="6-biological-pathways-and-processes">6. Biological Pathways and Processes</h2>
+<h3 id="61-intraflagellar-transport-ift">6.1 Intraflagellar Transport (IFT)</h3>
+<p>XBX-1 functions within the intraflagellar transport pathway, a bidirectional trafficking system essential for cilium assembly, maintenance, and signaling. In this pathway, anterograde IFT trains are assembled at the ciliary base, transported to the ciliary tip by kinesin-2 motors, and then remodeled at the tip for retrograde return driven by the dynein-2 motor complex containing XBX-1 (hao2011theretrogradeift pages 5-7, hiyamizu2023multipleinteractionsof pages 1-2). The dynein-2 complex must be transported as inactive cargo during anterograde transport and then activated at the ciliary tip for retrograde transport (hao2011theretrogradeift pages 3-5). Multiple interactions between dynein-2 subunits (including DYNC2H1–DYNC2LI1 and WDR60) and IFT-B subunits (particularly IFT54 and IFT57) are essential for properly coupling the motor to IFT trains (hiyamizu2023multipleinteractionsof pages 1-2).</p>
+<h3 id="62-transition-zone-assembly-and-ciliary-gating">6.2 Transition Zone Assembly and Ciliary Gating</h3>
+<p>Beyond its role in retrograde IFT, the dynein-2 complex containing XBX-1 has been implicated in transition zone (TZ) assembly and ciliary gating. Using a temperature-sensitive IFT-dynein mutant (<em>che-3</em> ts) in <em>C. elegans</em>, Jensen et al. (2018) demonstrated that retrograde IFT is required for proper assembly and maintenance of the TZ—a ciliary gate at the base of the cilium that controls protein entry and exit (jensen2018roleforintraflagellar pages 1-2, jensen2018roleforintraflagellar pages 3-5). When IFT-dynein function is disrupted, TZ proteins such as NPHP-4, MKS-6, and CEP-290 mislocalize ectopically into the ciliary axoneme, and the gating function that excludes periciliary membrane proteins from the cilium is compromised (jensen2018roleforintraflagellar pages 3-5). Importantly, restoring IFT function in adult animals reverses these TZ defects, demonstrating that active IFT-dynein-mediated transport is continuously required for TZ maintenance, although this capacity declines with age (jensen2018roleforintraflagellar pages 1-2).</p>
+<h3 id="63-olq-specific-ift-dynein">6.3 OLQ-Specific IFT-Dynein</h3>
+<p>An interesting finding relevant to <em>xbx-1</em> is the discovery that the outer labial quadrant (OLQ) neurons of <em>C. elegans</em> can assemble cilia independently of the conventional CHE-3/XBX-1-based IFT-dynein complex, implying the existence of a second IFT-dynein in these specific neurons (hao2011theretrogradeift pages 5-7). A novel dynein heavy chain, DHC-3, along with additional light chains, may constitute this alternative IFT-dynein complex in OLQ cilia (hao2011theretrogradeift pages 5-7).</p>
+<h2 id="7-transcriptional-regulation">7. Transcriptional Regulation</h2>
+<p>The promoter of <em>xbx-1</em> contains an X-box motif (consensus sequence GTTTCCATGGTAAC), which is recognized by the RFX-family transcription factor DAF-19, the master regulator of ciliogenesis gene expression in <em>C. elegans</em> (chu2012finetuningof pages 4-5, perrone2003anoveldynein pages 1-2). DAF-19 activates the expression of <em>xbx-1</em> and dozens of other ciliome genes in ciliated sensory neurons.</p>
+<p>Recent work (2023) has revealed that DAF-19 does not act alone: the Forkhead transcription factor FKH-8 cooperates with DAF-19/RFX as a direct co-regulator of ciliome genes, including <em>xbx-1</em>. FKH-8 is expressed in all ciliated sensory neurons, binds regulatory regions of ciliome genes near X-box motifs, and physically interacts with DAF-19 (brocalruiz2023forkheadtranscriptionfactor pages 1-2, brocalruiz2023forkheadtranscriptionfactor pages 6-7, brocalruiz2023forkheadtranscriptionfactor pages 7-8). ChIP-seq analysis showed that FKH-8 binding peaks are associated with 49% of ciliome genes and preferentially with core ciliome genes (75%), with approximately 62% of core ciliome genes containing both X-box motifs and FKH-8 binding sites (brocalruiz2023forkheadtranscriptionfactor pages 5-6). Point mutations disrupting FKH binding sites in the <em>xbx-1</em> regulatory region result in expression defects, confirming a direct regulatory role (brocalruiz2023forkheadtranscriptionfactor pages 9-10). This cooperative FKH-8/DAF-19 regulatory logic may represent an ancient trait predating functional cilia sub-specialization, as FKH-8 function can be replaced by mouse FOXJ1 and FOXN4 (brocalruiz2023forkheadtranscriptionfactor pages 1-2).</p>
+<h2 id="8-human-disease-relevance">8. Human Disease Relevance</h2>
+<p>The human ortholog of XBX-1, DYNC2LI1 (also known as LIC3 or D2LIC), is associated with skeletal ciliopathies when mutated. Pathogenic variants in <em>DYNC2LI1</em> cause short-rib thoracic dystrophy (SRTD), a form of Jeune asphyxiating thoracic dystrophy, as well as Ellis-van Creveld syndrome and short-rib polydactyly syndrome (OpenTargets Search: -DYNC2LI1, qiu2022combinationsofdeletion pages 2-4). Several pathogenic DYNC2LI1 variants, including p.(Leu117Val), p.(Ser302_Ile332del), and p.(Trp124*), have been shown to impair binding to DYNC2H1 and WDR60 (qiu2022combinationsofdeletion pages 2-4). In cell-based assays, combinations of deletion and missense variants—mimicking compound heterozygosity seen in patients—cause ciliary defects, whereas individual missense variants alone often do not produce substantial abnormalities (qiu2022combinationsofdeletion pages 2-4). These findings underscore the conservation of DYNC2LI1/XBX-1 function from nematodes to humans and its essential role in cilium biogenesis.</p>
+<h2 id="9-summary-of-key-functional-findings">9. Summary of Key Functional Findings</h2>
+<p>The following table provides a concise overview of the experimentally supported functional annotations for <em>xbx-1</em>:</p>
+<table>
+<thead>
+<tr>
+<th>Functional aspect</th>
+<th>Finding</th>
+<th>Evidence type</th>
+<th>Reference</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Molecular function</td>
+<td>XBX-1 is the light intermediate chain of the IFT-dynein (dynein-2) complex and is essential for retrograde intraflagellar transport in <em>C. elegans</em> sensory cilia. (hao2011theretrogradeift pages 5-7, hao2011theretrogradeift pages 1-2, hao2011theretrogradeift pages 9-9)</td>
+<td>Genetic/biochemical</td>
+<td>Hao et al. 2011</td>
+</tr>
+<tr>
+<td>Expression pattern</td>
+<td><em>xbx-1</em> is expressed in most or all ciliated sensory neurons and is an X-box-regulated ciliome gene under DAF-19/RFX control; more recent work supports cooperative regulation with FKH-8. (perrone2003anoveldynein pages 1-2, chu2012finetuningof pages 4-5, brocalruiz2023forkheadtranscriptionfactor pages 9-10, brocalruiz2023forkheadtranscriptionfactor pages 1-2)</td>
+<td>Reporter assays, transcription factor analysis</td>
+<td>Perrone et al. 2003; Chu et al. 2012; Brocal-Ruiz et al. 2023</td>
+</tr>
+<tr>
+<td>Subcellular localization</td>
+<td>XBX-1 localizes to ciliary axonemes of amphid and phasmid neurons, visualized with XBX-1::YFP/RFP/tdTomato reporters and knock-ins. (scheidel2018intraflagellartransportcomplex pages 3-4, hao2011theretrogradeift pages 1-2)</td>
+<td>XBX-1::YFP/tdTomato imaging</td>
+<td>Hao et al. 2011; Scheidel et al. 2018</td>
+</tr>
+<tr>
+<td>Transport properties</td>
+<td>XBX-1 is transported anterogradely at ~0.776 ± 0.08 µm/s in the middle segment and ~1.30 ± 0.18 µm/s in the distal segment; its movement is largely independent of IFT particle/BBSome coupling. (hao2011theretrogradeift pages 3-5, hao2011theretrogradeift pages 5-7)</td>
+<td>IFT velocity measurements</td>
+<td>Hao et al. 2011</td>
+</tr>
+<tr>
+<td>Loss-of-function phenotype</td>
+<td><em>xbx-1(ok279)</em> and related loss-of-function conditions cause highly abnormal phasmid cilia, dye-filling defects, and short/swollen cilia that accumulate IFT material, consistent with retrograde IFT failure. (hao2011theretrogradeift pages 1-2, perrone2003anoveldynein pages 1-2, williams2008functionalredundancyof pages 4-6)</td>
+<td>Mutant phenotyping, dye-fill assays, cilia morphology analysis</td>
+<td>Hao et al. 2011; Perrone et al. 2003; Williams et al. 2008</td>
+</tr>
+<tr>
+<td>Complex membership</td>
+<td>XBX-1/DYNC2LI1 forms the DYNC2H1-DYNC2LI1 core dynein-2 subcomplex and bridges the heavy chain tail to intermediate-chain modules in the holocomplex. (qiu2022combinationsofdeletion pages 1-2, hiyamizu2023multipleinteractionsof pages 2-3, tsurumi2019interactionsofthe pages 1-2, hiyamizu2023multipleinteractionsof pages 3-4)</td>
+<td>Structural analysis, cryo-EM, biochemical complex mapping</td>
+<td>Qiu et al. 2022; Tsurumi et al. 2019; Hiyamizu et al. 2023</td>
+</tr>
+<tr>
+<td>Transcriptional regulation</td>
+<td><em>xbx-1</em> is co-regulated by FKH-8 and DAF-19/RFX through nearby FKH-binding and X-box regulatory elements, supporting a cooperative ciliome transcription program. (brocalruiz2023forkheadtranscriptionfactor pages 9-10, brocalruiz2023forkheadtranscriptionfactor pages 3-5, brocalruiz2023forkheadtranscriptionfactor pages 6-7, brocalruiz2023forkheadtranscriptionfactor pages 7-8)</td>
+<td>ChIP-seq, reporter assays, cis-regulatory analysis</td>
+<td>Brocal-Ruiz et al. 2023</td>
+</tr>
+<tr>
+<td>Human disease relevance</td>
+<td>The human ortholog <strong>DYNC2LI1</strong> is implicated in skeletal ciliopathies, including short-rib thoracic dysplasia, and pathogenic variants can impair dynein-2 assembly and ciliary function. (qiu2022combinationsofdeletion pages 2-4, OpenTargets Search: -DYNC2LI1)</td>
+<td>Human genetics, cell-based functional studies</td>
+<td>Qiu et al. 2022; Open Targets context</td>
+</tr>
+</tbody>
+</table>
+<p><em>Table: This table summarizes the main experimentally supported functional findings for </em>C. elegans xbx-1<em>, including molecular role, localization, transport behavior, regulation, phenotype, and human ortholog relevance. It is useful as a compact evidence map for the gene’s annotation.</em></p>
+<h2 id="10-conclusions">10. Conclusions</h2>
+<p><em>xbx-1</em> encodes the light intermediate chain of the IFT-dynein (cytoplasmic dynein-2) complex in <em>C. elegans</em>. Its primary function is structural: it forms a core subcomplex with the dynein heavy chain CHE-3 (DYNC2H1), bridging it to intermediate and light chain modules that together constitute the retrograde IFT motor. XBX-1 is essential for retrograde intraflagellar transport—the recycling of IFT components and associated cargo from the ciliary tip back to the base—and its loss results in structurally abnormal, truncated cilia. The protein localizes exclusively to sensory cilia, where it undergoes bidirectional transport, and it is uniquely transported as cargo independently of IFT particle subcomplexes and the BBSome. Beyond retrograde transport, the dynein-2 complex containing XBX-1 contributes to transition zone assembly, ciliary gating, and ciliary maintenance. Transcriptionally, <em>xbx-1</em> is co-regulated by DAF-19/RFX and FKH-8, representing a conserved ciliome gene regulatory program. The human ortholog DYNC2LI1 is mutated in skeletal ciliopathies, confirming the deep evolutionary conservation of this gene's function in cilium biology.</p>
+<p>References</p>
+<ol>
+<li>
+<p>(perrone2003anoveldynein pages 1-2): Catherine A. Perrone, Douglas Tritschler, Patrick Taulman, Raqual Bower, Bradley K. Yoder, and Mary E. Porter. A novel dynein light intermediate chain colocalizes with the retrograde motor for intraflagellar transport at sites of axoneme assembly in chlamydomonas and mammalian cells. Molecular biology of the cell, 14 5:2041-56, May 2003. URL: https://doi.org/10.1091/mbc.e02-10-0682, doi:10.1091/mbc.e02-10-0682. This article has 165 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(chu2012finetuningof pages 4-5): J. S. C. Chu, M. Tarailo-Graovac, D. Zhang, J. Wang, B. Uyar, D. Tu, J. Trinh, D. L. Baillie, and N. Chen. Fine tuning of rfx/daf-19-regulated target gene expression through binding to multiple sites in caenorhabditis elegans. Nucleic Acids Research, 40:53-64, Sep 2012. URL: https://doi.org/10.1093/nar/gkr690, doi:10.1093/nar/gkr690. This article has 13 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(hao2011theretrogradeift pages 5-7): Limin Hao, Evgeni Efimenko, Peter Swoboda, and Jonathan M. Scholey. The retrograde ift machinery of c. elegans cilia: two ift dynein complexes? PLoS ONE, 6:e20995, Jun 2011. URL: https://doi.org/10.1371/journal.pone.0020995, doi:10.1371/journal.pone.0020995. This article has 59 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(hao2011theretrogradeift pages 1-2): Limin Hao, Evgeni Efimenko, Peter Swoboda, and Jonathan M. Scholey. The retrograde ift machinery of c. elegans cilia: two ift dynein complexes? PLoS ONE, 6:e20995, Jun 2011. URL: https://doi.org/10.1371/journal.pone.0020995, doi:10.1371/journal.pone.0020995. This article has 59 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(hao2011theretrogradeift pages 3-5): Limin Hao, Evgeni Efimenko, Peter Swoboda, and Jonathan M. Scholey. The retrograde ift machinery of c. elegans cilia: two ift dynein complexes? PLoS ONE, 6:e20995, Jun 2011. URL: https://doi.org/10.1371/journal.pone.0020995, doi:10.1371/journal.pone.0020995. This article has 59 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(hao2011theretrogradeift pages 9-9): Limin Hao, Evgeni Efimenko, Peter Swoboda, and Jonathan M. Scholey. The retrograde ift machinery of c. elegans cilia: two ift dynein complexes? PLoS ONE, 6:e20995, Jun 2011. URL: https://doi.org/10.1371/journal.pone.0020995, doi:10.1371/journal.pone.0020995. This article has 59 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(tsurumi2019interactionsofthe pages 1-2): Yuta Tsurumi, Yuki Hamada, Yohei Katoh, and Kazuhisa Nakayama. Interactions of the dynein-2 intermediate chain wdr34 with the light chains are required for ciliary retrograde protein trafficking. Mar 2019. URL: https://doi.org/10.1091/mbc.e18-10-0678, doi:10.1091/mbc.e18-10-0678. This article has 47 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(qiu2022combinationsofdeletion pages 1-2): Hantian Qiu, Yuta Tsurumi, Yohei Katoh, and Kazuhisa Nakayama. Combinations of deletion and missense variations of the dynein-2 dync2li1 subunit found in skeletal ciliopathies cause ciliary defects. Scientific Reports, Jan 2022. URL: https://doi.org/10.1038/s41598-021-03950-0, doi:10.1038/s41598-021-03950-0. This article has 14 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(hiyamizu2023multipleinteractionsof pages 2-3): Shunya Hiyamizu, Hantian Qiu, Laura Vuolo, Nicola L. Stevenson, Caroline Shak, Kate J. Heesom, Yuki Hamada, Yuta Tsurumi, Shuhei Chiba, Yohei Katoh, David J. Stephens, and Kazuhisa Nakayama. Multiple interactions of the dynein-2 complex with the ift-b complex are required for effective intraflagellar transport. Journal of Cell Science, Feb 2023. URL: https://doi.org/10.1242/jcs.260462, doi:10.1242/jcs.260462. This article has 18 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(hiyamizu2023multipleinteractionsof pages 3-4): Shunya Hiyamizu, Hantian Qiu, Laura Vuolo, Nicola L. Stevenson, Caroline Shak, Kate J. Heesom, Yuki Hamada, Yuta Tsurumi, Shuhei Chiba, Yohei Katoh, David J. Stephens, and Kazuhisa Nakayama. Multiple interactions of the dynein-2 complex with the ift-b complex are required for effective intraflagellar transport. Journal of Cell Science, Feb 2023. URL: https://doi.org/10.1242/jcs.260462, doi:10.1242/jcs.260462. This article has 18 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(hiyamizu2023multipleinteractionsof pages 1-2): Shunya Hiyamizu, Hantian Qiu, Laura Vuolo, Nicola L. Stevenson, Caroline Shak, Kate J. Heesom, Yuki Hamada, Yuta Tsurumi, Shuhei Chiba, Yohei Katoh, David J. Stephens, and Kazuhisa Nakayama. Multiple interactions of the dynein-2 complex with the ift-b complex are required for effective intraflagellar transport. Journal of Cell Science, Feb 2023. URL: https://doi.org/10.1242/jcs.260462, doi:10.1242/jcs.260462. This article has 18 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(scheidel2018intraflagellartransportcomplex pages 3-4): Noémie Scheidel and Oliver E. Blacque. Intraflagellar transport complex a genes differentially regulate cilium formation and transition zone gating. Current Biology, 28:3279-3287.e2, Oct 2018. URL: https://doi.org/10.1016/j.cub.2018.08.017, doi:10.1016/j.cub.2018.08.017. This article has 59 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(wei2012thebbsomecontrols pages 14-16): Qing Wei, Yuxia Zhang, Yujie Li, Qing Zhang, Kun Ling, and Jinghua Hu. The bbsome controls ift assembly and turnaround in cilia. Aug 2012. URL: https://doi.org/10.1038/ncb2560, doi:10.1038/ncb2560. This article has 273 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(williams2008functionalredundancyof pages 4-6): Corey L. Williams, Marlene E. Winkelbauer, Jenny C. Schafer, Edward J. Michaud, and Bradley K. Yoder. Functional redundancy of the b9 proteins and nephrocystins in caenorhabditis elegans ciliogenesis. Molecular biology of the cell, 19 5:2154-68, May 2008. URL: https://doi.org/10.1091/mbc.e07-10-1070, doi:10.1091/mbc.e07-10-1070. This article has 120 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(jensen2018roleforintraflagellar pages 1-2): Victor L Jensen, Nils J Lambacher, Chunmei Li, Swetha Mohan, Corey L Williams, Peter N Inglis, Bradley K Yoder, Oliver E Blacque, and Michel R Leroux. Role for intraflagellar transport in building a functional transition zone. EMBO reports, Nov 2018. URL: https://doi.org/10.15252/embr.201845862, doi:10.15252/embr.201845862. This article has 51 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(jensen2018roleforintraflagellar pages 3-5): Victor L Jensen, Nils J Lambacher, Chunmei Li, Swetha Mohan, Corey L Williams, Peter N Inglis, Bradley K Yoder, Oliver E Blacque, and Michel R Leroux. Role for intraflagellar transport in building a functional transition zone. EMBO reports, Nov 2018. URL: https://doi.org/10.15252/embr.201845862, doi:10.15252/embr.201845862. This article has 51 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(brocalruiz2023forkheadtranscriptionfactor pages 1-2): Rebeca Brocal-Ruiz, Ainara Esteve-Serrano, Carlos Mora-Martínez, Maria Luisa Franco-Rivadeneira, Peter Swoboda, Juan J Tena, Marçal Vilar, and Nuria Flames. Forkhead transcription factor fkh-8 cooperates with rfx in the direct regulation of sensory cilia in caenorhabditis elegans. eLife, Jul 2023. URL: https://doi.org/10.7554/elife.89702, doi:10.7554/elife.89702. This article has 15 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(brocalruiz2023forkheadtranscriptionfactor pages 6-7): Rebeca Brocal-Ruiz, Ainara Esteve-Serrano, Carlos Mora-Martínez, Maria Luisa Franco-Rivadeneira, Peter Swoboda, Juan J Tena, Marçal Vilar, and Nuria Flames. Forkhead transcription factor fkh-8 cooperates with rfx in the direct regulation of sensory cilia in caenorhabditis elegans. eLife, Jul 2023. URL: https://doi.org/10.7554/elife.89702, doi:10.7554/elife.89702. This article has 15 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(brocalruiz2023forkheadtranscriptionfactor pages 7-8): Rebeca Brocal-Ruiz, Ainara Esteve-Serrano, Carlos Mora-Martínez, Maria Luisa Franco-Rivadeneira, Peter Swoboda, Juan J Tena, Marçal Vilar, and Nuria Flames. Forkhead transcription factor fkh-8 cooperates with rfx in the direct regulation of sensory cilia in caenorhabditis elegans. eLife, Jul 2023. URL: https://doi.org/10.7554/elife.89702, doi:10.7554/elife.89702. This article has 15 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(brocalruiz2023forkheadtranscriptionfactor pages 5-6): Rebeca Brocal-Ruiz, Ainara Esteve-Serrano, Carlos Mora-Martínez, Maria Luisa Franco-Rivadeneira, Peter Swoboda, Juan J Tena, Marçal Vilar, and Nuria Flames. Forkhead transcription factor fkh-8 cooperates with rfx in the direct regulation of sensory cilia in caenorhabditis elegans. eLife, Jul 2023. URL: https://doi.org/10.7554/elife.89702, doi:10.7554/elife.89702. This article has 15 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(brocalruiz2023forkheadtranscriptionfactor pages 9-10): Rebeca Brocal-Ruiz, Ainara Esteve-Serrano, Carlos Mora-Martínez, Maria Luisa Franco-Rivadeneira, Peter Swoboda, Juan J Tena, Marçal Vilar, and Nuria Flames. Forkhead transcription factor fkh-8 cooperates with rfx in the direct regulation of sensory cilia in caenorhabditis elegans. eLife, Jul 2023. URL: https://doi.org/10.7554/elife.89702, doi:10.7554/elife.89702. This article has 15 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(OpenTargets Search: -DYNC2LI1): Open Targets Query (-DYNC2LI1, 5 results). Buniello, A. et al. (2025). Open Targets Platform: facilitating therapeutic hypotheses building in drug discovery. Nucleic Acids Research.</p>
+</li>
+<li>
+<p>(qiu2022combinationsofdeletion pages 2-4): Hantian Qiu, Yuta Tsurumi, Yohei Katoh, and Kazuhisa Nakayama. Combinations of deletion and missense variations of the dynein-2 dync2li1 subunit found in skeletal ciliopathies cause ciliary defects. Scientific Reports, Jan 2022. URL: https://doi.org/10.1038/s41598-021-03950-0, doi:10.1038/s41598-021-03950-0. This article has 14 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(brocalruiz2023forkheadtranscriptionfactor pages 3-5): Rebeca Brocal-Ruiz, Ainara Esteve-Serrano, Carlos Mora-Martínez, Maria Luisa Franco-Rivadeneira, Peter Swoboda, Juan J Tena, Marçal Vilar, and Nuria Flames. Forkhead transcription factor fkh-8 cooperates with rfx in the direct regulation of sensory cilia in caenorhabditis elegans. eLife, Jul 2023. URL: https://doi.org/10.7554/elife.89702, doi:10.7554/elife.89702. This article has 15 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+</ol>
+<h2 id="artifacts">Artifacts</h2>
+<ul>
+<li><a href="xbx-1-deep-research-falcon_artifacts/artifact-00.md">Edison artifact artifact-00</a></li>
+<li><a href="xbx-1-deep-research-falcon_artifacts/artifact-01.md">Edison artifact artifact-01</a></li>
+</ul>
+<h2 id="citations">Citations</h2>
+<ol>
+<li>hao2011theretrogradeift pages 1-2</li>
+<li>tsurumi2019interactionsofthe pages 1-2</li>
+<li>scheidel2018intraflagellartransportcomplex pages 3-4</li>
+<li>hao2011theretrogradeift pages 5-7</li>
+<li>williams2008functionalredundancyof pages 4-6</li>
+<li>hao2011theretrogradeift pages 3-5</li>
+<li>hiyamizu2023multipleinteractionsof pages 1-2</li>
+<li>jensen2018roleforintraflagellar pages 3-5</li>
+<li>jensen2018roleforintraflagellar pages 1-2</li>
+<li>brocalruiz2023forkheadtranscriptionfactor pages 5-6</li>
+<li>brocalruiz2023forkheadtranscriptionfactor pages 9-10</li>
+<li>brocalruiz2023forkheadtranscriptionfactor pages 1-2</li>
+<li>qiu2022combinationsofdeletion pages 2-4</li>
+<li>perrone2003anoveldynein pages 1-2</li>
+<li>chu2012finetuningof pages 4-5</li>
+<li>hao2011theretrogradeift pages 9-9</li>
+<li>qiu2022combinationsofdeletion pages 1-2</li>
+<li>hiyamizu2023multipleinteractionsof pages 2-3</li>
+<li>hiyamizu2023multipleinteractionsof pages 3-4</li>
+<li>wei2012thebbsomecontrols pages 14-16</li>
+<li>brocalruiz2023forkheadtranscriptionfactor pages 6-7</li>
+<li>brocalruiz2023forkheadtranscriptionfactor pages 7-8</li>
+<li>brocalruiz2023forkheadtranscriptionfactor pages 3-5</li>
+<li>https://doi.org/10.1091/mbc.e02-10-0682,</li>
+<li>https://doi.org/10.1093/nar/gkr690,</li>
+<li>https://doi.org/10.1371/journal.pone.0020995,</li>
+<li>https://doi.org/10.1091/mbc.e18-10-0678,</li>
+<li>https://doi.org/10.1038/s41598-021-03950-0,</li>
+<li>https://doi.org/10.1242/jcs.260462,</li>
+<li>https://doi.org/10.1016/j.cub.2018.08.017,</li>
+<li>https://doi.org/10.1038/ncb2560,</li>
+<li>https://doi.org/10.1091/mbc.e07-10-1070,</li>
+<li>https://doi.org/10.15252/embr.201845862,</li>
+<li>https://doi.org/10.7554/elife.89702,</li>
+</ol>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(xbx-1-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="Q19119" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="xbx-1-caenorhabditis-elegans-research-notes">xbx-1 (Caenorhabditis elegans) — research notes</h1>
+<p>Gene: <strong>xbx-1</strong> (X-Box promoter gene 1) / WormBase F02D8.3 / WBGene00006960<br />
+UniProt: <strong>Q19119</strong> (Cytoplasmic dynein 2 light intermediate chain 1)<br />
+Human ortholog: <strong>DYNC2LI1 / D2LIC</strong> (UniProt Q8TCX1); PANTHER family <strong>PTHR13236</strong> (subfamily SF0<br />
+"CYTOPLASMIC DYNEIN 2 LIGHT INTERMEDIATE CHAIN 1"), Pfam <strong>PF05783 (DLIC)</strong>.</p>
+<h2 id="identity-bioinformatic-context">Identity / bioinformatic context</h2>
+<ul>
+<li>UniProt RecName: "Cytoplasmic dynein 2 light intermediate chain 1"; SIMILARITY: "Belongs to the<br />
+  dynein light intermediate chain family." Sequence 370 aa; contains a P-loop (Walker A) motif<br />
+<code>AGNRKSGKSS</code> near residue ~55 (Gene3D P-loop NTPase / SSF52540), characteristic of the DLIC family,<br />
+  although DLICs are catalytically inert G-domain-like folds (no established GTPase/ATPase activity of<br />
+  the LIC itself).</li>
+<li>Name origin: "xbx" = <strong>X-box</strong>; the gene was found as an X-box (RFX/DAF-19) promoter-motif gene,<br />
+  i.e. a member of the DAF-19-regulated ciliary gene battery.</li>
+</ul>
+<h2 id="known-well-supported">KNOWN (well supported)</h2>
+<p><strong>Molecular role — a light intermediate chain of the cytoplasmic dynein-2 (retrograde IFT) motor.</strong><br />
+- xbx-1 "shares homology with a mammalian dynein light intermediate chain (D2LIC)"<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/12802075" title="a novel \nCaenorhabditis elegans gene, xbx-1, that is required for retrograde IFT and \nshares homology with a mammalian dynein light intermediate chain (D2LIC)">PMID:12802075</a>.<br />
+- XBX-1 functions together with the CHE-3 dynein heavy chain in retrograde IFT:<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/12802075" title="the DLIC protein XBX-1 functions together with the CHE-3 dynein in retrograde IFT, \ndownstream of the complex A proteins">PMID:12802075</a>.<br />
+  CHE-3 is the C. elegans cytoplasmic dynein-2 heavy chain (DYNC2H1 ortholog); XBX-1 is its LIC<br />
+  partner. This is the basis of the ISS "dynein heavy chain binding" (GO:0045504) annotation<br />
+  (with/from UniProtKB:Q6AY43 = rat D2LIC).<br />
+- In the BBSome paper XBX-1 is referred to as "the retrograde IFT motor dynein light chain XBX-1<br />
+  (the ortholog of human D2LIC)" <a href="https://pubmed.ncbi.nlm.nih.gov/22922713" title="the retrograde IFT motor dynein light chain XBX-1 (the ortholog of human D2LIC)">PMID:22922713</a>.</p>
+<p><strong>Biological process — retrograde intraflagellar transport (IFT) required for cilium assembly.</strong><br />
+- xbx-1 is "required for retrograde IFT and shares homology with a mammalian dynein light intermediate<br />
+  chain" <a href="https://pubmed.ncbi.nlm.nih.gov/12802075">PMID:12802075</a>.<br />
+- Loss of xbx-1 gives short, malformed cilia with a distal bulb where IFT proteins pile up (the<br />
+  classic retrograde-IFT/dynein-mutant phenotype): <a href="https://pubmed.ncbi.nlm.nih.gov/12802075" title="Analysis of cilia in xbx-1 mutants   reveals that they are shortened and have a bulb like \nstructure in which IFT proteins accumulate">PMID:12802075</a>.<br />
+  This underlies the IMP annotations to intraciliary retrograde transport (GO:0035721) and non-motile<br />
+  cilium assembly (GO:1905515).<br />
+- Placement in the pathway: XBX-1/CHE-3 dynein acts downstream of the IFT-A (complex A) proteins;<br />
+  notably "retrograde XBX-1 movement was detected in complex A mutants" <a href="https://pubmed.ncbi.nlm.nih.gov/12802075" title="retrograde \nXBX-1 movement was detected in complex A mutants">PMID:12802075</a>, distinguishing dynein-2 motor behaviour from<br />
+  IFT-A cargo.</p>
+<p><strong>Localization — ciliary base/basal body and the axoneme, moving bidirectionally.</strong><br />
+- "XBX-1 localizes to the base of the cilia and undergoes anterograde and \nretrograde movement along<br />
+  the axoneme" <a href="https://pubmed.ncbi.nlm.nih.gov/12802075">PMID:12802075</a>. (Note: the anterograde run reflects the motor being carried as<br />
+  inactive cargo by kinesin-2 to the ciliary tip, then powering the retrograde run.)<br />
+- Restated in later work: "The dynein light intermediate chain protein XBX-1 localizes to the basal<br />
+  body and undergoes bidirectional movement along the ciliary axoneme (Schafer et al., 2003)"<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/33460640">PMID:33460640</a>.<br />
+- Used as a canonical IFT/ciliary marker: "tdTomato-tagged XBX-1 (IFT protein that localises to the<br />
+  ciliary base and axoneme)" <a href="https://pubmed.ncbi.nlm.nih.gov/27930654">PMID:27930654</a>.<br />
+- Curated experimental (IDA) localizations across papers cover: ciliary base (GO:0097546), ciliary<br />
+  basal body (GO:0036064), axoneme (GO:0005930), ciliary transition zone (GO:0035869), cilium<br />
+  (GO:0005929), and non-motile cilium (GO:0097730). Several of these come from studies that used<br />
+  XBX-1::GFP/tdTomato as the reference IFT/ciliary marker while assaying other proteins<br />
+  (PMID:27930654 RAB-28; PMID:25335890 AFD bipartite compartment; PMID:17420466 DYF-5;<br />
+  PMID:27623382 GRDN-1/Girdin; PMID:33460640 GRDN-1; PMID:22922713 BBSome). The curators annotating<br />
+  these IDA calls read the full text.</p>
+<p><strong>Transcriptional regulation.</strong><br />
+- xbx-1 is part of the DAF-19 (RFX) ciliary gene battery: "xbx-1 \nexpression in ciliated sensory<br />
+  neurons is regulated by the transcription factor \nDAF-19" <a href="https://pubmed.ncbi.nlm.nih.gov/12802075">PMID:12802075</a>. (This is regulation OF<br />
+  xbx-1, not a molecular function of the protein — informative for the gene's identity as an X-box<br />
+  ciliary gene, but not a GO MF/BP annotation for the protein.)</p>
+<h2 id="not-known-uncertain-candidate-knowledge-gaps">NOT known / uncertain (candidate knowledge gaps)</h2>
+<ul>
+<li>The <strong>specific role of the LIC subunit within dynein-2</strong> is not resolved in C. elegans. In<br />
+  mammals/Chlamydomonas the DLIC (D2LIC/DYNC2LI1) is required for dynein-2 complex stability and for<br />
+  loading/coupling the motor for IFT, but the precise molecular contribution of XBX-1 — motor complex<br />
+  assembly/stability vs. cargo adaptor/IFT-train coupling vs. regulation of motor<br />
+  activation/autoinhibition at the tip — has not been dissected in the worm. The LIC itself has no<br />
+  demonstrated enzymatic activity; the ATP-dependent minus-end-directed motor activity is a property<br />
+  of the dynein-2 heavy chain (CHE-3)/complex.</li>
+<li>Whether XBX-1 has any <strong>dynein-2-independent function</strong> (e.g. at the basal body/centriole outside<br />
+  the assembled motor) is untested.</li>
+<li>The <strong>G-domain/P-loop of the DLIC fold</strong>: whether the residual nucleotide-binding fold in XBX-1<br />
+  binds a nucleotide or is a purely structural relic in vivo is unknown.</li>
+<li><strong>Ontology gap:</strong> GO has no specific "cytoplasmic dynein 2 complex" cellular-component term; the<br />
+  closest available term is GO:0005868 "cytoplasmic dynein complex" (which conflates dynein-1 and<br />
+  dynein-2). OLS search for "cytoplasmic dynein 2 complex" returns only HGNC gene-group, not a GO<br />
+  class (checked 2026-07-04).</li>
+</ul>
+<h2 id="annotation-review-plan-summary-of-decisions">Annotation review plan (summary of decisions)</h2>
+<p>Core (keep, represent the evolved function):<br />
+- GO:0045504 dynein heavy chain binding (MF) — its own molecular function (binds CHE-3 HC). ACCEPT.<br />
+- GO:0005868 cytoplasmic dynein complex (CC, part_of) — dynein-2 motor membership. ACCEPT (best<br />
+  available term; a dynein-2-specific term would be preferable — ontology gap).<br />
+- GO:0035721 intraciliary retrograde transport (BP) — ACCEPT (core; IMP + IBA).<br />
+- GO:0035735 intraciliary transport involved in cilium assembly (BP) — ACCEPT (core; broader IFT/<br />
+  assembly framing).<br />
+- GO:1905515 non-motile cilium assembly (BP, IMP) — ACCEPT (core; C. elegans sensory cilia are<br />
+  non-motile).<br />
+Locations (accept as experimentally supported; non-core CC context):<br />
+- GO:0097546 ciliary base, GO:0036064 ciliary basal body, GO:0005930 axoneme, GO:0035869 ciliary<br />
+  transition zone, GO:0005929 cilium, GO:0097730 non-motile cilium — ACCEPT (IDA/IBA).<br />
+IEA/electronic:<br />
+- GO:0005813 centrosome (IEA, SubCell) — KEEP_AS_NON_CORE / cautious: centrosome is the SubCell<br />
+  mapping of the basal body/MTOC; in C. elegans sensory neurons the relevant structure is the ciliary<br />
+  basal body, and there is no direct evidence for a canonical mitotic centrosome role. Mark non-core.<br />
+- Duplicate IEA (InterPro/SubCell) mirrors of IDA/IBA terms (dynein complex, axoneme, retrograde<br />
+  transport, IFT-in-assembly) — ACCEPT as consistent electronic support (redundant with experimental<br />
+  calls).</p>
+<h2 id="falcon-deep-research-summary-xbx-1-deep-research-falconmd-2026-07-04">Falcon deep-research summary (xbx-1-deep-research-falcon.md, 2026-07-04)</h2>
+<p>The falcon report (provider Edison Scientific Literature; 34 citations) is consistent with the<br />
+primary-literature review above and adds complex-composition/structural detail (citation keys are<br />
+falcon-internal, NOT PMIDs; not imported into the review YAML to avoid unverifiable citations):<br />
+- C. elegans IFT-dynein (dynein-2) composition: heavy chain CHE-3 (DYNC2H1), light intermediate chain<br />
+  XBX-1 (DYNC2LI1), plus Tctex-type light chains DYLT-1/DYLT-2 and a Roadblock-type light chain<br />
+  DYRB-1 (falcon: "hao2011theretrogradeift"). This supports XBX-1's assignment as the LIC of the<br />
+  retrograde IFT motor.<br />
+- Mammalian dynein-2 cryo-EM: DYNC2LI1 binds directly to the N-terminal non-motor tail of DYNC2H1;<br />
+  the holocomplex is 11 subunits in three subcomplexes with ~2:2:1:1 DYNC2H1:DYNC2LI1:WDR60:WDR34<br />
+  stoichiometry (falcon: "qiu2022combinationsofdeletion", "hiyamizu2023multipleinteractionsof",<br />
+  "tsurumi2019interactionsofthe"). This frames XBX-1 as a structural bridge between the heavy-chain<br />
+  motor and the intermediate/light-chain tail module — consistent with, but not fully resolving, the<br />
+  C. elegans-specific mechanistic knowledge gap (assembly/stability vs. IFT-train coupling vs. motor<br />
+  regulation).<br />
+- Reaffirms XBX-1 is non-enzymatic (structural/regulatory), that loss gives short cilia with IFT<br />
+  accumulation, and that xbx-1 is DAF-19/X-box regulated.<br />
+These points reinforce the review; none contradict it, and none required changing an action.</p>
+<h2 id="references-consulted">References consulted</h2>
+<ul>
+<li>PMID:12802075 Schafer et al. 2003 MBoC — primary XBX-1 characterization (abstract-only in cache;<br />
+  rich abstract). HIGH relevance.</li>
+<li>PMID:22922713 Wei et al. 2012 (BBSome controls IFT assembly/turnaround) — XBX-1 as dynein-2 marker.</li>
+<li>PMID:27930654 Jensen et al. 2016 (RAB-28) — XBX-1::tdTomato as base/axoneme IFT marker.</li>
+<li>PMID:25335890 Nguyen et al. 2014 (AFD bipartite compartment) — XBX-1 as ciliary/axoneme marker.</li>
+<li>PMID:17420466 Burghoorn et al. 2007 (DYF-5) — XBX-1 as non-motile cilium marker (abstract has no<br />
+  xbx-1 mention; IDA from full text).</li>
+<li>PMID:27623382 Nechipurenko et al. 2016 (Girdin/GRDN-1 BB positioning) — cilium marker (abstract has<br />
+  no xbx-1 mention; IDA from full text).</li>
+<li>PMID:33460640 Nechipurenko et al. 2021 (GRDN-1 dendrite/cilium position) — restates XBX-1 basal<br />
+  body + axoneme localization.</li>
+</ul>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: Q19119
+gene_symbol: xbx-1
+product_type: PROTEIN
+status: COMPLETE
+taxon:
+  id: NCBITaxon:6239
+  label: Caenorhabditis elegans
+description: &gt;-
+  xbx-1 encodes the Caenorhabditis elegans cytoplasmic dynein-2 light intermediate
+  chain, the ortholog of mammalian DYNC2LI1/D2LIC. It is a non-catalytic subunit of
+  the dynein-2 (IFT-dynein) motor, which also contains the CHE-3 heavy chain.
+  Dynein-2 is the minus-end-directed microtubule motor that powers retrograde
+  intraflagellar transport (IFT), returning IFT trains and turned-over cargo from
+  the ciliary tip back to the base. XBX-1 binds the dynein heavy chain and is
+  required to build and maintain the sensory cilia of C. elegans: it localizes to
+  the ciliary base and basal body and moves bidirectionally along the axoneme
+  (carried anterogradely as inactive cargo by kinesin-2, then powering the
+  retrograde run). Loss of xbx-1 gives short, malformed cilia with a distal bulb in
+  which IFT proteins accumulate, together with the sensory-behaviour defects typical
+  of ciliary mutants. xbx-1 belongs to the DAF-19 (RFX) X-box-regulated ciliary gene
+  battery, from which it takes its name.
+references:
+- id: GO_REF:0000002
+  title: Gene Ontology annotation through association of InterPro records with GO
+    terms
+  findings: []
+- id: GO_REF:0000033
+  title: Annotation inferences using phylogenetic trees
+  findings: []
+- id: GO_REF:0000044
+  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location
+    vocabulary mapping, accompanied by conservative changes to GO terms applied by
+    UniProt
+  findings: []
+- id: PMID:12802075
+  title: XBX-1 encodes a dynein light intermediate chain required for retrograde intraflagellar
+    transport and cilia assembly in Caenorhabditis elegans.
+  findings:
+  - statement: &gt;-
+      xbx-1 is required for retrograde IFT and is homologous to the mammalian dynein
+      light intermediate chain D2LIC.
+    supporting_text: &gt;-
+      xbx-1, that is required for retrograde IFT and shares homology with a mammalian
+      dynein light intermediate chain (D2LIC)
+  - statement: &gt;-
+      XBX-1 functions together with the CHE-3 dynein heavy chain in retrograde IFT,
+      downstream of the IFT-A (complex A) proteins.
+    supporting_text: &gt;-
+      the DLIC protein XBX-1 functions together with the CHE-3 dynein in retrograde
+      IFT, downstream of the complex A proteins
+  - statement: &gt;-
+      XBX-1 localizes to the ciliary base and moves bidirectionally (anterograde and
+      retrograde) along the axoneme.
+    supporting_text: &gt;-
+      XBX-1 localizes to the base of the cilia and undergoes anterograde and
+      retrograde movement along the axoneme
+  - statement: &gt;-
+      Loss of xbx-1 produces short cilia with a distal bulb in which IFT proteins
+      accumulate, the hallmark of retrograde IFT failure.
+    supporting_text: &gt;-
+      they are shortened and have a bulb like structure in which IFT proteins
+      accumulate
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Primary characterization of XBX-1. PubMed-verified; abstract-only in cache but
+      the abstract directly supports the dynein light intermediate chain identity,
+      D2LIC homology, requirement for retrograde IFT, cilium assembly phenotype
+      (short cilia with a distal IFT-protein bulb), base/axoneme localization with
+      bidirectional movement, and functional partnership with the CHE-3 dynein
+      downstream of IFT-A.
+- id: PMID:17420466
+  title: Mutation of the MAP kinase DYF-5 affects docking and undocking of kinesin-2
+    motors and reduces their speed in the cilia of Caenorhabditis elegans.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Paper is about DYF-5/kinesin-2; the cached abstract does not mention xbx-1.
+      XBX-1 is used in the full text as a ciliary/IFT marker, which is the basis of
+      the IDA non-motile cilium localization annotation. Contextual for xbx-1.
+- id: PMID:22922713
+  title: The BBSome controls IFT assembly and turnaround in cilia.
+  findings: []
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Full text refers to XBX-1 explicitly as the retrograde IFT motor dynein light
+      chain and D2LIC ortholog; the basis of the IDA basal body localization. The
+      cached abstract does not mention xbx-1.
+- id: PMID:25335890
+  title: Ciliopathy proteins establish a bipartite signaling compartment in a C. elegans
+    thermosensory neuron.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Paper concerns the AFD bipartite signaling compartment; cached abstract does
+      not mention xbx-1. XBX-1 is used in the full text as an axoneme/ciliary-base
+      marker, the basis of the IDA localization annotations.
+- id: PMID:27623382
+  title: A Conserved Role for Girdin in Basal Body Positioning and Ciliogenesis.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Paper concerns GRDN-1/Girdin and basal body positioning; cached abstract does
+      not mention xbx-1. XBX-1 is used in the full text as a cilium marker, the basis
+      of the IDA cilium localization annotation.
+- id: PMID:27930654
+  title: Whole-Organism Developmental Expression Profiling Identifies RAB-28 as a
+    Novel Ciliary GTPase Associated with the BBSome and Intraflagellar Transport.
+  findings: []
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Full text uses tdTomato-tagged XBX-1 as the reference IFT marker localizing to
+      the ciliary base and axoneme; the basis of the IDA axoneme, ciliary base and
+      transition-zone annotations. The cached abstract does not mention xbx-1.
+- id: PMID:33460640
+  title: GRDN-1/Girdin regulates dendrite morphogenesis and cilium position in two
+    specialized sensory neuron types in C. elegans.
+  findings: []
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Full text restates that the dynein light intermediate chain XBX-1 localizes to
+      the basal body and moves bidirectionally along the ciliary axoneme (citing
+      Schafer et al., 2003); the basis of the IDA basal body annotation. The cached
+      abstract does not mention xbx-1.
+existing_annotations:
+- term:
+    id: GO:0036064
+    label: ciliary basal body
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: is_active_in
+  review:
+    summary: &gt;-
+      XBX-1 localizes to the ciliary base/basal body, where dynein-2 is loaded onto
+      IFT trains. Phylogenetically inferred and corroborated by multiple IDA calls
+      (PMID:33460640, PMID:22922713).
+    action: ACCEPT
+    reason: &gt;-
+      Consistent with experimentally observed base/basal body localization of XBX-1
+      and with the known site of dynein-2 loading. A non-core location term but
+      correct.
+    supported_by:
+    - reference_id: PMID:12802075
+      supporting_text: &gt;-
+        XBX-1 localizes to the base of the cilia and undergoes anterograde and
+        retrograde movement along the axoneme
+- term:
+    id: GO:0045504
+    label: dynein heavy chain binding
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Core molecular function: as the dynein-2 light intermediate chain, XBX-1 binds
+      the dynein-2 heavy chain (CHE-3) within the retrograde IFT motor.
+    action: ACCEPT
+    reason: &gt;-
+      This is the defining, informative molecular function of a dynein light
+      intermediate chain. Supported by orthology to D2LIC and by the functional
+      partnership with CHE-3 in retrograde IFT. Retained as core.
+    supported_by:
+    - reference_id: PMID:12802075
+      supporting_text: &gt;-
+        the DLIC protein XBX-1 functions together with the CHE-3 dynein in
+        retrograde IFT, downstream of the complex A proteins
+- term:
+    id: GO:0005868
+    label: cytoplasmic dynein complex
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: part_of
+  review:
+    summary: &gt;-
+      Core complex membership: XBX-1 is a subunit of the cytoplasmic dynein-2
+      (IFT-dynein) motor complex.
+    action: ACCEPT
+    reason: &gt;-
+      Well supported; XBX-1 is the light intermediate chain of dynein-2. GO:0005868
+      is the most specific available term (GO lacks a dedicated &#34;cytoplasmic
+      dynein 2 complex&#34; cellular-component class; see knowledge_gaps). Retained as
+      core.
+    supported_by:
+    - reference_id: PMID:12802075
+      supporting_text: &gt;-
+        the DLIC protein XBX-1 functions together with the CHE-3 dynein in
+        retrograde IFT, downstream of the complex A proteins
+- term:
+    id: GO:0035721
+    label: intraciliary retrograde transport
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Core biological process: XBX-1 is part of the dynein-2 motor that drives
+      retrograde IFT (tip-to-base) in cilia.
+    action: ACCEPT
+    reason: &gt;-
+      Directly supported by IMP evidence (PMID:12802075) and orthology; this is the
+      central process for the gene. Retained as core.
+    supported_by:
+    - reference_id: PMID:12802075
+      supporting_text: &gt;-
+        xbx-1, that is required for retrograde IFT and shares homology with a
+        mammalian dynein light intermediate chain (D2LIC)
+- term:
+    id: GO:0035735
+    label: intraciliary transport involved in cilium assembly
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      IFT (including the retrograde arm powered by dynein-2/XBX-1) is required for
+      cilium assembly and maintenance.
+    action: ACCEPT
+    reason: &gt;-
+      Consistent with the xbx-1 loss-of-function cilium-assembly phenotype and with
+      the established role of IFT in ciliogenesis. Broader BP framing complementary
+      to the more specific retrograde-transport and non-motile-cilium-assembly terms.
+    supported_by:
+    - reference_id: PMID:12802075
+      supporting_text: &gt;-
+        they are shortened and have a bulb like structure in which IFT proteins
+        accumulate
+- term:
+    id: GO:0005930
+    label: axoneme
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: is_active_in
+  review:
+    summary: &gt;-
+      XBX-1 moves along the ciliary axoneme as part of IFT, where the dynein-2 motor
+      operates during retrograde transport.
+    action: ACCEPT
+    reason: &gt;-
+      Phylogenetically inferred and corroborated by IDA axoneme localization
+      (PMID:12802075, PMID:27930654, PMID:25335890). Correct location.
+    supported_by:
+    - reference_id: PMID:12802075
+      supporting_text: &gt;-
+        XBX-1 localizes to the base of the cilia and undergoes anterograde and
+        retrograde movement along the axoneme
+- term:
+    id: GO:0005813
+    label: centrosome
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000044
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Electronic annotation transferred from the UniProt Subcellular Location
+      &#34;microtubule organizing center, centrosome&#34; mapping. In C. elegans ciliated
+      sensory neurons the relevant MTOC is the centriole-derived ciliary basal body,
+      already captured by IDA basal body annotations.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Dynein-2 is the ciliary/IFT dynein, not the mitotic-spindle dynein; there is no
+      direct evidence for a canonical mitotic centrosome role for XBX-1. The
+      &#34;centrosome&#34; call over-generalizes the basal-body/MTOC localization. Kept
+      (basal bodies are centriole-derived MTOCs) but flagged non-core.
+- term:
+    id: GO:0005868
+    label: cytoplasmic dynein complex
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: part_of
+  review:
+    summary: &gt;-
+      InterPro-based electronic support for dynein-2 complex membership, redundant
+      with the IBA part_of annotation.
+    action: ACCEPT
+    reason: &gt;-
+      Consistent electronic corroboration of the experimentally/phylogenetically
+      supported dynein complex membership.
+- term:
+    id: GO:0005930
+    label: axoneme
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000044
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Electronic (Subcellular Location) support for axoneme localization, redundant
+      with IDA axoneme annotations.
+    action: ACCEPT
+    reason: &gt;-
+      Consistent with experimentally observed axoneme localization.
+- term:
+    id: GO:0035721
+    label: intraciliary retrograde transport
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      InterPro-based electronic support for the core retrograde IFT process,
+      redundant with IMP/IBA annotations.
+    action: ACCEPT
+    reason: &gt;-
+      Consistent electronic corroboration of the central biological process.
+- term:
+    id: GO:0035735
+    label: intraciliary transport involved in cilium assembly
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      InterPro-based electronic support for the role of IFT in cilium assembly,
+      redundant with the IBA annotation.
+    action: ACCEPT
+    reason: &gt;-
+      Consistent with the gene&#39;s established role in ciliogenesis via IFT.
+- term:
+    id: GO:0036064
+    label: ciliary basal body
+  evidence_type: IDA
+  original_reference_id: PMID:33460640
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Direct observation that XBX-1 localizes to the basal body and moves
+      bidirectionally along the axoneme.
+    action: ACCEPT
+    reason: &gt;-
+      Experimentally supported basal body localization (curator read full text); the
+      site where dynein-2 is loaded onto IFT trains. Corroborated by the primary
+      characterization (PMID:12802075). Correct non-core location.
+    supported_by:
+    - reference_id: PMID:12802075
+      supporting_text: &gt;-
+        XBX-1 localizes to the base of the cilia and undergoes anterograde and
+        retrograde movement along the axoneme
+- term:
+    id: GO:0005930
+    label: axoneme
+  evidence_type: IDA
+  original_reference_id: PMID:27930654
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      XBX-1::tdTomato was used as an IFT marker localizing to the ciliary base and
+      axoneme.
+    action: ACCEPT
+    reason: &gt;-
+      Experimentally supported axoneme localization (curator read full text),
+      corroborated by the primary characterization (PMID:12802075). Consistent with
+      IFT movement of the dynein-2 motor.
+    supported_by:
+    - reference_id: PMID:12802075
+      supporting_text: &gt;-
+        XBX-1 localizes to the base of the cilia and undergoes anterograde and
+        retrograde movement along the axoneme
+- term:
+    id: GO:0035869
+    label: ciliary transition zone
+  evidence_type: IDA
+  original_reference_id: PMID:27930654
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      XBX-1 traverses the ciliary base/transition zone during IFT, where the dynein-2
+      motor enters and exits the ciliary compartment.
+    action: ACCEPT
+    reason: &gt;-
+      IDA annotation from a study using XBX-1 as a ciliary marker; the curator read
+      the full text. XBX-1 passes through the transition zone as part of IFT, so the
+      localization is biologically consistent. Non-core location.
+- term:
+    id: GO:0097546
+    label: ciliary base
+  evidence_type: IDA
+  original_reference_id: PMID:27930654
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Direct observation of XBX-1 at the ciliary base, the site of dynein-2 loading
+      and IFT-train assembly/turnaround.
+    action: ACCEPT
+    reason: &gt;-
+      Experimentally supported and central to dynein-2 function (loading/unloading);
+      corroborated by the primary characterization (PMID:12802075). Correct location.
+    supported_by:
+    - reference_id: PMID:12802075
+      supporting_text: &gt;-
+        XBX-1 localizes to the base of the cilia and undergoes anterograde and
+        retrograde movement along the axoneme
+- term:
+    id: GO:0005929
+    label: cilium
+  evidence_type: IDA
+  original_reference_id: PMID:27623382
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      XBX-1 localizes to cilia (general ciliary compartment), consistent with its
+      role in IFT.
+    action: ACCEPT
+    reason: &gt;-
+      Experimentally supported general ciliary localization (curator read full text);
+      a parent of the more specific non-motile cilium term also annotated.
+      Corroborated by the primary characterization (PMID:12802075). Correct but
+      non-core.
+    supported_by:
+    - reference_id: PMID:12802075
+      supporting_text: &gt;-
+        XBX-1 localizes to the base of the cilia and undergoes anterograde and
+        retrograde movement along the axoneme
+- term:
+    id: GO:0097730
+    label: non-motile cilium
+  evidence_type: IDA
+  original_reference_id: PMID:17420466
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      XBX-1 localizes to the non-motile sensory cilia of C. elegans, where it
+      operates in IFT.
+    action: ACCEPT
+    reason: &gt;-
+      IDA from a study using XBX-1 as a ciliary/IFT marker (curator read full text);
+      C. elegans sensory cilia are non-motile. Corroborated by the primary
+      characterization (PMID:12802075). Correct location for the cell type. Non-core.
+    supported_by:
+    - reference_id: PMID:12802075
+      supporting_text: &gt;-
+        XBX-1 localizes to the base of the cilia and undergoes anterograde and
+        retrograde movement along the axoneme
+- term:
+    id: GO:0005930
+    label: axoneme
+  evidence_type: IDA
+  original_reference_id: PMID:25335890
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      XBX-1 used as an axoneme/ciliary marker in AFD sensory neurons.
+    action: ACCEPT
+    reason: &gt;-
+      Experimentally supported axoneme localization (curator read full text),
+      redundant with other IDA axoneme calls and corroborated by the primary
+      characterization (PMID:12802075). Correct location.
+    supported_by:
+    - reference_id: PMID:12802075
+      supporting_text: &gt;-
+        XBX-1 localizes to the base of the cilia and undergoes anterograde and
+        retrograde movement along the axoneme
+- term:
+    id: GO:0035721
+    label: intraciliary retrograde transport
+  evidence_type: IMP
+  original_reference_id: PMID:12802075
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Loss of xbx-1 disrupts retrograde IFT, causing IFT proteins to accumulate in a
+      distal ciliary bulb; XBX-1 functions with the CHE-3 dynein downstream of IFT-A.
+    action: ACCEPT
+    reason: &gt;-
+      Primary experimental (IMP) evidence for the gene&#39;s central biological process.
+      Retained as core.
+    supported_by:
+    - reference_id: PMID:12802075
+      supporting_text: &gt;-
+        the DLIC protein XBX-1 functions together with the CHE-3 dynein in
+        retrograde IFT, downstream of the complex A proteins
+    - reference_id: PMID:12802075
+      supporting_text: &gt;-
+        they are shortened and have a bulb like structure in which IFT proteins
+        accumulate
+- term:
+    id: GO:0045504
+    label: dynein heavy chain binding
+  evidence_type: ISS
+  original_reference_id: PMID:12802075
+  qualifier: enables
+  review:
+    summary: &gt;-
+      By sequence similarity to mammalian D2LIC, XBX-1 binds the dynein-2 heavy
+      chain within the retrograde IFT motor.
+    action: ACCEPT
+    reason: &gt;-
+      Informative, specific molecular function (not generic protein binding).
+      Supported by orthology to D2LIC (with/from rat D2LIC) and by the functional
+      partnership with CHE-3. Retained as core.
+    supported_by:
+    - reference_id: PMID:12802075
+      supporting_text: &gt;-
+        xbx-1, that is required for retrograde IFT and shares homology with a
+        mammalian dynein light intermediate chain (D2LIC)
+- term:
+    id: GO:0097546
+    label: ciliary base
+  evidence_type: IDA
+  original_reference_id: PMID:25335890
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      XBX-1 localizes to the ciliary base in AFD sensory neurons.
+    action: ACCEPT
+    reason: &gt;-
+      Experimentally supported ciliary base localization (curator read full text),
+      redundant with other IDA base calls and corroborated by the primary
+      characterization (PMID:12802075). Correct location.
+    supported_by:
+    - reference_id: PMID:12802075
+      supporting_text: &gt;-
+        XBX-1 localizes to the base of the cilia and undergoes anterograde and
+        retrograde movement along the axoneme
+- term:
+    id: GO:1905515
+    label: non-motile cilium assembly
+  evidence_type: IMP
+  original_reference_id: PMID:12802075
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      xbx-1 mutants have short, malformed sensory cilia with a distal IFT-protein
+      bulb, showing XBX-1 is required for assembly of non-motile cilia.
+    action: ACCEPT
+    reason: &gt;-
+      Primary experimental (IMP) evidence for the cilium-assembly requirement; C.
+      elegans sensory cilia are non-motile. Retained as core.
+    supported_by:
+    - reference_id: PMID:12802075
+      supporting_text: &gt;-
+        they are shortened and have a bulb like structure in which IFT proteins
+        accumulate
+- term:
+    id: GO:0036064
+    label: ciliary basal body
+  evidence_type: IDA
+  original_reference_id: PMID:22922713
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      XBX-1 (dynein-2 light chain, D2LIC ortholog) used as a retrograde IFT motor
+      marker localizing to cilia/basal body.
+    action: ACCEPT
+    reason: &gt;-
+      Experimentally supported basal body localization (curator read full text),
+      redundant with the PMID:33460640 IDA call and corroborated by the primary
+      characterization (PMID:12802075). Correct location.
+    supported_by:
+    - reference_id: PMID:12802075
+      supporting_text: &gt;-
+        XBX-1 localizes to the base of the cilia and undergoes anterograde and
+        retrograde movement along the axoneme
+- term:
+    id: GO:0097730
+    label: non-motile cilium
+  evidence_type: IDA
+  original_reference_id: PMID:12802075
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      XBX-1 localizes within the non-motile sensory cilia, moving between the base
+      and the axoneme.
+    action: ACCEPT
+    reason: &gt;-
+      Experimentally supported localization to C. elegans (non-motile) sensory cilia.
+      Correct location.
+    supported_by:
+    - reference_id: PMID:12802075
+      supporting_text: &gt;-
+        XBX-1 localizes to the base of the cilia and undergoes anterograde and
+        retrograde movement along the axoneme
+- term:
+    id: GO:0005930
+    label: axoneme
+  evidence_type: IDA
+  original_reference_id: PMID:12802075
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      XBX-1 undergoes bidirectional movement along the ciliary axoneme.
+    action: ACCEPT
+    reason: &gt;-
+      Primary experimental evidence for axoneme localization/movement of the
+      dynein-2 motor. Correct location.
+    supported_by:
+    - reference_id: PMID:12802075
+      supporting_text: &gt;-
+        XBX-1 localizes to the base of the cilia and undergoes anterograde and
+        retrograde movement along the axoneme
+core_functions:
+- description: &gt;-
+    Cytoplasmic dynein-2 light intermediate chain: a non-catalytic subunit of the
+    dynein-2 (IFT-dynein) motor that binds the CHE-3 dynein heavy chain and
+    contributes to the complex&#39;s minus-end-directed microtubule motor activity,
+    powering retrograde intraflagellar transport required for sensory cilium
+    assembly and maintenance.
+  molecular_function:
+    id: GO:0045504
+    label: dynein heavy chain binding
+  contributes_to_molecular_function:
+    id: GO:0008569
+    label: minus-end-directed microtubule motor activity
+  directly_involved_in:
+  - id: GO:0035721
+    label: intraciliary retrograde transport
+  - id: GO:1905515
+    label: non-motile cilium assembly
+  locations:
+  - id: GO:0005930
+    label: axoneme
+  - id: GO:0097730
+    label: non-motile cilium
+  in_complex:
+    id: GO:0005868
+    label: cytoplasmic dynein complex
+  supported_by:
+  - reference_id: PMID:12802075
+    supporting_text: &gt;-
+      the DLIC protein XBX-1 functions together with the CHE-3 dynein in retrograde
+      IFT, downstream of the complex A proteins
+  - reference_id: PMID:12802075
+    supporting_text: &gt;-
+      xbx-1, that is required for retrograde IFT and shares homology with a mammalian
+      dynein light intermediate chain (D2LIC)
+proposed_new_terms:
+- proposed_name: cytoplasmic dynein 2 complex
+  proposed_definition: &gt;-
+    A cytoplasmic dynein complex, distinct from the cytoplasmic dynein 1 complex,
+    that is specialized for retrograde intraflagellar transport within cilia and
+    flagella. It is built around the dynein-2 heavy chain (DYNC2H1/CHE-3) together
+    with dynein-2-specific light intermediate (DYNC2LI1/D2LIC/XBX-1), intermediate,
+    light and associated chains, and generates minus-end-directed (tip-to-base)
+    movement along the ciliary axoneme.
+  justification: &gt;-
+    GO has a single cellular-component term GO:0005868 &#34;cytoplasmic dynein complex&#34;
+    that conflates the functionally and compositionally distinct dynein-1 (mitotic/
+    trafficking) and dynein-2 (ciliary/IFT) motors. A dynein-2-specific term would
+    let XBX-1 and its partners be annotated to their actual complex. This benefits
+    dynein-2 subunit annotation across species, not just XBX-1 — e.g. the heavy chain
+    CHE-3/DYNC2H1, the intermediate chains WDR60/WDR34, and the dynein-2 light chains
+    — and would separate IFT-dynein from dynein-1 in enrichment analyses and GO-CAM
+    models.
+  proposed_parent:
+    id: GO:0005868
+    label: cytoplasmic dynein complex
+knowledge_gaps:
+- gap_statement: &gt;-
+    The specific molecular contribution of the XBX-1 light intermediate chain to
+    dynein-2 function in C. elegans is undetermined: whether it is chiefly required
+    for dynein-2 complex assembly/stability, for coupling the motor to IFT trains as
+    a cargo adaptor, or for regulating motor activation/autoinhibition at the ciliary
+    tip.
+  boundary: &gt;-
+    It is firmly established that XBX-1 is the dynein-2 LIC (D2LIC ortholog), binds
+    the CHE-3 heavy chain, localizes to the ciliary base/axoneme, and is required for
+    retrograde IFT and cilium assembly. The light intermediate chain itself has no
+    demonstrated enzymatic activity; the ATP-dependent minus-end-directed motor
+    activity is a property of the CHE-3 heavy chain/dynein-2 complex.
+  gap_kind:
+  - BIOLOGY
+  dark_aspect: RESIDUAL_SUBGAP
+  status: OPEN
+  significance: &gt;-
+    DYNC2LI1 mutations cause skeletal ciliopathies (short-rib thoracic dysplasia);
+    understanding the LIC&#39;s mechanistic role would clarify how dynein-2 assembly and
+    IFT-train coupling are controlled and how they fail in disease.
+  resolution: &gt;-
+    Structure-function dissection of XBX-1 (domain/point mutants) with biochemical
+    assays of dynein-2 assembly and heavy-chain binding, plus live IFT imaging of
+    train coupling and velocities in xbx-1 alleles.
+  provenance:
+  - reference_id: PMID:12802075
+    supporting_text: &gt;-
+      the DLIC protein XBX-1 functions together with the CHE-3 dynein in retrograde
+      IFT, downstream of the complex A proteins
+- gap_statement: &gt;-
+    No GO cellular-component term expresses the cytoplasmic dynein-2 (IFT-dynein)
+    complex distinctly from cytoplasmic dynein-1, so XBX-1&#39;s actual complex
+    membership can only be annotated with the conflated parent term GO:0005868.
+  boundary: &gt;-
+    XBX-1 is unambiguously a subunit of the ciliary retrograde IFT dynein-2 motor
+    (with CHE-3/DYNC2H1); the only available GO CC term, GO:0005868 &#34;cytoplasmic
+    dynein complex&#34;, also covers dynein-1.
+  gap_kind:
+  - ONTOLOGY
+  dark_aspect: CC_DARK
+  status: OPEN
+  significance: &gt;-
+    A dynein-2-specific complex term would let IFT-dynein subunits be annotated to
+    their true complex and separated from dynein-1 in enrichment and model building.
+  resolution: &gt;-
+    Add a &#34;cytoplasmic dynein 2 complex&#34; cellular-component term as a child of
+    GO:0005868 (see proposed_new_terms).
+suggested_questions:
+- question: &gt;-
+    Does XBX-1 act mainly to stabilize/assemble the dynein-2 motor, to couple it to
+    IFT trains, or to regulate its activation during ciliary turnaround?
+  experts:
+  - Intraflagellar transport / dynein-2 motor biologists
+- question: &gt;-
+    Does XBX-1 have any dynein-2-independent role at the basal body/centriole?
+  experts:
+  - C. elegans ciliary cell biologists
+suggested_experiments:
+- hypothesis: &gt;-
+    XBX-1 is required for dynein-2 complex stability and for coupling the motor to
+    IFT trains.
+  description: &gt;-
+    Structure-function analysis of XBX-1 (targeted deletions/point mutations of the
+    DLIC fold) combined with co-immunoprecipitation of CHE-3 and live imaging of
+    IFT-train velocities and turnaround in the mutant alleles.
+  experiment_type: structure-function / live imaging
+- hypothesis: &gt;-
+    XBX-1 loss selectively impairs the retrograde (dynein-2) IFT arm.
+  description: &gt;-
+    Dual-color live imaging of anterograde (kinesin-2/IFT-B) and retrograde
+    (XBX-1/CHE-3) markers in xbx-1 mutants to quantify which transport arm and which
+    ciliary segment are affected.
+  experiment_type: live imaging
+tags:
+- caeel-ciliopathy
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/pages/projects/CAEEL_CILIOPATHY.html
+++ b/pages/projects/CAEEL_CILIOPATHY.html
@@ -387,7 +387,7 @@
 - <strong><a href="../../genes/worm/osm-5/osm-5-ai-review.html">osm-5</a></strong> - IFT88 ortholog (IFT-B complex)<br />
 - <strong><a href="../../genes/worm/osm-6/osm-6-ai-review.html">osm-6</a></strong> - IFT52 ortholog<br />
 - <strong><a href="../../genes/worm/che-2/che-2-ai-review.html">che-2</a></strong> - IFT80 ortholog<br />
-- <strong>che-13</strong> - IFT57 ortholog<br />
+- <strong><a href="../../genes/worm/che-13/che-13-ai-review.html">che-13</a></strong> - IFT57 ortholog<br />
 - <strong><a href="../../genes/worm/dyf-1/dyf-1-ai-review.html">dyf-1</a></strong> - Required for <a href="../../genes/worm/osm-3/osm-3-ai-review.html">osm-3</a> function<br />
 - <strong><a href="../../genes/worm/dyf-3/dyf-3-ai-review.html">dyf-3</a></strong> - IFT54 ortholog<br />
 - <strong>dyf-6</strong> - IFT46 ortholog<br />
@@ -396,7 +396,7 @@
 <h3 id="3-intraflagellar-transport-ift-retrograde">3. Intraflagellar Transport (IFT) - Retrograde</h3>
 <p>Dynein motor and IFT-A complex:<br />
 - <strong><a href="../../genes/worm/che-3/che-3-ai-review.html">che-3</a></strong> - Cytoplasmic dynein heavy chain<br />
-- <strong>xbx-1</strong> - Dynein light intermediate chain<br />
+- <strong><a href="../../genes/worm/xbx-1/xbx-1-ai-review.html">xbx-1</a></strong> - Dynein light intermediate chain<br />
 - <strong><a href="../../genes/worm/dyf-2/dyf-2-ai-review.html">dyf-2</a></strong> - IFT144/WDR19 ortholog (IFT-A)<br />
 - <strong><a href="../../genes/worm/daf-10/daf-10-ai-review.html">daf-10</a></strong> - IFT122 ortholog (IFT-A)<br />
 - <strong><a href="../../genes/worm/che-11/che-11-ai-review.html">che-11</a></strong> - IFT140 ortholog (IFT-A)</p>
@@ -428,7 +428,7 @@
 </ul>
 <h3 id="7-ciliary-signalingfunction">7. Ciliary Signaling/Function</h3>
 <ul>
-<li><strong>tax-2</strong> - Cyclic nucleotide-gated channel alpha</li>
+<li><strong><a href="../../genes/worm/tax-2/tax-2-ai-review.html">tax-2</a></strong> - Cyclic nucleotide-gated channel alpha</li>
 <li><strong><a href="../../genes/worm/tax-4/tax-4-ai-review.html">tax-4</a></strong> - Cyclic nucleotide-gated channel beta</li>
 <li><strong>odr-1</strong> - Guanylyl cyclase</li>
 <li><strong><a href="../../genes/worm/pef-1/pef-1-ai-review.html">pef-1</a></strong> - PPEF phosphatase (2024 discovery)</li>

--- a/pages/projects/CAEEL_MITOPHAGY.html
+++ b/pages/projects/CAEEL_MITOPHAGY.html
@@ -435,7 +435,7 @@
 <ul>
 <li><strong><a href="../../genes/worm/sod-2/sod-2-ai-review.html">sod-2</a></strong> - Mn-SOD (mitochondrial)</li>
 <li><strong><a href="../../genes/worm/sod-3/sod-3-ai-review.html">sod-3</a></strong> - Fe-SOD</li>
-<li><strong>clk-1</strong> - COQ7 (ubiquinone synthesis)</li>
+<li><strong><a href="../../genes/worm/clk-1/clk-1-ai-review.html">clk-1</a></strong> - COQ7 (ubiquinone synthesis)</li>
 <li><strong><a href="../../genes/worm/isp-1/isp-1-ai-review.html">isp-1</a></strong> - Rieske iron-sulfur protein</li>
 </ul>
 <h2 id="genes-for-review-priority-order">Genes for Review (Priority Order)</h2>

--- a/pages/projects/CAEEL_MITOPHAGY/CAEEL_MITOPHAGY-pathway.html
+++ b/pages/projects/CAEEL_MITOPHAGY/CAEEL_MITOPHAGY-pathway.html
@@ -475,7 +475,7 @@ flowchart TD
 - Accumulation of dysfunctional mitochondria<br />
 - Increased mitochondrial mass with decreased ATP<br />
 - Elevated ROS and membrane depolarization<br />
-- Shortened lifespan in long-lived mutants (<a href="../../../genes/worm/daf-2/daf-2-ai-review.html">daf-2</a>, <a href="../../../genes/worm/isp-1/isp-1-ai-review.html">isp-1</a>, clk-1)</p>
+- Shortened lifespan in long-lived mutants (<a href="../../../genes/worm/daf-2/daf-2-ai-review.html">daf-2</a>, <a href="../../../genes/worm/isp-1/isp-1-ai-review.html">isp-1</a>, <a href="../../../genes/worm/clk-1/clk-1-ai-review.html">clk-1</a>)</p>
 <hr />
 <h2 id="mitochondrial-dynamics-fission-vs-fusion">Mitochondrial Dynamics: Fission vs Fusion</h2>
 <h3 id="drp-1-the-fission-gtpase"><a href="../../../genes/worm/drp-1/drp-1-ai-review.html">DRP-1</a> - The Fission GTPase</h3>
@@ -556,7 +556,7 @@ The balance between ATFS-1-mediated repair (UPRmt) and <a href="../../../genes/w
 2. TOR inhibition (let-363)<br />
 3. Dietary restriction (eat-2)<br />
 4. Reduced insulin/IGF signaling (<a href="../../../genes/worm/daf-2/daf-2-ai-review.html">daf-2</a>)<br />
-5. Reduced mitochondrial respiration (clk-1, <a href="../../../genes/worm/isp-1/isp-1-ai-review.html">isp-1</a>)<br />
+5. Reduced mitochondrial respiration (<a href="../../../genes/worm/clk-1/clk-1-ai-review.html">clk-1</a>, <a href="../../../genes/worm/isp-1/isp-1-ai-review.html">isp-1</a>)<br />
 6. Reduced translation (rsks-1)</p>
 <p><a href="../../../genes/worm/hlh-30/hlh-30-ai-review.html">HLH-30</a> overexpression extends lifespan by 15-20%. Nuclear localization is enhanced in all six longevity models [PMID:23925298].</p>
 <p><strong>Innate Immunity:</strong><br />


### PR DESCRIPTION
## Summary

Automated regeneration of static assets after gene review or template changes.

## Generated Assets

| Asset | Count/Status |
|-------|--------------|
| Gene review YAML files | 2893 |
| Gene review HTML pages | 2893 |
| Project pages | 1098 |
| Module pages | 87 |
| Browser app (data.js) | Updated |
| Validation report | Updated |

## Trigger

This PR was triggered by changes to:
- genes/**/*.yaml - gene review data files
- src/ai_gene_review/schema/** - LinkML schema files
- src/ai_gene_review/templates/** - Jinja2 templates
- src/ai_gene_review/render.py - rendering code
- src/ai_gene_review/render_modules.py - module rendering code
- src/ai_gene_review/export/** - export code
- src/ai_gene_review/browser/** - browser app assets
- src/ai_gene_review/tools/minify_linkml_browser_data.py - browser data compaction
- projects/*.md - project definitions
- modules/**/*.yaml - module definitions
- project.justfile - just recipes used by CI
- .github/workflows/generate-pages.yaml - workflow definition

## Review

- [ ] Spot-check a few gene review HTML pages render correctly
- [ ] Spot-check module tree browser pages render correctly
- [ ] Verify browser app loads and filters work
- [ ] Check validation report for new issues
