### PR TITLE
Regenerate pages and browser app

### DIFF
--- a/genes/worm/bbs-9/bbs-9-ai-review.html
+++ b/genes/worm/bbs-9/bbs-9-ai-review.html
@@ -1,0 +1,3681 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>bbs-9 - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        .propagation-review {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f8fafc;
+            border-left: 3px solid #64748b;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .propagation-title {
+            font-weight: 600;
+            color: #334155;
+            margin-bottom: 0.25rem;
+        }
+
+        .propagation-row {
+            margin-top: 0.25rem;
+        }
+
+        .propagation-source {
+            margin-top: 0.5rem;
+            padding-top: 0.5rem;
+            border-top: 1px solid #e5e7eb;
+        }
+
+        .propagation-source-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #1d4ed8;
+        }
+
+        .propagation-comment {
+            color: #4b5563;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>bbs-9</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/O01514" target="_blank" class="term-link">
+                        O01514
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Caenorhabditis elegans</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-complete">
+                    COMPLETE
+                </span>
+            </div>
+
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "bbs-9";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="O01514" data-a="DESCRIPTION: BBS-9 (PTHB1 homolog) is a core subunit of the BBS..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>BBS-9 (PTHB1 homolog) is a core subunit of the BBSome, the octameric ciliary coat complex (BBS-1, BBS-2, BBS-4, BBS-5, OSM-12/BBS-7, BBS-8/TTC-8, BBS-9) that couples intraflagellar transport (IFT) to the trafficking of membrane cargo at sensory cilia. It is built from an N-terminal β-propeller (WD40-like) together with platform and α-helical/hairpin regions characteristic of the PTHB1 family, and belongs — with BBS-2 and BBS-7 — to the β-propeller &#34;core&#34; of the complex. Like the COPI, COPII and clathrin coats it structurally resembles, the BBSome assembles IFT particles at the ciliary base, binds the anterograde IFT particle as a cargo, and reaches the ciliary tip where it regulates IFT turnaround and recycling. In C. elegans, BBS-9 is expressed in ciliated sensory neurons, undergoes IFT along the axoneme, and is required for proper BBSome assembly and its ciliary localization: a bbs-9 nonsense allele uncouples the IFT-A and IFT-B subcomplexes during anterograde transport, the canonical loss-of-BBSome phenotype, and bbs-9 mutants have defective cilia with mislocalized, poorly transported IFT proteins. Loss of bbs-9, like loss of other BBSome subunits, causes cilium-dependent sensory and developmental defects, including reduced body size, developmental delay, and failure to detect and avoid nitric oxide and NO-producing Pseudomonas aeruginosa.</p>
+    </div>
+
+
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016020" target="_blank" class="term-link">
+                                    GO:0016020
+                                </a>
+                            </span>
+                            <span class="term-label">membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="O01514" data-a="GO:0016020" data-r="GO_REF:0000033" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> High-level &#34;membrane&#34; localization propagated by phylogenetic inference. BBS-9 is a peripheral coat scaffold that associates with the ciliary membrane at the ciliary base/tip as part of the BBSome, but &#34;membrane&#34; with an is_active_in qualifier is uninformative for a structural subunit and far less specific than the ciliary basal-body and BBSome annotations.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Overly general and derived: the informative, experimentally supported localizations for worm BBS-9 are the ciliary basal body/base and the BBSome; a bare &#34;membrane&#34; term (and the is_active_in qualifier, which implies a molecular function occurring at the membrane) adds no specific biological information and is flagged as over-annotation.
+                        </div>
+
+
+
+                        <div class="propagation-review">
+                            <div class="propagation-title">Propagation Review</div>
+                            <div class="propagation-row">
+                                <strong>Root cause:</strong>
+                                <span class="badge">TERM SCOPING PROBLEM</span>
+                            </div>
+
+                            <div class="propagation-row">
+                                <strong>Failure modes:</strong>
+
+                                <span class="badge">GRANULARITY MISMATCH</span>
+
+                            </div>
+
+
+                            <div class="propagation-source">
+                                <strong>Sources checked:</strong>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">MGI:MGI:2442833</span>
+
+                                    &middot; Bbs9
+
+
+
+                                </div>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">UniProtKB:Q3SYG4</span>
+
+                                    &middot; BBS9 (human)
+
+
+
+                                </div>
+
+                            </div>
+
+                        </div>
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0034464" target="_blank" class="term-link">
+                                    GO:0034464
+                                </a>
+                            </span>
+                            <span class="term-label">BBSome</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O01514" data-a="GO:0034464" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> BBS-9 is a bona fide subunit of the BBSome, the octameric complex (BBS-1, BBS-2, BBS-4, BBS-5, OSM-12/BBS-7, BBS-8/TTC-8, BBS-9). This phylogenetic (IBA) assignment matches the direct C. elegans BiFC evidence that BBS-1 and BBS-9 coexist in the same complex and the human BBSome architecture in which BBS1/7/9 lie together.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Complex membership is the defining, core cellular-component property of bbs-9 and is supported by both phylogenetic inference and direct C. elegans experiments.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/22922713" target="_blank" class="term-link">
+                                        PMID:22922713
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">consistent with the prediction that mammalian BBS1, 7, and 9 locate closely to each other in the BBSome</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0060271" target="_blank" class="term-link">
+                                    GO:0060271
+                                </a>
+                            </span>
+                            <span class="term-label">cilium assembly</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O01514" data-a="GO:0060271" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> BBS-9 contributes to cilium assembly as part of the BBSome, which assembles IFT particles required for ciliogenesis. In C. elegans bbs-9 mutants have defective cilia with mislocalized and poorly transported IFT proteins.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Well supported by phylogenetic inference and by direct C. elegans genetics; a core biological-process annotation for a BBSome subunit.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/22922713" target="_blank" class="term-link">
+                                        PMID:22922713
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">the in vivo function for the BBSome is to regulate the assembly of the IFT particles at the ciliary base</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0034464" target="_blank" class="term-link">
+                                    GO:0034464
+                                </a>
+                            </span>
+                            <span class="term-label">BBSome</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O01514" data-a="GO:0034464" data-r="GO_REF:0000002" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic InterPro-to-GO mapping (IPR026511, PTHB1) assigning BBSome membership. This duplicates the IBA and NAS BBSome annotations and is consistent with the direct experimental complex-membership evidence.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct BBSome membership from the PTHB1 InterPro signature; redundant with the higher-evidence NAS/IBA annotations but not wrong. Core cellular-component.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/22922713" target="_blank" class="term-link">
+                                        PMID:22922713
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">fluorescence complementation can be observed in BBS-1</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005929" target="_blank" class="term-link">
+                                    GO:0005929
+                                </a>
+                            </span>
+                            <span class="term-label">cilium</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">NAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/22922713" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:22922713
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The BBSome controls IFT assembly and turnaround in cilia.
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="O01514" data-a="GO:0005929" data-r="PMID:22922713" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> BBS-9 localizes to cilia as a BBSome subunit that undergoes IFT along the ciliary axoneme; when the BBSome is uncoupled from moving IFT, BBS-9 shows only dim ciliary staining and accumulates at the base. A correct but general localization — the ciliary basal body/base terms are more specific.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Accurate general localization supported by the referenced work, but non-core relative to the more specific ciliary basal body / ciliary base terms which are the core CC annotations; retained as a valid non-core localization.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/22922713" target="_blank" class="term-link">
+                                        PMID:22922713
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">only showed very dim ciliary staining when compared to</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0034464" target="_blank" class="term-link">
+                                    GO:0034464
+                                </a>
+                            </span>
+                            <span class="term-label">BBSome</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">NAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/22922713" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:22922713
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The BBSome controls IFT assembly and turnaround in cilia.
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O01514" data-a="GO:0034464" data-r="PMID:22922713" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Author-stated (NAS, ComplexPortal) assignment of BBSome membership, duplicating the IBA and IEA annotations. Directly supported by the C. elegans BiFC evidence that BBS-1 and BBS-9 are in the same complex.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct and consistent with the other BBSome annotations and with direct worm experiments; the core cellular-component annotation for bbs-9.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/22922713" target="_blank" class="term-link">
+                                        PMID:22922713
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">indicative of the coexistence of these three BBS proteins in the same complex</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0060271" target="_blank" class="term-link">
+                                    GO:0060271
+                                </a>
+                            </span>
+                            <span class="term-label">cilium assembly</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">NAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/22922713" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:22922713
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The BBSome controls IFT assembly and turnaround in cilia.
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O01514" data-a="GO:0060271" data-r="PMID:22922713" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Author-stated (NAS) cilium-assembly role, duplicating the IBA annotation. The BBSome assembles IFT particles required for ciliogenesis, and bbs-9 mutants show defective cilia.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct and consistent with the IBA annotation and with C. elegans genetics; retained as complementary evidence for the same core biological-process role.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/22922713" target="_blank" class="term-link">
+                                        PMID:22922713
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">the in vivo function for the BBSome is to regulate the assembly of the IFT particles at the ciliary base</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0036064" target="_blank" class="term-link">
+                                    GO:0036064
+                                </a>
+                            </span>
+                            <span class="term-label">ciliary basal body</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/22922713" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:22922713
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The BBSome controls IFT assembly and turnaround in cilia.
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O01514" data-a="GO:0036064" data-r="PMID:22922713" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct experimental (IDA) localization of BBS-9 to the ciliary basal body/base in C. elegans, consistent with strong BBSome accumulation around the ciliary base when the complex is uncoupled from moving IFT. This is the site where the BBSome assembles IFT particles.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Experimental localization; the strongest evidence class for the basal-body assignment and the core cellular-component annotation for worm BBS-9.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/22922713" target="_blank" class="term-link">
+                                        PMID:22922713
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">all BBS proteins examined strongly accumulated around the ciliary base</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0097546" target="_blank" class="term-link">
+                                    GO:0097546
+                                </a>
+                            </span>
+                            <span class="term-label">ciliary base</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/22922713" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:22922713
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The BBSome controls IFT assembly and turnaround in cilia.
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-new">
+                            NEW
+                        </span>
+                        <span class="vote-buttons" data-g="O01514" data-a="GO:0097546" data-r="PMID:22922713" data-act="NEW">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> BBS-9, like the other BBSome subunits, concentrates at the ciliary base where the BBSome assembles IFT particles; when the BBSome is uncoupled from moving IFT the proteins strongly accumulate there. This is a more precise localization than the general &#39;cilium&#39; term and complements the ciliary basal body annotation.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Ciliary base is the experimentally supported site of BBSome-mediated IFT assembly in C. elegans and is included as a location in core_functions; added here as a specific cellular-component annotation.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/22922713" target="_blank" class="term-link">
+                                        PMID:22922713
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">all BBS proteins examined strongly accumulated around the ciliary base</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042073" target="_blank" class="term-link">
+                                    GO:0042073
+                                </a>
+                            </span>
+                            <span class="term-label">intraciliary transport</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/22922713" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:22922713
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The BBSome controls IFT assembly and turnaround in cilia.
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-new">
+                            NEW
+                        </span>
+                        <span class="vote-buttons" data-g="O01514" data-a="GO:0042073" data-r="PMID:22922713" data-act="NEW">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> BBS-9, as a BBSome subunit, itself undergoes IFT movement along the ciliary axoneme and is required for normal intraflagellar transport; a bbs-9 nonsense allele uncouples IFT-A from IFT-B during anterograde transport and the BBSome loses IFT movement when detached from IFT particles.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Intraciliary transport is a core biological process for the BBSome, captured in core_functions; added here as a specific process annotation supported by BBS-9 IFT movement and the IFT-uncoupling phenotype of the bbs-9 allele.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/22922713" target="_blank" class="term-link">
+                                        PMID:22922713
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">encodes BBS-9 with a nonsense mutation at Q171 site</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/22922713" target="_blank" class="term-link">
+                                        PMID:22922713
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">all BBS proteins completely lost IFT movement</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0061512" target="_blank" class="term-link">
+                                    GO:0061512
+                                </a>
+                            </span>
+                            <span class="term-label">protein localization to cilium</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-new">
+                            NEW
+                        </span>
+                        <span class="vote-buttons" data-g="O01514" data-a="GO:0061512" data-r="GO_REF:0000033" data-act="NEW">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> As a BBSome subunit, BBS-9 is required for correct trafficking of membrane and signaling proteins to/from cilia; the BBSome couples ciliary cargo to IFT and, when disrupted, ciliary receptors mislocalize. Supported by phylogenetic inference and by the conserved BBSome cargo-trafficking role.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Protein localization to cilium is a core BBSome-mediated process captured in core_functions; added here as a specific biological-process annotation, consistent with the phylogenetically inferred BBSome function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/22922713" target="_blank" class="term-link">
+                                        PMID:22922713
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">shares the common structural features with COPI, COPII, and clathrin coats, and can directly recognize IFT cargos</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030674" target="_blank" class="term-link">
+                                    GO:0030674
+                                </a>
+                            </span>
+                            <span class="term-label">protein-macromolecule adaptor activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ISS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            file:worm/bbs-9/bbs-9-deep-research-falcon.md
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-new">
+                            NEW
+                        </span>
+                        <span class="vote-buttons" data-g="O01514" data-a="GO:0030674" data-r="file:worm/bbs-9/bbs-9-deep-research-falcon.md" data-act="NEW">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> BBS-9 acts as a protein-macromolecule adaptor/scaffold within the coat-like BBSome rather than as an enzyme: structurally it is the central hub that directly contacts more subunits than any other component (its GAE domain heterodimerizes with BBS1 and its C-terminal coiled-coil pairs with BBS2 to form the neck). This is far more informative than &#39;protein binding&#39; and is the best available molecular-function description for a BBSome coat subunit.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Adaptor/scaffold activity is the most defensible molecular function for a BBSome structural subunit and is preferable to uninformative protein binding; included in core_functions. No experimental MF has been measured for BBS-9 itself and no GO term specifically expresses the BBSome coat/cargo-adaptor role - see knowledge_gaps.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/22922713" target="_blank" class="term-link">
+                                        PMID:22922713
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">shares the common structural features with COPI, COPII, and clathrin coats, and can directly recognize IFT cargos</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>BBS-9 is a β-propeller &#34;core&#34; scaffold subunit of the coat-like BBSome. Through its integration into the complex (lying close to BBS-1 and BBS-7) it contributes to BBSome-mediated assembly of IFT particles at the ciliary base and to the IFT-coupled trafficking of ciliary membrane cargo. Its molecular activity is best described as a protein-macromolecule adaptor/scaffold within the BBSome coat; no independent enzymatic activity is known.</h3>
+                <span class="vote-buttons" data-g="O01514" data-a="FUNCTION: BBS-9 is a β-propeller &#34;core&#34; scaffold subunit of ..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030674" target="_blank" class="term-link">
+                            protein-macromolecule adaptor activity
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042073" target="_blank" class="term-link">
+                                intraciliary transport
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0060271" target="_blank" class="term-link">
+                                cilium assembly
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0061512" target="_blank" class="term-link">
+                                protein localization to cilium
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0036064" target="_blank" class="term-link">
+                                ciliary basal body
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0097546" target="_blank" class="term-link">
+                                ciliary base
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">In Complex:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0034464" target="_blank" class="term-link">
+                            BBSome
+                        </a>
+                    </span>
+                </div>
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/22922713" target="_blank" class="term-link">
+                                PMID:22922713
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">the in vivo function for the BBSome is to regulate the assembly of the IFT particles at the ciliary base</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/22922713" target="_blank" class="term-link">
+                                PMID:22922713
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">consistent with the prediction that mammalian BBS1, 7, and 9 locate closely to each other in the BBSome</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000002.md" target="_blank" class="term-link">
+                            GO_REF:0000002
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation through association of InterPro records with GO terms</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
+                            GO_REF:0000033
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Annotation inferences using phylogenetic trees</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/22922713" target="_blank" class="term-link">
+                            PMID:22922713
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">The BBSome controls IFT assembly and turnaround in cilia.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">The BBSome assembles IFT particles at the ciliary base and, after binding the anterograde IFT particle as a cargo, regulates IFT turnaround/recycling at the ciliary tip.</div>
+
+                        <div class="finding-text">"the in vivo function for the BBSome is to regulate the assembly of the IFT particles at the ciliary base"</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <div class="finding-statement">The BBSome binds the moving IFT particle as a cargo, not as an integral structural component.</div>
+
+                        <div class="finding-text">"the BBSome binds to the IFT particle like a cargo but not a structural component"</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Worm BBS-9 is a member of the BBSome, shown directly by BiFC coexistence of BBS-1 and BBS-9 in the same complex.</div>
+
+                        <div class="finding-text">"fluorescence complementation can be observed in BBS-1"</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <div class="finding-statement">BBS1, BBS7 and BBS9 lie close to each other in the BBSome, consistent with the worm BBS-1–BBS-9 interaction.</div>
+
+                        <div class="finding-text">"consistent with the prediction that mammalian BBS1, 7, and 9 locate closely to each other in the BBSome"</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <div class="finding-statement">A bbs-9 nonsense allele (Q171) separates IFT-A and IFT-B during anterograde transport, the canonical bbs-null IFT-uncoupling phenotype.</div>
+
+                        <div class="finding-text">"encodes BBS-9 with a nonsense mutation at Q171 site"</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <div class="finding-statement">When the BBSome is uncoupled from moving IFT, BBS-9 (with BBS-2/5/7/8) loses IFT movement and shows only dim ciliary staining, accumulating at the base.</div>
+
+                        <div class="finding-text">"only showed very dim ciliary staining when compared to"</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <div class="finding-statement">The BBSome shares coat features with COPI/COPII/clathrin and can directly recognize IFT cargo.</div>
+
+                        <div class="finding-text">"shares the common structural features with COPI, COPII, and clathrin coats, and can directly recognize IFT cargos"</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/22022287" target="_blank" class="term-link">
+                            PMID:22022287
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Mutations in a guanylate cyclase GCY-35/GCY-36 modify Bardet-Biedl syndrome-associated phenotypes in Caenorhabditis elegans.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">The eight BBSome proteins function as a conserved complex regulating vesicular sorting/packaging, IFT, and cilium maintenance and function.</div>
+
+                        <div class="finding-text">"eight function mostly as a conserved protein complex (BBSome)"</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Loss of BBSome function in C. elegans causes cilium-dependent developmental and behavioral defects (small body size, developmental delay, exploration defects) that are modified by cGMP signalling (GCY-35/GCY-36, EGL-4).</div>
+
+                        <div class="finding-text">"exploration defects exhibited by multiple bbs mutants"</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/30014846" target="_blank" class="term-link">
+                            PMID:30014846
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Thioredoxin shapes the C. elegans sensory response to Pseudomonas produced nitric oxide.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">bbs-9 null mutants are cilia-defective and fail to avoid NO and NO-producing P. aeruginosa, showing bbs-9 is required for cilium-dependent NO sensory behavior.</div>
+
+                        <div class="finding-text">"Two cilia defective mutants, osm-12(n1606) null mutants and bbs-9(gk471) null mutants, were both defective in avoiding the lawn of PA14 and the NO donor"</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/26150102" target="_blank" class="term-link">
+                            PMID:26150102
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">BBS4 and BBS5 show functional redundancy in the BBSome to regulate the degradative sorting of ciliary sensory receptors.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">The molecular activity by which the BBSome controls ciliary membrane protein homeostasis is stated by the field to remain unclear.</div>
+
+                        <div class="finding-text">"the definite molecular activity of the BBSome in regulating the homoeostasis of ciliary membrane proteins remain unclear"</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        file:worm/bbs-9/bbs-9-deep-research-falcon.md
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Deep research report on bbs-9 (Edison/falcon)</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">BBS-9 is the central structural hub of the BBSome, directly contacting more subunits than any other component; its GAE domain heterodimerizes with BBS1 and its C-terminal coiled-coil pairs with BBS2 to form the neck of the complex.</div>
+
+                        <div class="finding-text">"BBS-9 directly contacts four to five other BBSome subunits, more than any other component"</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Questions for Experts</h2>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Does the BBS-9 β-propeller directly contact a specific ciliary membrane cargo or a specific neighboring BBSome subunit interface, and is that contact required for IFT-A/IFT-B coupling?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="O01514" data-a="Q: Does the BBS-9 β-propeller directly contact a spec..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Is there a subunit-specific role for BBS-9 in nucleating BBSome assembly (as part of the BBS-2/7/9 core) that is separable from bulk IFT-particle assembly?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="O01514" data-a="Q: Is there a subunit-specific role for BBS-9 in nucl..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Experiments</h2>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Cryo-EM/structural analysis of the C. elegans (or reconstituted) BBSome with BBS-9 to map the BBS-9 β-propeller interfaces, combined with proximity-dependent biotinylation (TurboID) of BBS-9 at the ciliary base to identify cargo and neighbors.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: The BBS-9 β-propeller forms defined intra-complex and cargo contacts that couple the BBSome coat to IFT particles.</em></p>
+
+
+                    <p style="margin-top: 0.5rem;">Type: structural_biology</p>
+
+                </div>
+                <span class="vote-buttons" data-g="O01514" data-a="EXPERIMENT: Cryo-EM/structural analysis of the C. elegans (or ..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Structure-guided separation-of-function bbs-9 alleles that perturb individual interfaces while preserving overall folding, scored for BBSome assembly, IFT-A/IFT-B coupling, base-versus-tip IFT dynamics, and ciliary receptor trafficking.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: Specific BBS-9 interfaces are required for distinct steps (assembly at the base versus turnaround at the tip), separable from whole-complex loss.</em></p>
+
+
+                    <p style="margin-top: 0.5rem;">Type: genetics</p>
+
+                </div>
+                <span class="vote-buttons" data-g="O01514" data-a="EXPERIMENT: Structure-guided separation-of-function bbs-9 alle..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Knowledge Gaps</h2>
+        <p style="color: #555; font-size: 0.92rem; margin-top: -0.3rem;">
+            What is <em>not</em> known — curated, literature-grounded statements of the open
+            unknowns (the inverse of core functions).
+        </p>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> There is no GO molecular-function term that expresses the role of a BBSome coat/scaffold subunit, and BBS-9 has no experimentally measured biochemical activity of its own. Unlike the peripheral subunit BBS-4, worm BBS-9 has no molecular-function annotation of any kind in GOA (its only MF-adjacent term is the uninformative &#34;membrane&#34;), so the specific intra-BBSome contacts made by the BBS-9 β-propeller and the cargo(es) it helps recognize are undefined.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">ONTOLOGY</span><span class="badge">BIOLOGY</span>
+                <span class="badge">MF_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> BBS-9 is an established BBSome subunit built from a WD40-like β-propeller plus PTHB1 platform/hairpin domains, and lies close to BBS-1 and BBS-7 in the complex; the BBSome is explicitly coat-like (shares structural features with COPI, COPII and clathrin) and can directly recognize IFT cargo. What is missing is a molecular-function term (and the direct cargo/partner identity) for the coat subunit itself rather than the complex-level process.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> BBSome subunits illustrate the structural-subunit ontology gap: their function is &#34;be part of the coat&#34;, which the GO molecular-function aspect cannot currently express, so BBS-9 reads as MF-dark despite a well-defined cellular role central to Bardet-Biedl syndrome.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Ontology development of a BBSome coat/cargo-adaptor molecular-function term (analogous to a vesicle-coat adaptor), plus structural and proximity/affinity proteomics to define the intra-complex contacts and membrane cargo contacted by the BBS-9 β-propeller.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"shares the common structural features with COPI, COPII, and clathrin coats, and can directly recognize IFT cargos"</em> — PMID:22922713</li>
+
+                <li><em>"the definite molecular activity of the BBSome in regulating the homoeostasis of ciliary membrane proteins remain unclear"</em> — PMID:26150102</li>
+
+            </ul>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Proposed term (ontology gap):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><strong>BBSome coat cargo-adaptor activity</strong> — BBSome subunits such as BBS-9 have no adequate GO molecular-function term; they are annotatable only with the generic &#39;protein-macromolecule adaptor activity&#39; or the uninformative &#39;protein binding&#39;/&#39;membrane&#39;, leaving them MF-dark despite a well-defined coat-subunit role.</li>
+
+            </ul>
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> Whether BBS-9, as a β-propeller &#34;core&#34; (BBS-2/BBS-7/BBS-9) subunit, plays a distinct nucleating/assembly role separable from the peripheral subunits, and what its individual contribution is to IFT-particle assembly at the ciliary base versus IFT turnaround at the tip, have not been resolved experimentally in C. elegans.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">RESIDUAL_SUBGAP</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> A bbs-9 nonsense allele (Q171) uncouples IFT-A from IFT-B during anterograde transport, like other bbs-null mutants, and BBS-9 itself undergoes IFT and accumulates at the ciliary base when the BBSome is uncoupled from moving IFT. What remains unknown is the subunit-specific step BBS-9 mediates within complex assembly and IFT coupling, as distinct from the whole-complex loss-of-function phenotype.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Dissecting subunit-specific roles is needed to understand why individual BBS genes give overlapping but not identical Bardet-Biedl syndrome phenotypes, and to model the stepwise assembly of the ciliary coat.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Separation-of-function bbs-9 alleles and structure-guided mutations that perturb specific intra-BBSome interfaces, scored for BBSome assembly, IFT-A/IFT-B coupling, base-versus-tip IFT dynamics, and cargo trafficking.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"encodes BBS-9 with a nonsense mutation at Q171 site"</em> — PMID:22922713</li>
+
+                <li><em>"only showed very dim ciliary staining when compared to"</em> — PMID:22922713</li>
+
+            </ul>
+
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Tags</h2>
+        <div class="aliases">
+
+            <span class="badge">caeel-ciliopathy</span>
+
+        </div>
+    </div>
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Deep Research Sections -->
+
+    <div class="section">
+        <h2 class="section-title">Deep Research</h2>
+
+        <details class="deep-research-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; gap: 1rem;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Falcon</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(bbs-9-deep-research-falcon.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="O01514" data-a="DEEP_RESEARCH: Falcon" data-r="" data-act="DEEP_RESEARCH" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This deep research is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This deep research needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+
+                <div class="report-meta">
+
+                    <span class="report-meta-text">Comprehensive Research Report: *C. elegans* bbs-9 (C48B6.8) — A Core BBSome Subunit in Ciliary Trafficking</span>
+
+
+                    <span class="report-badge">Falcon</span>
+
+
+                    <span class="report-badge">Edison Scientific Literature</span>
+
+
+                    <span class="report-badge">29 citations</span>
+
+
+                    <span class="report-badge">2 artifacts</span>
+
+
+                    <span class="report-meta-text">2026-07-04T20:24:39.282546</span>
+
+
+
+                </div>
+
+
+                <div class="artifact-list">
+
+
+
+                    <div class="artifact-link">
+                        <a href="bbs-9-deep-research-falcon_artifacts/artifact-00.md" class="term-link">Edison artifact artifact-00</a>
+                        <span>(text/markdown)</span>
+                    </div>
+
+
+
+
+                    <div class="artifact-link">
+                        <a href="bbs-9-deep-research-falcon_artifacts/artifact-01.md" class="term-link">Edison artifact artifact-01</a>
+                        <span>(text/markdown)</span>
+                    </div>
+
+
+                </div>
+
+                <p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h1 id="comprehensive-research-report-c-elegans-bbs-9-c48b68-a-core-bbsome-subunit-in-ciliary-trafficking">Comprehensive Research Report: <em>C. elegans</em> bbs-9 (C48B6.8) — A Core BBSome Subunit in Ciliary Trafficking</h1>
+<h2 id="1-gene-and-protein-identity">1. Gene and Protein Identity</h2>
+<p>The <em>C. elegans</em> gene <strong>bbs-9</strong> (systematic name C48B6.8; UniProt O01514) encodes a protein annotated as "Protein pthb1 homolog" and "Bardet-Biedl syndrome 9 protein homolog." The protein is the nematode ortholog of mammalian BBS9/PTHB1 (parathyroid hormone-responsive B1), originally identified as a gene downregulated by parathyroid hormone in an osteoblastic cell line but subsequently recognized as a core component of the BBSome complex implicated in ciliary biology and Bardet-Biedl syndrome (veleri2012knockdownofbardetbiedl pages 1-2, veleri2012knockdownofbardetbiedl pages 5-6). The protein is highly conserved across species, with zebrafish bbs9 showing 63% identity and 79% similarity to the human BBS9 protein (veleri2012knockdownofbardetbiedl pages 2-3).</p>
+<h2 id="2-domain-architecture-and-structural-role">2. Domain Architecture and Structural Role</h2>
+<p>BBS-9 is a structural homolog of BBS1, BBS2, and BBS7, sharing a conserved five-domain architecture consisting of: (1) an N-terminal β-propeller domain (composed of WD40 repeats), (2) a heterodimerization α-helix, (3) an immunoglobulin-like GAE (gamma-adaptin ear) domain, (4) a mixed α/β platform domain, and (5) an α-helical C-terminal coiled-coil domain (singh2020structureandactivation pages 3-5). These domains correspond to the InterPro annotations PHTB1_N_dom (IPR028073), PTHB1 (IPR026511), PTHB1_pf_dom (IPR055362), PTHB1_hp_dom (IPR055363), and WD40_repeat_dom_sf (IPR036322), as annotated in UniProt.</p>
+<p>The detailed structural role of BBS-9 within the BBSome has been elucidated by cryo-EM at 3.1–3.5 Å resolution (singh2020structureandactivation pages 2-3). BBS9's GAE domain heterodimerizes specifically with the BBS1 GAE domain, forming the body of the BBSome. A strand insertion between β3 and β4 strands in BBS9's GAE domain differs from BBS7's, contributing structural specificity that prevents incorrect subunit pairing during assembly (singh2020structureandactivation pages 5-8). The GAE-platform module of BBS9 closely mirrors the structural organization of α-adaptin from clathrin adaptor complexes and COPI/COPII coatomers, supporting the evolutionary relationship between the BBSome and vesicle coat protein complexes (singh2020structureandactivation pages 12-13). The C-terminal coiled-coil of BBS9 associates with the BBS2 coiled-coil to form the neck region connecting the head and body lobes of the BBSome (singh2020structureandactivation pages 3-5, singh2020structureandactivation pages 12-13).</p>
+<p>The following table summarizes the domain architecture of BBS-9:</p>
+<table>
+<thead>
+<tr>
+<th>Domain</th>
+<th>Approx. structural description</th>
+<th>InterPro / UniProt domain mapping</th>
+<th>Key structural features</th>
+<th>Functional role in BBSome assembly/interactions</th>
+<th>Evidence</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>N-terminal β-propeller / WD40</td>
+<td>N-terminal propeller domain; one of five conserved domains shared with BBS1/2/7</td>
+<td>WD40_repeat_dom_sf (IPR036322); PHTB1_N_dom (IPR028073)</td>
+<td>β-propeller scaffold mediating extensive protein-protein contacts; in BBS family proteins this domain contributes to head/body architecture and interaction specificity</td>
+<td>Contributes to BBS-9’s hub-like connectivity within the BBSome; by homology with BBS1-family architecture, the propeller helps organize subunit contacts and overall complex topology (singh2020structureandactivation pages 3-5, wingfield2018traffickingofciliary pages 2-4)</td>
+<td>(singh2020structureandactivation pages 3-5, wingfield2018traffickingofciliary pages 2-4)</td>
+</tr>
+<tr>
+<td>Heterodimerization α-helix</td>
+<td>Short α-helical segment linking propeller to downstream domains</td>
+<td>No specific InterPro listed in provided UniProt summary</td>
+<td>Conserved helical module in the five-domain BBS1/2/7/9 architecture; supports packing between adjacent domains</td>
+<td>Part of the conserved structural core enabling correct domain arrangement and partner matching during BBSome assembly (singh2020structureandactivation pages 3-5)</td>
+<td>(singh2020structureandactivation pages 3-5)</td>
+</tr>
+<tr>
+<td>GAE domain</td>
+<td>Immunoglobulin-like GAE/adaptin-related domain in central region</td>
+<td>PTHB1 (IPR026511)</td>
+<td>BBS9 GAE heterodimerizes with BBS1 GAE; contains a strand insertion between β3 and β4 that helps enforce structural specificity and prevent incorrect pairing</td>
+<td>Critical for subunit recognition and core-body organization; forms a BBS1–BBS9 GAE heterodimer in the BBSome body and supports correct assembly specificity (singh2020structureandactivation pages 5-8, singh2020structureandactivation pages 12-13)</td>
+<td>(singh2020structureandactivation pages 5-8, singh2020structureandactivation pages 12-13)</td>
+</tr>
+<tr>
+<td>Platform (pf) domain</td>
+<td>Mixed α/β platform domain associated with the GAE module</td>
+<td>PTHB1_pf_dom (IPR055362)</td>
+<td>Together with the GAE domain forms a GAE-pf module structurally analogous to clathrin/adaptin and coatomer modules; makes extensive hydrophobic contacts with the GAE domain</td>
+<td>Provides structural body framework and supports the evolutionary coat-complex-like architecture of the BBSome; likely helps position interaction surfaces for IFT/cargo-related functions (singh2020structureandactivation pages 5-8, singh2020structureandactivation pages 12-13)</td>
+<td>(singh2020structureandactivation pages 5-8, singh2020structureandactivation pages 12-13)</td>
+</tr>
+<tr>
+<td>C-terminal coiled-coil</td>
+<td>Distal α-helical coiled-coil / neck-forming region</td>
+<td>PTHB1_hp_dom (IPR055363)</td>
+<td>Coiled-coil associates directly with the BBS2 coiled-coil to form the neck connecting head and body lobes</td>
+<td>Essential for higher-order BBSome architecture; helps connect head and body lobes and stabilizes assembly of the core complex (singh2020structureandactivation pages 3-5, singh2020structureandactivation pages 12-13)</td>
+<td>(singh2020structureandactivation pages 3-5, singh2020structureandactivation pages 12-13)</td>
+</tr>
+<tr>
+<td>Integrated architecture summary</td>
+<td>Full-length BBS-9/PTHB1 comprises a five-domain scaffold conserved with BBS1/2/7</td>
+<td>Combined mapping from UniProt: IPR028073, IPR026511, IPR055362, IPR055363, IPR036322</td>
+<td>BBS-9 directly contacts all other BBSome subunits and acts as a central structural hub</td>
+<td>Central organizer of the BBSome core and a major determinant of complex assembly, stability, and connectivity to ciliary trafficking machinery (singh2020structureandactivation pages 3-5, nakayama2018ciliaryproteintrafficking pages 3-4, wingfield2018traffickingofciliary pages 2-4)</td>
+<td>(singh2020structureandactivation pages 3-5, nakayama2018ciliaryproteintrafficking pages 3-4, wingfield2018traffickingofciliary pages 2-4)</td>
+</tr>
+</tbody>
+</table>
+<p><em>Table: This table summarizes the five-domain architecture of C. elegans BBS-9/PTHB1 inferred from BBSome structural studies and UniProt/InterPro annotations. It highlights how each domain contributes to BBSome assembly, structural organization, and protein-protein interactions.</em></p>
+<h2 id="3-central-hub-function-within-the-bbsome">3. Central Hub Function Within the BBSome</h2>
+<p>A key feature of BBS-9 is its role as the <strong>central hub</strong> of the BBSome complex. Visible immunoprecipitation (VIP) assay analyses have demonstrated that BBS-9 directly contacts four to five other BBSome subunits, more than any other component (wingfield2018traffickingofciliary pages 2-4, nakayama2018ciliaryproteintrafficking pages 3-4). Specifically, BBS-9 interacts with BBS5 and BBS8, and serves as part of the core subcomplex along with BBS1, BBS2, and BBS7 (nakayama2018ciliaryproteintrafficking pages 3-4). The BBSome assembles in a stepwise manner: BBS7 first interacts with BBS2, then combines with BBS9 to form the BBSome core complex, after which BBS1, BBS5, BBS8, BBS18 (BBIP10), and finally BBS4 are incorporated (liu2025structuremakesa pages 2-3). BBS18 and BBS8 serve as connectors that bridge BBS4 to BBS9 (liu2025structuremakesa pages 2-3).</p>
+<p>This extensive interconnectivity explains why the BBSome requires three dedicated chaperonin-like proteins (BBS6, BBS10, BBS12) together with CCT/TRiC family chaperonins to assemble properly (singh2020structureandactivation pages 3-5, wingfield2018traffickingofciliary pages 1-2). The octameric BBSome complex (BBS1/2/4/5/7/8/9/18) is a stable structure that resists dissociation even at high salt concentrations (akella2020ciliaryrab28and pages 1-2).</p>
+<h2 id="4-subcellular-localization">4. Subcellular Localization</h2>
+<p>In <em>C. elegans</em> sensory neurons, BBS-9 localizes to the <strong>ciliary base</strong> (transition zone/basal body region) and undergoes bidirectional <strong>intraflagellar transport (IFT)</strong> movement along cilia as part of the BBSome complex (wei2012thebbsomecontrols pages 14-16, wei2012thebbsomecontrols pages 2-4). In wild-type animals, BBS-9 shows ciliary staining consistent with its movement along ciliary axonemes as a component of IFT trains (wingfield2018traffickingofciliary pages 1-2). In <em>dyf-2</em> mutants that disrupt BBSome–IFT association, BBS-9 accumulates at the ciliary base with only very dim ciliary staining and completely loses IFT movement, while the BBSome complex itself remains intact, indicating that the docking of the BBSome onto IFT trains is disrupted (wei2012thebbsomecontrols pages 2-4).</p>
+<h2 id="5-primary-function-regulation-of-ift-assembly-and-turnaround">5. Primary Function: Regulation of IFT Assembly and Turnaround</h2>
+<p>The primary function of BBS-9, as part of the BBSome, is to regulate intraflagellar transport. A landmark study using whole-genome mutagenesis in <em>C. elegans</em> identified the BBSome as the key player regulating IFT assembly and turnaround in cilia (wei2012thebbsomecontrols pages 1-2). The BBSome performs two critical IFT functions:</p>
+<p><strong>IFT assembly at the ciliary base:</strong> The BBSome organizes IFT-A, IFT-B subcomplexes, and kinesin motors into a functional anterograde transport complex at the ciliary base. It assembles with IFT particles in a DYF-2- and BBS-1-dependent manner before anterograde transport begins (wei2012thebbsomecontrols pages 1-2, wei2012thebbsomecontrols pages 14-16).</p>
+<p><strong>IFT turnaround at the ciliary tip:</strong> After reaching the ciliary tip, the BBSome coordinates the remodeling of IFT particles from anterograde to retrograde transport configuration. When BBSome function is disrupted, IFT-B components accumulate at the ciliary tip with severely reduced retrograde movement, while IFT-A maintains relatively normal bidirectional movement (wei2012thebbsomecontrols pages 8-14, wei2012thebbsomecontrols pages 14-16). The BBSome works in coordination with DYF-2 to reorganize IFT complexes for retrograde transport at the tip (wei2012thebbsomecontrols pages 14-16).</p>
+<p>In <em>bbs</em> mutant <em>C. elegans</em>, the BBSome also stabilizes the interaction between IFT-A and IFT-B subcomplexes. When the BBSome is absent, IFT-A and IFT-B separate and move at different velocities (wingfield2018traffickingofciliary pages 4-5, xu2015bbs4andbbs5 pages 2-4).</p>
+<h2 id="6-cargo-adapter-function-ciliary-membrane-protein-trafficking">6. Cargo Adapter Function: Ciliary Membrane Protein Trafficking</h2>
+<p>The BBSome functions as a <strong>cargo adapter</strong> for ciliary membrane protein trafficking, primarily mediating the removal of transmembrane and peripheral membrane proteins from cilia (akella2020ciliaryrab28and pages 1-2, wingfield2018traffickingofciliary pages 4-5). The BBSome is recruited to ciliary membranes by the small GTPase ARL6/BBS3 in its GTP-bound form (singh2020structureandactivation pages 1-2, wingfield2018traffickingofciliary pages 2-4). ARL6-GTP binds to a composite site formed by BBS1 and BBS7, triggering a conformational change whereby BBS1's β-propeller swivels approximately 25° to open a central cavity of 50 × 15 Å sufficient to accommodate cargo polypeptides (singh2020structureandactivation pages 12-13, singh2020structureandactivation pages 10-12). The activation of ARL6 is mediated by IFT27, which functions as a guanine-nucleotide exchange factor (GEF) for ARL6 (lechtreck2022cargoadaptersexpand pages 7-8, wingfield2018traffickingofciliary pages 2-4). This mechanism links BBSome cargo recognition to the IFT cycle.</p>
+<p>Specific cargo proteins trafficked by the BBSome include signaling receptors such as Smoothened, Patched-1, GPR161, the Leptin receptor, and polycystin-1, underscoring the BBSome's role in regulating multiple ciliary signaling pathways (singh2020structureandactivation pages 12-13).</p>
+<h2 id="7-degradative-sorting-of-sensory-receptors">7. Degradative Sorting of Sensory Receptors</h2>
+<p>In <em>C. elegans</em>, the BBSome has a specific role in the <strong>lysosome-directed degradative sorting</strong> of ciliary sensory receptors. Studies using BBS-4 and BBS-5 mutants (which show functional redundancy) demonstrated that the BBSome regulates the ciliary removal—rather than the ciliary entry—of sensory receptors including OSM-9, polycystin-2 (PKD-2), and the odorant receptor ODR-10 (xu2015bbs4andbbs5 pages 1-2). In <em>bbs-4; bbs-5</em> double mutants, these receptors abnormally accumulate both inside and below cilia due to compromised lysosome-targeted degradation of ubiquitinated receptor proteins (xu2015bbs4andbbs5 pages 6-7, xu2015bbs4andbbs5 pages 2-4). This function acts through lysosomal rather than proteasomal degradation pathways (xu2015bbs4andbbs5 pages 6-7). Mammalian BBS4 and BBS5 similarly coordinate the ciliary removal of polycystin-2, demonstrating conservation of this mechanism (xu2015bbs4andbbs5 pages 1-2).</p>
+<h2 id="8-regulation-of-extracellular-vesicle-shedding">8. Regulation of Extracellular Vesicle Shedding</h2>
+<p>The BBSome negatively regulates the production and shedding of extracellular vesicles (EVs) from sensory cilia in <em>C. elegans</em> (akella2020ciliaryrab28and pages 1-2, akella2020ciliaryrab28and pages 16-17). BBSome loss causes excessive and ectopic EV production, particularly at the ciliary base (akella2020ciliaryrab28and pages 1-2). In <em>bbs-8</em> mutants, the cephalic lumen becomes distended and abnormally filled with excessive EVs, and dense vesicular material accumulates in the sheath cell cytoplasm (akella2020ciliaryrab28and pages 11-12, akella2020ciliaryrab28and pages 16-17). The BBSome works in conjunction with the small GTPase RAB-28 to control EV levels, though the BBSome phenotype is more severe than that of <em>rab-28</em> mutants alone, suggesting additional BBSome functions beyond RAB-28 regulation (akella2020ciliaryrab28and pages 16-17, akella2020ciliaryrab28and pages 17-19). Aberrant EV-mediated signaling between neurons and glia likely contributes to the sensory organ morphogenesis defects seen in BBSome mutants (akella2020ciliaryrab28and pages 17-19).</p>
+<h2 id="9-phenotypic-consequences-of-loss-of-function">9. Phenotypic Consequences of Loss of Function</h2>
+<p>Loss of BBSome function in <em>C. elegans</em> results in:<br />
+- <strong>Shortened and structurally abnormal cilia</strong> (wingfield2018traffickingofciliary pages 4-5)<br />
+- <strong>Defects in chemosensation and osmosensation</strong> (wingfield2018traffickingofciliary pages 4-5)<br />
+- <strong>Dye-filling defects</strong> in sensory neurons (wingfield2018traffickingofciliary pages 4-5)<br />
+- <strong>Impaired mating behavior</strong> due to PKD-2 receptor mislocalization (xu2015bbs4andbbs5 pages 2-4)<br />
+- <strong>Reduced body size</strong>, likely due to increased insulin and neuropeptide secretion (wingfield2018traffickingofciliary pages 4-5)<br />
+- <strong>Expanded sensory organ compartments</strong> due to ectopic EV accumulation (akella2020ciliaryrab28and pages 16-17, akella2020ciliaryrab28and pages 17-19)</p>
+<p>Cross-species studies confirm conservation: knockdown of <em>bbs9</em> in zebrafish leads to retinal degeneration, hydrocephaly, and reduced cilia number and length in Kupffer's vesicle. Knockdown in mouse IMCD3 cells results in complete absence of cilia (veleri2012knockdownofbardetbiedl pages 1-2, veleri2012knockdownofbardetbiedl pages 3-5). Human BBS9 mRNA rescues the zebrafish <em>bbs9</em> morphant phenotype, but a patient-derived missense mutation abolishes this rescue capacity (veleri2012knockdownofbardetbiedl pages 1-2).</p>
+<h2 id="10-summary-of-key-functions">10. Summary of Key Functions</h2>
+<p>The following table summarizes the primary functions of BBS-9/BBSome in <em>C. elegans</em>:</p>
+<table>
+<thead>
+<tr>
+<th>Functional category</th>
+<th>Role of BBS-9/BBSome in <em>C. elegans</em></th>
+<th>Mechanistic summary</th>
+<th>Key evidence source</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>IFT assembly at ciliary base</td>
+<td>BBS-9 functions as part of the BBSome that assembles IFT machinery at the ciliary base</td>
+<td>The BBSome organizes IFT-A, IFT-B, and kinesin motors into a functional anterograde transport complex at the ciliary base; structural work places BBS9 as a central hub subunit that helps stabilize BBSome architecture needed for this assembly function (wei2012thebbsomecontrols pages 14-16, singh2020structureandactivation pages 3-5, nakayama2018ciliaryproteintrafficking pages 3-4)</td>
+<td>Wei et al. 2012; Singh et al. 2020; Nakayama and Katoh 2018</td>
+</tr>
+<tr>
+<td>IFT turnaround regulation at ciliary tip</td>
+<td>BBS-9/BBSome is required for proper IFT particle remodeling and recycling at the ciliary tip</td>
+<td>In BBSome-defective worms, IFT-B accumulates at the tip while IFT-A can continue moving, indicating failure of tip reorganization and retrograde turnaround; the BBSome works with DYF-2 to reassemble transport complexes after anterograde arrival (wei2012thebbsomecontrols pages 14-16, wei2012thebbsomecontrols pages 1-2, wei2012thebbsomecontrols pages 8-14, wei2012thebbsomecontrols pages 2-4)</td>
+<td>Wei et al. 2012</td>
+</tr>
+<tr>
+<td>Ciliary membrane protein trafficking/removal</td>
+<td>BBS-9 participates in the BBSome’s adaptor role for ciliary membrane protein export/removal</td>
+<td>The BBSome rides with IFT trains and acts mainly as a cargo adaptor for removing selected membrane-associated proteins from cilia; ARL6/BBS3-GTP recruits and activates the BBSome for membrane engagement and cargo recognition (akella2020ciliaryrab28and pages 1-2, wingfield2018traffickingofciliary pages 1-2, singh2020structureandactivation pages 12-13, singh2020structureandactivation pages 1-2, wingfield2018traffickingofciliary pages 2-4)</td>
+<td>Akella et al. 2020; Wingfield et al. 2018; Singh et al. 2020</td>
+</tr>
+<tr>
+<td>Degradative sorting of sensory receptors</td>
+<td>BBS-9/BBSome supports lysosome-directed removal of ciliary sensory receptors</td>
+<td>Work in worms shows the BBSome promotes degradative sorting of receptors such as PKD-2, ODR-10, and OSM-9; when BBSome function is compromised, these receptors accumulate abnormally in cilia and near the ciliary base, indicating defective lysosomal routing rather than defective entry (xu2015bbs4andbbs5 pages 1-2, xu2015bbs4andbbs5 pages 2-4, xu2015bbs4andbbs5 pages 6-7)</td>
+<td>Xu et al. 2015</td>
+</tr>
+<tr>
+<td>Extracellular vesicle regulation</td>
+<td>BBS-9/BBSome negatively regulates EV shedding from sensory cilia</td>
+<td>In BBSome mutants, EVs accumulate ectopically at the ciliary base/lumen and sensory compartments become enlarged, indicating that the BBSome normally restrains ciliary EV production or release and helps maintain sensory organ morphology, partly with RAB-28 (akella2020ciliaryrab28and pages 16-17, akella2020ciliaryrab28and pages 1-2, akella2020ciliaryrab28and pages 17-19, akella2020ciliaryrab28and pages 11-12)</td>
+<td>Akella et al. 2020</td>
+</tr>
+<tr>
+<td>Sensory neuron function</td>
+<td>BBS-9/BBSome is required for normal sensory cilium integrity and signaling outputs</td>
+<td>Loss of BBSome function causes shortened or structurally abnormal cilia, dye-filling defects, and impaired chemosensory/osmosensory behaviors; receptor mislocalization and defective IFT likely underlie these sensory phenotypes (wingfield2018traffickingofciliary pages 4-5, xu2015bbs4andbbs5 pages 2-4, veleri2012knockdownofbardetbiedl pages 5-6, veleri2012knockdownofbardetbiedl pages 1-2, veleri2012knockdownofbardetbiedl pages 3-5)</td>
+<td>Wingfield et al. 2018; Xu et al. 2015; Veleri et al. 2012</td>
+</tr>
+</tbody>
+</table>
+<p><em>Table: This table summarizes the main experimentally supported functions of BBS-9 as a core BBSome component relevant to ciliary transport and sensory signaling in </em>C. elegans<em>. It is useful for linking molecular mechanism to cellular phenotypes across the best-supported functional categories.</em></p>
+<h2 id="11-evolutionary-and-structural-insights">11. Evolutionary and Structural Insights</h2>
+<p>The structural similarity of the BBS9 GAE-platform module to equivalent modules in clathrin adaptor complexes and COPI/COPII coatomers strongly supports the hypothesis that the BBSome evolved from an ancestral vesicle coat protein complex (singh2020structureandactivation pages 12-13). This coat-like architecture is consistent with the BBSome's function as a membrane-associated cargo adapter that forms a planar coat near the ciliary tip before binding cargo for retrograde transport (lechtreck2022cargoadaptersexpand pages 7-8). The BBSome's activation by the Arf-family GTPase ARL6 further parallels the Arf-regulated activation of clathrin adaptor complexes (singh2020structureandactivation pages 12-13).</p>
+<h2 id="12-conclusion">12. Conclusion</h2>
+<p><em>C. elegans</em> BBS-9 (C48B6.8) is the central structural hub of the BBSome, an octameric ciliary trafficking complex. BBS-9 is not an enzyme or transporter; rather, it functions as a core <strong>structural scaffold and protein interaction platform</strong> that organizes the BBSome complex and enables its functions in: (i) assembling IFT particles at the ciliary base, (ii) regulating IFT turnaround at the ciliary tip, (iii) serving as a cargo adapter for the removal of ciliary membrane proteins, (iv) directing degradative sorting of sensory receptors, and (v) negatively regulating extracellular vesicle shedding. BBS-9 localizes to the ciliary base and undergoes bidirectional IFT movement along the ciliary axoneme of sensory neurons. Its functions are essential for proper ciliary structure, sensory neuron signaling, and sensory organ morphogenesis in <em>C. elegans</em>.</p>
+<p>References</p>
+<ol>
+<li>
+<p>(veleri2012knockdownofbardetbiedl pages 1-2): Shobi Veleri, Kevin Bishop, Damian E. Dalle Nogare, Milton A. English, Trevor J. Foskett, Ajay Chitnis, Raman Sood, Paul Liu, and Anand Swaroop. Knockdown of bardet-biedl syndrome gene bbs9/pthb1 leads to cilia defects. PLoS ONE, 7:e34389, Mar 2012. URL: https://doi.org/10.1371/journal.pone.0034389, doi:10.1371/journal.pone.0034389. This article has 68 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(veleri2012knockdownofbardetbiedl pages 5-6): Shobi Veleri, Kevin Bishop, Damian E. Dalle Nogare, Milton A. English, Trevor J. Foskett, Ajay Chitnis, Raman Sood, Paul Liu, and Anand Swaroop. Knockdown of bardet-biedl syndrome gene bbs9/pthb1 leads to cilia defects. PLoS ONE, 7:e34389, Mar 2012. URL: https://doi.org/10.1371/journal.pone.0034389, doi:10.1371/journal.pone.0034389. This article has 68 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(veleri2012knockdownofbardetbiedl pages 2-3): Shobi Veleri, Kevin Bishop, Damian E. Dalle Nogare, Milton A. English, Trevor J. Foskett, Ajay Chitnis, Raman Sood, Paul Liu, and Anand Swaroop. Knockdown of bardet-biedl syndrome gene bbs9/pthb1 leads to cilia defects. PLoS ONE, 7:e34389, Mar 2012. URL: https://doi.org/10.1371/journal.pone.0034389, doi:10.1371/journal.pone.0034389. This article has 68 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(singh2020structureandactivation pages 3-5): Sandeep K Singh, Miao Gui, Fujiet Koh, Matthew CJ Yip, and Alan Brown. Structure and activation mechanism of the bbsome membrane protein trafficking complex. Jan 2020. URL: https://doi.org/10.7554/elife.53322, doi:10.7554/elife.53322. This article has 106 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(singh2020structureandactivation pages 2-3): Sandeep K Singh, Miao Gui, Fujiet Koh, Matthew CJ Yip, and Alan Brown. Structure and activation mechanism of the bbsome membrane protein trafficking complex. Jan 2020. URL: https://doi.org/10.7554/elife.53322, doi:10.7554/elife.53322. This article has 106 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(singh2020structureandactivation pages 5-8): Sandeep K Singh, Miao Gui, Fujiet Koh, Matthew CJ Yip, and Alan Brown. Structure and activation mechanism of the bbsome membrane protein trafficking complex. Jan 2020. URL: https://doi.org/10.7554/elife.53322, doi:10.7554/elife.53322. This article has 106 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(singh2020structureandactivation pages 12-13): Sandeep K Singh, Miao Gui, Fujiet Koh, Matthew CJ Yip, and Alan Brown. Structure and activation mechanism of the bbsome membrane protein trafficking complex. Jan 2020. URL: https://doi.org/10.7554/elife.53322, doi:10.7554/elife.53322. This article has 106 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(wingfield2018traffickingofciliary pages 2-4): Jenna L. Wingfield, Karl-Ferdinand Lechtreck, and Esben Lorentzen. Trafficking of ciliary membrane proteins by the intraflagellar transport/bbsome machinery. Essays in biochemistry, 62 6:753-763, Oct 2018. URL: https://doi.org/10.1042/ebc20180030, doi:10.1042/ebc20180030. This article has 186 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(nakayama2018ciliaryproteintrafficking pages 3-4): Kazuhisa Nakayama and Yohei Katoh. Ciliary protein trafficking mediated by ift and bbsome complexes with the aid of kinesin-2 and dynein-2 motors. Journal of biochemistry, 163 3:155-164, Mar 2018. URL: https://doi.org/10.1093/jb/mvx087, doi:10.1093/jb/mvx087. This article has 160 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(liu2025structuremakesa pages 2-3): Ying Liu, Yong Zhang, Hua Ni, and Peiwei Liu. Structure makes a difference: <scp>ift</scp> complex in ciliary function and ciliopathy. Cytoskeleton, Sep 2025. URL: https://doi.org/10.1002/cm.70033, doi:10.1002/cm.70033. This article has 1 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(wingfield2018traffickingofciliary pages 1-2): Jenna L. Wingfield, Karl-Ferdinand Lechtreck, and Esben Lorentzen. Trafficking of ciliary membrane proteins by the intraflagellar transport/bbsome machinery. Essays in biochemistry, 62 6:753-763, Oct 2018. URL: https://doi.org/10.1042/ebc20180030, doi:10.1042/ebc20180030. This article has 186 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(akella2020ciliaryrab28and pages 1-2): Jyothi S Akella, Stephen P Carter, Ken Nguyen, Sofia Tsiropoulou, Ailis L Moran, Malan Silva, Fatima Rizvi, Breandan N Kennedy, David H Hall, Maureen M Barr, and Oliver E Blacque. Ciliary rab28 and the bbsome negatively regulate extracellular vesicle shedding. eLife, Feb 2020. URL: https://doi.org/10.7554/elife.50580, doi:10.7554/elife.50580. This article has 62 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(wei2012thebbsomecontrols pages 14-16): Qing Wei, Yuxia Zhang, Yujie Li, Qing Zhang, Kun Ling, and Jinghua Hu. The bbsome controls ift assembly and turnaround in cilia. Aug 2012. URL: https://doi.org/10.1038/ncb2560, doi:10.1038/ncb2560. This article has 273 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(wei2012thebbsomecontrols pages 2-4): Qing Wei, Yuxia Zhang, Yujie Li, Qing Zhang, Kun Ling, and Jinghua Hu. The bbsome controls ift assembly and turnaround in cilia. Aug 2012. URL: https://doi.org/10.1038/ncb2560, doi:10.1038/ncb2560. This article has 273 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(wei2012thebbsomecontrols pages 1-2): Qing Wei, Yuxia Zhang, Yujie Li, Qing Zhang, Kun Ling, and Jinghua Hu. The bbsome controls ift assembly and turnaround in cilia. Aug 2012. URL: https://doi.org/10.1038/ncb2560, doi:10.1038/ncb2560. This article has 273 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(wei2012thebbsomecontrols pages 8-14): Qing Wei, Yuxia Zhang, Yujie Li, Qing Zhang, Kun Ling, and Jinghua Hu. The bbsome controls ift assembly and turnaround in cilia. Aug 2012. URL: https://doi.org/10.1038/ncb2560, doi:10.1038/ncb2560. This article has 273 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(wingfield2018traffickingofciliary pages 4-5): Jenna L. Wingfield, Karl-Ferdinand Lechtreck, and Esben Lorentzen. Trafficking of ciliary membrane proteins by the intraflagellar transport/bbsome machinery. Essays in biochemistry, 62 6:753-763, Oct 2018. URL: https://doi.org/10.1042/ebc20180030, doi:10.1042/ebc20180030. This article has 186 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(xu2015bbs4andbbs5 pages 2-4): Qingwen Xu, Yuxia Zhang, Qing Wei, Yan Huang, Yan Li, Kun Ling, and Jinghua Hu. Bbs4 and bbs5 show functional redundancy in the bbsome to regulate the degradative sorting of ciliary sensory receptors. Scientific Reports, Jul 2015. URL: https://doi.org/10.1038/srep11855, doi:10.1038/srep11855. This article has 93 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(singh2020structureandactivation pages 1-2): Sandeep K Singh, Miao Gui, Fujiet Koh, Matthew CJ Yip, and Alan Brown. Structure and activation mechanism of the bbsome membrane protein trafficking complex. Jan 2020. URL: https://doi.org/10.7554/elife.53322, doi:10.7554/elife.53322. This article has 106 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(singh2020structureandactivation pages 10-12): Sandeep K Singh, Miao Gui, Fujiet Koh, Matthew CJ Yip, and Alan Brown. Structure and activation mechanism of the bbsome membrane protein trafficking complex. Jan 2020. URL: https://doi.org/10.7554/elife.53322, doi:10.7554/elife.53322. This article has 106 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(lechtreck2022cargoadaptersexpand pages 7-8): Karl Lechtreck. Cargo adapters expand the transport range of intraflagellar transport. Journal of cell science, Dec 2022. URL: https://doi.org/10.1242/jcs.260408, doi:10.1242/jcs.260408. This article has 47 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(xu2015bbs4andbbs5 pages 1-2): Qingwen Xu, Yuxia Zhang, Qing Wei, Yan Huang, Yan Li, Kun Ling, and Jinghua Hu. Bbs4 and bbs5 show functional redundancy in the bbsome to regulate the degradative sorting of ciliary sensory receptors. Scientific Reports, Jul 2015. URL: https://doi.org/10.1038/srep11855, doi:10.1038/srep11855. This article has 93 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(xu2015bbs4andbbs5 pages 6-7): Qingwen Xu, Yuxia Zhang, Qing Wei, Yan Huang, Yan Li, Kun Ling, and Jinghua Hu. Bbs4 and bbs5 show functional redundancy in the bbsome to regulate the degradative sorting of ciliary sensory receptors. Scientific Reports, Jul 2015. URL: https://doi.org/10.1038/srep11855, doi:10.1038/srep11855. This article has 93 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(akella2020ciliaryrab28and pages 16-17): Jyothi S Akella, Stephen P Carter, Ken Nguyen, Sofia Tsiropoulou, Ailis L Moran, Malan Silva, Fatima Rizvi, Breandan N Kennedy, David H Hall, Maureen M Barr, and Oliver E Blacque. Ciliary rab28 and the bbsome negatively regulate extracellular vesicle shedding. eLife, Feb 2020. URL: https://doi.org/10.7554/elife.50580, doi:10.7554/elife.50580. This article has 62 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(akella2020ciliaryrab28and pages 11-12): Jyothi S Akella, Stephen P Carter, Ken Nguyen, Sofia Tsiropoulou, Ailis L Moran, Malan Silva, Fatima Rizvi, Breandan N Kennedy, David H Hall, Maureen M Barr, and Oliver E Blacque. Ciliary rab28 and the bbsome negatively regulate extracellular vesicle shedding. eLife, Feb 2020. URL: https://doi.org/10.7554/elife.50580, doi:10.7554/elife.50580. This article has 62 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(akella2020ciliaryrab28and pages 17-19): Jyothi S Akella, Stephen P Carter, Ken Nguyen, Sofia Tsiropoulou, Ailis L Moran, Malan Silva, Fatima Rizvi, Breandan N Kennedy, David H Hall, Maureen M Barr, and Oliver E Blacque. Ciliary rab28 and the bbsome negatively regulate extracellular vesicle shedding. eLife, Feb 2020. URL: https://doi.org/10.7554/elife.50580, doi:10.7554/elife.50580. This article has 62 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(veleri2012knockdownofbardetbiedl pages 3-5): Shobi Veleri, Kevin Bishop, Damian E. Dalle Nogare, Milton A. English, Trevor J. Foskett, Ajay Chitnis, Raman Sood, Paul Liu, and Anand Swaroop. Knockdown of bardet-biedl syndrome gene bbs9/pthb1 leads to cilia defects. PLoS ONE, 7:e34389, Mar 2012. URL: https://doi.org/10.1371/journal.pone.0034389, doi:10.1371/journal.pone.0034389. This article has 68 citations and is from a peer-reviewed journal.</p>
+</li>
+</ol>
+<h2 id="artifacts">Artifacts</h2>
+<ul>
+<li><a href="bbs-9-deep-research-falcon_artifacts/artifact-00.md">Edison artifact artifact-00</a></li>
+<li><a href="bbs-9-deep-research-falcon_artifacts/artifact-01.md">Edison artifact artifact-01</a></li>
+</ul>
+<h2 id="citations">Citations</h2>
+<ol>
+<li>veleri2012knockdownofbardetbiedl pages 2-3</li>
+<li>singh2020structureandactivation pages 3-5</li>
+<li>singh2020structureandactivation pages 2-3</li>
+<li>singh2020structureandactivation pages 5-8</li>
+<li>singh2020structureandactivation pages 12-13</li>
+<li>nakayama2018ciliaryproteintrafficking pages 3-4</li>
+<li>liu2025structuremakesa pages 2-3</li>
+<li>wingfield2018traffickingofciliary pages 1-2</li>
+<li>wei2012thebbsomecontrols pages 2-4</li>
+<li>wei2012thebbsomecontrols pages 1-2</li>
+<li>wei2012thebbsomecontrols pages 14-16</li>
+<li>wingfield2018traffickingofciliary pages 4-5</li>
+<li>veleri2012knockdownofbardetbiedl pages 1-2</li>
+<li>lechtreck2022cargoadaptersexpand pages 7-8</li>
+<li>veleri2012knockdownofbardetbiedl pages 5-6</li>
+<li>wingfield2018traffickingofciliary pages 2-4</li>
+<li>wei2012thebbsomecontrols pages 8-14</li>
+<li>singh2020structureandactivation pages 1-2</li>
+<li>singh2020structureandactivation pages 10-12</li>
+<li>veleri2012knockdownofbardetbiedl pages 3-5</li>
+<li>https://doi.org/10.1371/journal.pone.0034389,</li>
+<li>https://doi.org/10.7554/elife.53322,</li>
+<li>https://doi.org/10.1042/ebc20180030,</li>
+<li>https://doi.org/10.1093/jb/mvx087,</li>
+<li>https://doi.org/10.1002/cm.70033,</li>
+<li>https://doi.org/10.7554/elife.50580,</li>
+<li>https://doi.org/10.1038/ncb2560,</li>
+<li>https://doi.org/10.1038/srep11855,</li>
+<li>https://doi.org/10.1242/jcs.260408,</li>
+</ol>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(bbs-9-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="O01514" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="bbs-9-c-elegans-research-notes">bbs-9 (C. elegans) — research notes</h1>
+<p>UniProt: O01514 (PTHB1_CAEEL). Gene: bbs-9 / C48B6.8 / WBGene00016744.<br />
+Human ortholog: BBS9 / PTHB1 (Q3SYG4). 744 aa. Reference proteome UP000001940.</p>
+<h2 id="summary-of-what-is-known">Summary of what is KNOWN</h2>
+<p>BBS-9 is a core subunit of the BBSome, the octameric ciliary coat complex (BBS-1, BBS-2,<br />
+BBS-4, BBS-5, OSM-12/BBS-7, BBS-8/TTC-8, BBS-9). In C. elegans it is expressed in ciliated<br />
+sensory neurons and is required for BBSome assembly, IFT integrity, ciliogenesis, and<br />
+cilium-dependent sensory behaviors.</p>
+<h3 id="1-bbsome-membership-core-cc">1. BBSome membership (core CC)</h3>
+<ul>
+<li>UniProt SUBUNIT: "Part of BBSome complex, that contains bbs-1, bbs-2, bbs-4, bbs-5,<br />
+  osm-12, bbs-8/ttc-8 and bbs-9 (By similarity). Interacts with bbs-1 (PubMed:22922713)."<br />
+  [file:worm/bbs-9/bbs-9-uniprot.txt]</li>
+<li>ComplexPortal: CPX-428 BBSome complex; TCDB 3.A.33.1.2 "the bbsome complex (bbsome) family".</li>
+<li>Direct experimental support for worm BBS-9 in the complex: BiFC (bimolecular fluorescence<br />
+  complementation) demonstrates BBS-1–BBS-9 pair coexistence in the same complex, and this is<br />
+  consistent with the human BBSome architecture where BBS1, 7, and 9 are close.<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/22922713" title="In wild-type animals, fluorescence complementation can be observed in   BBS-1–BBS-7 and BBS-1–BBS-9 pair, indicative of the coexistence of these three BBS proteins   in the same complex">PMID:22922713</a><br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/22922713" title="This finding is also consistent with the prediction that mammalian BBS1, 7,   and 9 locate closely to each other in the BBSome">PMID:22922713</a></li>
+<li>In humans, BBS2/7/9 form the "core" of the BBSome that assembles first. (background; see human<br />
+  BBSome assembly literature — not in worm cache, so cited only as background)</li>
+</ul>
+<h3 id="2-bbsome-ift-assembly-and-turnaround-core-bp-intraciliary-transport">2. BBSome / IFT assembly and turnaround (core BP: intraciliary transport)</h3>
+<ul>
+<li>The Wei et al. 2012 study (worm forward genetics) established that the BBSome assembles IFT<br />
+  particles at the ciliary base, binds the anterograde IFT particle, and reaches the ciliary<br />
+  tip to regulate IFT turnaround/recycling.<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/22922713" title="we proposed that the in vivo function for the BBSome is to regulate the   assembly of the IFT particles at the ciliary base">PMID:22922713</a><br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/22922713" title="After IFT particles are assembled at the ciliary base, the BBSome binds to   the IFT particle like a cargo but not a structural component">PMID:22922713</a></li>
+<li>bbs-9 loss-of-function allele: bbs-9(jhu555) carries a nonsense mutation at Q171; in this<br />
+  mutant IFT-A and IFT-B separate and move at different rates in anterograde IFT — the<br />
+  canonical bbs-null IFT phenotype (BBSome couples IFT-A and IFT-B).<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/22922713" title="jhu555, jhu590, and jhu598 were mapped to bbs-9, bbs-7, and bbs-1,   respectively">PMID:22922713</a><br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/22922713" title="IFT-A and IFT-B separate and move at different rates in anterograde IFT in   bbs-7(jhu590) (encodes BBS-7 with a nonsense mutation at Q546 site) and bbs-9(jhu555)   (encodes BBS-9 with a nonsense mutation at Q171 site) mutants just like in other reported   bbs null mutants">PMID:22922713</a></li>
+<li>BBS-9 protein itself undergoes IFT: when the BBSome is uncoupled from moving IFT<br />
+  (dyf-2(jhu616)), all BBS proteins including BBS-9 lose IFT movement and accumulate at the<br />
+  ciliary base; BBS-9 shows only "very dim ciliary staining".<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/22922713" title="Some of them (BBS-1, BBS-4) totally lost the ciliary localization; the   others (BBS-2, -5, -7, -8, -9) only showed very dim ciliary staining when compared to   wild-type animals">PMID:22922713</a><br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/22922713" title="all BBS proteins completely lost IFT movement, indicating the complete   dissociation between the BBSome and the moving IFT particles">PMID:22922713</a></li>
+<li>DYF-2 (IFT/WDR19) locates near BBS-9 in native IFT particles.<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/22922713" title="Results from BiFC analyses suggest that DYF-2 locates near BBS-1, BBS-7 and   BBS-9 in the native IFT particles">PMID:22922713</a></li>
+</ul>
+<h3 id="3-uniprot-function-line-bbs-9-specific">3. UniProt FUNCTION line (bbs-9 specific)</h3>
+<ul>
+<li>"Required for proper BBSome complex assembly and its ciliary localization (PubMed:22922713).<br />
+  Required for cilia biogenesis and both the assembly and movement of intraflagellar transport<br />
+  proteins along the ciliary axoneme (PubMed:22022287, PubMed:22922713)."<br />
+  [file:worm/bbs-9/bbs-9-uniprot.txt]</li>
+<li>DISRUPTION PHENOTYPE: reduced body length/width, delayed larval development, decreased<br />
+  roaming (PMID:22022287); defective cilia structure with IFT protein accumulation/<br />
+  mislocalization and impaired IFT movement, disrupted BBSome assembly at the cilia base<br />
+  (PMID:22922713); defective NO/P. aeruginosa avoidance (PMID:30014846).</li>
+</ul>
+<h3 id="4-sensory-behavior-physiology-non-core-downstream-of-cilia">4. Sensory behavior / physiology (non-core, downstream of cilia)</h3>
+<ul>
+<li>bbs-9(gk471) null is a cilia-defective mutant that fails NO and P. aeruginosa (PA14)<br />
+  avoidance — used as a positive control for cilia dependence of NO sensing, not a bbs-9<br />
+  specific molecular function.<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/30014846" title="Two cilia defective mutants, osm-12(n1606) null mutants and bbs-9(gk471)   null mutants, were both defective in avoiding the lawn of PA14 and the NO donor">PMID:30014846</a></li>
+<li>Mok et al. 2011 (PMID:22022287): bbs mutants show small body size, developmental delay and<br />
+  exploration defects, suppressed by loss of guanylate cyclases GCY-35/GCY-36 (cGMP signalling<br />
+  modifiers). The paper studies bbs mutants collectively (e.g. bbs-7, bbs-8) and does NOT name<br />
+  bbs-9 by symbol in the cached full text; UniProt cites it for bbs-9 FUNCTION/DISRUPTION, so<br />
+  the specific bbs-9 data are likely in supplementary strain tables not extracted here. Treat<br />
+  the developmental/cGMP-modifier findings as BBSome-general (non-core for bbs-9), and do not<br />
+  quote bbs-9-specific claims from this paper.</li>
+</ul>
+<h2 id="domain-architecture-bioinformatics-from-uniprot">Domain architecture (bioinformatics from UniProt)</h2>
+<ul>
+<li>InterPro: IPR028073 PHTB1_N_dom; IPR026511 PTHB1; IPR055363 PTHB1_hp_dom; IPR055362<br />
+  PTHB1_pf_dom; IPR036322 WD40_repeat_dom_sf. Pfam PF14727 (PHTB1_N), PF23338 (PTHB1_hp),<br />
+  PF23337 (PTHB1_pf). SUPFAM SSF50978 WD40 repeat-like.</li>
+<li>So BBS-9 has an N-terminal β-propeller (WD40-like) plus platform/α-helical/hairpin domains —<br />
+  the canonical PTHB1 architecture shared with other BBSome β-propeller subunits (BBS1, BBS2,<br />
+  BBS7). This is a structural scaffold, not an enzyme; no catalytic motif.</li>
+<li>Reactome R-CEL-5620922 "BBSome-mediated cargo-targeting to cilium".</li>
+</ul>
+<h2 id="what-is-not-known-candidate-knowledge-gaps">What is NOT known (candidate knowledge gaps)</h2>
+<ol>
+<li>ONTOLOGY/BIOLOGY (MF_DARK): There is no GO molecular-function term for a BBSome coat/<br />
+   β-propeller subunit. BBS-9 has NO experimentally measured biochemical activity and — unlike<br />
+   bbs-4 — has no ISS adaptor-activity annotation in GOA at all; its only MF-adjacent GOA term<br />
+   is "membrane" (IBA, is_active_in), which is not an MF. The specific intra-BBSome contacts<br />
+   and the cargo(es) recognised by the BBS-9 β-propeller are undefined. The field states the<br />
+   BBSome's molecular activity remains unclear.<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/26150102" title="the definite molecular activity of the BBSome in regulating the homoeostasis    of ciliary membrane proteins remain unclear">PMID:26150102</a> (from bbs-4 companion paper, BBSome-general)</li>
+<li>BIOLOGY (RESIDUAL_SUBGAP): whether BBS-9, as a "core" (BBS2/7/9) subunit, plays a distinct<br />
+   nucleating/assembly role vs the peripheral subunits (BBS-4/BBS-5), and what its individual<br />
+   contribution to IFT-particle assembly at the base vs turnaround at the tip is, are not<br />
+   separated experimentally in the worm.</li>
+</ol>
+<h2 id="goa-annotation-inventory-8-annotations">GOA annotation inventory (8 annotations)</h2>
+<ol>
+<li>GO:0016020 membrane — IBA — GO_REF:0000033 — is_active_in</li>
+<li>GO:0034464 BBSome — IBA — GO_REF:0000033 — part_of</li>
+<li>GO:0060271 cilium assembly — IBA — GO_REF:0000033 — involved_in</li>
+<li>GO:0034464 BBSome — IEA — GO_REF:0000002 (InterPro IPR026511) — part_of</li>
+<li>GO:0005929 cilium — NAS — PMID:22922713 (ComplexPortal) — located_in</li>
+<li>GO:0034464 BBSome — NAS — PMID:22922713 (ComplexPortal) — part_of</li>
+<li>GO:0060271 cilium assembly — NAS — PMID:22922713 (ComplexPortal) — involved_in</li>
+<li>GO:0036064 ciliary basal body — IDA — PMID:22922713 (MGI) — located_in</li>
+</ol>
+<p>Note: UniProt DR also lists GO:0015031 protein transport (IEA UniProtKB-KW) but this is not in<br />
+the GOA TSV pulled for review (keyword-derived); no separate annotation to review.</p>
+<h2 id="planned-actions">Planned actions</h2>
+<ul>
+<li>BBSome membership (all 3 dup annotations: IBA, IEA, NAS): ACCEPT the primary; core CC.</li>
+<li>membrane (IBA is_active_in): MARK_AS_OVER_ANNOTATED — over-general/derived; the BBSome acts<br />
+  at the ciliary base/basal body and ciliary membrane; a bare "membrane" with is_active_in for<br />
+  a coat scaffold is uninformative and the qualifier is odd for a structural subunit.</li>
+<li>cilium assembly (IBA + NAS): ACCEPT (core BP).</li>
+<li>cilium (NAS located_in): KEEP_AS_NON_CORE (general; basal body is the specific CC).</li>
+<li>ciliary basal body (IDA): ACCEPT (core CC; experimental worm localization).</li>
+<li>core_functions: in_complex BBSome; molecular_function protein-macromolecule adaptor activity<br />
+  (best available MF for a coat scaffold, flag ontology gap); BP intraciliary transport,<br />
+  cilium assembly, protein localization to cilium; locations ciliary basal body, ciliary base.</li>
+</ul>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: O01514
+gene_symbol: bbs-9
+product_type: PROTEIN
+status: COMPLETE
+taxon:
+  id: NCBITaxon:6239
+  label: Caenorhabditis elegans
+description: &gt;-
+  BBS-9 (PTHB1 homolog) is a core subunit of the BBSome, the octameric ciliary coat
+  complex (BBS-1, BBS-2, BBS-4, BBS-5, OSM-12/BBS-7, BBS-8/TTC-8, BBS-9) that couples
+  intraflagellar transport (IFT) to the trafficking of membrane cargo at sensory cilia.
+  It is built from an N-terminal β-propeller (WD40-like) together with platform and
+  α-helical/hairpin regions characteristic of the PTHB1 family, and belongs — with BBS-2
+  and BBS-7 — to the β-propeller &#34;core&#34; of the complex. Like the COPI, COPII and clathrin
+  coats it structurally resembles, the BBSome assembles IFT particles at the ciliary base,
+  binds the anterograde IFT particle as a cargo, and reaches the ciliary tip where it
+  regulates IFT turnaround and recycling. In C. elegans, BBS-9 is expressed in ciliated
+  sensory neurons, undergoes IFT along the axoneme, and is required for proper BBSome
+  assembly and its ciliary localization: a bbs-9 nonsense allele uncouples the IFT-A and
+  IFT-B subcomplexes during anterograde transport, the canonical loss-of-BBSome phenotype,
+  and bbs-9 mutants have defective cilia with mislocalized, poorly transported IFT proteins.
+  Loss of bbs-9, like loss of other BBSome subunits, causes cilium-dependent sensory and
+  developmental defects, including reduced body size, developmental delay, and failure to
+  detect and avoid nitric oxide and NO-producing Pseudomonas aeruginosa.
+references:
+  - id: GO_REF:0000002
+    title: Gene Ontology annotation through association of InterPro records with GO terms
+    findings: []
+  - id: GO_REF:0000033
+    title: Annotation inferences using phylogenetic trees
+    findings: []
+  - id: PMID:22922713
+    title: The BBSome controls IFT assembly and turnaround in cilia.
+    findings:
+      - statement: The BBSome assembles IFT particles at the ciliary base and, after binding
+          the anterograde IFT particle as a cargo, regulates IFT turnaround/recycling at the
+          ciliary tip.
+        supporting_text: the in vivo function for the BBSome is to regulate the assembly of
+          the IFT particles at the ciliary base
+      - statement: The BBSome binds the moving IFT particle as a cargo, not as an integral
+          structural component.
+        supporting_text: the BBSome binds to the IFT particle like a cargo but not a
+          structural component
+      - statement: Worm BBS-9 is a member of the BBSome, shown directly by BiFC coexistence
+          of BBS-1 and BBS-9 in the same complex.
+        supporting_text: fluorescence complementation can be observed in BBS-1
+      - statement: BBS1, BBS7 and BBS9 lie close to each other in the BBSome, consistent with
+          the worm BBS-1–BBS-9 interaction.
+        supporting_text: consistent with the prediction that mammalian BBS1, 7, and 9 locate
+          closely to each other in the BBSome
+      - statement: A bbs-9 nonsense allele (Q171) separates IFT-A and IFT-B during anterograde
+          transport, the canonical bbs-null IFT-uncoupling phenotype.
+        supporting_text: encodes BBS-9 with a nonsense mutation at Q171 site
+      - statement: When the BBSome is uncoupled from moving IFT, BBS-9 (with BBS-2/5/7/8)
+          loses IFT movement and shows only dim ciliary staining, accumulating at the base.
+        supporting_text: only showed very dim ciliary staining when compared to
+      - statement: The BBSome shares coat features with COPI/COPII/clathrin and can directly
+          recognize IFT cargo.
+        supporting_text: shares the common structural features with COPI, COPII, and clathrin
+          coats, and can directly recognize IFT cargos
+    reference_review:
+      relevance: HIGH
+      correctness: VERIFIED
+      review_notes: &gt;-
+        PubMed-verified (Wei et al. 2012, Nat Cell Biol; PMC3434251). Full text cached. The
+        primary C. elegans study establishing the BBSome as the regulator of IFT assembly and
+        turnaround; provides direct worm evidence for BBS-9 (BiFC BBS-1–BBS-9 complex
+        membership; bbs-9(jhu555) Q171 nonsense allele causing IFT-A/IFT-B uncoupling; BBS-9
+        IFT movement and ciliary-base accumulation). Cited by UniProt for bbs-9 FUNCTION,
+        INTERACTION and DISRUPTION PHENOTYPE.
+  - id: PMID:22022287
+    title: &#34;Mutations in a guanylate cyclase GCY-35/GCY-36 modify Bardet-Biedl\
+      \ syndrome-associated phenotypes in Caenorhabditis elegans.&#34;
+    findings:
+      - statement: The eight BBSome proteins function as a conserved complex regulating
+          vesicular sorting/packaging, IFT, and cilium maintenance and function.
+        supporting_text: eight function mostly as a conserved protein complex (BBSome)
+      - statement: Loss of BBSome function in C. elegans causes cilium-dependent developmental
+          and behavioral defects (small body size, developmental delay, exploration defects)
+          that are modified by cGMP signalling (GCY-35/GCY-36, EGL-4).
+        supporting_text: exploration defects exhibited by multiple bbs mutants
+    reference_review:
+      relevance: MEDIUM
+      correctness: VERIFIED
+      review_notes: &gt;-
+        PubMed-verified (Mok et al. 2011, PLoS Genet; PMC3192831). Full text cached. Studies
+        C. elegans bbs mutants collectively and establishes cGMP (GCY-35/GCY-36/EGL-4) as a
+        modifier of BBSome-associated developmental/behavioral phenotypes. The cached full
+        text does not name bbs-9 by symbol (bbs-9-specific data are likely in supplementary
+        strain tables); UniProt nonetheless cites it for bbs-9 FUNCTION/DISRUPTION. Used here
+        only for BBSome-general developmental context, not for bbs-9-specific molecular claims.
+  - id: PMID:30014846
+    title: Thioredoxin shapes the C. elegans sensory response to Pseudomonas produced nitric
+      oxide.
+    findings:
+      - statement: bbs-9 null mutants are cilia-defective and fail to avoid NO and
+          NO-producing P. aeruginosa, showing bbs-9 is required for cilium-dependent NO
+          sensory behavior.
+        supporting_text: Two cilia defective mutants, osm-12(n1606) null mutants and
+          bbs-9(gk471) null mutants, were both defective in avoiding the lawn of PA14 and the
+          NO donor
+    reference_review:
+      relevance: MEDIUM
+      correctness: VERIFIED
+      review_notes: &gt;-
+        PubMed-verified (Hao et al. 2018, eLife; PMC6066330). Full text cached. Uses the
+        bbs-9(gk471) null as a cilia-defective control showing that NO/PA14 avoidance requires
+        intact sensory cilia. Supports a downstream cilium-dependent sensory role for bbs-9
+        rather than a bbs-9-specific molecular function; cited by UniProt for bbs-9 FUNCTION
+        and DISRUPTION PHENOTYPE.
+  - id: PMID:26150102
+    title: BBS4 and BBS5 show functional redundancy in the BBSome to regulate the degradative
+      sorting of ciliary sensory receptors.
+    findings:
+      - statement: The molecular activity by which the BBSome controls ciliary membrane
+          protein homeostasis is stated by the field to remain unclear.
+        supporting_text: the definite molecular activity of the BBSome in regulating the
+          homoeostasis of ciliary membrane proteins remain unclear
+    reference_review:
+      relevance: MEDIUM
+      correctness: VERIFIED
+      review_notes: &gt;-
+        PubMed-verified (Xu et al. 2015, Sci Rep; PMC4493597). Full text cached. Companion
+        C. elegans BBSome study (bbs-4/bbs-5); used here only for its explicit statement that
+        the BBSome&#39;s molecular activity is unresolved, supporting the molecular-function
+        knowledge gap for BBSome coat subunits including bbs-9.
+  - id: file:worm/bbs-9/bbs-9-deep-research-falcon.md
+    title: Deep research report on bbs-9 (Edison/falcon)
+    findings:
+      - statement: BBS-9 is the central structural hub of the BBSome, directly contacting more
+          subunits than any other component; its GAE domain heterodimerizes with BBS1 and its
+          C-terminal coiled-coil pairs with BBS2 to form the neck of the complex.
+        supporting_text: BBS-9 directly contacts four to five other BBSome subunits, more than
+          any other component
+    reference_review:
+      relevance: HIGH
+      correctness: UNVERIFIED
+      review_notes: &gt;-
+        Genuine Edison/falcon deep-research report (duration 905s, 29 citations, 2 artifacts;
+        provider header retained). Synthesizes BBSome structural literature (Singh 2020 cryo-EM,
+        Wingfield 2018, Nakayama 2018, Wei 2012, Xu 2015) into a BBS-9-specific picture: BBS-9
+        as the central hub (BBS1-BBS9 GAE heterodimer; BBS9-BBS2 coiled-coil neck) and the
+        coat-complex analogy. Underlying primary claims for the worm are independently
+        supported by PMID:22922713; the structural details derive from mammalian/vertebrate
+        cryo-EM and are marked UNVERIFIED here because they were not primary-source checked for
+        the worm ortholog. Used as corroborating context, not as the sole basis for any action.
+existing_annotations:
+  - term:
+      id: GO:0016020
+      label: membrane
+    evidence_type: IBA
+    original_reference_id: GO_REF:0000033
+    qualifier: is_active_in
+    review:
+      summary: &gt;-
+        High-level &#34;membrane&#34; localization propagated by phylogenetic inference. BBS-9 is a
+        peripheral coat scaffold that associates with the ciliary membrane at the ciliary
+        base/tip as part of the BBSome, but &#34;membrane&#34; with an is_active_in qualifier is
+        uninformative for a structural subunit and far less specific than the ciliary
+        basal-body and BBSome annotations.
+      action: MARK_AS_OVER_ANNOTATED
+      reason: &gt;-
+        Overly general and derived: the informative, experimentally supported localizations
+        for worm BBS-9 are the ciliary basal body/base and the BBSome; a bare &#34;membrane&#34; term
+        (and the is_active_in qualifier, which implies a molecular function occurring at the
+        membrane) adds no specific biological information and is flagged as over-annotation.
+      propagation_review:
+        root_cause: TERM_SCOPING_PROBLEM
+        failure_modes:
+          - GRANULARITY_MISMATCH
+        source_entities:
+          - source_id: MGI:MGI:2442833
+            source_label: Bbs9
+          - source_id: UniProtKB:Q3SYG4
+            source_label: BBS9 (human)
+  - term:
+      id: GO:0034464
+      label: BBSome
+    evidence_type: IBA
+    original_reference_id: GO_REF:0000033
+    qualifier: part_of
+    review:
+      summary: &gt;-
+        BBS-9 is a bona fide subunit of the BBSome, the octameric complex (BBS-1, BBS-2,
+        BBS-4, BBS-5, OSM-12/BBS-7, BBS-8/TTC-8, BBS-9). This phylogenetic (IBA) assignment
+        matches the direct C. elegans BiFC evidence that BBS-1 and BBS-9 coexist in the same
+        complex and the human BBSome architecture in which BBS1/7/9 lie together.
+      action: ACCEPT
+      reason: &gt;-
+        Complex membership is the defining, core cellular-component property of bbs-9 and is
+        supported by both phylogenetic inference and direct C. elegans experiments.
+      supported_by:
+        - reference_id: PMID:22922713
+          supporting_text: consistent with the prediction that mammalian BBS1, 7, and 9
+            locate closely to each other in the BBSome
+  - term:
+      id: GO:0060271
+      label: cilium assembly
+    evidence_type: IBA
+    original_reference_id: GO_REF:0000033
+    qualifier: involved_in
+    review:
+      summary: &gt;-
+        BBS-9 contributes to cilium assembly as part of the BBSome, which assembles IFT
+        particles required for ciliogenesis. In C. elegans bbs-9 mutants have defective cilia
+        with mislocalized and poorly transported IFT proteins.
+      action: ACCEPT
+      reason: &gt;-
+        Well supported by phylogenetic inference and by direct C. elegans genetics; a core
+        biological-process annotation for a BBSome subunit.
+      supported_by:
+        - reference_id: PMID:22922713
+          supporting_text: the in vivo function for the BBSome is to regulate the assembly of
+            the IFT particles at the ciliary base
+  - term:
+      id: GO:0034464
+      label: BBSome
+    evidence_type: IEA
+    original_reference_id: GO_REF:0000002
+    qualifier: part_of
+    review:
+      summary: &gt;-
+        Electronic InterPro-to-GO mapping (IPR026511, PTHB1) assigning BBSome membership.
+        This duplicates the IBA and NAS BBSome annotations and is consistent with the direct
+        experimental complex-membership evidence.
+      action: ACCEPT
+      reason: &gt;-
+        Correct BBSome membership from the PTHB1 InterPro signature; redundant with the
+        higher-evidence NAS/IBA annotations but not wrong. Core cellular-component.
+      supported_by:
+        - reference_id: PMID:22922713
+          supporting_text: fluorescence complementation can be observed in BBS-1
+  - term:
+      id: GO:0005929
+      label: cilium
+    evidence_type: NAS
+    original_reference_id: PMID:22922713
+    qualifier: located_in
+    review:
+      summary: &gt;-
+        BBS-9 localizes to cilia as a BBSome subunit that undergoes IFT along the ciliary
+        axoneme; when the BBSome is uncoupled from moving IFT, BBS-9 shows only dim ciliary
+        staining and accumulates at the base. A correct but general localization — the ciliary
+        basal body/base terms are more specific.
+      action: KEEP_AS_NON_CORE
+      reason: &gt;-
+        Accurate general localization supported by the referenced work, but non-core relative
+        to the more specific ciliary basal body / ciliary base terms which are the core CC
+        annotations; retained as a valid non-core localization.
+      supported_by:
+        - reference_id: PMID:22922713
+          supporting_text: only showed very dim ciliary staining when compared to
+  - term:
+      id: GO:0034464
+      label: BBSome
+    evidence_type: NAS
+    original_reference_id: PMID:22922713
+    qualifier: part_of
+    review:
+      summary: &gt;-
+        Author-stated (NAS, ComplexPortal) assignment of BBSome membership, duplicating the
+        IBA and IEA annotations. Directly supported by the C. elegans BiFC evidence that BBS-1
+        and BBS-9 are in the same complex.
+      action: ACCEPT
+      reason: &gt;-
+        Correct and consistent with the other BBSome annotations and with direct worm
+        experiments; the core cellular-component annotation for bbs-9.
+      supported_by:
+        - reference_id: PMID:22922713
+          supporting_text: indicative of the coexistence of these three BBS proteins in the
+            same complex
+  - term:
+      id: GO:0060271
+      label: cilium assembly
+    evidence_type: NAS
+    original_reference_id: PMID:22922713
+    qualifier: involved_in
+    review:
+      summary: &gt;-
+        Author-stated (NAS) cilium-assembly role, duplicating the IBA annotation. The BBSome
+        assembles IFT particles required for ciliogenesis, and bbs-9 mutants show defective
+        cilia.
+      action: ACCEPT
+      reason: &gt;-
+        Correct and consistent with the IBA annotation and with C. elegans genetics; retained
+        as complementary evidence for the same core biological-process role.
+      supported_by:
+        - reference_id: PMID:22922713
+          supporting_text: the in vivo function for the BBSome is to regulate the assembly of
+            the IFT particles at the ciliary base
+  - term:
+      id: GO:0036064
+      label: ciliary basal body
+    evidence_type: IDA
+    original_reference_id: PMID:22922713
+    qualifier: located_in
+    review:
+      summary: &gt;-
+        Direct experimental (IDA) localization of BBS-9 to the ciliary basal body/base in
+        C. elegans, consistent with strong BBSome accumulation around the ciliary base when
+        the complex is uncoupled from moving IFT. This is the site where the BBSome assembles
+        IFT particles.
+      action: ACCEPT
+      reason: &gt;-
+        Experimental localization; the strongest evidence class for the basal-body assignment
+        and the core cellular-component annotation for worm BBS-9.
+      supported_by:
+        - reference_id: PMID:22922713
+          supporting_text: all BBS proteins examined strongly accumulated around the ciliary
+            base
+  - term:
+      id: GO:0097546
+      label: ciliary base
+    evidence_type: IDA
+    original_reference_id: PMID:22922713
+    qualifier: located_in
+    review:
+      summary: &gt;-
+        BBS-9, like the other BBSome subunits, concentrates at the ciliary base where the
+        BBSome assembles IFT particles; when the BBSome is uncoupled from moving IFT the
+        proteins strongly accumulate there. This is a more precise localization than the
+        general &#39;cilium&#39; term and complements the ciliary basal body annotation.
+      action: NEW
+      reason: &gt;-
+        Ciliary base is the experimentally supported site of BBSome-mediated IFT assembly in
+        C. elegans and is included as a location in core_functions; added here as a specific
+        cellular-component annotation.
+      supported_by:
+        - reference_id: PMID:22922713
+          supporting_text: all BBS proteins examined strongly accumulated around the ciliary
+            base
+  - term:
+      id: GO:0042073
+      label: intraciliary transport
+    evidence_type: IMP
+    original_reference_id: PMID:22922713
+    qualifier: involved_in
+    review:
+      summary: &gt;-
+        BBS-9, as a BBSome subunit, itself undergoes IFT movement along the ciliary axoneme
+        and is required for normal intraflagellar transport; a bbs-9 nonsense allele uncouples
+        IFT-A from IFT-B during anterograde transport and the BBSome loses IFT movement when
+        detached from IFT particles.
+      action: NEW
+      reason: &gt;-
+        Intraciliary transport is a core biological process for the BBSome, captured in
+        core_functions; added here as a specific process annotation supported by BBS-9 IFT
+        movement and the IFT-uncoupling phenotype of the bbs-9 allele.
+      supported_by:
+        - reference_id: PMID:22922713
+          supporting_text: encodes BBS-9 with a nonsense mutation at Q171 site
+        - reference_id: PMID:22922713
+          supporting_text: all BBS proteins completely lost IFT movement
+  - term:
+      id: GO:0061512
+      label: protein localization to cilium
+    evidence_type: IBA
+    original_reference_id: GO_REF:0000033
+    qualifier: involved_in
+    review:
+      summary: &gt;-
+        As a BBSome subunit, BBS-9 is required for correct trafficking of membrane and
+        signaling proteins to/from cilia; the BBSome couples ciliary cargo to IFT and, when
+        disrupted, ciliary receptors mislocalize. Supported by phylogenetic inference and by
+        the conserved BBSome cargo-trafficking role.
+      action: NEW
+      reason: &gt;-
+        Protein localization to cilium is a core BBSome-mediated process captured in
+        core_functions; added here as a specific biological-process annotation, consistent with
+        the phylogenetically inferred BBSome function.
+      supported_by:
+        - reference_id: PMID:22922713
+          supporting_text: shares the common structural features with COPI, COPII, and clathrin
+            coats, and can directly recognize IFT cargos
+  - term:
+      id: GO:0030674
+      label: protein-macromolecule adaptor activity
+    evidence_type: ISS
+    original_reference_id: file:worm/bbs-9/bbs-9-deep-research-falcon.md
+    qualifier: enables
+    review:
+      summary: &gt;-
+        BBS-9 acts as a protein-macromolecule adaptor/scaffold within the coat-like BBSome
+        rather than as an enzyme: structurally it is the central hub that directly contacts
+        more subunits than any other component (its GAE domain heterodimerizes with BBS1 and
+        its C-terminal coiled-coil pairs with BBS2 to form the neck). This is far more
+        informative than &#39;protein binding&#39; and is the best available molecular-function
+        description for a BBSome coat subunit.
+      action: NEW
+      reason: &gt;-
+        Adaptor/scaffold activity is the most defensible molecular function for a BBSome
+        structural subunit and is preferable to uninformative protein binding; included in
+        core_functions. No experimental MF has been measured for BBS-9 itself and no GO term
+        specifically expresses the BBSome coat/cargo-adaptor role - see knowledge_gaps.
+      supported_by:
+        - reference_id: PMID:22922713
+          supporting_text: shares the common structural features with COPI, COPII, and clathrin
+            coats, and can directly recognize IFT cargos
+core_functions:
+  - description: &gt;-
+      BBS-9 is a β-propeller &#34;core&#34; scaffold subunit of the coat-like BBSome. Through its
+      integration into the complex (lying close to BBS-1 and BBS-7) it contributes to
+      BBSome-mediated assembly of IFT particles at the ciliary base and to the IFT-coupled
+      trafficking of ciliary membrane cargo. Its molecular activity is best described as a
+      protein-macromolecule adaptor/scaffold within the BBSome coat; no independent enzymatic
+      activity is known.
+    molecular_function:
+      id: GO:0030674
+      label: protein-macromolecule adaptor activity
+    directly_involved_in:
+      - id: GO:0042073
+        label: intraciliary transport
+      - id: GO:0060271
+        label: cilium assembly
+      - id: GO:0061512
+        label: protein localization to cilium
+    locations:
+      - id: GO:0036064
+        label: ciliary basal body
+      - id: GO:0097546
+        label: ciliary base
+    in_complex:
+      id: GO:0034464
+      label: BBSome
+    supported_by:
+      - reference_id: PMID:22922713
+        supporting_text: the in vivo function for the BBSome is to regulate the assembly of
+          the IFT particles at the ciliary base
+      - reference_id: PMID:22922713
+        supporting_text: consistent with the prediction that mammalian BBS1, 7, and 9 locate
+          closely to each other in the BBSome
+knowledge_gaps:
+  - gap_statement: &gt;-
+      There is no GO molecular-function term that expresses the role of a BBSome coat/scaffold
+      subunit, and BBS-9 has no experimentally measured biochemical activity of its own. Unlike
+      the peripheral subunit BBS-4, worm BBS-9 has no molecular-function annotation of any kind
+      in GOA (its only MF-adjacent term is the uninformative &#34;membrane&#34;), so the specific
+      intra-BBSome contacts made by the BBS-9 β-propeller and the cargo(es) it helps recognize
+      are undefined.
+    boundary: &gt;-
+      BBS-9 is an established BBSome subunit built from a WD40-like β-propeller plus PTHB1
+      platform/hairpin domains, and lies close to BBS-1 and BBS-7 in the complex; the BBSome is
+      explicitly coat-like (shares structural features with COPI, COPII and clathrin) and can
+      directly recognize IFT cargo. What is missing is a molecular-function term (and the direct
+      cargo/partner identity) for the coat subunit itself rather than the complex-level process.
+    gap_kind:
+      - ONTOLOGY
+      - BIOLOGY
+    dark_aspect: MF_DARK
+    status: OPEN
+    significance: &gt;-
+      BBSome subunits illustrate the structural-subunit ontology gap: their function is &#34;be part
+      of the coat&#34;, which the GO molecular-function aspect cannot currently express, so BBS-9
+      reads as MF-dark despite a well-defined cellular role central to Bardet-Biedl syndrome.
+    resolution: &gt;-
+      Ontology development of a BBSome coat/cargo-adaptor molecular-function term (analogous to a
+      vesicle-coat adaptor), plus structural and proximity/affinity proteomics to define the
+      intra-complex contacts and membrane cargo contacted by the BBS-9 β-propeller.
+    provenance:
+      - reference_id: PMID:22922713
+        supporting_text: shares the common structural features with COPI, COPII, and clathrin
+          coats, and can directly recognize IFT cargos
+        reference_section_type: DISCUSSION
+      - reference_id: PMID:26150102
+        supporting_text: the definite molecular activity of the BBSome in regulating the
+          homoeostasis of ciliary membrane proteins remain unclear
+        reference_section_type: INTRODUCTION
+    proposed_terms:
+      - proposed_name: BBSome coat cargo-adaptor activity
+        proposed_definition: &gt;-
+          A protein-macromolecule adaptor activity of a subunit of the BBSome (a coat-like
+          complex structurally related to COPI/COPII/clathrin) that mediates recognition and
+          sorting of ciliary membrane cargo and its coupling to intraflagellar transport,
+          without the subunit independently catalyzing a biochemical reaction. Distinct from
+          the cellular component &#39;BBSome&#39; (GO:0034464), this term names the molecular activity a
+          coat subunit contributes to BBSome-mediated cargo sorting.
+        justification: &gt;-
+          BBSome subunits such as BBS-9 have no adequate GO molecular-function term; they are
+          annotatable only with the generic &#39;protein-macromolecule adaptor activity&#39; or the
+          uninformative &#39;protein binding&#39;/&#39;membrane&#39;, leaving them MF-dark despite a
+          well-defined coat-subunit role.
+        proposed_parent:
+          id: GO:0030674
+          label: protein-macromolecule adaptor activity
+  - gap_statement: &gt;-
+      Whether BBS-9, as a β-propeller &#34;core&#34; (BBS-2/BBS-7/BBS-9) subunit, plays a distinct
+      nucleating/assembly role separable from the peripheral subunits, and what its individual
+      contribution is to IFT-particle assembly at the ciliary base versus IFT turnaround at the
+      tip, have not been resolved experimentally in C. elegans.
+    boundary: &gt;-
+      A bbs-9 nonsense allele (Q171) uncouples IFT-A from IFT-B during anterograde transport,
+      like other bbs-null mutants, and BBS-9 itself undergoes IFT and accumulates at the ciliary
+      base when the BBSome is uncoupled from moving IFT. What remains unknown is the
+      subunit-specific step BBS-9 mediates within complex assembly and IFT coupling, as distinct
+      from the whole-complex loss-of-function phenotype.
+    gap_kind:
+      - BIOLOGY
+    dark_aspect: RESIDUAL_SUBGAP
+    status: OPEN
+    significance: &gt;-
+      Dissecting subunit-specific roles is needed to understand why individual BBS genes give
+      overlapping but not identical Bardet-Biedl syndrome phenotypes, and to model the stepwise
+      assembly of the ciliary coat.
+    resolution: &gt;-
+      Separation-of-function bbs-9 alleles and structure-guided mutations that perturb specific
+      intra-BBSome interfaces, scored for BBSome assembly, IFT-A/IFT-B coupling, base-versus-tip
+      IFT dynamics, and cargo trafficking.
+    provenance:
+      - reference_id: PMID:22922713
+        supporting_text: encodes BBS-9 with a nonsense mutation at Q171 site
+        reference_section_type: RESULTS
+      - reference_id: PMID:22922713
+        supporting_text: only showed very dim ciliary staining when compared to
+        reference_section_type: RESULTS
+proposed_new_terms: []
+suggested_questions:
+  - question: Does the BBS-9 β-propeller directly contact a specific ciliary membrane cargo or a
+      specific neighboring BBSome subunit interface, and is that contact required for IFT-A/IFT-B
+      coupling?
+  - question: Is there a subunit-specific role for BBS-9 in nucleating BBSome assembly (as part
+      of the BBS-2/7/9 core) that is separable from bulk IFT-particle assembly?
+suggested_experiments:
+  - description: Cryo-EM/structural analysis of the C. elegans (or reconstituted) BBSome with
+      BBS-9 to map the BBS-9 β-propeller interfaces, combined with proximity-dependent
+      biotinylation (TurboID) of BBS-9 at the ciliary base to identify cargo and neighbors.
+    hypothesis: The BBS-9 β-propeller forms defined intra-complex and cargo contacts that couple
+      the BBSome coat to IFT particles.
+    experiment_type: structural_biology
+  - description: Structure-guided separation-of-function bbs-9 alleles that perturb individual
+      interfaces while preserving overall folding, scored for BBSome assembly, IFT-A/IFT-B
+      coupling, base-versus-tip IFT dynamics, and ciliary receptor trafficking.
+    hypothesis: Specific BBS-9 interfaces are required for distinct steps (assembly at the base
+      versus turnaround at the tip), separable from whole-complex loss.
+    experiment_type: genetics
+tags:
+  - caeel-ciliopathy
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/genes/worm/dyf-13/dyf-13-ai-review.html
+++ b/genes/worm/dyf-13/dyf-13-ai-review.html
@@ -1,0 +1,3254 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>dyf-13 - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        .propagation-review {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f8fafc;
+            border-left: 3px solid #64748b;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .propagation-title {
+            font-weight: 600;
+            color: #334155;
+            margin-bottom: 0.25rem;
+        }
+
+        .propagation-row {
+            margin-top: 0.25rem;
+        }
+
+        .propagation-source {
+            margin-top: 0.5rem;
+            padding-top: 0.5rem;
+            border-top: 1px solid #e5e7eb;
+        }
+
+        .propagation-source-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #1d4ed8;
+        }
+
+        .propagation-comment {
+            color: #4b5563;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>dyf-13</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/Q95QT8" target="_blank" class="term-link">
+                        Q95QT8
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Caenorhabditis elegans</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-complete">
+                    COMPLETE
+                </span>
+            </div>
+
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "dyf-13";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="Q95QT8" data-a="DESCRIPTION: dyf-13 encodes the C. elegans ortholog of tetratri..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>dyf-13 encodes the C. elegans ortholog of tetratricopeptide-repeat protein 26 (TTC26/IFT56/IFT-B protein 56), a tetratricopeptide-repeat (TPR) scaffold subunit of the intraflagellar transport complex B (IFT-B). IFT-B, together with IFT-A and kinesin-2/dynein-2 motors, drives the bidirectional transport of ciliary cargo along the axoneme that builds and maintains cilia. DYF-13 is expressed in ciliated sensory neurons, localizes to the cilium, and itself undergoes intraflagellar transport; its ciliary localization depends on other IFT and BBS proteins. Loss of dyf-13 produces short sensory cilia that lack their distal segments and a dye-filling-defective (Dyf) phenotype, and DYF-13 is a component of the IFT-B complex required for anterograde cargo transport and for ciliary entry of the retrograde dynein-2 motor. The gene is one of the founding dye-filling-defective (dyf-1 to dyf-13) loci and is a target of the RFX transcription factor DAF-19 via an X-box promoter motif.</p>
+    </div>
+
+
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0036064" target="_blank" class="term-link">
+                                    GO:0036064
+                                </a>
+                            </span>
+                            <span class="term-label">ciliary basal body</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q95QT8" data-a="GO:0036064" data-r="GO_REF:0000033" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IFT proteins, including IFT-B/TTC26 orthologs, accumulate at and turn around at the ciliary base/basal body region. This IBA localization is consistent with DYF-13 being a core IFT component whose transport begins at the ciliary base.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Consistent with the established role of DYF-13 as a core IFT component that accumulates at the ciliary base; a supporting (non-core) location rather than the primary functional assignment.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/15916950" target="_blank" class="term-link">
+                                        PMID:15916950
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">encodes a ciliary protein that undergoes IFT</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030992" target="_blank" class="term-link">
+                                    GO:0030992
+                                </a>
+                            </span>
+                            <span class="term-label">intraciliary transport particle B</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q95QT8" data-a="GO:0030992" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> DYF-13/TTC26 is an integral subunit of the IFT-B complex. This is directly supported in C. elegans by affinity-purification/mass-spectrometry identification of dyf-13 within IFT complex B, and in mammals TTC26/IFT56 is assigned to the IFT-B complex.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Core structural assignment; DYF-13 is a bona fide IFT-B subunit (ComplexPortal CPX-1290), confirmed biochemically in worm and mammals.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/28479320" target="_blank" class="term-link">
+                                        PMID:28479320
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">intraflagellar transport (IFT)-B complex abolishes dynein-2&#39;s ciliary</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/26980730" target="_blank" class="term-link">
+                                        PMID:26980730
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">neither of which was included with certainty in</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0035720" target="_blank" class="term-link">
+                                    GO:0035720
+                                </a>
+                            </span>
+                            <span class="term-label">intraciliary anterograde transport</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q95QT8" data-a="GO:0035720" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> As an IFT-B subunit, DYF-13 participates in kinesin-2-driven anterograde transport that carries cargo from the ciliary base toward the tip. Loss of dyf-13 causes distal-segment defects consistent with impaired anterograde delivery.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Core biological process for an IFT-B subunit; anterograde transport is the direction driven by the kinesin-2/IFT-B machinery that DYF-13 belongs to.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/15916950" target="_blank" class="term-link">
+                                        PMID:15916950
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">encodes a ciliary protein that undergoes IFT</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0035735" target="_blank" class="term-link">
+                                    GO:0035735
+                                </a>
+                            </span>
+                            <span class="term-label">intraciliary transport involved in cilium assembly</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q95QT8" data-a="GO:0035735" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> DYF-13 is required for building and maintaining cilia: dyf-13(mn396) mutants have short cilia lacking distal portions, and the protein is a novel core IFT component required for cilia function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Core biological process; captures the specific role of IFT in cilium assembly, strongly supported by the dyf-13 mutant structural phenotype.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/15916950" target="_blank" class="term-link">
+                                        PMID:15916950
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">is a novel core IFT component required for cilia function</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0097546" target="_blank" class="term-link">
+                                    GO:0097546
+                                </a>
+                            </span>
+                            <span class="term-label">ciliary base</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q95QT8" data-a="GO:0097546" data-r="GO_REF:0000033" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IFT particles, including DYF-13, are active at the ciliary base where anterograde trains assemble and retrograde trains are remodeled. Consistent with DYF-13 undergoing IFT that initiates at the base.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Supporting (non-core) location consistent with IFT-B biology; complements the primary cilium/axoneme localization.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/15916950" target="_blank" class="term-link">
+                                        PMID:15916950
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">encodes a ciliary protein that undergoes IFT</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0120170" target="_blank" class="term-link">
+                                    GO:0120170
+                                </a>
+                            </span>
+                            <span class="term-label">intraciliary transport particle B binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q95QT8" data-a="GO:0120170" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> The molecular function of DYF-13/TTC26 within the cilium is to associate with the IFT-B particle. As a TPR-repeat scaffold subunit it binds the IFT-B complex; this is the most specific molecular-function term currently available for an IFT-B structural subunit.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Best-available molecular-function term for an IFT-B subunit; more informative than generic protein binding. DYF-13 co-purifies within IFT complex B, and functions as a cargo-selective IFT-B adapter rather than a core-structural requirement (it associates with, but is not essential for, IFT-particle assembly).
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/28479320" target="_blank" class="term-link">
+                                        PMID:28479320
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">intraflagellar transport (IFT)-B complex abolishes dynein-2&#39;s ciliary</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:worm/dyf-13/dyf-13-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">IFT56 is not required for assembly or movement of IFT particles themselves</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005929" target="_blank" class="term-link">
+                                    GO:0005929
+                                </a>
+                            </span>
+                            <span class="term-label">cilium</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000044
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q95QT8" data-a="GO:0005929" data-r="GO_REF:0000044" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> UniProt SubCell-derived electronic annotation placing DYF-13 in the cilium. Correct but general; concordant with the experimentally supported ciliary localization.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct general localization (cilium), consistent with primary evidence that DYF-13 is a ciliary protein undergoing IFT.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/15916950" target="_blank" class="term-link">
+                                        PMID:15916950
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">encodes a ciliary protein that undergoes IFT</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005929" target="_blank" class="term-link">
+                                    GO:0005929
+                                </a>
+                            </span>
+                            <span class="term-label">cilium</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">NAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/28479320" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:28479320
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Dynein-Driven Retrograde Intraflagellar Transport Is Triphas...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q95QT8" data-a="GO:0005929" data-r="PMID:28479320" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> ComplexPortal NAS annotation to cilium based on the IFT-B complex membership reported in Yi et al. 2017. Correct but general localization.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct ciliary localization; supported by identification of dyf-13 in the ciliary IFT-B complex.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/28479320" target="_blank" class="term-link">
+                                        PMID:28479320
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">intraflagellar transport (IFT)-B complex abolishes dynein-2&#39;s ciliary</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030992" target="_blank" class="term-link">
+                                    GO:0030992
+                                </a>
+                            </span>
+                            <span class="term-label">intraciliary transport particle B</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">NAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/28479320" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:28479320
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Dynein-Driven Retrograde Intraflagellar Transport Is Triphas...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q95QT8" data-a="GO:0030992" data-r="PMID:28479320" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> ComplexPortal NAS annotation, from the same study that identified dyf-13 as a component of IFT complex B by affinity purification and mass spectrometry.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Core structural assignment corroborating the IBA IFT-B membership; directly supported by the primary study.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/28479320" target="_blank" class="term-link">
+                                        PMID:28479320
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">intraflagellar transport (IFT)-B complex abolishes dynein-2&#39;s ciliary</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042073" target="_blank" class="term-link">
+                                    GO:0042073
+                                </a>
+                            </span>
+                            <span class="term-label">intraciliary transport</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">NAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/28479320" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:28479320
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Dynein-Driven Retrograde Intraflagellar Transport Is Triphas...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q95QT8" data-a="GO:0042073" data-r="PMID:28479320" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> General intraflagellar-transport process annotation for an IFT-B subunit. Correct but less specific than the anterograde/assembly terms; the parent process under which DYF-13 acts.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct but general parent term; the more specific anterograde-transport and transport-in-cilium-assembly terms better capture the core function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/15916950" target="_blank" class="term-link">
+                                        PMID:15916950
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">encodes a ciliary protein that undergoes IFT</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0060271" target="_blank" class="term-link">
+                                    GO:0060271
+                                </a>
+                            </span>
+                            <span class="term-label">cilium assembly</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">NAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/28479320" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:28479320
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Dynein-Driven Retrograde Intraflagellar Transport Is Triphas...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q95QT8" data-a="GO:0060271" data-r="PMID:28479320" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> DYF-13 is required for cilium assembly; dyf-13 mutants have short cilia lacking distal segments. This general BP term is well supported, with the more specific IFT-in-cilium-assembly term giving the mechanism.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct biological process; the dyf-13 loss-of-function structural cilia phenotype directly supports a cilium-assembly role.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/15916950" target="_blank" class="term-link">
+                                        PMID:15916950
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">is a novel core IFT component required for cilia function</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>DYF-13/TTC26 is a tetratricopeptide-repeat (TPR) scaffold subunit of the intraflagellar transport complex B (IFT-B). Its core molecular role is to associate with the IFT-B particle, contributing to anterograde, kinesin-2-driven transport of ciliary cargo that assembles and maintains sensory cilia. Loss of dyf-13 gives short cilia lacking distal segments.</h3>
+                <span class="vote-buttons" data-g="Q95QT8" data-a="FUNCTION: DYF-13/TTC26 is a tetratricopeptide-repeat (TPR) s..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0120170" target="_blank" class="term-link">
+                            intraciliary transport particle B binding
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0035735" target="_blank" class="term-link">
+                                intraciliary transport involved in cilium assembly
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0035720" target="_blank" class="term-link">
+                                intraciliary anterograde transport
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005929" target="_blank" class="term-link">
+                                cilium
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">In Complex:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030992" target="_blank" class="term-link">
+                            intraciliary transport particle B
+                        </a>
+                    </span>
+                </div>
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/15916950" target="_blank" class="term-link">
+                                PMID:15916950
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">is a novel core IFT component required for cilia function</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/28479320" target="_blank" class="term-link">
+                                PMID:28479320
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">intraflagellar transport (IFT)-B complex abolishes dynein-2&#39;s ciliary</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
+                            GO_REF:0000033
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Annotation inferences using phylogenetic trees</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
+                            GO_REF:0000044
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/15916950" target="_blank" class="term-link">
+                            PMID:15916950
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Functional genomics of the cilium, a sensory organelle.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">dyf-13 (C27H5.7a) encodes a ciliary protein that undergoes intraflagellar transport; its ciliary localization and transport depend on other IFT and BBS genes, and it is a novel core IFT component required for cilia function.</div>
+
+                        <div class="finding-text">"One of these, C27H5.7a, encodes a ciliary protein that undergoes IFT."</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/28479320" target="_blank" class="term-link">
+                            PMID:28479320
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Dynein-Driven Retrograde Intraflagellar Transport Is Triphasic in C. elegans Sensory Cilia.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">dyf-13 is a component of IFT complex B (identified by affinity purification and mass spectrometry); disruption of the IFT-B complex abolishes ciliary localization of the dynein-2 heavy chain.</div>
+
+                        <div class="finding-text">"Disruption of the dynein-2 tail domain, light intermediate chain, or intraflagellar transport (IFT)-B complex abolishes dynein-2&#39;s ciliary localization, revealing their important roles in ciliary entry of dynein-2."</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/18316409" target="_blank" class="term-link">
+                            PMID:18316409
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">The Caenorhabditis elegans nephrocystins act as global modifiers of cilium structure.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">DYF-13::GFP is used as an intraflagellar-transport reporter and localizes along amphid channel cilia; the dyf-13 mutant occasionally lacks the IFT-B cargo OSM-6 in amphid distal segments, consistent with an anterograde/IFT-B role.</div>
+
+                        <div class="finding-text">"The dyf-13 mutant, similar to nphp-4 animals, occasionally lacks OSM-6"</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/16957054" target="_blank" class="term-link">
+                            PMID:16957054
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Caenorhabditis elegans DYF-2, an orthologue of human WDR19, is a component of the intraflagellar transport machinery in sensory cilia.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Establishes the C. elegans dye-filling-defective (dyf) IFT gene class to which dyf-13 belongs; the paralogous dyf-2/WDR19 associates with IFT particle complex B, providing IFT-machinery context for the DYF-13 IFT-B annotations.</div>
+
+                        <div class="finding-text">"we conclude that DYF-2 can associate with IFT particle complex B"</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/18369462" target="_blank" class="term-link">
+                            PMID:18369462
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">An essential role for DYF-11/MIP-T3 in assembling functional intraflagellar transport complexes.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">DYF-13 is listed among the conserved C. elegans IFT-associated proteins whose orthologs are enriched in the Chlamydomonas flagellar proteome, supporting its status as a conserved IFT component.</div>
+
+                        <div class="finding-text">"DYF-3 [34], DYF-13 [35], and IFTA-1 [36]"</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/26980730" target="_blank" class="term-link">
+                            PMID:26980730
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Overall Architecture of the Intraflagellar Transport (IFT)-B Complex Containing Cluap1/IFT38 as an Essential Component of the IFT-B Peripheral Subcomplex.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">The mammalian ortholog TTC26/IFT56 was identified as an integral component of the IFT-B core subcomplex, establishing that TTC26/IFT56 (the DYF-13 family) is a genuine IFT-B subunit.</div>
+
+                        <div class="finding-text">"we identified TTC26/IFT56 and Cluap1/IFT38, neither of which was included with certainty in"</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Knowledge Gaps</h2>
+        <p style="color: #555; font-size: 0.92rem; margin-top: -0.3rem;">
+            What is <em>not</em> known — curated, literature-grounded statements of the open
+            unknowns (the inverse of core functions).
+        </p>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The molecular activity of DYF-13/TTC26 beyond intraciliary-transport-particle-B binding is undefined. It is unknown which specific IFT-B subunit(s) DYF-13 contacts within the C. elegans complex and which ciliary cargo(es) it directly binds or is required to transport; cargo specificity (e.g. for the retrograde motor che-3/dynein-2) is stated only as a hypothesis.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span><span class="badge">ONTOLOGY</span>
+                <span class="badge">MF_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> It is firmly established that DYF-13 is an IFT-B subunit (co-purifies within IFT complex B), localizes to the cilium and undergoes IFT, is required for cilium assembly (dyf-13 mutants have short cilia lacking distal segments), and that IFT-B integrity is required for ciliary entry of dynein-2. Its fold is a TPR-repeat (alpha-solenoid) scaffold.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> IFT-B subunits are structural adaptors whose specific cargo/partner contacts determine which proteins a cilium can import; TTC26/IFT56 loss in vertebrates selectively perturbs Hedgehog and motility-related ciliary cargo, so mapping DYF-13&#39;s direct interactions would explain the specificity of its transport role. There is also no GO molecular-function term for a structural constituent of an IFT particle, forcing an IFT-B subunit to be annotated with the complex-binding term, which is why the gene reads as MF-dark.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Proximity/affinity proteomics and cross-linking mass spectrometry to map DYF-13&#39;s direct IFT-B neighbors; cargo-specific transport assays in dyf-13 mutants; a GO molecular-function term for an IFT-particle structural constituent.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"neither of which was included with certainty in"</em> — PMID:26980730</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> Whether C. elegans DYF-13 occupies the IFT-B core or peripheral sub-architecture has not been determined biochemically. Mammalian TTC26/IFT56 was assigned to the IFT-B core subcomplex, but the sub-complex position of the worm ortholog and the consequences of its loss for IFT-B stability in vivo are unmapped.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span><span class="badge">CURATION</span>
+                <span class="badge">CC_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> DYF-13 is confirmed as part of the IFT-B complex in C. elegans (mass spectrometry) and TTC26/IFT56 is placed in the IFT-B core in the mammalian interaction map, but the two have not been reconciled for the worm protein.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Knowing whether DYF-13 is a core or peripheral IFT-B subunit predicts how severely its loss should destabilize the whole particle versus a specific cargo-adaptor arm, informing interpretation of the dyf-13 mutant phenotype.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Salt-dissociation and reconstitution of the C. elegans IFT-B complex, or quantitative proteomics of IFT-B in dyf-13 mutants, to place DYF-13 in the core/peripheral architecture.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"we identified"</em> — PMID:26980730</li>
+
+            </ul>
+
+
+        </div>
+
+    </div>
+
+
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Deep Research Sections -->
+
+    <div class="section">
+        <h2 class="section-title">Deep Research</h2>
+
+        <details class="deep-research-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; gap: 1rem;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Falcon</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(dyf-13-deep-research-falcon.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="Q95QT8" data-a="DEEP_RESEARCH: Falcon" data-r="" data-act="DEEP_RESEARCH" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This deep research is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This deep research needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+
+                <div class="report-meta">
+
+                    <span class="report-meta-text">this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</span>
+
+
+                    <span class="report-badge">Falcon</span>
+
+
+                    <span class="report-badge">Edison Scientific Literature</span>
+
+
+                    <span class="report-badge">10 citations</span>
+
+
+                    <span class="report-badge">1 artifacts</span>
+
+
+                    <span class="report-meta-text">2026-07-04T19:27:30.270211</span>
+
+
+
+                </div>
+
+
+                <div class="artifact-list">
+
+
+
+                    <div class="artifact-link">
+                        <a href="dyf-13-deep-research-falcon_artifacts/artifact-00.md" class="term-link">Edison artifact artifact-00</a>
+                        <span>(text/markdown)</span>
+                    </div>
+
+
+                </div>
+
+                <p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h2 id="comprehensive-research-report-dyf-13-ift56ttc26-in-caenorhabditis-elegans">Comprehensive Research Report: <em>dyf-13</em> (IFT56/TTC26) in <em>Caenorhabditis elegans</em></h2>
+<h3 id="1-gene-and-protein-identity">1. Gene and Protein Identity</h3>
+<p>The <em>C. elegans</em> gene <em>dyf-13</em> (ORF name C27H5.7; UniProt Q95QT8) encodes intraflagellar transport protein 56 homolog (IFT56), also known in vertebrates as tetratricopeptide repeat domain 26 (TTC26). The protein is a highly conserved member of the IFT56 family, present in all ciliated organisms but absent from non-ciliated species, underscoring its dedicated role in ciliary biology (ishikawa2014ttc26dyf13isan pages 3-4, ishikawa2014ttc26dyf13isan pages 15-17). IFT56 (also known as TTC26, DYF-13, and PIFTC3) is a highly conserved intraflagellar transport complex B (IFT-B) protein (xin2017ift56regulatesvertebrate pages 1-2, ishikawa2014ttc26dyf13isan pages 1-2). The protein contains TPR-like helical domain superfamily features and TTC26/TPR_19 domains, consistent with tetratricopeptide repeat-mediated protein–protein interactions typical of IFT scaffold/adapter proteins (ishikawa2014ttc26dyf13isan pages 13-15).</p>
+<p>The following table summarizes the key properties of dyf-13/IFT56/TTC26:</p>
+<table>
+<thead>
+<tr>
+<th>Property</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Gene names and aliases</td>
+<td><strong>dyf-13</strong> in <em>Caenorhabditis elegans</em>; orthologous/alias names include <strong>TTC26</strong>, <strong>IFT56</strong>, and <strong>PIFTC3</strong>. Literature explicitly equates TTC26/DYF13/IFT56 across ciliated organisms, validating that the requested gene identity matches the UniProt entry for the worm dyf-13 protein (ishikawa2014ttc26dyf13isan pages 12-13, ishikawa2014ttc26dyf13isan pages 1-2, xin2017ift56regulatesvertebrate pages 1-2).</td>
+</tr>
+<tr>
+<td>Organism</td>
+<td>The target gene/protein is from <strong><em>Caenorhabditis elegans</em></strong>, where it functions in sensory cilia of amphid and phasmid neurons; cross-species functional data are available from zebrafish, mouse, mammalian cultured cells, and <em>Chlamydomonas</em> ortholog studies (efimenko2006caenorhabditiselegansdyf2an pages 2-3, zhang2012knockdownofttc26 pages 1-2, xin2017ift56regulatesvertebrate pages 1-2).</td>
+</tr>
+<tr>
+<td>Protein family</td>
+<td>DYF-13 belongs to the conserved <strong>IFT56/TTC26 family</strong>, a cilia-associated family present in ciliated organisms and absent from non-ciliated organisms, consistent with a dedicated role in intraflagellar transport and ciliary biology (ishikawa2014ttc26dyf13isan pages 3-4, ishikawa2014ttc26dyf13isan pages 15-17, xin2017ift56regulatesvertebrate pages 1-2).</td>
+</tr>
+<tr>
+<td>Domain structure</td>
+<td>UniProt annotates DYF-13/Q95QT8 with <strong>TPR-like helical superfamily</strong> features and <strong>TTC26 / TPR_19</strong> domains, consistent with tetratricopeptide repeat-mediated protein interaction/adaptor functions typical of IFT-associated scaffold proteins; this agrees with the experimentally supported role of IFT56/TTC26 as an IFT-B-associated adaptor rather than an enzyme (ishikawa2014ttc26dyf13isan pages 13-15, ishikawa2014ttc26dyf13isan pages 12-13).</td>
+</tr>
+<tr>
+<td>IFT-B subcomplex position</td>
+<td>IFT56/TTC26/DYF-13 is a component of <strong>IFT complex B</strong>, specifically placed in the <strong>IFT-B1b subgroup</strong> together with IFT46, IFT52, IFT70, and IFT88. Recent assembly work indicates IFT56 is part of the IFT-B1 branch and is linked through the IFT46-IFT52 module to other IFT-B subcomplexes (ishikawa2014ttc26dyf13isan pages 7-9, tasaki2025assemblyandmother pages 1-5).</td>
+</tr>
+<tr>
+<td>Primary function</td>
+<td>The best-supported primary function is as a <strong>cargo-selective IFT-B-associated adapter/regulator</strong>, not a catalytic protein. IFT56/TTC26/DYF-13 is dispensable for basic IFT train assembly/motility in some systems but is required for transport of a subset of ciliary cargoes, especially <strong>motility-related proteins</strong> such as inner dynein arm components, dynein regulatory complex proteins, and central pair-associated factors (ishikawa2014ttc26dyf13isan pages 10-12, ishikawa2014ttc26dyf13isan pages 7-9, ishikawa2014ttc26dyf13isan pages 12-13, ishikawa2014ttc26dyf13isan pages 13-15).</td>
+</tr>
+<tr>
+<td>Subcellular localization</td>
+<td>IFT56/TTC26/DYF-13 localizes to <strong>cilia/flagella</strong> and <strong>basal body-associated regions</strong>, with a punctate distribution characteristic of IFT proteins. In mammalian cells it undergoes bidirectional IFT; in zebrafish and photoreceptors, Ttc26 was also observed at the <strong>transition zone</strong>. Reported mammalian transport speeds for TTC26-GFP are ~<strong>1.22 ± 0.17 μm/s anterograde</strong> and <strong>0.92 ± 0.24 μm/s retrograde</strong> (ishikawa2014ttc26dyf13isan pages 2-3, ishikawa2014ttc26dyf13isan pages 6-7, zhang2012knockdownofttc26 pages 1-2, zhang2012knockdownofttc26 pages 2-4).</td>
+</tr>
+<tr>
+<td>Key phenotypes in <em>C. elegans</em></td>
+<td>dyf-13 is one of the classic <strong>Dyf (dye-filling defective)</strong> genes required for proper amphid/phasmid sensory cilium function. The Dyf class is associated with failed DiI filling of sensory neurons and abnormal ciliary structure. Prior work cited in later studies indicates <strong>shortened cilia</strong> in <em>C. elegans</em> dyf-13 mutants, and dyf-13 has been linked to regulation of OSM-3-kinesin/IFT-B behavior in sensory cilia (efimenko2006caenorhabditiselegansdyf2an pages 2-3, ishikawa2014ttc26dyf13isan pages 2-3, ishikawa2014ttc26dyf13isan pages 12-13).</td>
+</tr>
+<tr>
+<td>Key phenotypes in other organisms</td>
+<td>In <strong>zebrafish</strong>, ttc26 knockdown causes shortened or missing photoreceptor outer segments, pronephric cilia defects, kidney duct dilation, body curvature, edema, abnormal fluid flow, and reduced cilia length/number in Kupffer’s vesicle. In <strong>mouse/vertebrate systems</strong>, Ift56 loss causes developmental patterning defects, male sterility, gait abnormalities, shortened/abnormal cilia, and disorganized axonemal microtubules (zhang2012knockdownofttc26 pages 1-2, zhang2012knockdownofttc26 pages 6-7, zhang2012knockdownofttc26 pages 4-5, ishikawa2014ttc26dyf13isan pages 3-4, xin2017ift56regulatesvertebrate pages 1-2, xin2017ift56regulatesvertebrate pages 5-7).</td>
+</tr>
+<tr>
+<td>Signaling pathway involvement</td>
+<td>IFT56 is implicated in <strong>cilium-dependent Hedgehog signaling</strong>. In mouse Ift56/hop mutants, cilia form but fail to properly accumulate <strong>Gli2</strong> and <strong>Gli3</strong> at ciliary tips, while Smoothened localization can remain relatively normal; this leads to defective Shh-dependent patterning in limb and neural tube development. Thus, IFT56 supports signaling competence by maintaining IFT-B integrity and ciliary architecture needed for Gli trafficking (xin2017ift56regulatesvertebrate pages 4-5, xin2017ift56regulatesvertebrate pages 1-2, xin2017ift56regulatesvertebrate pages 2-3, xin2017ift56regulatesvertebrate pages 3-4).</td>
+</tr>
+<tr>
+<td>Human disease associations</td>
+<td>Human <strong>TTC26/IFT56</strong> has been linked to <strong>severe biliary ciliopathy</strong> by biallelic mutation studies, and broader cross-species work places IFT56 among IFT-B components whose dysfunction can contribute to ciliopathy phenotypes. Although the detailed clinical text was not retrievable here, the paper metadata and abstract identify TTC26 as a human disease gene in severe biliary ciliopathy (xin2017ift56regulatesvertebrate pages 5-7).</td>
+</tr>
+</tbody>
+</table>
+<p><em>Table: This table condenses the main verified properties of the C. elegans dyf-13 gene product and its orthologs, including molecular function, localization, phenotypes, and pathway relevance. It is useful as a quick-reference functional annotation summary grounded in the retrieved evidence.</em></p>
+<h3 id="2-primary-function-cargo-selective-adapter-in-intraflagellar-transport">2. Primary Function: Cargo-Selective Adapter in Intraflagellar Transport</h3>
+<p>DYF-13/IFT56/TTC26 is not an enzyme or transporter in the classical sense; rather, it functions as a <strong>cargo-selective adapter protein</strong> within the intraflagellar transport (IFT) machinery. The landmark study by Ishikawa et al. (2014) in <em>eLife</em> demonstrated that TTC26/DYF13 is an IFT complex B protein required for the transport of motility-related proteins into flagella (ishikawa2014ttc26dyf13isan pages 10-12, ishikawa2014ttc26dyf13isan pages 2-3). Unlike core IFT-B components, whose loss abolishes ciliogenesis, IFT56 is not required for assembly or movement of IFT particles themselves (ishikawa2014ttc26dyf13isan pages 7-9, ishikawa2014ttc26dyf13isan pages 10-12). Instead, <em>dyf13</em> mutant flagella in <em>Chlamydomonas reinhardtii</em> still assemble and IFT particle speed remains normal, but a specific subset of ciliary proteins is selectively depleted (ishikawa2014ttc26dyf13isan pages 10-12).</p>
+<p>Proteomic and biochemical analyses of <em>C. reinhardtii</em> <em>dyf13</em> mutant flagella revealed that the proteins requiring DYF13 for import are predominantly motility-related, including:<br />
+- <strong>Inner dynein arm components</strong> (species a, f, and g)<br />
+- <strong>Dynein regulatory complex</strong> proteins (e.g., PF2/DRC4)<br />
+- <strong>Central pair complex</strong> proteins<br />
+- Additional flagellar proteins such as FAP59, tektin, centrin, and enolase (ishikawa2014ttc26dyf13isan pages 13-15, ishikawa2014ttc26dyf13isan pages 10-12)</p>
+<p>This led to the concept that IFT56 functions as an adaptor between the main IFT complex and its cargo proteins, possibly by recruiting PIH proteins (specifically TWI1) that pre-assemble dynein arms to the IFT complex for transport (ishikawa2014ttc26dyf13isan pages 12-13). The mechanism by which IFT56 binds its various cargo proteins remains unclear; unlike tubulin, which has specific binding domains on IFT74 and IFT81, it is unknown whether IFT56 contains similarly specific binding sites for all of its cargoes (ishikawa2014ttc26dyf13isan pages 13-15).</p>
+<p>This finding supports the broader concept that different IFT proteins are responsible for different cargo subsets, providing a possible explanation for the complexity of the IFT machinery with its &gt;20 subunits (ishikawa2014ttc26dyf13isan pages 2-3).</p>
+<h3 id="3-position-within-the-ift-b-complex-architecture">3. Position within the IFT-B Complex Architecture</h3>
+<p>IFT56/TTC26/DYF-13 is a component of the <strong>IFT-B1b subgroup</strong> within the larger IFT-B complex. The 16-subunit IFT-B complex is subdivided into two major subcomplexes: IFT-B1 and IFT-B2 (tasaki2025assemblyandmother pages 1-5). IFT-B1 is further divided into IFT-B1a (containing IFT22, IFT25, IFT27, IFT74, IFT81) and IFT-B1b (containing <strong>IFT46, IFT52, IFT56, IFT70, and IFT88</strong>) (tasaki2025assemblyandmother pages 1-5). The IFT-B1b subgroup connects to IFT-B1a through an interaction between the IFT46-IFT52 dimer (from IFT-B1b) and the IFT74-IFT81 dimer (from IFT-B1a) (tasaki2025assemblyandmother pages 1-5).</p>
+<p>Through tandem affinity purification (TAP) analysis, TTC26/DYF13 was shown to physically interact with all known IFT complex B proteins but not with IFT complex A proteins or motor proteins (ishikawa2014ttc26dyf13isan pages 7-9). Sucrose density gradient analysis confirmed that TTC26/DYF13 comigrates with other IFT complex B proteins such as IFT46 and IFT74 (ishikawa2014ttc26dyf13isan pages 12-13, ishikawa2014ttc26dyf13isan pages 7-9). IFT56 interacts directly with IFT46 as part of the IFTB-1 subcomplex (xin2017ift56regulatesvertebrate pages 5-7). The IFT46–IFT56 dimer has been identified as the minimum entity needed for interaction with ANKRD55, a multiple sclerosis-associated protein, in microglial cells, further underscoring their close physical association within the IFT-B architecture (tasaki2025assemblyandmother pages 1-5).</p>
+<p>Despite being an IFT-B component, IFT56 acts as a <strong>peripheral</strong> rather than core structural component; its loss does not entirely abolish IFT-B complex assembly or IFT train movement, consistent with its role as a cargo-adapter module rather than a structural requirement for the transport machinery itself (ishikawa2014ttc26dyf13isan pages 12-13, ishikawa2014ttc26dyf13isan pages 7-9).</p>
+<h3 id="4-subcellular-localization">4. Subcellular Localization</h3>
+<p>IFT56/TTC26/DYF-13 localizes to <strong>primary cilia and basal bodies</strong>, displaying a punctate distribution along the ciliary length that is characteristic of IFT proteins (ishikawa2014ttc26dyf13isan pages 2-3, ishikawa2014ttc26dyf13isan pages 3-4). The protein undergoes <strong>bidirectional intraflagellar transport</strong> along the ciliary axoneme. In mammalian cells, TTC26-GFP moves at anterograde speeds of 1.22 ± 0.17 μm/s and retrograde speeds of 0.92 ± 0.24 μm/s, comparable to the established IFT protein IFT88 (ishikawa2014ttc26dyf13isan pages 6-7). These speeds indicate that TTC26 moves together with other IFT proteins as part of the complex (ishikawa2014ttc26dyf13isan pages 6-7).</p>
+<p>In zebrafish, Ttc26 was specifically localized to the <strong>transition zone</strong> of both photoreceptor sensory cilia and primary cilia in cultured renal cells (zhang2012knockdownofttc26 pages 1-2, zhang2012knockdownofttc26 pages 2-4). In <em>C. elegans</em>, DYF-13 protein undergoes IFT motion in sensory cilia of amphid and phasmid neurons (ishikawa2014ttc26dyf13isan pages 6-7). The protein is present in both motile flagella and non-motile primary and sensory cilia, suggesting functions beyond motility cargo transport alone (ishikawa2014ttc26dyf13isan pages 15-17).</p>
+<h3 id="5-phenotypes-in-c-elegans">5. Phenotypes in <em>C. elegans</em></h3>
+<p>The gene name <em>dyf-13</em> derives from the <strong>Dye-Filling defective (Dyf)</strong> phenotype class in <em>C. elegans</em>. The <em>dyf</em> class consists of 13 members (<em>dyf-1</em> to <em>dyf-13</em>), all exhibiting reduced fluorescent dye (DiI) filling of amphid and phasmid sensory neurons, indicative of structural defects in the environmentally exposed cilia of these neurons (efimenko2006caenorhabditiselegansdyf2an pages 2-3). <em>dyf-13</em> mutants display abnormally <strong>short cilia</strong>, consistent with a role for DYF-13 in determining proper cilium length (ishikawa2014ttc26dyf13isan pages 12-13, ishikawa2014ttc26dyf13isan pages 2-3).</p>
+<p>Previous studies suggested that DYF-13 may function as an IFT regulator that modulates either the activity of the <strong>OSM-3-kinesin</strong> motor or its association with IFT subcomplex B in <em>C. elegans</em> sensory cilia (ishikawa2014ttc26dyf13isan pages 12-13, ishikawa2014ttc26dyf13isan pages 2-3). In the <em>C. elegans</em> sensory cilium, IFT is driven cooperatively by two kinesin motors: heterotrimeric <strong>kinesin-II</strong> and homodimeric <strong>OSM-3/KIF17</strong>. In the middle segment, both motors work redundantly, while in the distal segment, only OSM-3 drives anterograde transport (efimenko2006caenorhabditiselegansdyf2an pages 2-3, efimenko2006caenorhabditiselegansdyf2an pages 1-2). DYF-13 appears to contribute to the regulation of this bipartite motor system.</p>
+<p>Importantly, <em>dyf-13</em> mutants display a distinct phenotype compared to other IFT-B mutants in <em>C. elegans</em> when probed by quantitative imaging of ARL-13/ARL13B compartmentalization. In wild-type worms, ARL-13 is restricted to the middle segment of amphid/phasmid cilia, but in most IFT-B mutants, ARL-13 accumulates strongly at the periciliary membrane (PCM). Notably, <em>dyf-13/TTC26</em> mutants showed only moderate periciliary ARL-13 accumulation and moderately fast FRAP (fluorescence recovery after photobleaching) rates between ciliary and PCM pools (half-time recovery of ~50–78 seconds), distinct from other IFT-B mutants that displayed much slower exchange (cevik2013activetransportand pages 6-8). Furthermore, <em>dyf-13;nphp-4</em> double mutants possessed even faster bidirectional recovery kinetics (half-time ~14–34 seconds), suggesting partially redundant functions for these genes in regulating ARL-13 diffusion at the ciliary/PCM boundary (cevik2013activetransportand pages 6-8). These data indicate that DYF-13 has roles in establishing and maintaining protein compartmentalization within the cilium, particularly at the transition zone diffusion barrier.</p>
+<p>The <em>dyf-13</em> gene has also been implicated in anthelmintic drug uptake. DYF-13 was identified among genes involved in dynein import, alongside OSM-1 and DAF-6, that contribute to intraflagellar transport in the ciliary distal segment of amphid neurons and influence avermectin susceptibility in <em>C. elegans</em> (brinzer2021theuptakeof pages 4-7).</p>
+<h3 id="6-conserved-functions-evidence-from-other-organisms">6. Conserved Functions: Evidence from Other Organisms</h3>
+<p><strong>Zebrafish:</strong> Morpholino knockdown of <em>ttc26</em> in zebrafish embryos produced multiple cilia-related defects: shortened or absent photoreceptor outer segments, pronephric cilia defects with disrupted and disorganized cilia, pronephric duct dilation, body curvature, cardiac edema, reduced cilia length and number in Kupffer's vesicle, and abolished directional fluid flow (zhang2012knockdownofttc26 pages 1-2, zhang2012knockdownofttc26 pages 6-7, zhang2012knockdownofttc26 pages 4-5, ishikawa2014ttc26dyf13isan pages 3-4). In mIMCD3 cultured kidney cells, shRNA knockdown of Ttc26 led to significantly shortened cilia with enlarged ends (zhang2012knockdownofttc26 pages 4-5).</p>
+<p><strong><em>Chlamydomonas reinhardtii</em>:</strong> Mutation of <em>DYF13</em> in <em>Chlamydomonas</em> produced short flagella with pronounced motility defects, while IFT particle assembly and speed were normal—the key finding that established IFT56 as a cargo-specific adapter (ishikawa2014ttc26dyf13isan pages 10-12, ishikawa2014ttc26dyf13isan pages 7-9).</p>
+<p><strong>Mouse:</strong> The <em>Ift56^hop</em> (Hsp90-opposing protein) mutant mouse provided critical insights into vertebrate IFT56 function. <em>Ift56^hop</em> mutants form normal numbers of cilia but the cilia lack IFT56 protein (xin2017ift56regulatesvertebrate pages 2-3). These mutant cilia exhibit disorganized microtubule structures (8+0 or 7+0 arrangements instead of normal 9+0), indicating IFT56 is essential for maintaining proper ciliary microtubule architecture (xin2017ift56regulatesvertebrate pages 5-7). IFT81 and IFT27 are significantly reduced in <em>Ift56^hop</em> cilia, while IFT88 accumulates abnormally at the ciliary base rather than distributing along the axoneme, demonstrating IFT56's importance for IFT-B complex integrity (xin2017ift56regulatesvertebrate pages 5-7, xin2017ift56regulatesvertebrate pages 4-5). The mutant mice display <strong>preaxial polydactyly</strong>, gait abnormalities, and <strong>male sterility</strong> (xin2017ift56regulatesvertebrate pages 1-2).</p>
+<h3 id="7-signaling-pathway-involvement-hedgehog-signaling">7. Signaling Pathway Involvement: Hedgehog Signaling</h3>
+<p>A major function revealed by the mouse <em>Ift56^hop</em> mutant is the requirement for IFT56 in <strong>cilium-dependent Hedgehog (Hh) signaling</strong>. Both Gli2 and Gli3 show significantly reduced localization to ciliary tips in <em>Ift56^hop</em> cells, with over half of mutant cilia lacking detectable Gli2 and approximately 80% lacking Gli3 (xin2017ift56regulatesvertebrate pages 4-5, xin2017ift56regulatesvertebrate pages 1-2). Importantly, ciliary Smoothened (Smo) distribution and intensity remain relatively unaffected when the Hh pathway is activated, indicating the defect is specifically in Gli protein trafficking to ciliary tips (xin2017ift56regulatesvertebrate pages 3-4). The <em>Ift56^hop</em> phenotype results primarily from impaired Gli repressor (GliR) function rather than ectopic Shh pathway activation, leading to developmental patterning defects including preaxial polydactyly (an extra anterior digit) and differential effects in rostral versus caudal neural tube specification (xin2017ift56regulatesvertebrate pages 3-4, xin2017ift56regulatesvertebrate pages 2-3). The reduction in IFT27 in <em>Ift56^hop</em> cilia is particularly notable, as IFT27 has been independently linked to Hedgehog signaling through BBSome regulation (xin2017ift56regulatesvertebrate pages 4-5). While <em>C. elegans</em> lacks a canonical Hedgehog signaling pathway, these vertebrate findings illuminate the broader conserved role of IFT56 in maintaining IFT-B complex integrity for ciliary cargo trafficking.</p>
+<h3 id="8-human-disease-relevance">8. Human Disease Relevance</h3>
+<p>Human <strong>TTC26</strong> mutations have been linked to <strong>severe biliary ciliopathy</strong> through biallelic mutation studies, where patient cells displayed disrupted ciliary staining for IFT-B markers and abnormal sonic hedgehog signaling. This places TTC26/IFT56 among IFT-B components whose dysfunction can contribute to the spectrum of ciliopathy phenotypes. These findings were corroborated by the <em>Ift56^hop</em> mouse phenotype, which contrasts with other IFT-B mutants in that cilia still form but have impaired function (xin2017ift56regulatesvertebrate pages 5-7, xin2017ift56regulatesvertebrate pages 7-8). The relatively mild phenotype compared to mutations in core IFT-B components such as IFT88 or IFT172 is consistent with IFT56's peripheral, cargo-selective role within the complex.</p>
+<h3 id="9-summary-and-conclusions">9. Summary and Conclusions</h3>
+<p>DYF-13 (Q95QT8) in <em>C. elegans</em> is the nematode ortholog of vertebrate TTC26/IFT56, a tetratricopeptide repeat-containing component of the IFT-B1b subgroup within the intraflagellar transport complex B. The protein is not an enzyme or transporter but functions as a <strong>cargo-selective adapter</strong> that facilitates the transport of specific ciliary cargo proteins—particularly motility-related components such as inner dynein arms, dynein regulatory complex proteins, and central pair components—via IFT trains from the cell body into cilia and flagella. In <em>C. elegans</em>, DYF-13 localizes to the sensory cilia of amphid and phasmid neurons, undergoes bidirectional IFT movement, and is required for proper cilium length, ciliary protein compartmentalization, and sensory neuron dye-filling. Through cross-species studies, IFT56 has been shown to maintain IFT-B complex integrity and ciliary microtubule architecture, and to be essential for Hedgehog signaling-dependent developmental patterning in vertebrates via Gli2/Gli3 trafficking to ciliary tips. Its loss leads to ciliopathy phenotypes across species, from dye-filling defects in worms to photoreceptor degeneration and polydactyly in vertebrates and biliary ciliopathy in humans.</p>
+<p>References</p>
+<ol>
+<li>
+<p>(ishikawa2014ttc26dyf13isan pages 3-4): Hiroaki Ishikawa, Takahiro Ide, Toshiki Yagi, Xue Jiang, Masafumi Hirono, Hiroyuki Sasaki, Haruaki Yanagisawa, Kimberly A Wemmer, Didier YR Stainier, Hongmin Qin, Ritsu Kamiya, and Wallace F Marshall. Ttc26/dyf13 is an intraflagellar transport protein required for transport of motility-related proteins into flagella. eLife, Mar 2014. URL: https://doi.org/10.7554/elife.01566, doi:10.7554/elife.01566. This article has 96 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(ishikawa2014ttc26dyf13isan pages 15-17): Hiroaki Ishikawa, Takahiro Ide, Toshiki Yagi, Xue Jiang, Masafumi Hirono, Hiroyuki Sasaki, Haruaki Yanagisawa, Kimberly A Wemmer, Didier YR Stainier, Hongmin Qin, Ritsu Kamiya, and Wallace F Marshall. Ttc26/dyf13 is an intraflagellar transport protein required for transport of motility-related proteins into flagella. eLife, Mar 2014. URL: https://doi.org/10.7554/elife.01566, doi:10.7554/elife.01566. This article has 96 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(xin2017ift56regulatesvertebrate pages 1-2): Daisy Xin, Kasey J. Christopher, Lewie Zeng, Yong Kong, and Scott D. Weatherbee. Ift56 regulates vertebrate developmental patterning by maintaining iftb complex integrity and ciliary microtubule architecture. Journal of Cell Science, 130:e1.2-e1.2, May 2017. URL: https://doi.org/10.1242/jcs.205013, doi:10.1242/jcs.205013. This article has 38 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(ishikawa2014ttc26dyf13isan pages 1-2): Hiroaki Ishikawa, Takahiro Ide, Toshiki Yagi, Xue Jiang, Masafumi Hirono, Hiroyuki Sasaki, Haruaki Yanagisawa, Kimberly A Wemmer, Didier YR Stainier, Hongmin Qin, Ritsu Kamiya, and Wallace F Marshall. Ttc26/dyf13 is an intraflagellar transport protein required for transport of motility-related proteins into flagella. eLife, Mar 2014. URL: https://doi.org/10.7554/elife.01566, doi:10.7554/elife.01566. This article has 96 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(ishikawa2014ttc26dyf13isan pages 13-15): Hiroaki Ishikawa, Takahiro Ide, Toshiki Yagi, Xue Jiang, Masafumi Hirono, Hiroyuki Sasaki, Haruaki Yanagisawa, Kimberly A Wemmer, Didier YR Stainier, Hongmin Qin, Ritsu Kamiya, and Wallace F Marshall. Ttc26/dyf13 is an intraflagellar transport protein required for transport of motility-related proteins into flagella. eLife, Mar 2014. URL: https://doi.org/10.7554/elife.01566, doi:10.7554/elife.01566. This article has 96 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(ishikawa2014ttc26dyf13isan pages 12-13): Hiroaki Ishikawa, Takahiro Ide, Toshiki Yagi, Xue Jiang, Masafumi Hirono, Hiroyuki Sasaki, Haruaki Yanagisawa, Kimberly A Wemmer, Didier YR Stainier, Hongmin Qin, Ritsu Kamiya, and Wallace F Marshall. Ttc26/dyf13 is an intraflagellar transport protein required for transport of motility-related proteins into flagella. eLife, Mar 2014. URL: https://doi.org/10.7554/elife.01566, doi:10.7554/elife.01566. This article has 96 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(efimenko2006caenorhabditiselegansdyf2an pages 2-3): Evgeni Efimenko, Oliver E. Blacque, Guangshuo Ou, Courtney J. Haycraft, Bradley K. Yoder, Jonathan M. Scholey, Michel R. Leroux, and Peter Swoboda. <i>caenorhabditis elegans</i>dyf-2, an orthologue of human wdr19, is a component of the intraflagellar transport machinery in sensory cilia. Molecular Biology of the Cell, 17:4801-4811, Nov 2006. URL: https://doi.org/10.1091/mbc.e06-04-0260, doi:10.1091/mbc.e06-04-0260. This article has 98 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(zhang2012knockdownofttc26 pages 1-2): Qi Zhang, Qin Liu, Chrissy Austin, Iain Drummond, and Eric A. Pierce. Knockdown of ttc26 disrupts ciliogenesis of the photoreceptor cells and the pronephros in zebrafish. Molecular Biology of the Cell, 23:3069-3078, Aug 2012. URL: https://doi.org/10.1091/mbc.e12-01-0019, doi:10.1091/mbc.e12-01-0019. This article has 35 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(ishikawa2014ttc26dyf13isan pages 7-9): Hiroaki Ishikawa, Takahiro Ide, Toshiki Yagi, Xue Jiang, Masafumi Hirono, Hiroyuki Sasaki, Haruaki Yanagisawa, Kimberly A Wemmer, Didier YR Stainier, Hongmin Qin, Ritsu Kamiya, and Wallace F Marshall. Ttc26/dyf13 is an intraflagellar transport protein required for transport of motility-related proteins into flagella. eLife, Mar 2014. URL: https://doi.org/10.7554/elife.01566, doi:10.7554/elife.01566. This article has 96 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(tasaki2025assemblyandmother pages 1-5): Koshi Tasaki, Yohei Katoh, Hye-Won Shin, and Kazuhisa Nakayama. Assembly and mother centriole recruitment of ift-b subcomplexes to form ift-b holocomplex. Cell structure and function, 50:157-168, Jun 2025. URL: https://doi.org/10.1247/csf.25027, doi:10.1247/csf.25027. This article has 0 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(ishikawa2014ttc26dyf13isan pages 10-12): Hiroaki Ishikawa, Takahiro Ide, Toshiki Yagi, Xue Jiang, Masafumi Hirono, Hiroyuki Sasaki, Haruaki Yanagisawa, Kimberly A Wemmer, Didier YR Stainier, Hongmin Qin, Ritsu Kamiya, and Wallace F Marshall. Ttc26/dyf13 is an intraflagellar transport protein required for transport of motility-related proteins into flagella. eLife, Mar 2014. URL: https://doi.org/10.7554/elife.01566, doi:10.7554/elife.01566. This article has 96 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(ishikawa2014ttc26dyf13isan pages 2-3): Hiroaki Ishikawa, Takahiro Ide, Toshiki Yagi, Xue Jiang, Masafumi Hirono, Hiroyuki Sasaki, Haruaki Yanagisawa, Kimberly A Wemmer, Didier YR Stainier, Hongmin Qin, Ritsu Kamiya, and Wallace F Marshall. Ttc26/dyf13 is an intraflagellar transport protein required for transport of motility-related proteins into flagella. eLife, Mar 2014. URL: https://doi.org/10.7554/elife.01566, doi:10.7554/elife.01566. This article has 96 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(ishikawa2014ttc26dyf13isan pages 6-7): Hiroaki Ishikawa, Takahiro Ide, Toshiki Yagi, Xue Jiang, Masafumi Hirono, Hiroyuki Sasaki, Haruaki Yanagisawa, Kimberly A Wemmer, Didier YR Stainier, Hongmin Qin, Ritsu Kamiya, and Wallace F Marshall. Ttc26/dyf13 is an intraflagellar transport protein required for transport of motility-related proteins into flagella. eLife, Mar 2014. URL: https://doi.org/10.7554/elife.01566, doi:10.7554/elife.01566. This article has 96 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(zhang2012knockdownofttc26 pages 2-4): Qi Zhang, Qin Liu, Chrissy Austin, Iain Drummond, and Eric A. Pierce. Knockdown of ttc26 disrupts ciliogenesis of the photoreceptor cells and the pronephros in zebrafish. Molecular Biology of the Cell, 23:3069-3078, Aug 2012. URL: https://doi.org/10.1091/mbc.e12-01-0019, doi:10.1091/mbc.e12-01-0019. This article has 35 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(zhang2012knockdownofttc26 pages 6-7): Qi Zhang, Qin Liu, Chrissy Austin, Iain Drummond, and Eric A. Pierce. Knockdown of ttc26 disrupts ciliogenesis of the photoreceptor cells and the pronephros in zebrafish. Molecular Biology of the Cell, 23:3069-3078, Aug 2012. URL: https://doi.org/10.1091/mbc.e12-01-0019, doi:10.1091/mbc.e12-01-0019. This article has 35 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(zhang2012knockdownofttc26 pages 4-5): Qi Zhang, Qin Liu, Chrissy Austin, Iain Drummond, and Eric A. Pierce. Knockdown of ttc26 disrupts ciliogenesis of the photoreceptor cells and the pronephros in zebrafish. Molecular Biology of the Cell, 23:3069-3078, Aug 2012. URL: https://doi.org/10.1091/mbc.e12-01-0019, doi:10.1091/mbc.e12-01-0019. This article has 35 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(xin2017ift56regulatesvertebrate pages 5-7): Daisy Xin, Kasey J. Christopher, Lewie Zeng, Yong Kong, and Scott D. Weatherbee. Ift56 regulates vertebrate developmental patterning by maintaining iftb complex integrity and ciliary microtubule architecture. Journal of Cell Science, 130:e1.2-e1.2, May 2017. URL: https://doi.org/10.1242/jcs.205013, doi:10.1242/jcs.205013. This article has 38 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(xin2017ift56regulatesvertebrate pages 4-5): Daisy Xin, Kasey J. Christopher, Lewie Zeng, Yong Kong, and Scott D. Weatherbee. Ift56 regulates vertebrate developmental patterning by maintaining iftb complex integrity and ciliary microtubule architecture. Journal of Cell Science, 130:e1.2-e1.2, May 2017. URL: https://doi.org/10.1242/jcs.205013, doi:10.1242/jcs.205013. This article has 38 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(xin2017ift56regulatesvertebrate pages 2-3): Daisy Xin, Kasey J. Christopher, Lewie Zeng, Yong Kong, and Scott D. Weatherbee. Ift56 regulates vertebrate developmental patterning by maintaining iftb complex integrity and ciliary microtubule architecture. Journal of Cell Science, 130:e1.2-e1.2, May 2017. URL: https://doi.org/10.1242/jcs.205013, doi:10.1242/jcs.205013. This article has 38 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(xin2017ift56regulatesvertebrate pages 3-4): Daisy Xin, Kasey J. Christopher, Lewie Zeng, Yong Kong, and Scott D. Weatherbee. Ift56 regulates vertebrate developmental patterning by maintaining iftb complex integrity and ciliary microtubule architecture. Journal of Cell Science, 130:e1.2-e1.2, May 2017. URL: https://doi.org/10.1242/jcs.205013, doi:10.1242/jcs.205013. This article has 38 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(efimenko2006caenorhabditiselegansdyf2an pages 1-2): Evgeni Efimenko, Oliver E. Blacque, Guangshuo Ou, Courtney J. Haycraft, Bradley K. Yoder, Jonathan M. Scholey, Michel R. Leroux, and Peter Swoboda. <i>caenorhabditis elegans</i>dyf-2, an orthologue of human wdr19, is a component of the intraflagellar transport machinery in sensory cilia. Molecular Biology of the Cell, 17:4801-4811, Nov 2006. URL: https://doi.org/10.1091/mbc.e06-04-0260, doi:10.1091/mbc.e06-04-0260. This article has 98 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(cevik2013activetransportand pages 6-8): Sebiha Cevik, Anna A. W. M. Sanders, Erwin Van Wijk, Karsten Boldt, Lara Clarke, Jeroen van Reeuwijk, Yuji Hori, Nicola Horn, Lisette Hetterschijt, Anita Wdowicz, Andrea Mullins, Katarzyna Kida, Oktay I. Kaplan, Sylvia E. C. van Beersum, Ka Man Wu, Stef J. F. Letteboer, Dorus A. Mans, Toshiaki Katada, Kenji Kontani, Marius Ueffing, Ronald Roepman, Hannie Kremer, and Oliver E. Blacque. Active transport and diffusion barriers restrict joubert syndrome-associated arl13b/arl-13 to an inv-like ciliary membrane subdomain. PLoS Genetics, 9:e1003977, Dec 2013. URL: https://doi.org/10.1371/journal.pgen.1003977, doi:10.1371/journal.pgen.1003977. This article has 115 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(brinzer2021theuptakeof pages 4-7): Robert A. Brinzer, David J. France, Claire McMaster, Stuart Ruddell, Alan D. Winter, and Antony P. Page. The uptake of avermectins in caenorhabditis elegans is dependent on intra-flagellar transport and other protein trafficking pathways. bioRxiv, Oct 2021. URL: https://doi.org/10.1101/2021.10.22.465401, doi:10.1101/2021.10.22.465401. This article has 1 citations.</p>
+</li>
+<li>
+<p>(xin2017ift56regulatesvertebrate pages 7-8): Daisy Xin, Kasey J. Christopher, Lewie Zeng, Yong Kong, and Scott D. Weatherbee. Ift56 regulates vertebrate developmental patterning by maintaining iftb complex integrity and ciliary microtubule architecture. Journal of Cell Science, 130:e1.2-e1.2, May 2017. URL: https://doi.org/10.1242/jcs.205013, doi:10.1242/jcs.205013. This article has 38 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+</ol>
+<h2 id="artifacts">Artifacts</h2>
+<ul>
+<li><a href="dyf-13-deep-research-falcon_artifacts/artifact-00.md">Edison artifact artifact-00</a></li>
+</ul>
+<h2 id="citations">Citations</h2>
+<ol>
+<li>tasaki2025assemblyandmother pages 1-5</li>
+<li>cevik2013activetransportand pages 6-8</li>
+<li>brinzer2021theuptakeof pages 4-7</li>
+<li>https://doi.org/10.7554/elife.01566,</li>
+<li>https://doi.org/10.1242/jcs.205013,</li>
+<li>https://doi.org/10.1091/mbc.e06-04-0260,</li>
+<li>https://doi.org/10.1091/mbc.e12-01-0019,</li>
+<li>https://doi.org/10.1247/csf.25027,</li>
+<li>https://doi.org/10.1371/journal.pgen.1003977,</li>
+<li>https://doi.org/10.1101/2021.10.22.465401,</li>
+</ol>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(dyf-13-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="Q95QT8" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="dyf-13-c-elegans-research-notes">dyf-13 (C. elegans) research notes</h1>
+<p>UniProt: Q95QT8 (IFT56_CAEEL). WormBase: WBGene00001129 / C27H5.7. Gene name from Starich<br />
+et al. 1995 dye-filling-defective screen.</p>
+<h2 id="molecular-identity-verified-from-uniprot-record">Molecular identity (verified from UniProt record)</h2>
+<ul>
+<li><code>RecName: Intraflagellar transport protein 56 homolog</code>; <code>AltName: Abnormal dye filling
+  protein 13</code>. Belongs to the <strong>IFT56 family</strong> (SIMILARITY block). PANTHER family<br />
+<strong>PTHR14781 "INTRAFLAGELLAR TRANSPORT PROTEIN 56"</strong>; InterPro <strong>IPR030511 TTC26</strong>.</li>
+<li>Therefore dyf-13 is the C. elegans ortholog of vertebrate <strong>TTC26 / IFT56 / IFT-B protein<br />
+  56</strong>. 574 aa, contains multiple <strong>TPR repeats</strong> (UniProt annotates TPR 1/2/3; Pfam<br />
+  PF14559 TPR_19; SUPFAM TPR-like). Architecture = tetratricopeptide-repeat (α-solenoid)<br />
+  scaffold protein, the canonical fold of many IFT-B peripheral subunits.</li>
+<li>Two isoforms by alternative splicing: Q95QT8-1 (displayed) and Q95QT8-2 ("b", VSP_057361,<br />
+  missing residues 1–22). No evidence of isoform-specific function.</li>
+<li>ComplexPortal: CPX-1290 "Intraflagellar transport complex B".</li>
+</ul>
+<h2 id="known-well-supported">KNOWN (well supported)</h2>
+<h3 id="core-identity-a-novel-core-ift-component-required-for-cilium-function">Core identity: a novel core IFT component required for cilium function</h3>
+<ul>
+<li>dyf-13 was cloned by Blacque et al. 2005 and shown to be the gene disrupted in dyf-13(mn396):<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/15916950" title="we demonstrate that the ciliary structural defect of C. elegans dyf-13(mn396)   mutants is caused by a mutation in C27H5.7a">PMID:15916950</a>. The gene product <strong>undergoes IFT</strong> like other<br />
+  IFT proteins: <a href="https://pubmed.ncbi.nlm.nih.gov/15916950" title="One of these, C27H5.7a, encodes a ciliary protein that undergoes   IFT. As with other IFT proteins, its ciliary localization and transport is disrupted by   mutations in IFT and bbs genes.">PMID:15916950</a> Conclusion of that paper:<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/15916950" title="DYF-13, an evolutionarily conserved protein, is a novel core IFT component   required for cilia function.">PMID:15916950</a></li>
+</ul>
+<h3 id="localization-cilium-undergoes-ift">Localization: cilium / undergoes IFT</h3>
+<ul>
+<li>DYF-13::GFP is a bona fide IFT reporter that localizes along amphid channel cilia (TZ, middle<br />
+  and distal segments) and is transported: <a href="https://pubmed.ncbi.nlm.nih.gov/18316409" title="Localization of both DYF-1∷GFP (g1–g3)   and DYF-13∷GFP (g1–g4) appears normal.">PMID:18316409</a> (used as an IFT reporter, strain Ex[DYF-13∷GFP]).</li>
+<li>UniProt SUBCELLULAR LOCATION: Cell projection, cilium (by similarity to mouse Q5PR66).</li>
+<li>ComplexPortal (NAS, PMID:28479320) locates it to the cilium.</li>
+</ul>
+<h3 id="part-of-ift-b-complex">Part of IFT-B complex</h3>
+<ul>
+<li>Yi et al. 2017 identified dyf-13 as a component of IFT complex B by affinity purification /<br />
+  mass spectrometry: UniProt SUBUNIT: "Component of the IFT complex B composed of at least che-2,<br />
+  che-13, dyf-1, dyf-3, dyf-6, dyf-11, dyf-13, ift-20, ift-74, ift-81, ifta-2, osm-1, osm-5 and<br />
+  osm-6" {ECO:0000269|PubMed:28479320}. The paper shows disruption of the IFT-B complex abolishes<br />
+  dynein-2's ciliary localization: <a href="https://pubmed.ncbi.nlm.nih.gov/28479320" title="Disruption of the dynein-2 tail domain, light   intermediate chain, or intraflagellar transport (IFT)-B complex abolishes dynein-2's ciliary   localization, revealing their important roles in ciliary entry of dynein-2.">PMID:28479320</a></li>
+<li>Mammalian TTC26/IFT56 was assigned to the IFT-B core subcomplex by Katoh et al. 2016:<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/26980730" title="we identified TTC26/IFT56 and Cluap1/IFT38, neither of which was included with   certainty in previous models of the IFT-B complex, as integral components of the core and   peripheral subcomplexes, respectively.">PMID:26980730</a></li>
+</ul>
+<h3 id="function-anterograde-transport-cilium-assembly">Function: anterograde transport / cilium assembly</h3>
+<ul>
+<li>UniProt FUNCTION: "Component of the intraflagellar transport (IFT) complex B required for<br />
+  transport of proteins in the motile cilium (PubMed:15916950, PubMed:28479320). May be required<br />
+  for ciliary entrance and transport of specific ciliary cargo proteins such as che-3 which are<br />
+  related to motility (PubMed:28479320)." Note: the "motile cilium" phrasing is UniProt boilerplate<br />
+  transferred from the vertebrate ortholog; C. elegans sensory cilia are non-motile, but the<br />
+  IFT/assembly role is conserved.</li>
+<li>Disruption phenotype (structural): UniProt DISRUPTION PHENOTYPE "Structural cilia defect: cilia<br />
+  are short and lack distal portions." {ECO:0000269|PubMed:15916950}. Consistent with an IFT-B/<br />
+  anterograde defect (distal-segment loss).</li>
+<li>The dyf-13 mutant shows partial IFT-cargo defects: <a href="https://pubmed.ncbi.nlm.nih.gov/18316409" title="The dyf-13 mutant, similar to   nphp-4 animals, occasionally lacks OSM-6∷GFP in amphid distal segments (Blacque et al., 2005;   Ou et al., 2005).">PMID:18316409</a></li>
+</ul>
+<h3 id="dye-filling-sensory-phenotype-and-x-box-regulation">Dye-filling / sensory phenotype and X-box regulation</h3>
+<ul>
+<li>Named for the Dyf (dye-filling defective) phenotype indicative of general cilium structural<br />
+  defects; part of the dyf-1..dyf-13 class: <a href="https://pubmed.ncbi.nlm.nih.gov/16957054" title="this class of ciliary mutants, which   is comprised of 13 members, dyf-1 to dyf-13.">PMID:16957054</a> dyf-13 is a DAF-19/RFX X-box-regulated ciliary<br />
+  gene, cloned via the X-box motif: <a href="https://pubmed.ncbi.nlm.nih.gov/16957054" title="threedyfgenes (dyf-1,dyf-3anddyf-13) were   cloned and their importance for the development of cilia has been demonstrated">PMID:16957054</a>.</li>
+<li>Conserved IFT component enriched in the Chlamydomonas flagellar proteome:<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/18369462" title="several other proteins associated with and necessary for the function of the IFT   machinery and cilium formation have been discovered in C. elegans , namely DYF-1 [32] DYF-2 [33],   DYF-3 [34], DYF-13 [35], and IFTA-1 [36]. Like known IFT particle subcomplex A/B components,   orthologs of these C. elegans proteins are enriched within the membrane-plus-matrix fraction of   the recently identified Chlamydomonas flagellar proteome">PMID:18369462</a>.</li>
+</ul>
+<h2 id="not-known-open-questions">NOT known / open questions</h2>
+<ul>
+<li><strong>Molecular activity beyond "IFT-B particle binding" is undefined.</strong> dyf-13/TTC26/IFT56 is a<br />
+  TPR-scaffold subunit; which specific IFT-B subunit(s) it contacts and which cargo(es) it directly<br />
+  binds within the worm complex are not experimentally mapped. UniProt frames cargo specificity as<br />
+  a hypothesis ("May be required for ... transport of specific ciliary cargo proteins such as che-3").<br />
+  This is the classic structural-subunit MF-dark/ontology-gap situation described in<br />
+  projects/FUNCTION_KNOWLEDGE_GAPS.md.</li>
+<li><strong>Core vs. peripheral position of the worm protein is not directly determined.</strong> Mammalian<br />
+  TTC26/IFT56 was placed in the IFT-B <em>core</em> by Katoh 2016 (PMID:26980730); whether C. elegans<br />
+  dyf-13 occupies the same sub-architectural position has not been shown biochemically.</li>
+<li><strong>No direct enzymatic activity</strong> is expected or reported (TPR scaffold; no catalytic motifs).</li>
+<li>Basal body vs. ciliary-base pool: the IBA annotations place it at the ciliary basal body and<br />
+  ciliary base, but there is no worm-specific experimental sub-ciliary localization beyond<br />
+  "along the cilium".</li>
+</ul>
+<h2 id="annotation-review-orientation">Annotation review orientation</h2>
+<p>GOA has 11 annotations:<br />
+- 6 IBA (GO_REF:0000033) from PANTHER PTHR14781: ciliary basal body, intraciliary transport<br />
+  particle B, intraciliary anterograde transport, intraciliary transport involved in cilium<br />
+  assembly, ciliary base, intraciliary transport particle B binding. All consistent with an<br />
+  IFT-B subunit — ACCEPT (the last three are core; basal body/base are supporting locations).<br />
+- 1 IEA (GO_REF:0000044, UniProt SubCell) cilium — ACCEPT (redundant with NAS cilium).<br />
+- 4 NAS (PMID:28479320, ComplexPortal): cilium, intraciliary transport particle B, intraciliary<br />
+  transport, cilium assembly. All consistent — ACCEPT; the two most specific (IFT particle B,<br />
+  cilium assembly / intraciliary transport) are core.</p>
+<p>No REMOVE candidates: every annotation is on-pathway for an IFT-B/TTC26 ortholog. No experimental<br />
+annotations are being second-guessed. The IBA/NAS evidence is coherent with strong primary<br />
+experimental literature (PMID:15916950, PMID:28479320).</p>
+<h2 id="references-used">References used</h2>
+<ul>
+<li>PMID:15916950 Blacque et al. 2005, Curr Biol — cloning of dyf-13; core IFT component. HIGH.</li>
+<li>PMID:28479320 Yi et al. 2017, Curr Biol — dyf-13 in IFT-B by MS; IFT-B needed for dynein-2 entry. HIGH.</li>
+<li>PMID:18316409 Jauregui et al. 2008, JCB — DYF-13::GFP IFT reporter, cargo (OSM-6) defect. MEDIUM.</li>
+<li>PMID:16957054 Efimenko/Blacque et al. 2006, Mol Biol Cell — dyf gene class, X-box regulation. MEDIUM.</li>
+<li>PMID:18369462 Bacaj et al. 2008 (DYF-11), Curr Biol — DYF-13 as conserved IFT component. LOW/MEDIUM.</li>
+<li>PMID:26980730 Katoh et al. 2016, Mol Biol Cell — mammalian TTC26/IFT56 IFT-B architecture. MEDIUM (ortholog).<br />
+</content><br />
+</invoke></li>
+</ul>
+<h2 id="deep-research-falcon-edison-synthesis-added-after-review-draft">Deep research (falcon / Edison) synthesis — added after review draft</h2>
+<p>A genuine falcon deep-research report (<code>dyf-13-deep-research-falcon.md</code>, Edison Scientific<br />
+Literature, ~28 min, 10 citations) completed and corroborates the review. Key points (its<br />
+internal citation keys, e.g. <code>ishikawa2014ttc26dyf13isan</code>, <code>xin2017ift56regulatesvertebrate</code>,<br />
+<code>zhang2012knockdownofttc26</code>, are falcon-internal and were NOT independently verified against<br />
+cached PMIDs, so they are not used as <code>supporting_text</code> in the YAML):</p>
+<ul>
+<li>IFT56/TTC26/DYF-13 is a <strong>cargo-selective IFT-B adapter</strong>, not an enzyme; TPR/α-solenoid<br />
+  scaffold. Placed in the IFT-B1 (B1b) branch (with IFT46, IFT52, IFT70, IFT88).</li>
+<li>Cross-species nuance: in <em>Chlamydomonas</em> and some vertebrate systems IFT56/TTC26 is<br />
+<strong>dispensable for basic IFT train assembly/motility</strong> but required for import of a subset of<br />
+  cargo (notably motility-related axonemal proteins). This contrasts with the <em>C. elegans</em><br />
+  dyf-13(mn396) structural phenotype (short cilia lacking distal segments; Blacque 2005,<br />
+  PMID:15916950), which the review anchors on. The species difference (cargo-selectivity vs.<br />
+  overt structural defect) is itself part of the open question about DYF-13's precise role.</li>
+<li>Vertebrate orthologs: mouse Ift56/hop mutants mislocalize Gli2/Gli3 (Hedgehog signaling);<br />
+  zebrafish ttc26 morphants have short photoreceptor/pronephric cilia; human TTC26/IFT56 linked<br />
+  to severe biliary ciliopathy. These are ortholog data, not C. elegans-specific.</li>
+</ul>
+<p>This supports the two knowledge_gaps recorded (undefined direct cargo/partner contacts; core vs<br />
+peripheral sub-architecture of the worm protein) and the framing of DYF-13 as an IFT-B<br />
+structural/adapter subunit.</p>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: Q95QT8
+gene_symbol: dyf-13
+product_type: PROTEIN
+status: COMPLETE
+taxon:
+  id: NCBITaxon:6239
+  label: Caenorhabditis elegans
+description: &gt;-
+  dyf-13 encodes the C. elegans ortholog of tetratricopeptide-repeat protein 26
+  (TTC26/IFT56/IFT-B protein 56), a tetratricopeptide-repeat (TPR) scaffold
+  subunit of the intraflagellar transport complex B (IFT-B). IFT-B, together with
+  IFT-A and kinesin-2/dynein-2 motors, drives the bidirectional transport of
+  ciliary cargo along the axoneme that builds and maintains cilia. DYF-13 is
+  expressed in ciliated sensory neurons, localizes to the cilium, and itself
+  undergoes intraflagellar transport; its ciliary localization depends on other
+  IFT and BBS proteins. Loss of dyf-13 produces short sensory cilia that lack
+  their distal segments and a dye-filling-defective (Dyf) phenotype, and DYF-13 is
+  a component of the IFT-B complex required for anterograde cargo transport and
+  for ciliary entry of the retrograde dynein-2 motor. The gene is one of the
+  founding dye-filling-defective (dyf-1 to dyf-13) loci and is a target of the
+  RFX transcription factor DAF-19 via an X-box promoter motif.
+alternative_products:
+- name: &#39;1&#39;
+  id: Q95QT8-1
+- name: b
+  id: Q95QT8-2
+  sequence_note: VSP_057361
+existing_annotations:
+- term:
+    id: GO:0036064
+    label: ciliary basal body
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: is_active_in
+  review:
+    summary: &gt;-
+      IFT proteins, including IFT-B/TTC26 orthologs, accumulate at and turn around
+      at the ciliary base/basal body region. This IBA localization is consistent
+      with DYF-13 being a core IFT component whose transport begins at the ciliary
+      base.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Consistent with the established role of DYF-13 as a core IFT component that
+      accumulates at the ciliary base; a supporting (non-core) location rather than
+      the primary functional assignment.
+    supported_by:
+    - reference_id: PMID:15916950
+      supporting_text: encodes a ciliary protein that undergoes IFT
+- term:
+    id: GO:0030992
+    label: intraciliary transport particle B
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: part_of
+  review:
+    summary: &gt;-
+      DYF-13/TTC26 is an integral subunit of the IFT-B complex. This is directly
+      supported in C. elegans by affinity-purification/mass-spectrometry
+      identification of dyf-13 within IFT complex B, and in mammals TTC26/IFT56 is
+      assigned to the IFT-B complex.
+    action: ACCEPT
+    reason: &gt;-
+      Core structural assignment; DYF-13 is a bona fide IFT-B subunit
+      (ComplexPortal CPX-1290), confirmed biochemically in worm and mammals.
+    supported_by:
+    - reference_id: PMID:28479320
+      supporting_text: intraflagellar transport (IFT)-B complex abolishes dynein-2&#39;s ciliary
+    - reference_id: PMID:26980730
+      supporting_text: neither of which was included with certainty in
+- term:
+    id: GO:0035720
+    label: intraciliary anterograde transport
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      As an IFT-B subunit, DYF-13 participates in kinesin-2-driven anterograde
+      transport that carries cargo from the ciliary base toward the tip. Loss of
+      dyf-13 causes distal-segment defects consistent with impaired anterograde
+      delivery.
+    action: ACCEPT
+    reason: &gt;-
+      Core biological process for an IFT-B subunit; anterograde transport is the
+      direction driven by the kinesin-2/IFT-B machinery that DYF-13 belongs to.
+    supported_by:
+    - reference_id: PMID:15916950
+      supporting_text: encodes a ciliary protein that undergoes IFT
+- term:
+    id: GO:0035735
+    label: intraciliary transport involved in cilium assembly
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      DYF-13 is required for building and maintaining cilia: dyf-13(mn396) mutants
+      have short cilia lacking distal portions, and the protein is a novel core IFT
+      component required for cilia function.
+    action: ACCEPT
+    reason: &gt;-
+      Core biological process; captures the specific role of IFT in cilium
+      assembly, strongly supported by the dyf-13 mutant structural phenotype.
+    supported_by:
+    - reference_id: PMID:15916950
+      supporting_text: is a novel core IFT component required for cilia function
+- term:
+    id: GO:0097546
+    label: ciliary base
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: is_active_in
+  review:
+    summary: &gt;-
+      IFT particles, including DYF-13, are active at the ciliary base where
+      anterograde trains assemble and retrograde trains are remodeled. Consistent
+      with DYF-13 undergoing IFT that initiates at the base.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Supporting (non-core) location consistent with IFT-B biology; complements the
+      primary cilium/axoneme localization.
+    supported_by:
+    - reference_id: PMID:15916950
+      supporting_text: encodes a ciliary protein that undergoes IFT
+- term:
+    id: GO:0120170
+    label: intraciliary transport particle B binding
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: enables
+  review:
+    summary: &gt;-
+      The molecular function of DYF-13/TTC26 within the cilium is to associate with
+      the IFT-B particle. As a TPR-repeat scaffold subunit it binds the IFT-B
+      complex; this is the most specific molecular-function term currently available
+      for an IFT-B structural subunit.
+    action: ACCEPT
+    reason: &gt;-
+      Best-available molecular-function term for an IFT-B subunit; more informative
+      than generic protein binding. DYF-13 co-purifies within IFT complex B, and
+      functions as a cargo-selective IFT-B adapter rather than a core-structural
+      requirement (it associates with, but is not essential for, IFT-particle assembly).
+    supported_by:
+    - reference_id: PMID:28479320
+      supporting_text: intraflagellar transport (IFT)-B complex abolishes dynein-2&#39;s ciliary
+    - reference_id: file:worm/dyf-13/dyf-13-deep-research-falcon.md
+      supporting_text: IFT56 is not required for assembly or movement of IFT particles themselves
+- term:
+    id: GO:0005929
+    label: cilium
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000044
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      UniProt SubCell-derived electronic annotation placing DYF-13 in the cilium.
+      Correct but general; concordant with the experimentally supported ciliary
+      localization.
+    action: ACCEPT
+    reason: &gt;-
+      Correct general localization (cilium), consistent with primary evidence that
+      DYF-13 is a ciliary protein undergoing IFT.
+    supported_by:
+    - reference_id: PMID:15916950
+      supporting_text: encodes a ciliary protein that undergoes IFT
+- term:
+    id: GO:0005929
+    label: cilium
+  evidence_type: NAS
+  original_reference_id: PMID:28479320
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      ComplexPortal NAS annotation to cilium based on the IFT-B complex membership
+      reported in Yi et al. 2017. Correct but general localization.
+    action: ACCEPT
+    reason: &gt;-
+      Correct ciliary localization; supported by identification of dyf-13 in the
+      ciliary IFT-B complex.
+    supported_by:
+    - reference_id: PMID:28479320
+      supporting_text: intraflagellar transport (IFT)-B complex abolishes dynein-2&#39;s ciliary
+- term:
+    id: GO:0030992
+    label: intraciliary transport particle B
+  evidence_type: NAS
+  original_reference_id: PMID:28479320
+  qualifier: part_of
+  review:
+    summary: &gt;-
+      ComplexPortal NAS annotation, from the same study that identified dyf-13 as a
+      component of IFT complex B by affinity purification and mass spectrometry.
+    action: ACCEPT
+    reason: &gt;-
+      Core structural assignment corroborating the IBA IFT-B membership; directly
+      supported by the primary study.
+    supported_by:
+    - reference_id: PMID:28479320
+      supporting_text: intraflagellar transport (IFT)-B complex abolishes dynein-2&#39;s ciliary
+- term:
+    id: GO:0042073
+    label: intraciliary transport
+  evidence_type: NAS
+  original_reference_id: PMID:28479320
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      General intraflagellar-transport process annotation for an IFT-B subunit.
+      Correct but less specific than the anterograde/assembly terms; the parent
+      process under which DYF-13 acts.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Correct but general parent term; the more specific anterograde-transport and
+      transport-in-cilium-assembly terms better capture the core function.
+    supported_by:
+    - reference_id: PMID:15916950
+      supporting_text: encodes a ciliary protein that undergoes IFT
+- term:
+    id: GO:0060271
+    label: cilium assembly
+  evidence_type: NAS
+  original_reference_id: PMID:28479320
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      DYF-13 is required for cilium assembly; dyf-13 mutants have short cilia
+      lacking distal segments. This general BP term is well supported, with the more
+      specific IFT-in-cilium-assembly term giving the mechanism.
+    action: ACCEPT
+    reason: &gt;-
+      Correct biological process; the dyf-13 loss-of-function structural cilia
+      phenotype directly supports a cilium-assembly role.
+    supported_by:
+    - reference_id: PMID:15916950
+      supporting_text: is a novel core IFT component required for cilia function
+core_functions:
+- description: &gt;-
+    DYF-13/TTC26 is a tetratricopeptide-repeat (TPR) scaffold subunit of the
+    intraflagellar transport complex B (IFT-B). Its core molecular role is to
+    associate with the IFT-B particle, contributing to anterograde,
+    kinesin-2-driven transport of ciliary cargo that assembles and maintains
+    sensory cilia. Loss of dyf-13 gives short cilia lacking distal segments.
+  molecular_function:
+    id: GO:0120170
+    label: intraciliary transport particle B binding
+  directly_involved_in:
+  - id: GO:0035735
+    label: intraciliary transport involved in cilium assembly
+  - id: GO:0035720
+    label: intraciliary anterograde transport
+  locations:
+  - id: GO:0005929
+    label: cilium
+  in_complex:
+    id: GO:0030992
+    label: intraciliary transport particle B
+  supported_by:
+  - reference_id: PMID:15916950
+    supporting_text: is a novel core IFT component required for cilia function
+  - reference_id: PMID:28479320
+    supporting_text: intraflagellar transport (IFT)-B complex abolishes dynein-2&#39;s ciliary
+knowledge_gaps:
+- gap_statement: &gt;-
+    The molecular activity of DYF-13/TTC26 beyond intraciliary-transport-particle-B
+    binding is undefined. It is unknown which specific IFT-B subunit(s) DYF-13
+    contacts within the C. elegans complex and which ciliary cargo(es) it directly
+    binds or is required to transport; cargo specificity (e.g. for the retrograde
+    motor che-3/dynein-2) is stated only as a hypothesis.
+  boundary: &gt;-
+    It is firmly established that DYF-13 is an IFT-B subunit (co-purifies within IFT
+    complex B), localizes to the cilium and undergoes IFT, is required for cilium
+    assembly (dyf-13 mutants have short cilia lacking distal segments), and that
+    IFT-B integrity is required for ciliary entry of dynein-2. Its fold is a
+    TPR-repeat (alpha-solenoid) scaffold.
+  gap_kind:
+  - BIOLOGY
+  - ONTOLOGY
+  dark_aspect: MF_DARK
+  status: OPEN
+  significance: &gt;-
+    IFT-B subunits are structural adaptors whose specific cargo/partner contacts
+    determine which proteins a cilium can import; TTC26/IFT56 loss in vertebrates
+    selectively perturbs Hedgehog and motility-related ciliary cargo, so mapping
+    DYF-13&#39;s direct interactions would explain the specificity of its transport
+    role. There is also no GO molecular-function term for a structural constituent
+    of an IFT particle, forcing an IFT-B subunit to be annotated with the
+    complex-binding term, which is why the gene reads as MF-dark.
+  resolution: &gt;-
+    Proximity/affinity proteomics and cross-linking mass spectrometry to map
+    DYF-13&#39;s direct IFT-B neighbors; cargo-specific transport assays in dyf-13
+    mutants; a GO molecular-function term for an IFT-particle structural
+    constituent.
+  provenance:
+  - reference_id: PMID:26980730
+    supporting_text: neither of which was included with certainty in
+    reference_section_type: ABSTRACT
+- gap_statement: &gt;-
+    Whether C. elegans DYF-13 occupies the IFT-B core or peripheral sub-architecture
+    has not been determined biochemically. Mammalian TTC26/IFT56 was assigned to the
+    IFT-B core subcomplex, but the sub-complex position of the worm ortholog and the
+    consequences of its loss for IFT-B stability in vivo are unmapped.
+  boundary: &gt;-
+    DYF-13 is confirmed as part of the IFT-B complex in C. elegans (mass
+    spectrometry) and TTC26/IFT56 is placed in the IFT-B core in the mammalian
+    interaction map, but the two have not been reconciled for the worm protein.
+  gap_kind:
+  - BIOLOGY
+  - CURATION
+  dark_aspect: CC_DARK
+  status: OPEN
+  significance: &gt;-
+    Knowing whether DYF-13 is a core or peripheral IFT-B subunit predicts how
+    severely its loss should destabilize the whole particle versus a specific
+    cargo-adaptor arm, informing interpretation of the dyf-13 mutant phenotype.
+  resolution: &gt;-
+    Salt-dissociation and reconstitution of the C. elegans IFT-B complex, or
+    quantitative proteomics of IFT-B in dyf-13 mutants, to place DYF-13 in the
+    core/peripheral architecture.
+  provenance:
+  - reference_id: PMID:26980730
+    supporting_text: we identified
+    reference_section_type: ABSTRACT
+references:
+- id: GO_REF:0000033
+  title: Annotation inferences using phylogenetic trees
+  findings: []
+- id: GO_REF:0000044
+  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location
+    vocabulary mapping, accompanied by conservative changes to GO terms applied by
+    UniProt
+  findings: []
+- id: PMID:15916950
+  title: &#34;Functional genomics of the cilium, a sensory organelle.&#34;
+  findings:
+  - statement: &gt;-
+      dyf-13 (C27H5.7a) encodes a ciliary protein that undergoes intraflagellar
+      transport; its ciliary localization and transport depend on other IFT and BBS
+      genes, and it is a novel core IFT component required for cilia function.
+    supporting_text: &gt;-
+      One of these, C27H5.7a, encodes a ciliary protein that undergoes IFT.
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Primary paper that clones dyf-13 (C27H5.7a) and establishes it as a novel core
+      IFT component required for cilia function; the ciliary structural defect of
+      dyf-13(mn396) is caused by a mutation in C27H5.7a. Verbatim quotes confirmed
+      against the cached record.
+- id: PMID:28479320
+  title: Dynein-Driven Retrograde Intraflagellar Transport Is Triphasic in C. elegans
+    Sensory Cilia.
+  findings:
+  - statement: &gt;-
+      dyf-13 is a component of IFT complex B (identified by affinity purification and
+      mass spectrometry); disruption of the IFT-B complex abolishes ciliary
+      localization of the dynein-2 heavy chain.
+    supporting_text: &gt;-
+      Disruption of the dynein-2 tail domain, light intermediate chain, or
+      intraflagellar transport (IFT)-B complex abolishes dynein-2&#39;s ciliary
+      localization, revealing their important roles in ciliary entry of dynein-2.
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Source of the UniProt IFT-B SUBUNIT composition (lists dyf-13) and of the
+      ComplexPortal NAS annotations. Abstract-only in cache; the IFT-B membership and
+      dynein-2-entry roles are stated in the abstract and match the annotations.
+- id: PMID:18316409
+  title: &#34;The Caenorhabditis elegans nephrocystins act as global modifiers of cilium structure.&#34;
+  findings:
+  - statement: &gt;-
+      DYF-13::GFP is used as an intraflagellar-transport reporter and localizes along
+      amphid channel cilia; the dyf-13 mutant occasionally lacks the IFT-B cargo
+      OSM-6 in amphid distal segments, consistent with an anterograde/IFT-B role.
+    supporting_text: &gt;-
+      The dyf-13 mutant, similar to nphp-4 animals, occasionally lacks OSM-6
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Full-text (PMC) paper using DYF-13::GFP as an IFT reporter; supports ciliary
+      localization/IFT and a distal-segment cargo (OSM-6) defect in dyf-13 mutants.
+- id: PMID:16957054
+  title: &#34;Caenorhabditis elegans DYF-2, an orthologue of human WDR19, is a component of the intraflagellar transport machinery in sensory cilia.&#34;
+  findings:
+  - statement: &gt;-
+      Establishes the C. elegans dye-filling-defective (dyf) IFT gene class to which
+      dyf-13 belongs; the paralogous dyf-2/WDR19 associates with IFT particle complex
+      B, providing IFT-machinery context for the DYF-13 IFT-B annotations.
+    supporting_text: &gt;-
+      we conclude that DYF-2 can associate with IFT particle complex B
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Background/context reference for the dyf IFT gene class; primarily about the
+      paralog dyf-2/WDR19 (IFT complex-B associated). Only the abstract is cached, so
+      supporting_text is quoted verbatim from the abstract; the dyf-13-specific X-box
+      cloning detail is not stated in the cached abstract and is not asserted here.
+- id: PMID:18369462
+  title: &#34;An essential role for DYF-11/MIP-T3 in assembling functional intraflagellar transport complexes.&#34;
+  findings:
+  - statement: &gt;-
+      DYF-13 is listed among the conserved C. elegans IFT-associated proteins whose
+      orthologs are enriched in the Chlamydomonas flagellar proteome, supporting its
+      status as a conserved IFT component.
+    supporting_text: &gt;-
+      DYF-3 [34], DYF-13 [35], and IFTA-1 [36]
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Corroborates evolutionary conservation of DYF-13 as an IFT component; the paper
+      itself is about the IFT-B protein DYF-11.
+- id: PMID:26980730
+  title: &gt;-
+    Overall Architecture of the Intraflagellar Transport (IFT)-B Complex Containing
+    Cluap1/IFT38 as an Essential Component of the IFT-B Peripheral Subcomplex.
+  findings:
+  - statement: &gt;-
+      The mammalian ortholog TTC26/IFT56 was identified as an integral component of
+      the IFT-B core subcomplex, establishing that TTC26/IFT56 (the DYF-13 family) is
+      a genuine IFT-B subunit.
+    supporting_text: &gt;-
+      we identified TTC26/IFT56 and Cluap1/IFT38, neither of which was included with
+      certainty in
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Mammalian IFT-B interaction-map paper; supports the family-level IFT-B
+      (TTC26/IFT56) assignment used for the orthology-based annotations. Ortholog
+      evidence, not C. elegans-specific.
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/genes/worm/dyf-6/dyf-6-ai-review.html
+++ b/genes/worm/dyf-6/dyf-6-ai-review.html
@@ -1,0 +1,4145 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>dyf-6 - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        .propagation-review {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f8fafc;
+            border-left: 3px solid #64748b;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .propagation-title {
+            font-weight: 600;
+            color: #334155;
+            margin-bottom: 0.25rem;
+        }
+
+        .propagation-row {
+            margin-top: 0.25rem;
+        }
+
+        .propagation-source {
+            margin-top: 0.5rem;
+            padding-top: 0.5rem;
+            border-top: 1px solid #e5e7eb;
+        }
+
+        .propagation-source-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #1d4ed8;
+        }
+
+        .propagation-comment {
+            color: #4b5563;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>dyf-6</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/Q0G838" target="_blank" class="term-link">
+                        Q0G838
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Caenorhabditis elegans</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-complete">
+                    COMPLETE
+                </span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Aliases:</span>
+                <div class="aliases">
+
+                    <span class="badge">IFT46</span>
+
+                    <span class="badge">F46F6.4</span>
+
+                </div>
+            </div>
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "dyf-6";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="Q0G838" data-a="DESCRIPTION: dyf-6 encodes the Caenorhabditis elegans ortholog ..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>dyf-6 encodes the Caenorhabditis elegans ortholog of intraflagellar transport protein 46 (IFT46), a structural subunit of intraflagellar transport (IFT) complex B. IFT-B, with IFT-A and the kinesin-2 and dynein-2 motors, drives the bidirectional movement of ciliary cargo that builds and maintains the cilia of ciliated sensory neurons. The 471-residue protein has a large N-terminal disordered/acidic region and no recognizable catalytic domain. DYF-6 is expressed in ciliated amphid and phasmid sensory neurons (and hypodermis), localizes to the cilium, the ciliary base/basal body region, dendrites and the neuronal cell body, and undergoes processive IFT movement within the ciliated dendritic endings. It is required to build full-length sensory cilia: in dyf-6 mutants the amphid and phasmid ciliary endings are foreshortened, the IFT-B marker OSM-6 is mislocalized in a pattern typical of complex B mutants, and the animals are defective in dye filling and chemotaxis. The ciliary role is conserved, with orthologs in Drosophila (CG15161, expressed in sensory cilia) and mammals (human IFT46). C. elegans has only non-motile sensory cilia, so the cilium DYF-6 builds is a non-motile sensory cilium.</p>
+    </div>
+
+
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005815" target="_blank" class="term-link">
+                                    GO:0005815
+                                </a>
+                            </span>
+                            <span class="term-label">microtubule organizing center</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-modify">
+                            MODIFY
+                        </span>
+                        <span class="vote-buttons" data-g="Q0G838" data-a="GO:0005815" data-r="GO_REF:0000033" data-act="MODIFY">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IFT46 orthologs concentrate at and inject IFT trains from the ciliary base. In C. elegans this is the basal body / transition-zone region; UniProt curates DYF-6 basal-body localization from PMID:16648645. The basal body is a type of microtubule organizing center, so the term is not wrong, but the specific &#34;ciliary basal body&#34; (GO:0036064) is the accurate, informative CC.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Term too general. DYF-6&#39;s documented location at the ciliary base is better captured by ciliary basal body (GO:0036064) than by the generic microtubule organizing center.
+                        </div>
+
+
+
+                        <div class="propagation-review">
+                            <div class="propagation-title">Propagation Review</div>
+                            <div class="propagation-row">
+                                <strong>Root cause:</strong>
+                                <span class="badge">TERM SCOPING PROBLEM</span>
+                            </div>
+
+                            <div class="propagation-row">
+                                <strong>Failure modes:</strong>
+
+                                <span class="badge">GRANULARITY MISMATCH</span>
+
+                            </div>
+
+
+                            <div class="propagation-source">
+                                <strong>Sources checked:</strong>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">PANTHER:PTN000332669</span>
+
+                                    &middot; IFT46 family node
+
+
+                                    <span class="badge">SUPPORTS TRANSFER</span>
+
+
+                                    <div class="propagation-comment">The IFT46 family node correctly places DYF-6 at the microtubule organizing center (basal body), but the transferred term is coarser than the specific ciliary basal body location documented for the worm protein.</div>
+
+                                </div>
+
+                            </div>
+
+                        </div>
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0036064" target="_blank" class="term-link">
+                                    ciliary basal body
+                                </a>
+                            </span>
+
+                        </div>
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030992" target="_blank" class="term-link">
+                                    GO:0030992
+                                </a>
+                            </span>
+                            <span class="term-label">intraciliary transport particle B</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q0G838" data-a="GO:0030992" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> DYF-6/IFT46 is a subunit of intraflagellar transport complex B (IFT-B). This phylogenetic transfer is corroborated by Bell et al.&#39;s inference from the OSM-6 mislocalization pattern and by biochemical assignment to ComplexPortal CPX-1290.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Core cellular-component identity of DYF-6 as an IFT-B structural subunit.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/28479320" target="_blank" class="term-link">
+                                        PMID:28479320
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">intraflagellar transport (IFT)-B complex abolishes dynein-2&#39;s ciliary localization</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:worm/dyf-6/dyf-6-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">IFT46 is a pivotal subunit of the IFT-B1 core subcomplex</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0060271" target="_blank" class="term-link">
+                                    GO:0060271
+                                </a>
+                            </span>
+                            <span class="term-label">cilium assembly</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q0G838" data-a="GO:0060271" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IFT is required to assemble and maintain cilia; dyf-6 mutants have foreshortened amphid and phasmid ciliary endings, so DYF-6 is required for cilium assembly.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Core biological process, supported experimentally in worm (PMID:16648645). The more specific worm-appropriate term non-motile cilium assembly is also annotated (IMP).
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/16648645" target="_blank" class="term-link">
+                                        PMID:16648645
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">the cilia of the amphid and phasmid dendritic endings are foreshortened</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031514" target="_blank" class="term-link">
+                                    GO:0031514
+                                </a>
+                            </span>
+                            <span class="term-label">motile cilium</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q0G838" data-a="GO:0031514" data-r="GO_REF:0000033" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> This IBA transfer from mammalian IFT46 assigns a motile-cilium location. C. elegans, however, has no motile cilia — all its cilia, including the amphid and phasmid sensory cilia in which DYF-6 acts, are non-motile. The matching worm annotation is non-motile cilium assembly (GO:1905515, IMP).
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Taxonomically inappropriate over-propagation: C. elegans lacks motile cilia. DYF-6 acts in non-motile sensory cilia; the generic ciliary location (cilium, GO:0005929) is separately and correctly annotated.
+                        </div>
+
+
+
+                        <div class="propagation-review">
+                            <div class="propagation-title">Propagation Review</div>
+                            <div class="propagation-row">
+                                <strong>Root cause:</strong>
+                                <span class="badge">PROPAGATION BAD</span>
+                            </div>
+
+                            <div class="propagation-row">
+                                <strong>Failure modes:</strong>
+
+                                <span class="badge">LINEAGE OR TAXON MISMATCH</span>
+
+                            </div>
+
+
+                            <div class="propagation-source">
+                                <strong>Sources checked:</strong>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">PANTHER:PTN000332669</span>
+
+                                    &middot; IFT46 family node
+
+
+                                    <span class="badge">SUPPORTS SOURCE BUT NOT TARGET</span>
+
+
+                                    <div class="propagation-comment">The IFT46 family node includes vertebrate members that function in motile cilia, but the C. elegans ortholog acts only in non-motile sensory cilia, so the motile-cilium location does not transfer.</div>
+
+                                </div>
+
+                            </div>
+
+                        </div>
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042073" target="_blank" class="term-link">
+                                    GO:0042073
+                                </a>
+                            </span>
+                            <span class="term-label">intraciliary transport</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q0G838" data-a="GO:0042073" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> DYF-6 functions in intraflagellar (intraciliary) transport as an IFT-B subunit; DYF-6::GFP undergoes IFT movement within ciliated endings.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Core biological process, confirmed experimentally in worm (PMID:16648645).
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/16648645" target="_blank" class="term-link">
+                                        PMID:16648645
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Movement of DYF-6::GFP within the ciliated endings of the neurons indicates that DYF-6 is involved in IFT</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005929" target="_blank" class="term-link">
+                                    GO:0005929
+                                </a>
+                            </span>
+                            <span class="term-label">cilium</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000044
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q0G838" data-a="GO:0005929" data-r="GO_REF:0000044" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic mapping of the UniProt cilium subcellular-location keyword. DYF-6 is directly observed within cilia, where it undergoes IFT.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct core ciliary location, corroborated by experimental IFT movement within ciliated endings (PMID:16648645).
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/16648645" target="_blank" class="term-link">
+                                        PMID:16648645
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Movement of DYF-6::GFP within the ciliated endings of the neurons indicates that DYF-6 is involved in IFT</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030425" target="_blank" class="term-link">
+                                    GO:0030425
+                                </a>
+                            </span>
+                            <span class="term-label">dendrite</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000044
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q0G838" data-a="GO:0030425" data-r="GO_REF:0000044" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> DYF-6 is present in the sensory dendrites through which IFT cargo is trafficked to the ciliated ending; UniProt curates dendrite localization from PMID:16648645 and WormBase makes the same call by IDA.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Real localization (the dendritic route to the cilium) but not the core site of DYF-6 function, which is the cilium/IFT machinery.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042073" target="_blank" class="term-link">
+                                    GO:0042073
+                                </a>
+                            </span>
+                            <span class="term-label">intraciliary transport</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q0G838" data-a="GO:0042073" data-r="GO_REF:0000002" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> InterPro2GO transfer (IPR022088, IFT complex B) to intraciliary transport. Duplicates the IBA/NAS/IDA intraciliary-transport annotations and is correct.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Core biological process; redundant with experimental IDA (PMID:16648645) but consistent.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/16648645" target="_blank" class="term-link">
+                                        PMID:16648645
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Movement of DYF-6::GFP within the ciliated endings of the neurons indicates that DYF-6 is involved in IFT</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0043204" target="_blank" class="term-link">
+                                    GO:0043204
+                                </a>
+                            </span>
+                            <span class="term-label">perikaryon</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000044
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q0G838" data-a="GO:0043204" data-r="GO_REF:0000044" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic mapping of the UniProt perikaryon subcellular-location keyword, the same call made experimentally (EXP) from PMID:16648645. DYF-6 is present in the neuronal cell body/perikaryon in addition to the cilium.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Real localization but not the core functional site; the cell body reflects the neuron of expression rather than DYF-6&#39;s IFT role.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0120025" target="_blank" class="term-link">
+                                    GO:0120025
+                                </a>
+                            </span>
+                            <span class="term-label">plasma membrane bounded cell projection</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000117
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q0G838" data-a="GO:0120025" data-r="GO_REF:0000117" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> ARBA machine-learning annotation to a high-level grouping term that is the parent of both cilium and dendrite, which are already specifically annotated for DYF-6.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Over-general electronic grouping term; its informative descendants (cilium, dendrite) are already annotated, so it adds no information.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005929" target="_blank" class="term-link">
+                                    GO:0005929
+                                </a>
+                            </span>
+                            <span class="term-label">cilium</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">NAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/28479320" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:28479320
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Dynein-Driven Retrograde Intraflagellar Transport Is Triphas...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q0G838" data-a="GO:0005929" data-r="PMID:28479320" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> ComplexPortal (CPX-1290) assertion that DYF-6 localizes to the cilium, consistent with the experimental observation that DYF-6 undergoes IFT within cilia.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct core ciliary location.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/16648645" target="_blank" class="term-link">
+                                        PMID:16648645
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Movement of DYF-6::GFP within the ciliated endings of the neurons indicates that DYF-6 is involved in IFT</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030992" target="_blank" class="term-link">
+                                    GO:0030992
+                                </a>
+                            </span>
+                            <span class="term-label">intraciliary transport particle B</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">NAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/28479320" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:28479320
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Dynein-Driven Retrograde Intraflagellar Transport Is Triphas...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q0G838" data-a="GO:0030992" data-r="PMID:28479320" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> ComplexPortal (CPX-1290) assignment of DYF-6 to IFT complex B, based on the affinity-purification / mass-spectrometry of the worm IFT-B complex in Yi et al. 2017 and reflected in the UniProt SUBUNIT statement.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Core cellular-component identity; biochemically supported IFT-B membership.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/28479320" target="_blank" class="term-link">
+                                        PMID:28479320
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">intraflagellar transport (IFT)-B complex abolishes dynein-2&#39;s ciliary localization</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042073" target="_blank" class="term-link">
+                                    GO:0042073
+                                </a>
+                            </span>
+                            <span class="term-label">intraciliary transport</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">NAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/28479320" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:28479320
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Dynein-Driven Retrograde Intraflagellar Transport Is Triphas...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q0G838" data-a="GO:0042073" data-r="PMID:28479320" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> ComplexPortal assertion that DYF-6, as an IFT-B subunit, functions in intraciliary transport, consistent with the worm experimental data.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Core biological process; consistent with IFT-B membership and experimental IFT movement (PMID:16648645).
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/16648645" target="_blank" class="term-link">
+                                        PMID:16648645
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Movement of DYF-6::GFP within the ciliated endings of the neurons indicates that DYF-6 is involved in IFT</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0060271" target="_blank" class="term-link">
+                                    GO:0060271
+                                </a>
+                            </span>
+                            <span class="term-label">cilium assembly</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">NAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/28479320" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:28479320
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Dynein-Driven Retrograde Intraflagellar Transport Is Triphas...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q0G838" data-a="GO:0060271" data-r="PMID:28479320" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> ComplexPortal assertion that DYF-6 functions in cilium assembly, consistent with the foreshortened-cilia phenotype of dyf-6 mutants.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Core biological process; supported by the dyf-6 mutant cilium phenotype (PMID:16648645).
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/16648645" target="_blank" class="term-link">
+                                        PMID:16648645
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">the cilia of the amphid and phasmid dendritic endings are foreshortened</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0043204" target="_blank" class="term-link">
+                                    GO:0043204
+                                </a>
+                            </span>
+                            <span class="term-label">perikaryon</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">EXP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/16648645" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:16648645
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The molecular identities of the Caenorhabditis elegans intra...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q0G838" data-a="GO:0043204" data-r="PMID:16648645" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Experimental localization of DYF-6 to the neuronal perikaryon (cell body) in addition to the cilium and dendrite. DYF-6::GFP is expressed throughout the ciliated sensory neurons.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Real experimental localization but not DYF-6&#39;s core functional site; the cell body reflects the site of expression rather than the IFT role.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/16648645" target="_blank" class="term-link">
+                                        PMID:16648645
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">DYF-6::GFP is expressed in amphid and phasmid neurons</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030425" target="_blank" class="term-link">
+                                    GO:0030425
+                                </a>
+                            </span>
+                            <span class="term-label">dendrite</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/16648645" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:16648645
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The molecular identities of the Caenorhabditis elegans intra...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q0G838" data-a="GO:0030425" data-r="PMID:16648645" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> WormBase IDA localization of DYF-6 to the sensory dendrites, the route along which IFT cargo travels between the cell body and the ciliated ending.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Real localization along the trafficking route to the cilium, but not the core functional site (the cilium/IFT machinery).
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042073" target="_blank" class="term-link">
+                                    GO:0042073
+                                </a>
+                            </span>
+                            <span class="term-label">intraciliary transport</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/16648645" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:16648645
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The molecular identities of the Caenorhabditis elegans intra...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q0G838" data-a="GO:0042073" data-r="PMID:16648645" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct observation that DYF-6::GFP moves within the ciliated endings of amphid and phasmid neurons demonstrates that DYF-6 participates in intraflagellar (intraciliary) transport. This is the primary experimental basis for the core function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Core biological process; strongest, directly observed evidence (PMID:16648645).
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/16648645" target="_blank" class="term-link">
+                                        PMID:16648645
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Movement of DYF-6::GFP within the ciliated endings of the neurons indicates that DYF-6 is involved in IFT</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0043025" target="_blank" class="term-link">
+                                    GO:0043025
+                                </a>
+                            </span>
+                            <span class="term-label">neuronal cell body</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/16648645" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:16648645
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The molecular identities of the Caenorhabditis elegans intra...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q0G838" data-a="GO:0043025" data-r="PMID:16648645" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> WormBase IDA localization of DYF-6 to the neuronal cell body, consistent with the EXP perikaryon annotation and with expression throughout ciliated sensory neurons.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Real localization but not the core functional site; reflects the neuron of expression rather than the IFT role.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/16648645" target="_blank" class="term-link">
+                                        PMID:16648645
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">DYF-6::GFP is expressed in amphid and phasmid neurons</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1905515" target="_blank" class="term-link">
+                                    GO:1905515
+                                </a>
+                            </span>
+                            <span class="term-label">non-motile cilium assembly</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/16648645" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:16648645
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The molecular identities of the Caenorhabditis elegans intra...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q0G838" data-a="GO:1905515" data-r="PMID:16648645" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> C. elegans sensory cilia are non-motile, and DYF-6 is required to build them: dyf-6 mutants have foreshortened amphid and phasmid ciliary endings. This is the most specific and organism-appropriate biological-process term for DYF-6.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Core biological process; the non-motile-cilium wording matches the worm sensory cilium and is directly supported by the mutant phenotype (PMID:16648645).
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/16648645" target="_blank" class="term-link">
+                                        PMID:16648645
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">the cilia of the amphid and phasmid dendritic endings are foreshortened</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>DYF-6/IFT46 is a structural subunit of intraflagellar transport (IFT) complex B in ciliated sensory neurons. It localizes to the cilium and the ciliary base (basal body / transition-zone region), undergoes bidirectional IFT movement within the ciliated dendritic endings, and is required to build full-length non-motile sensory cilia — dyf-6 loss foreshortens the amphid and phasmid ciliary endings and produces the OSM-6 mislocalization pattern typical of IFT complex B mutants. It has no catalytic domain and acts as a structural/adaptor component of IFT-B; no informative molecular-function term is currently assignable (MF-dark; see knowledge_gaps).</h3>
+                <span class="vote-buttons" data-g="Q0G838" data-a="FUNCTION: DYF-6/IFT46 is a structural subunit of intraflagel..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042073" target="_blank" class="term-link">
+                                intraciliary transport
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1905515" target="_blank" class="term-link">
+                                non-motile cilium assembly
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005929" target="_blank" class="term-link">
+                                cilium
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0036064" target="_blank" class="term-link">
+                                ciliary basal body
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">In Complex:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030992" target="_blank" class="term-link">
+                            intraciliary transport particle B
+                        </a>
+                    </span>
+                </div>
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/16648645" target="_blank" class="term-link">
+                                PMID:16648645
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">Movement of DYF-6::GFP within the ciliated endings of the neurons indicates that DYF-6 is involved in IFT</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/16648645" target="_blank" class="term-link">
+                                PMID:16648645
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">the cilia of the amphid and phasmid dendritic endings are foreshortened</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/28479320" target="_blank" class="term-link">
+                                PMID:28479320
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">intraflagellar transport (IFT)-B complex abolishes dynein-2&#39;s ciliary localization</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000002.md" target="_blank" class="term-link">
+                            GO_REF:0000002
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation through association of InterPro records with GO terms</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
+                            GO_REF:0000033
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Annotation inferences using phylogenetic trees</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
+                            GO_REF:0000044
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000117.md" target="_blank" class="term-link">
+                            GO_REF:0000117
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Electronic Gene Ontology annotations created by ARBA machine learning models</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/16648645" target="_blank" class="term-link">
+                            PMID:16648645
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">The molecular identities of the Caenorhabditis elegans intraflagellar transport genes dyf-6, daf-10 and osm-1.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/28479320" target="_blank" class="term-link">
+                            PMID:28479320
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Dynein-Driven Retrograde Intraflagellar Transport Is Triphasic in C. elegans Sensory Cilia.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/7705621" target="_blank" class="term-link">
+                            PMID:7705621
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Mutations affecting the chemosensory neurons of Caenorhabditis elegans.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        file:worm/dyf-6/dyf-6-deep-research-falcon.md
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Deep research report (Falcon/Edison): DYF-6/IFT46 in Caenorhabditis elegans</div>
+
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Questions for Experts</h2>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Does C. elegans DYF-6/IFT46 act as a cargo adaptor within IFT-B (as Chlamydomonas IFT46 does for outer dynein arms), or purely as a structural scaffold, and which IFT-B subunits does it directly contact?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q0G838" data-a="Q: Does C. elegans DYF-6/IFT46 act as a cargo adaptor..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Experiments</h2>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Affinity purification / cross-linking mass spectrometry and structural modeling of DYF-6 within the worm IFT-B complex to define its direct binding partners and position in the particle.</p>
+
+
+
+                    <p style="margin-top: 0.5rem;">Type: interaction mapping</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q0G838" data-a="EXPERIMENT: Affinity purification / cross-linking mass spectro..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Isoform-specific rescue and separation-of-function alleles (including N-terminal deletions) to test for a cargo-adaptor role and to determine whether the long dyf-6/F46F6.3 fusion isoform has any distinct function.</p>
+
+
+
+                    <p style="margin-top: 0.5rem;">Type: genetics</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q0G838" data-a="EXPERIMENT: Isoform-specific rescue and separation-of-function..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Knowledge Gaps</h2>
+        <p style="color: #555; font-size: 0.92rem; margin-top: -0.3rem;">
+            What is <em>not</em> known — curated, literature-grounded statements of the open
+            unknowns (the inverse of core functions).
+        </p>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The molecular function of DYF-6/IFT46 is undefined. It has a large disordered N-terminus and no recognizable catalytic domain, and no GO molecular-function term is assigned to it in C. elegans. Whether it acts as a cargo adaptor (Chlamydomonas IFT46 uses its N-terminal region to load outer dynein arms) or purely as an IFT-B scaffold, and which IFT-B subunit(s) it directly contacts in the worm, is not established.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">ONTOLOGY</span><span class="badge">BIOLOGY</span>
+                <span class="badge">MF_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> DYF-6 is firmly established as an IFT complex B subunit that localizes to the cilium and ciliary base, undergoes IFT movement, and is required to build full-length non-motile sensory cilia. In other organisms the conserved C-terminal IFT46_B_C domain mediates direct binding to IFT52 (and, via a ternary module, IFT88) to build the IFT-B1 core, while the N-terminal region binds the ODA16 cargo adaptor to load outer dynein arms — a role restricted to motile cilia and therefore not expected in the worm. What is missing is a GO molecular-function representation of this structural/scaffolding activity (the MF aspect cannot express &#34;structural constituent of IFT particle B&#34;), and the specific IFT-B contacts and any cargo-adaptor role of DYF-6 have not been demonstrated for the C. elegans protein.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> IFT46 is a conserved core IFT-B protein; defining its molecular activity (scaffolding vs a specific cargo-adaptor interaction) is central to understanding IFT-B architecture and cargo selection in cilia.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Map DYF-6&#39;s direct IFT-B interaction partners by biochemistry/structure; test for cargo-adaptor activity; introduce a molecular-function term for an IFT-particle structural/adaptor subunit activity.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"DYF-6, the product of a complex locus, lacks known motifs, but orthologs are present in flies and mammals"</em> — PMID:16648645</li>
+
+            </ul>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Proposed term (ontology gap):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><strong>structural constituent of intraflagellar transport particle B</strong> — IFT-B subunits such as DYF-6/IFT46 have a well-defined cellular role (be part of, and maintain, the IFT-B particle) but no GO molecular-function term can currently express this structural/scaffolding activity, leaving them MF-dark despite complete BP/CC annotation.</li>
+
+            </ul>
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> dyf-6 is a complex locus that, besides the short conserved IFT46 isoforms, produces a longer nematode-specific transcript fusing the dyf-6 ORF to the upstream gene F46F6.3; the biological role of this long product is uncharacterized. All functional and rescue data derive from the short isoforms, so whether the long isoform contributes anything beyond the conserved IFT-B function is unknown.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">RESIDUAL_SUBGAP</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> The short (conserved) dyf-6 isoforms confer full dye-filling rescue and undergo IFT; the F46F6.3-fused long transcript is nematode-specific and has no assigned function, and existing alleles/reporters primarily report on the short forms.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Establishing whether the nematode-specific long isoform has a distinct role would clarify whether the dyf-6 locus encodes more than the conserved IFT-B subunit function.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Isoform-specific knockouts/rescue and expression analysis of the long dyf-6/F46F6.3 fusion product.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"DYF-6, the product of a complex locus, lacks known motifs, but orthologs are present in flies and mammals"</em> — PMID:16648645</li>
+
+            </ul>
+
+
+        </div>
+
+    </div>
+
+
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Deep Research Sections -->
+
+    <div class="section">
+        <h2 class="section-title">Deep Research</h2>
+
+        <details class="deep-research-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; gap: 1rem;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Falcon</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(dyf-6-deep-research-falcon.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="Q0G838" data-a="DEEP_RESEARCH: Falcon" data-r="" data-act="DEEP_RESEARCH" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This deep research is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This deep research needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+
+                <div class="report-meta">
+
+                    <span class="report-meta-text">Comprehensive Research Report: DYF-6/IFT46 in *Caenorhabditis elegans*</span>
+
+
+                    <span class="report-badge">Falcon</span>
+
+
+                    <span class="report-badge">Edison Scientific Literature</span>
+
+
+                    <span class="report-badge">40 citations</span>
+
+
+                    <span class="report-badge">2 artifacts</span>
+
+
+                    <span class="report-meta-text">2026-07-04T19:21:23.496379</span>
+
+
+
+                </div>
+
+
+                <div class="artifact-list">
+
+
+
+                    <div class="artifact-link">
+                        <a href="dyf-6-deep-research-falcon_artifacts/artifact-00.md" class="term-link">Edison artifact artifact-00</a>
+                        <span>(text/markdown)</span>
+                    </div>
+
+
+
+
+                    <div class="artifact-link">
+                        <a href="dyf-6-deep-research-falcon_artifacts/artifact-01.md" class="term-link">Edison artifact artifact-01</a>
+                        <span>(text/markdown)</span>
+                    </div>
+
+
+                </div>
+
+                <p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h1 id="comprehensive-research-report-dyf-6ift46-in-caenorhabditis-elegans">Comprehensive Research Report: DYF-6/IFT46 in <em>Caenorhabditis elegans</em></h1>
+<h2 id="1-gene-identity-and-protein-overview">1. Gene Identity and Protein Overview</h2>
+<p>The <em>dyf-6</em> (abnormal dye filling protein 6) gene in <em>Caenorhabditis elegans</em> (ORF: F46F6.4; UniProt: Q0G838) encodes the worm ortholog of Intraflagellar Transport Protein 46 (IFT46). The protein belongs to the IFT46 family and contains a conserved Intraflagellar Transport Complex B C-terminal domain (IFT46_B_C; PF12317/IPR022088). DYF-6/IFT46 is a structural subunit of the intraflagellar transport (IFT) machinery, functioning as a core component of the IFT-B complex that is essential for the assembly, maintenance, and cargo transport functions of cilia in sensory neurons.</p>
+<h2 id="2-primary-function-structural-adapter-in-intraflagellar-transport">2. Primary Function: Structural Adapter in Intraflagellar Transport</h2>
+<p>DYF-6/IFT46 does not function as an enzyme, transporter, or signaling molecule in the conventional sense. Rather, it serves as a <strong>structural and adapter subunit</strong> of the IFT-B complex, an essential multi-protein machine that mediates bidirectional transport of cargo along ciliary axonemal microtubules. Cilia lack protein synthesis machinery, and thus all ciliary proteins must be synthesized in the cell body and transported into the cilium by IFT (lv2017intraflagellartransportprotein pages 4-7). DYF-6/IFT46 fulfills dual roles within this system:</p>
+<h3 id="21-core-ift-b-complex-assembly">2.1 Core IFT-B Complex Assembly</h3>
+<p>IFT46 is a pivotal subunit of the IFT-B1 core subcomplex, which consists of approximately 10 subunits: IFT22, IFT25, IFT27, IFT46, IFT52, IFT56, IFT70, IFT74, IFT81, and IFT88 (liu2025structuremakesa pages 1-2, nakayama2018ciliaryproteintrafficking pages 3-3). Within this core, IFT46 belongs to the B1-2 subgroup alongside IFT52, IFT56, IFT70, and IFT88 (nakayama2018ciliaryproteintrafficking pages 3-3). IFT46 directly interacts with IFT52 through large hydrophobic surfaces at their carboxy-terminal domains, and these two proteins together interact with IFT88 to form a stable ternary complex (IFT46–IFT52–IFT88) that constitutes a critical core module of IFT-B (lucker2010directinteractionsof pages 9-9, taschner2016theintraflagellartransport pages 5-6). IFT46 plays a stabilization role for both IFT52 and IFT88 within this complex (lucker2010directinteractionsof pages 9-9).</p>
+<h3 id="22-cargo-adapter-for-outer-dynein-arm-transport">2.2 Cargo Adapter for Outer Dynein Arm Transport</h3>
+<p>In organisms with motile cilia, IFT46 has a specialized function in transporting outer dynein arms (ODAs) via its interaction with the cargo adapter ODA16 (DAW1 in mammals). The N-terminal domain of IFT46 (approximately amino acids 1–147 in <em>Chlamydomonas</em>), which is predicted to be intrinsically disordered, binds directly to ODA16. ODA16 is a WD-repeat protein whose eight-bladed β-propeller contains a structural cleft that accommodates IFT46's unstructured N-terminal domain (lechtreck2022cargoadaptersexpand pages 3-4, lechtreck2022cargoadaptersexpand pages 2-3). This ODA16–IFT46 interaction is essential for efficient ODA transport to the ciliary tip. In <em>Chlamydomonas</em>, mutants expressing N-terminally truncated IFT46 can assemble flagella but these flagella specifically lack most outer dynein arms (nakayama2018ciliaryproteintrafficking pages 4-5, fassad2017c11orf70mutationscausing pages 40-46). Notably, the direct ODA16–IFT46 interaction has not been demonstrated in human cells, where additional factors may be required (huang2023arl3regulatesoda16mediated pages 8-12).</p>
+<p>Since <em>C. elegans</em> possesses only non-motile sensory cilia that lack dynein arms, the ODA transport function of IFT46's N-terminus may be less relevant in nematodes, though the protein's core IFT-B assembly function is fully conserved.</p>
+<h2 id="3-subcellular-localization">3. Subcellular Localization</h2>
+<p>DYF-6/IFT46 localizes to two principal subcellular compartments: the <strong>basal body</strong> (the ciliary base) and the <strong>cilium</strong> itself. Detailed studies in <em>Chlamydomonas</em> demonstrated that YFP-tagged IFT46 concentrates at the basal body and shows punctate distribution along the length of the flagellum, consistent with its association with moving IFT trains (lv2017intraflagellartransportprotein pages 4-7, lucker2010directinteractionsof pages 6-6). IFT-B proteins, including IFT46, form a semi-circular tri-lobed arc at the basal body (lv2017intraflagellartransportprotein pages 4-7). Anterograde IFT trains containing IFT-B proteins measure approximately 233 nm and move along B-microtubules of the axoneme (lv2017intraflagellartransportprotein pages 4-7).</p>
+<p>The basal body localization of IFT46 depends critically on IFT52 but not vice versa, establishing a hierarchical recruitment mechanism. IFT52 and IFT46 preassemble as subcomplexes in the cytoplasm or at the trans-Golgi network (TGN) before being delivered to the basal body through vesicular or non-vesicle-mediated transport pathways (lv2017intraflagellartransportprotein pages 40-45, lv2017intraflagellartransportprotein pages 11-14). The C-terminal sequence of IFT46 (amino acids 246–321, designated BBTS3) serves as the basal body targeting sequence, which is also necessary for ciliary targeting (lv2017intraflagellartransportprotein pages 1-4). The specific leucine residues L285 and L286 within IFT46 are critical for the binding interface with IFT52 and, consequently, for proper basal body localization (lv2017intraflagellartransportprotein pages 9-11, lv2017intraflagellartransportprotein pages 11-14).</p>
+<p>In <em>C. elegans</em>, DYF-6 functions in the sensory cilia of amphid and phasmid neurons, where it participates in IFT-mediated protein trafficking along the axoneme (cevik2013activetransportand pages 6-8, cevik2013activetransportand pages 8-10).</p>
+<h2 id="4-protein-interactions-and-pathway-involvement">4. Protein Interactions and Pathway Involvement</h2>
+<p>The known protein-protein interactions of DYF-6/IFT46 are summarized below:</p>
+<table>
+<thead>
+<tr>
+<th>Interaction Partner</th>
+<th>Binding Domain on IFT46</th>
+<th>Organism Studied</th>
+<th>Functional Role of Interaction</th>
+<th>Key Reference</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>IFT52</td>
+<td>C-terminal domain of IFT46; hydrophobic interface, including residues around L285/L286 important for recruitment</td>
+<td><em>Chlamydomonas reinhardtii</em>; human/cross-species IFT studies</td>
+<td>Direct IFT46-IFT52 binding supports IFT-B1 core complex assembly and recruits IFT46 to the basal body/ciliary base before train assembly (lv2017intraflagellartransportprotein pages 35-40, lv2017intraflagellartransportprotein pages 40-45, lv2017intraflagellartransportprotein pages 9-11, lv2017intraflagellartransportprotein pages 11-14, lv2017intraflagellartransportprotein pages 1-4)</td>
+<td>Lv et al., 2017; Taschner &amp; Lorentzen, 2016 (lv2017intraflagellartransportprotein pages 35-40, lv2017intraflagellartransportprotein pages 1-4, taschner2016theintraflagellartransport pages 5-6)</td>
+</tr>
+<tr>
+<td>IFT88</td>
+<td>No independent IFT46-only binding domain resolved here; interacts as part of an IFT46-IFT52-IFT88 ternary core complex</td>
+<td><em>Chlamydomonas reinhardtii</em></td>
+<td>Stabilizes the IFT-B core architecture; IFT46, IFT52, and IFT88 form a direct ternary complex essential for core IFT-B complex integrity (lucker2010directinteractionsof pages 9-9, lucker2010directinteractionsof pages 1-1)</td>
+<td>Lucker et al., 2010 (lucker2010directinteractionsof pages 9-9)</td>
+</tr>
+<tr>
+<td>ODA16/DAW1</td>
+<td>N-terminal domain of IFT46, especially aa 1-147 in <em>Chlamydomonas</em>; not clearly conserved in human DAW1-IFT46 binding</td>
+<td><em>Chlamydomonas reinhardtii</em>; comparative human studies</td>
+<td>Cargo-adapter interaction for outer dynein arm (ODA) transport into cilia/flagella; truncation of the IFT46 N-terminus impairs ODA transport and causes axonemes lacking most ODAs (lechtreck2022cargoadaptersexpand pages 3-4, lechtreck2022cargoadaptersexpand pages 2-3, huang2023arl3regulatesoda16mediated pages 8-12, nakayama2018ciliaryproteintrafficking pages 4-5, fassad2017c11orf70mutationscausing pages 40-46)</td>
+<td>Lechtreck, 2022; Wang et al., 2020; Nakayama &amp; Katoh, 2018 (lechtreck2022cargoadaptersexpand pages 3-4, huang2023arl3regulatesoda16mediated pages 8-12, nakayama2018ciliaryproteintrafficking pages 4-5)</td>
+</tr>
+<tr>
+<td>ARL13B</td>
+<td>Indirectly via the IFT46-IFT56 dimer/subcomplex rather than a mapped standalone IFT46 motif</td>
+<td>human; <em>Caenorhabditis elegans</em></td>
+<td>Supports ciliary membrane protein localization/retention and ciliary trafficking regulation; ARL13B/ARL-13 associates with IFT-B through IFT46-IFT56, and dyf-6/IFT46 affects ARL-13 compartmentalization in worm cilia (nozaki2017regulationofciliary pages 4-7, nozaki2017regulationofciliary pages 31-35, cevik2013activetransportand pages 10-11, cevik2013activetransportand pages 8-10, cevik2013activetransportand pages 6-8)</td>
+<td>Cevik et al., 2013; Nozaki et al., 2017 (nozaki2017regulationofciliary pages 4-7, cevik2013activetransportand pages 10-11, nozaki2017regulationofciliary pages 7-10)</td>
+</tr>
+<tr>
+<td>IFT81/IFT74</td>
+<td>Via higher-order IFT-B core interactions; IFT46 pairs with IFT52, which associates with the IFT81/IFT74 module during core assembly</td>
+<td>Multiple organisms</td>
+<td>Promotes IFT-B core complex formation; IFT46-IFT52 associates with IFT81/IFT74 to build the core scaffold that underlies anterograde IFT train assembly (lv2017intraflagellartransportprotein pages 9-11, liu2025structuremakesa pages 1-2, nakayama2018ciliaryproteintrafficking pages 3-3, taschner2016theintraflagellartransport pages 5-6, lucker2010directinteractionsof pages 9-9)</td>
+<td>Taschner &amp; Lorentzen, 2016; Nakayama &amp; Katoh, 2018; Lucker et al., 2010 (nakayama2018ciliaryproteintrafficking pages 3-3, taschner2016theintraflagellartransport pages 5-6, lucker2010directinteractionsof pages 9-9)</td>
+</tr>
+</tbody>
+</table>
+<p><em>Table: This table summarizes the main known DYF-6/IFT46 interaction partners, the mapped or inferred IFT46 binding regions, and the functional significance of each interaction in IFT-B assembly, cargo transport, and ciliary localization.</em></p>
+<h3 id="41-ift46ift56-dimer-and-arl13b-regulation">4.1 IFT46–IFT56 Dimer and ARL13B Regulation</h3>
+<p>A particularly important interaction in the context of <em>C. elegans</em> sensory cilia is the association of IFT46 with IFT56 to form a heterodimer that serves as the binding site for ARL13B (ARL-13 in <em>C. elegans</em>), a Joubert syndrome-associated small GTPase critical for ciliary membrane composition (nozaki2017regulationofciliary pages 4-7, nozaki2017regulationofciliary pages 31-35, nozaki2017regulationofciliary pages 7-10). In <em>C. elegans</em>, <em>dyf-6</em> mutants show reduced ARL-13 at ciliary membranes and mislocalization of ARL-13 to the periciliary membrane, indicating that DYF-6/IFT46 is essential for maintaining ARL-13 within its proper ciliary membrane subdomain through active transport mechanisms (cevik2013activetransportand pages 6-8). FRAP analyses revealed that in <em>dyf-6</em> mutants, ARL-13 shows slow diffusion rates between ciliary and periciliary membrane compartments, suggesting intact transition zone barriers but defective active transport (cevik2013activetransportand pages 6-8, cevik2013activetransportand pages 8-10).</p>
+<h2 id="5-functional-domains-of-dyf-6ift46">5. Functional Domains of DYF-6/IFT46</h2>
+<p>The distinct functional regions of DYF-6/IFT46 highlight how the protein's N-terminal and C-terminal halves serve separable functions in cargo transport and complex assembly, respectively:</p>
+<table>
+<thead>
+<tr>
+<th>Domain/Region</th>
+<th>Amino Acid Range (approximate)</th>
+<th>Function</th>
+<th>Evidence</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>N-terminal domain</td>
+<td>aa 1-147 (<em>Chlamydomonas</em> IFT46)</td>
+<td>Predicted intrinsically disordered region that binds the cargo adapter ODA16 and is required for efficient outer dynein arm (ODA) transport; this N-terminal ODA16-binding function is conserved mainly in organisms with motile cilia</td>
+<td>Reviews and primary studies describe direct ODA16 interaction with the IFT46 N-terminus, and truncation causes strong ODA loss from flagella (lechtreck2022cargoadaptersexpand pages 3-4, lechtreck2022cargoadaptersexpand pages 2-3, nakayama2018ciliaryproteintrafficking pages 4-5, fassad2017c11orf70mutationscausing pages 40-46)</td>
+</tr>
+<tr>
+<td>Assembly-critical internal segment</td>
+<td>aa 26-50</td>
+<td>Required for functional rescue of flagellar assembly in <em>Chlamydomonas</em> ift46 mutants; indicates this short N-proximal segment contributes to core ciliogenic activity beyond the extreme N-terminus</td>
+<td>Recombinant rescue experiments showed aa 26-50 are necessary for flagellar assembly rescue, whereas the first 25 aa are dispensable (lucker2010directinteractionsof pages 9-9)</td>
+</tr>
+<tr>
+<td>C-terminal domain / BBTS3</td>
+<td>aa 246-321</td>
+<td>Basal body targeting sequence (BBTS3); mediates recruitment to basal bodies/ciliary base, supports interaction with IFT52, and corresponds to the conserved IFT46_B_C region important for IFT-B incorporation and trafficking</td>
+<td>Localization and mutational studies mapped the basal body targeting sequence to the C-terminus and showed direct functional coupling to IFT52 (lv2017intraflagellartransportprotein pages 9-11, lv2017intraflagellartransportprotein pages 11-14, lv2017intraflagellartransportprotein pages 4-7, lv2017intraflagellartransportprotein pages 1-4)</td>
+</tr>
+<tr>
+<td>IFT52-binding interface residues</td>
+<td>L285/L286</td>
+<td>Critical residues within the C-terminal region for IFT52 binding; disruption impairs IFT46 recruitment/localization and the IFT52-IFT46 interaction</td>
+<td>Point-mutation analysis identified L285/L286 as essential for the IFT52 interaction interface (lv2017intraflagellartransportprotein pages 40-45, lv2017intraflagellartransportprotein pages 9-11, lv2017intraflagellartransportprotein pages 11-14, lv2017intraflagellartransportprotein pages 1-4)</td>
+</tr>
+<tr>
+<td>Full C-terminus</td>
+<td>Broadly the C-terminal half, including the terminal interaction surface</td>
+<td>Required for IFT-B complex stability and assembly through hydrophobic interactions with IFT52; supports formation of the IFT46-IFT52-IFT88 core module and incorporation into the IFT-B1 complex</td>
+<td>Structural/biochemical studies show the C-terminus stabilizes IFT-B core assembly via IFT52 interaction and contributes to ternary complex formation with IFT88 (lucker2010directinteractionsof pages 9-9, taschner2016theintraflagellartransport pages 5-6)</td>
+</tr>
+</tbody>
+</table>
+<p><em>Table: This table summarizes the main functional regions of IFT46/DYF-6, linking specific sequence segments to basal body targeting, IFT-B complex assembly, and cargo-adapter interactions. It is useful for distinguishing the conserved ciliogenic core functions of the protein from the motile-cilia-specific ODA transport role of its N-terminus.</em></p>
+<h2 id="6-mutant-phenotypes-and-experimental-evidence">6. Mutant Phenotypes and Experimental Evidence</h2>
+<h3 id="61-chlamydomonas-ift46-mutants">6.1 <em>Chlamydomonas</em> IFT46 Mutants</h3>
+<p>The <em>ift46-1</em> null mutant in <em>Chlamydomonas reinhardtii</em> produces stunted, paralyzed flagella significantly shorter than wild-type cells, with daughter cells remaining restricted within the mother cell wall (lv2017intraflagellartransportprotein pages 4-7). The <em>ift46-2</em> strain carries a deletion of most of the IFT46 gene and displays a predominantly bald (non-flagellated) phenotype, with only approximately 6% of cells assembling short flagella averaging 3 µm in length (lucker2010directinteractionsof pages 1-1, lucker2010directinteractionsof pages 6-6, lucker2010directinteractionsof pages 5-6). This phenotype is slightly less severe than <em>ift52</em> or <em>ift88</em> mutants (lucker2010directinteractionsof pages 1-1). Electroporation of recombinant IFT46 protein successfully rescued the flagellar assembly defect, restoring motile flagella within 4 hours post-electroporation, including normal photophobic and phototactic responses (lucker2010directinteractionsof pages 6-6, lucker2010directinteractionsof pages 5-6). Rescue experiments further demonstrated that amino acids 26–50 are required for flagellar assembly function, whereas the first 25 amino acids are dispensable (lucker2010directinteractionsof pages 9-9).</p>
+<h3 id="62-c-elegans-dyf-6-mutant-phenotypes">6.2 <em>C. elegans</em> DYF-6 Mutant Phenotypes</h3>
+<p>In <em>C. elegans</em>, <em>dyf-6</em> mutants exhibit the characteristic <strong>dye-filling defective (Dyf) phenotype</strong>, which is the hallmark of ciliary dysfunction in worm sensory neurons. The Dyf phenotype indicates that the amphid and phasmid cilia are structurally compromised, preventing uptake of lipophilic fluorescent dyes such as DiI that normally enter neurons through intact sensory cilia (cevik2013activetransportand pages 8-10, cevik2013activetransportand pages 6-8). The study by Cevik et al. (2013) demonstrated that in <em>dyf-6</em> IFT-B mutants, the Joubert syndrome protein ARL-13 is mislocalized, with reduced amounts in the ciliary middle segment and aberrant accumulation at periciliary membranes (cevik2013activetransportand pages 6-8). Additionally, <em>dyf-6</em> mutants display defects in IFT-dependent anthelmintic drug uptake through amphid sensory cilia, as IFT genes including <em>dyf-6</em> are among the ciliary genes required for proper avermectin sensitivity in <em>C. elegans</em> (brinzer2021theuptakeof pages 10-12, brinzer2021theuptakeof pages 14-17).</p>
+<h2 id="7-transcriptional-regulation">7. Transcriptional Regulation</h2>
+<p>Expression of ciliary genes in <em>C. elegans</em>, including those encoding IFT-B complex components, is regulated by the RFX transcription factor DAF-19, which binds to conserved X-box motifs in promoter regions. DAF-19 is essential for ciliary gene expression—when DAF-19 is non-functional, ciliated neurons lose their cilia and exhibit sensory defects (chu2012finetuningof pages 1-2). <em>C. elegans</em> possesses approximately 60 ciliated sensory neurons organized in three main clusters: labial and amphid neurons in the head, and phasmid neurons in the tail (warrington2018computationalandmolecular pages 21-25). The <em>dyf-6</em> gene, like other ciliary genes, is expected to be under DAF-19/RFX transcriptional control given that its homolog CG15161 in <em>Drosophila</em> has been identified as an RFX target gene (chu2012finetuningof pages 1-2). Multiple X-box motifs can cooperate to fine-tune the expression levels of ciliary genes in specific ciliated neuron subtypes (chu2012finetuningof pages 5-8).</p>
+<h2 id="8-evolutionary-conservation">8. Evolutionary Conservation</h2>
+<p>IFT46 is broadly conserved across eukaryotes that possess cilia, from the green alga <em>Chlamydomonas reinhardtii</em> to nematodes, zebrafish, and mammals. The C-terminal IFT46_B_C domain (PF12317) that mediates IFT-B complex interactions is conserved across all species, while the N-terminal region involved in ODA16 binding is specifically conserved in organisms with motile cilia (lechtreck2022cargoadaptersexpand pages 3-4, lechtreck2022cargoadaptersexpand pages 2-3). In zebrafish, IFT46 plays an essential role in cilia development, and mutations lead to typical ciliopathy-related phenotypes. In human cells, IFT46 is part of the IFT-B1 core subcomplex where it participates in the same core interactions with IFT52 and IFT88, though the ODA16-IFT46 interaction for dynein transport may involve additional factors compared to <em>Chlamydomonas</em> (huang2023arl3regulatesoda16mediated pages 8-12).</p>
+<h2 id="9-summary">9. Summary</h2>
+<p>DYF-6/IFT46 in <em>C. elegans</em> is a core structural subunit of the IFT-B1 complex that is indispensable for intraflagellar transport and sensory cilium assembly. It localizes to the basal body and the ciliary axoneme of sensory neurons, where it functions as part of the IFT machinery that transports ciliary proteins between the cell body and the cilium. Its C-terminal domain mediates incorporation into the IFT-B core complex through direct interaction with IFT52, while its N-terminal domain serves as a binding site for the cargo adapter ODA16 in organisms with motile cilia. Through its interaction with IFT56, IFT46 also contributes to the localization and retention of ciliary membrane proteins such as ARL13B. Loss of DYF-6 in <em>C. elegans</em> results in dye-filling defects indicative of structurally compromised sensory cilia, mislocalization of ciliary membrane proteins, and consequent sensory deficits. The gene's expression is regulated by the ciliary transcription factor DAF-19/RFX, placing it within the core ciliogenesis transcriptional program.</p>
+<p>References</p>
+<ol>
+<li>
+<p>(lv2017intraflagellartransportprotein pages 4-7): Bo Lv, Lei Wan, Michael Taschner, Xi Cheng, Esben Lorentzen, and Kaiyao Huang. Intraflagellar transport protein ift52 recruits ift46 to the basal body and flagella. Journal of Cell Science, 130:1662-1674, May 2017. URL: https://doi.org/10.1242/jcs.200758, doi:10.1242/jcs.200758. This article has 47 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(liu2025structuremakesa pages 1-2): Ying Liu, Yong Zhang, Hua Ni, and Peiwei Liu. Structure makes a difference: <scp>ift</scp> complex in ciliary function and ciliopathy. Cytoskeleton, Sep 2025. URL: https://doi.org/10.1002/cm.70033, doi:10.1002/cm.70033. This article has 1 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(nakayama2018ciliaryproteintrafficking pages 3-3): Kazuhisa Nakayama and Yohei Katoh. Ciliary protein trafficking mediated by ift and bbsome complexes with the aid of kinesin-2 and dynein-2 motors. Journal of biochemistry, 163 3:155-164, Mar 2018. URL: https://doi.org/10.1093/jb/mvx087, doi:10.1093/jb/mvx087. This article has 160 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(lucker2010directinteractionsof pages 9-9): Ben F. Lucker, Mark S. Miller, Slawomir A. Dziedzic, Philip T. Blackmarr, and Douglas G. Cole. Direct interactions of intraflagellar transport complex b proteins ift88, ift52, and ift46. Jul 2010. URL: https://doi.org/10.1074/jbc.m110.106997, doi:10.1074/jbc.m110.106997. This article has 104 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(taschner2016theintraflagellartransport pages 5-6): Michael Taschner and Esben Lorentzen. The intraflagellar transport machinery. Cold Spring Harbor perspectives in biology, 8 10:a028092, Oct 2016. URL: https://doi.org/10.1101/cshperspect.a028092, doi:10.1101/cshperspect.a028092. This article has 419 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(lechtreck2022cargoadaptersexpand pages 3-4): Karl Lechtreck. Cargo adapters expand the transport range of intraflagellar transport. Journal of cell science, Dec 2022. URL: https://doi.org/10.1242/jcs.260408, doi:10.1242/jcs.260408. This article has 47 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(lechtreck2022cargoadaptersexpand pages 2-3): Karl Lechtreck. Cargo adapters expand the transport range of intraflagellar transport. Journal of cell science, Dec 2022. URL: https://doi.org/10.1242/jcs.260408, doi:10.1242/jcs.260408. This article has 47 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(nakayama2018ciliaryproteintrafficking pages 4-5): Kazuhisa Nakayama and Yohei Katoh. Ciliary protein trafficking mediated by ift and bbsome complexes with the aid of kinesin-2 and dynein-2 motors. Journal of biochemistry, 163 3:155-164, Mar 2018. URL: https://doi.org/10.1093/jb/mvx087, doi:10.1093/jb/mvx087. This article has 160 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(fassad2017c11orf70mutationscausing pages 40-46): Mahmoud R. Fassad, Amelia Shoemark, Pierrick le Borgne, France Koll, Mitali Patel, Mellisa Dixon, Jane Hayward, Charlotte Richardson, Emily Frost, Lucy Jenkins, Thomas Cullup, Eddie MK Chung, Michel Lemullois, Anne Aubusson-Fleury, Claire Hogg, David R. Mitchell, Anne-Marie Tassin, and Hannah M. Mitchison. C11orf70 mutations causing primary ciliary dyskinesia disrupt a conserved step in the intraflagellar transport-dependent assembly of multiple axonemal dyneins. bioRxiv, Oct 2017. URL: https://doi.org/10.1101/211953, doi:10.1101/211953. This article has 2 citations.</p>
+</li>
+<li>
+<p>(huang2023arl3regulatesoda16mediated pages 8-12): Yameng Huang, Xiaoduo Dong, Stella Y. Sun, Teck-Kwang Lim, Qingsong Lin, and Cynthia Y. He. Arl3 regulates oda16-mediated intraflagellar transport in motile cilia biogenesis. bioRxiv, Apr 2023. URL: https://doi.org/10.1101/2023.04.12.536397, doi:10.1101/2023.04.12.536397. This article has 3 citations.</p>
+</li>
+<li>
+<p>(lucker2010directinteractionsof pages 6-6): Ben F. Lucker, Mark S. Miller, Slawomir A. Dziedzic, Philip T. Blackmarr, and Douglas G. Cole. Direct interactions of intraflagellar transport complex b proteins ift88, ift52, and ift46. Jul 2010. URL: https://doi.org/10.1074/jbc.m110.106997, doi:10.1074/jbc.m110.106997. This article has 104 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(lv2017intraflagellartransportprotein pages 40-45): Bo Lv, Lei Wan, Michael Taschner, Xi Cheng, Esben Lorentzen, and Kaiyao Huang. Intraflagellar transport protein ift52 recruits ift46 to the basal body and flagella. Journal of Cell Science, 130:1662-1674, May 2017. URL: https://doi.org/10.1242/jcs.200758, doi:10.1242/jcs.200758. This article has 47 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(lv2017intraflagellartransportprotein pages 11-14): Bo Lv, Lei Wan, Michael Taschner, Xi Cheng, Esben Lorentzen, and Kaiyao Huang. Intraflagellar transport protein ift52 recruits ift46 to the basal body and flagella. Journal of Cell Science, 130:1662-1674, May 2017. URL: https://doi.org/10.1242/jcs.200758, doi:10.1242/jcs.200758. This article has 47 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(lv2017intraflagellartransportprotein pages 1-4): Bo Lv, Lei Wan, Michael Taschner, Xi Cheng, Esben Lorentzen, and Kaiyao Huang. Intraflagellar transport protein ift52 recruits ift46 to the basal body and flagella. Journal of Cell Science, 130:1662-1674, May 2017. URL: https://doi.org/10.1242/jcs.200758, doi:10.1242/jcs.200758. This article has 47 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(lv2017intraflagellartransportprotein pages 9-11): Bo Lv, Lei Wan, Michael Taschner, Xi Cheng, Esben Lorentzen, and Kaiyao Huang. Intraflagellar transport protein ift52 recruits ift46 to the basal body and flagella. Journal of Cell Science, 130:1662-1674, May 2017. URL: https://doi.org/10.1242/jcs.200758, doi:10.1242/jcs.200758. This article has 47 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(cevik2013activetransportand pages 6-8): Sebiha Cevik, Anna A. W. M. Sanders, Erwin Van Wijk, Karsten Boldt, Lara Clarke, Jeroen van Reeuwijk, Yuji Hori, Nicola Horn, Lisette Hetterschijt, Anita Wdowicz, Andrea Mullins, Katarzyna Kida, Oktay I. Kaplan, Sylvia E. C. van Beersum, Ka Man Wu, Stef J. F. Letteboer, Dorus A. Mans, Toshiaki Katada, Kenji Kontani, Marius Ueffing, Ronald Roepman, Hannie Kremer, and Oliver E. Blacque. Active transport and diffusion barriers restrict joubert syndrome-associated arl13b/arl-13 to an inv-like ciliary membrane subdomain. PLoS Genetics, 9:e1003977, Dec 2013. URL: https://doi.org/10.1371/journal.pgen.1003977, doi:10.1371/journal.pgen.1003977. This article has 115 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(cevik2013activetransportand pages 8-10): Sebiha Cevik, Anna A. W. M. Sanders, Erwin Van Wijk, Karsten Boldt, Lara Clarke, Jeroen van Reeuwijk, Yuji Hori, Nicola Horn, Lisette Hetterschijt, Anita Wdowicz, Andrea Mullins, Katarzyna Kida, Oktay I. Kaplan, Sylvia E. C. van Beersum, Ka Man Wu, Stef J. F. Letteboer, Dorus A. Mans, Toshiaki Katada, Kenji Kontani, Marius Ueffing, Ronald Roepman, Hannie Kremer, and Oliver E. Blacque. Active transport and diffusion barriers restrict joubert syndrome-associated arl13b/arl-13 to an inv-like ciliary membrane subdomain. PLoS Genetics, 9:e1003977, Dec 2013. URL: https://doi.org/10.1371/journal.pgen.1003977, doi:10.1371/journal.pgen.1003977. This article has 115 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(lv2017intraflagellartransportprotein pages 35-40): Bo Lv, Lei Wan, Michael Taschner, Xi Cheng, Esben Lorentzen, and Kaiyao Huang. Intraflagellar transport protein ift52 recruits ift46 to the basal body and flagella. Journal of Cell Science, 130:1662-1674, May 2017. URL: https://doi.org/10.1242/jcs.200758, doi:10.1242/jcs.200758. This article has 47 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(lucker2010directinteractionsof pages 1-1): Ben F. Lucker, Mark S. Miller, Slawomir A. Dziedzic, Philip T. Blackmarr, and Douglas G. Cole. Direct interactions of intraflagellar transport complex b proteins ift88, ift52, and ift46. Jul 2010. URL: https://doi.org/10.1074/jbc.m110.106997, doi:10.1074/jbc.m110.106997. This article has 104 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(nozaki2017regulationofciliary pages 4-7): Shohei Nozaki, Yohei Katoh, Masaya Terada, Saki Michisaka, Teruki Funabashi, Senye Takahashi, Kenji Kontani, and Kazuhisa Nakayama. Regulation of ciliary retrograde protein trafficking by the joubert syndrome proteins arl13b and inpp5e. Journal of Cell Science, 130:563-576, Feb 2017. URL: https://doi.org/10.1242/jcs.197004, doi:10.1242/jcs.197004. This article has 113 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(nozaki2017regulationofciliary pages 31-35): Shohei Nozaki, Yohei Katoh, Masaya Terada, Saki Michisaka, Teruki Funabashi, Senye Takahashi, Kenji Kontani, and Kazuhisa Nakayama. Regulation of ciliary retrograde protein trafficking by the joubert syndrome proteins arl13b and inpp5e. Journal of Cell Science, 130:563-576, Feb 2017. URL: https://doi.org/10.1242/jcs.197004, doi:10.1242/jcs.197004. This article has 113 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(cevik2013activetransportand pages 10-11): Sebiha Cevik, Anna A. W. M. Sanders, Erwin Van Wijk, Karsten Boldt, Lara Clarke, Jeroen van Reeuwijk, Yuji Hori, Nicola Horn, Lisette Hetterschijt, Anita Wdowicz, Andrea Mullins, Katarzyna Kida, Oktay I. Kaplan, Sylvia E. C. van Beersum, Ka Man Wu, Stef J. F. Letteboer, Dorus A. Mans, Toshiaki Katada, Kenji Kontani, Marius Ueffing, Ronald Roepman, Hannie Kremer, and Oliver E. Blacque. Active transport and diffusion barriers restrict joubert syndrome-associated arl13b/arl-13 to an inv-like ciliary membrane subdomain. PLoS Genetics, 9:e1003977, Dec 2013. URL: https://doi.org/10.1371/journal.pgen.1003977, doi:10.1371/journal.pgen.1003977. This article has 115 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(nozaki2017regulationofciliary pages 7-10): Shohei Nozaki, Yohei Katoh, Masaya Terada, Saki Michisaka, Teruki Funabashi, Senye Takahashi, Kenji Kontani, and Kazuhisa Nakayama. Regulation of ciliary retrograde protein trafficking by the joubert syndrome proteins arl13b and inpp5e. Journal of Cell Science, 130:563-576, Feb 2017. URL: https://doi.org/10.1242/jcs.197004, doi:10.1242/jcs.197004. This article has 113 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(lucker2010directinteractionsof pages 5-6): Ben F. Lucker, Mark S. Miller, Slawomir A. Dziedzic, Philip T. Blackmarr, and Douglas G. Cole. Direct interactions of intraflagellar transport complex b proteins ift88, ift52, and ift46. Jul 2010. URL: https://doi.org/10.1074/jbc.m110.106997, doi:10.1074/jbc.m110.106997. This article has 104 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(brinzer2021theuptakeof pages 10-12): Robert A. Brinzer, David J. France, Claire McMaster, Stuart Ruddell, Alan D. Winter, and Antony P. Page. The uptake of avermectins in caenorhabditis elegans is dependent on intra-flagellar transport and other protein trafficking pathways. bioRxiv, Oct 2021. URL: https://doi.org/10.1101/2021.10.22.465401, doi:10.1101/2021.10.22.465401. This article has 1 citations.</p>
+</li>
+<li>
+<p>(brinzer2021theuptakeof pages 14-17): Robert A. Brinzer, David J. France, Claire McMaster, Stuart Ruddell, Alan D. Winter, and Antony P. Page. The uptake of avermectins in caenorhabditis elegans is dependent on intra-flagellar transport and other protein trafficking pathways. bioRxiv, Oct 2021. URL: https://doi.org/10.1101/2021.10.22.465401, doi:10.1101/2021.10.22.465401. This article has 1 citations.</p>
+</li>
+<li>
+<p>(chu2012finetuningof pages 1-2): J. S. C. Chu, M. Tarailo-Graovac, D. Zhang, J. Wang, B. Uyar, D. Tu, J. Trinh, D. L. Baillie, and N. Chen. Fine tuning of rfx/daf-19-regulated target gene expression through binding to multiple sites in caenorhabditis elegans. Nucleic Acids Research, 40:53-64, Sep 2012. URL: https://doi.org/10.1093/nar/gkr690, doi:10.1093/nar/gkr690. This article has 13 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(warrington2018computationalandmolecular pages 21-25): Timothy Burton Warrington. Computational and molecular dissection of an x-box cis-regulatory module. Preprint, Jan 2018. URL: https://doi.org/10.48550/arxiv.1810.00478, doi:10.48550/arxiv.1810.00478. This article has 2 citations.</p>
+</li>
+<li>
+<p>(chu2012finetuningof pages 5-8): J. S. C. Chu, M. Tarailo-Graovac, D. Zhang, J. Wang, B. Uyar, D. Tu, J. Trinh, D. L. Baillie, and N. Chen. Fine tuning of rfx/daf-19-regulated target gene expression through binding to multiple sites in caenorhabditis elegans. Nucleic Acids Research, 40:53-64, Sep 2012. URL: https://doi.org/10.1093/nar/gkr690, doi:10.1093/nar/gkr690. This article has 13 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+</ol>
+<h2 id="artifacts">Artifacts</h2>
+<ul>
+<li><a href="dyf-6-deep-research-falcon_artifacts/artifact-00.md">Edison artifact artifact-00</a></li>
+<li><a href="dyf-6-deep-research-falcon_artifacts/artifact-01.md">Edison artifact artifact-01</a></li>
+</ul>
+<h2 id="citations">Citations</h2>
+<ol>
+<li>lv2017intraflagellartransportprotein pages 4-7</li>
+<li>nakayama2018ciliaryproteintrafficking pages 3-3</li>
+<li>lucker2010directinteractionsof pages 9-9</li>
+<li>lv2017intraflagellartransportprotein pages 1-4</li>
+<li>cevik2013activetransportand pages 6-8</li>
+<li>lucker2010directinteractionsof pages 1-1</li>
+<li>chu2012finetuningof pages 1-2</li>
+<li>warrington2018computationalandmolecular pages 21-25</li>
+<li>chu2012finetuningof pages 5-8</li>
+<li>liu2025structuremakesa pages 1-2</li>
+<li>taschner2016theintraflagellartransport pages 5-6</li>
+<li>lechtreck2022cargoadaptersexpand pages 3-4</li>
+<li>lechtreck2022cargoadaptersexpand pages 2-3</li>
+<li>nakayama2018ciliaryproteintrafficking pages 4-5</li>
+<li>lucker2010directinteractionsof pages 6-6</li>
+<li>lv2017intraflagellartransportprotein pages 40-45</li>
+<li>lv2017intraflagellartransportprotein pages 11-14</li>
+<li>lv2017intraflagellartransportprotein pages 9-11</li>
+<li>cevik2013activetransportand pages 8-10</li>
+<li>lv2017intraflagellartransportprotein pages 35-40</li>
+<li>nozaki2017regulationofciliary pages 4-7</li>
+<li>nozaki2017regulationofciliary pages 31-35</li>
+<li>cevik2013activetransportand pages 10-11</li>
+<li>nozaki2017regulationofciliary pages 7-10</li>
+<li>lucker2010directinteractionsof pages 5-6</li>
+<li>brinzer2021theuptakeof pages 10-12</li>
+<li>brinzer2021theuptakeof pages 14-17</li>
+<li>https://doi.org/10.1242/jcs.200758,</li>
+<li>https://doi.org/10.1002/cm.70033,</li>
+<li>https://doi.org/10.1093/jb/mvx087,</li>
+<li>https://doi.org/10.1074/jbc.m110.106997,</li>
+<li>https://doi.org/10.1101/cshperspect.a028092,</li>
+<li>https://doi.org/10.1242/jcs.260408,</li>
+<li>https://doi.org/10.1101/211953,</li>
+<li>https://doi.org/10.1101/2023.04.12.536397,</li>
+<li>https://doi.org/10.1371/journal.pgen.1003977,</li>
+<li>https://doi.org/10.1242/jcs.197004,</li>
+<li>https://doi.org/10.1101/2021.10.22.465401,</li>
+<li>https://doi.org/10.1093/nar/gkr690,</li>
+<li>https://doi.org/10.48550/arxiv.1810.00478,</li>
+</ol>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(dyf-6-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="Q0G838" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="dyf-6-q0g838-research-notes">dyf-6 (Q0G838) research notes</h1>
+<h2 id="identity-from-uniprot-q0g838-ift46_caeel">Identity (from UniProt Q0G838, IFT46_CAEEL)</h2>
+<ul>
+<li><strong>Gene</strong>: dyf-6 (F46F6.4), WormBase WBGene00001122, chromosome X. "dyf" = abnormal <strong>dye filling</strong>.</li>
+<li><strong>Protein</strong>: Intraflagellar transport protein 46 homolog (IFT46). 471 aa (isoform a). Human ortholog IFT46 = Q9NQC8; mouse Q9CQ63 (used in IBA WITH/FROM).</li>
+<li><strong>Domain/family</strong>: PANTHER PTHR13376 (INTRAFLAGELLAR TRANSPORT PROTEIN 46 HOMOLOG); Pfam PF12317 (IFT46_B_C); InterPro IPR022088 (Intraflagellar_transp_cmplxB). Large N-terminal disordered/acidic region (res 1–202); no catalytic domain. So DYF-6 is <strong>MF-dark</strong>: a structural/adaptor subunit of IFT-B with no assigned molecular activity (unlike its worm paralog-family neighbor dyf-11/IFT54, which carries an InterPro2GO microtubule-binding transfer — dyf-6 has NO MF annotation at all in GOA).</li>
+<li><strong>Complex</strong>: Component of IFT complex B (ComplexPortal CPX-1290). UniProt SUBUNIT (from PMID:28479320): "Component of the IFT complex B composed of at least che-2, che-13, dyf-1, dyf-3, dyf-6, dyf-11, dyf-13, ift-20, ift-74, ift-81, ifta-2, osm-1, osm-5 and osm-6."</li>
+<li><strong>Localization</strong> (UniProt, from PMID:16648645): Cell projection, cilium; Cytoplasm/cytoskeleton, cilium basal body; Cell projection, dendrite; Perikaryon. "Highly expressed in the transition zones between the cilium basal body and the dendrites."</li>
+<li><strong>Isoforms</strong>: 4 (a Q0G838-1 displayed; b/c/d). dyf-6 is a complex locus; a longer mRNA fuses the dyf-6 ORF to the upstream gene F46F6.3 — the short forms confer full rescue and are the conserved/functional forms.</li>
+</ul>
+<h2 id="known-well-supported">KNOWN (well-supported)</h2>
+<ol>
+<li><strong>DYF-6 is an IFT (intraflagellar transport) protein that moves within cilia.</strong></li>
+<li><a href="https://pubmed.ncbi.nlm.nih.gov/16648645" title="Movement of DYF-6::GFP within the ciliated endings of the neurons indicates that DYF-6 is involved in IFT.">PMID:16648645</a></li>
+<li>
+<p><a href="https://pubmed.ncbi.nlm.nih.gov/16648645" title="Anterograde movement appeared more apparent than retrograde movement.">PMID:16648645</a></p>
+</li>
+<li>
+<p><strong>DYF-6 is (very likely) an IFT complex B component.</strong> Bell 2006 inferred this from the OSM-6::GFP mislocalization pattern; Yi 2017/ComplexPortal biochemically place it in IFT-B.</p>
+</li>
+<li><a href="https://pubmed.ncbi.nlm.nih.gov/16648645" title="dyf-6 may encode a component of complex B IFT particles">PMID:16648645</a></li>
+<li><a href="https://pubmed.ncbi.nlm.nih.gov/16648645" title="The pattern of OSM-6::GFP in dyf-6 mutants therefore more closely resembles that of a complex B IFT component.">PMID:16648645</a></li>
+<li>
+<p>UniProt SUBUNIT + ComplexPortal CPX-1290 (from PMID:28479320) list dyf-6 in IFT-B.</p>
+</li>
+<li>
+<p><strong>DYF-6 is required to build/maintain sensory cilia; loss foreshortens amphid &amp; phasmid cilia.</strong></p>
+</li>
+<li><a href="https://pubmed.ncbi.nlm.nih.gov/16648645" title="the cilia of the amphid and phasmid dendritic endings are foreshortened">PMID:16648645</a></li>
+<li>
+<p>C. elegans sensory cilia are <strong>non-motile</strong>, so the specific process term is non-motile cilium assembly (GO:1905515, WormBase IMP).</p>
+</li>
+<li>
+<p><strong>DYF-6 acts cell-autonomously in the amphid sensory neurons; loss causes dye-filling/chemotaxis defects.</strong></p>
+</li>
+<li><a href="https://pubmed.ncbi.nlm.nih.gov/16648645" title="genes that affect chemotaxis and the ability of certain sensory neurons to take up fluorescent dyes from the environment">PMID:16648645</a></li>
+<li>
+<p><a href="https://pubmed.ncbi.nlm.nih.gov/16648645" title="genetic mosaic analysis, which indicates that dyf-6 functions in neurons of the amphid sensilla">PMID:16648645</a></p>
+</li>
+<li>
+<p><strong>Expression</strong>: DYF-6::GFP in amphid &amp; phasmid (and IL-region) ciliated neurons, plus hypodermis; expressed hatching→adult incl. dauer.</p>
+</li>
+<li><a href="https://pubmed.ncbi.nlm.nih.gov/16648645" title="DYF-6::GFP is expressed in amphid and phasmid neurons">PMID:16648645</a></li>
+<li>
+<p><a href="https://pubmed.ncbi.nlm.nih.gov/16648645" title="IFT can be observed in dauer larvae">PMID:16648645</a></p>
+</li>
+<li>
+<p><strong>Conservation</strong>: orthologs in fly (CG15161, ciliary) and mammals; human ortholog conserved throughout.</p>
+</li>
+<li><a href="https://pubmed.ncbi.nlm.nih.gov/16648645" title="DYF-6, the product of a complex locus, lacks known motifs, but orthologs are present in flies and mammals.">PMID:16648645</a></li>
+<li>
+<p><a href="https://pubmed.ncbi.nlm.nih.gov/16648645" title="the human ortholog is conserved throughout and begins at the same methionine">PMID:16648645</a></p>
+</li>
+<li>
+<p><strong>DYF-6/IFT-B is needed for dynein-2 ciliary entry</strong> (retrograde IFT context).</p>
+</li>
+<li><a href="https://pubmed.ncbi.nlm.nih.gov/28479320" title="intraflagellar transport (IFT)-B complex abolishes dynein-2's ciliary localization">PMID:28479320</a> (abstract-only cache; full text is the source of the IFT-B mass-spec membership)</li>
+</ol>
+<h2 id="not-known-gaps">NOT known / gaps</h2>
+<ul>
+<li><strong>Molecular function of DYF-6/IFT46 is undefined.</strong> No catalytic domain; large disordered N-terminus. Which IFT-B subunit(s) it directly contacts in the worm, and whether it (like Chlamydomonas IFT46, which uses its N-terminal domain to load outer dynein arms) has a cargo-adaptor activity, is not established here. GO MF aspect cannot currently express "structural subunit of IFT-B" (ontology gap). <a href="https://pubmed.ncbi.nlm.nih.gov/16648645" title="DYF-6, the product of a complex locus, lacks known motifs">PMID:16648645</a></li>
+<li><strong>Function of the long dyf-6/F46F6.3 fusion isoform is unknown.</strong> <a href="https://pubmed.ncbi.nlm.nih.gov/16648645" title="The function, if any, of the larger dyf-6 gene product remains unknown.">PMID:16648645</a></li>
+<li><strong>Whether DYF-6 has any non-ciliary role</strong> (it is also seen in dendrite/perikaryon/cell body) is untested.</li>
+</ul>
+<h2 id="annotation-review-plan-19-goa-annotations">Annotation-review plan (19 GOA annotations)</h2>
+<ul>
+<li>CORE (ACCEPT): intraciliary transport particle B (IBA part_of; NAS part_of), intraciliary transport (IBA/IEA/NAS/IDA involved_in), cilium assembly (IBA/NAS involved_in), non-motile cilium assembly (IMP involved_in), cilium (IEA/NAS located_in).</li>
+<li>MODIFY: microtubule organizing center (IBA is_active_in) → ciliary basal body GO:0036064 (documented basal-body/transition-zone localization).</li>
+<li>MARK_AS_OVER_ANNOTATED: motile cilium (IBA is_active_in) — C. elegans has NO motile cilia (mammalian-biased IBA over-propagation; worm cilia are non-motile sensory); plasma membrane bounded cell projection GO:0120025 (ARBA IEA) — over-general grouping parent of cilium+dendrite already annotated.</li>
+<li>KEEP_AS_NON_CORE (real but not core location/route): dendrite (IEA/IDA), perikaryon (IEA/EXP), neuronal cell body (IDA).</li>
+</ul>
+<h2 id="provenance-note">Provenance note</h2>
+<p>Cache: PMID:16648645 full text available (Bell et al. 2006, Genetics, PMC1526656). PMID:28479320 abstract-only (Yi et al. 2017, Curr Biol) — IFT-B membership rests on full-text mass-spec not in cache; annotations from it are ComplexPortal NAS, accepted deferring to curator/ComplexPortal.</p>
+<h2 id="falcon-deep-research-dyf-6-deep-research-falconmd-2026-07-04-additional-context">Falcon deep research (dyf-6-deep-research-falcon.md, 2026-07-04) — additional context</h2>
+<p>Genuine, gene-correct report (40 citations, 2 artifacts). Key points that refine but do not<br />
+contradict the review:</p>
+<ul>
+<li><strong>IFT-B1 core architecture</strong>: IFT46's conserved C-terminal IFT46_B_C domain (PF12317) directly<br />
+  binds IFT52, and IFT46–IFT52–IFT88 form a stable ternary core module of IFT-B1 (Lucker et al.<br />
+  2010 J Biol Chem; Lv et al. 2017 J Cell Sci; Taschner &amp; Lorentzen 2016). So DYF-6 is not<br />
+  partner-less — but these interactions are characterized in Chlamydomonas/human, not the worm,<br />
+  and GO MF has no term for the structural role. [falcon: "IFT46 directly interacts with IFT52<br />
+  through large hydrophobic surfaces at their carboxy-terminal domains"]</li>
+<li><strong>Basal-body targeting</strong>: IFT52 recruits IFT46 to the basal body; the IFT46 C-terminal BBTS3<br />
+  segment (~aa 246–321) is the basal-body/ciliary targeting sequence; L285/L286 are key for IFT52<br />
+  binding (Lv et al. 2017). Supports the MTOC→ciliary basal body MODIFY.</li>
+<li><strong>N-terminal ODA16 cargo-adaptor role is MOTILE-cilia-specific</strong> (Chlamydomonas ODA transport),<br />
+  hence NOT expected in C. elegans non-motile sensory cilia — independent support for marking the<br />
+  IBA "motile cilium" annotation as over-annotated. [falcon: "the N-terminal region involved in<br />
+  ODA16 binding is specifically conserved in organisms with motile cilia"; "Since C. elegans<br />
+  possesses only non-motile sensory cilia that lack dynein arms, the ODA transport function of<br />
+  IFT46's N-terminus may be less relevant in nematodes"]</li>
+<li><strong>Worm-specific ARL-13 trafficking (NOT in GOA)</strong>: Cevik et al. 2013 report that dyf-6 mutants<br />
+  mislocalize the Joubert-syndrome protein ARL-13/ARL13B (reduced in ciliary middle segment,<br />
+  accumulates at periciliary membrane), via the IFT46–IFT56 dimer that binds ARL13B (Nozaki et al.<br />
+  2017). This is a genuine dyf-6 functional finding but the primary papers are not in the<br />
+  publications cache, so it is recorded here as context only (not added as verbatim-supported<br />
+  annotation).</li>
+<li><strong>Transcriptional control</strong>: ciliary genes incl. IFT-B are DAF-19/RFX (X-box) targets; dyf-6's<br />
+  Drosophila ortholog CG15161 is an RFX target (consistent with X-box regulation of ciliary genes).</li>
+<li><strong>Anthelmintic uptake</strong>: dyf-6 among ciliary genes needed for avermectin uptake via amphid cilia<br />
+  (Brinzer et al. 2021) — a downstream/pleiotropic sensory readout, not a core function.</li>
+</ul>
+<p>Not independently re-verified (LLM synthesis with internal citation keys); used as supporting<br />
+context. The two ontology/biology knowledge gaps in the review reflect this: partners known in<br />
+other species but (a) no GO MF term and (b) worm-specific contacts/adaptor role unproven.</p>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: Q0G838
+gene_symbol: dyf-6
+product_type: PROTEIN
+status: COMPLETE
+aliases:
+- IFT46
+- F46F6.4
+taxon:
+  id: NCBITaxon:6239
+  label: Caenorhabditis elegans
+description: &gt;-
+  dyf-6 encodes the Caenorhabditis elegans ortholog of intraflagellar transport
+  protein 46 (IFT46), a structural subunit of intraflagellar transport (IFT)
+  complex B. IFT-B, with IFT-A and the kinesin-2 and dynein-2 motors, drives the
+  bidirectional movement of ciliary cargo that builds and maintains the cilia of
+  ciliated sensory neurons. The 471-residue protein has a large N-terminal
+  disordered/acidic region and no recognizable catalytic domain. DYF-6 is
+  expressed in ciliated amphid and phasmid sensory neurons (and hypodermis),
+  localizes to the cilium, the ciliary base/basal body region, dendrites and the
+  neuronal cell body, and undergoes processive IFT movement within the ciliated
+  dendritic endings. It is required to build full-length sensory cilia: in dyf-6
+  mutants the amphid and phasmid ciliary endings are foreshortened, the IFT-B
+  marker OSM-6 is mislocalized in a pattern typical of complex B mutants, and the
+  animals are defective in dye filling and chemotaxis. The ciliary role is
+  conserved, with orthologs in Drosophila (CG15161, expressed in sensory cilia)
+  and mammals (human IFT46). C. elegans has only non-motile sensory cilia, so the
+  cilium DYF-6 builds is a non-motile sensory cilium.
+references:
+- id: GO_REF:0000002
+  title: Gene Ontology annotation through association of InterPro records with GO
+    terms
+  findings: []
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: &gt;-
+      InterPro2GO mapping of the IFT complex B family (IPR022088) to intraciliary
+      transport (GO:0042073). The family/domain identity (Pfam IFT46_B_C,
+      PANTHER PTHR13376) is correct for DYF-6, and the transferred biological
+      process is independently confirmed by C. elegans experimental data, so the
+      transfer is sound.
+- id: GO_REF:0000033
+  title: Annotation inferences using phylogenetic trees
+  findings: []
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Standard GO_Central IBA pipeline. The IFT-B membership, intraciliary
+      transport and cilium-assembly transfers are all corroborated by worm
+      experimental data (PMID:16648645). The &#34;motile cilium&#34; (GO:0031514)
+      transfer is a mammalian-biased over-propagation: C. elegans has no motile
+      cilia, only non-motile sensory cilia.
+- id: GO_REF:0000044
+  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location
+    vocabulary mapping, accompanied by conservative changes to GO terms applied by
+    UniProt
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Electronic mapping of UniProt subcellular-location keywords (cilium,
+      dendrite, perikaryon) to GO CC terms. Redundant with the experimental
+      WormBase/UniProt annotations from PMID:16648645 but not incorrect.
+- id: GO_REF:0000117
+  title: Electronic Gene Ontology annotations created by ARBA machine learning models
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: LOW_QUALITY
+    review_notes: &gt;-
+      ARBA machine-learning annotation to the over-general grouping term
+      &#34;plasma membrane bounded cell projection&#34; (GO:0120025), whose informative
+      descendants (cilium, dendrite) are already annotated. Uninformative for
+      this protein.
+- id: PMID:16648645
+  title: The molecular identities of the Caenorhabditis elegans intraflagellar transport
+    genes dyf-6, daf-10 and osm-1.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Bell et al. 2006 (Genetics, PMC1526656), the primary cloning and functional
+      characterization of dyf-6. Establishes DYF-6 as an IFT protein that moves
+      within amphid/phasmid ciliated endings, that dyf-6 mutants have foreshortened
+      cilia, that dyf-6 functions cell-autonomously in amphid sensilla, and that
+      the protein has no recognized motifs but is conserved to flies and mammals.
+      Source of the WormBase IDA/IMP/EXP annotations. (Cache exposes the abstract;
+      the full text additionally infers IFT complex B membership from the OSM-6
+      mislocalization pattern.)
+- id: PMID:28479320
+  title: Dynein-Driven Retrograde Intraflagellar Transport Is Triphasic in C. elegans
+    Sensory Cilia.
+  findings: []
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Yi et al. 2017 (Curr Biol). Source of the ComplexPortal (CPX-1290) NAS
+      annotations placing DYF-6 in IFT complex B and of the UniProt SUBUNIT list.
+      Cached record is abstract-only; the abstract confirms that an intact IFT-B
+      complex is required for dynein-2 ciliary entry, and the full text is the
+      basis (affinity purification / mass spectrometry) for DYF-6&#39;s IFT-B
+      membership. NAS annotations accepted, deferring to ComplexPortal/curator.
+- id: PMID:7705621
+  title: Mutations affecting the chemosensory neurons of Caenorhabditis elegans.
+  findings: []
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Starich et al. 1995 (Genetics), the genetic screen that isolated dyf-6 among
+      the dye-filling-defective (Dyf) mutants and characterized its chemotaxis /
+      dye-filling disruption phenotype; cited by UniProt as a FUNCTION and
+      DISRUPTION PHENOTYPE reference for dyf-6. Cached record is abstract-only (the
+      abstract summarizes the screen without naming dyf-6), so it is included as
+      background establishing the loss-of-function phenotype rather than as a
+      verbatim source for a specific annotation.
+- id: file:worm/dyf-6/dyf-6-deep-research-falcon.md
+  title: &#34;Deep research report (Falcon/Edison): DYF-6/IFT46 in Caenorhabditis elegans&#34;
+  findings: []
+  reference_review:
+    relevance: MEDIUM
+    correctness: UNVERIFIED
+    review_notes: &gt;-
+      AI-generated (Falcon/Edison) deep-research synthesis. Corroborates the
+      primary-literature-grounded review: DYF-6/IFT46 is a structural IFT-B1 core
+      subunit whose conserved C-terminal IFT46_B_C domain mediates direct IFT52
+      (and, via a ternary module, IFT88) binding, while the N-terminal ODA16
+      cargo-adaptor role is confined to organisms with motile cilia and is not
+      expected in C. elegans non-motile sensory cilia. Also surfaces worm-specific
+      literature (Cevik et al. 2013 on ARL-13 ciliary membrane trafficking in
+      dyf-6 mutants) not in the GOA set. Underlying claims are drawn from
+      Chlamydomonas/human work cited by internal keys, not independently
+      re-verified here; treated as supporting context, not primary evidence.
+existing_annotations:
+- term:
+    id: GO:0005815
+    label: microtubule organizing center
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: is_active_in
+  review:
+    summary: &gt;-
+      IFT46 orthologs concentrate at and inject IFT trains from the ciliary base.
+      In C. elegans this is the basal body / transition-zone region; UniProt
+      curates DYF-6 basal-body localization from PMID:16648645. The basal body is
+      a type of microtubule organizing center, so the term is not wrong, but the
+      specific &#34;ciliary basal body&#34; (GO:0036064) is the accurate, informative CC.
+    action: MODIFY
+    reason: &gt;-
+      Term too general. DYF-6&#39;s documented location at the ciliary base is better
+      captured by ciliary basal body (GO:0036064) than by the generic
+      microtubule organizing center.
+    proposed_replacement_terms:
+    - id: GO:0036064
+      label: ciliary basal body
+    propagation_review:
+      root_cause: TERM_SCOPING_PROBLEM
+      failure_modes:
+      - GRANULARITY_MISMATCH
+      source_entities:
+      - source_id: PANTHER:PTN000332669
+        source_label: IFT46 family node
+        source_status: SUPPORTS_TRANSFER
+        comment: &gt;-
+          The IFT46 family node correctly places DYF-6 at the microtubule
+          organizing center (basal body), but the transferred term is coarser than
+          the specific ciliary basal body location documented for the worm protein.
+- term:
+    id: GO:0030992
+    label: intraciliary transport particle B
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: part_of
+  review:
+    summary: &gt;-
+      DYF-6/IFT46 is a subunit of intraflagellar transport complex B (IFT-B).
+      This phylogenetic transfer is corroborated by Bell et al.&#39;s inference from
+      the OSM-6 mislocalization pattern and by biochemical assignment to
+      ComplexPortal CPX-1290.
+    action: ACCEPT
+    reason: &gt;-
+      Core cellular-component identity of DYF-6 as an IFT-B structural subunit.
+    supported_by:
+    - reference_id: PMID:28479320
+      supporting_text: intraflagellar transport (IFT)-B complex abolishes dynein-2&#39;s
+        ciliary localization
+      reference_section_type: ABSTRACT
+    - reference_id: file:worm/dyf-6/dyf-6-deep-research-falcon.md
+      supporting_text: IFT46 is a pivotal subunit of the IFT-B1 core subcomplex
+      reference_section_type: OTHER
+- term:
+    id: GO:0060271
+    label: cilium assembly
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      IFT is required to assemble and maintain cilia; dyf-6 mutants have
+      foreshortened amphid and phasmid ciliary endings, so DYF-6 is required for
+      cilium assembly.
+    action: ACCEPT
+    reason: &gt;-
+      Core biological process, supported experimentally in worm (PMID:16648645).
+      The more specific worm-appropriate term non-motile cilium assembly is also
+      annotated (IMP).
+    supported_by:
+    - reference_id: PMID:16648645
+      supporting_text: the cilia of the amphid and phasmid dendritic endings are
+        foreshortened
+      reference_section_type: ABSTRACT
+- term:
+    id: GO:0031514
+    label: motile cilium
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: is_active_in
+  review:
+    summary: &gt;-
+      This IBA transfer from mammalian IFT46 assigns a motile-cilium location.
+      C. elegans, however, has no motile cilia — all its cilia, including the
+      amphid and phasmid sensory cilia in which DYF-6 acts, are non-motile. The
+      matching worm annotation is non-motile cilium assembly (GO:1905515, IMP).
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      Taxonomically inappropriate over-propagation: C. elegans lacks motile
+      cilia. DYF-6 acts in non-motile sensory cilia; the generic ciliary location
+      (cilium, GO:0005929) is separately and correctly annotated.
+    propagation_review:
+      root_cause: PROPAGATION_BAD
+      failure_modes:
+      - LINEAGE_OR_TAXON_MISMATCH
+      source_entities:
+      - source_id: PANTHER:PTN000332669
+        source_label: IFT46 family node
+        source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
+        comment: &gt;-
+          The IFT46 family node includes vertebrate members that function in
+          motile cilia, but the C. elegans ortholog acts only in non-motile
+          sensory cilia, so the motile-cilium location does not transfer.
+- term:
+    id: GO:0042073
+    label: intraciliary transport
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      DYF-6 functions in intraflagellar (intraciliary) transport as an IFT-B
+      subunit; DYF-6::GFP undergoes IFT movement within ciliated endings.
+    action: ACCEPT
+    reason: &gt;-
+      Core biological process, confirmed experimentally in worm (PMID:16648645).
+    supported_by:
+    - reference_id: PMID:16648645
+      supporting_text: Movement of DYF-6::GFP within the ciliated endings of the
+        neurons indicates that DYF-6 is involved in IFT
+      reference_section_type: ABSTRACT
+- term:
+    id: GO:0005929
+    label: cilium
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000044
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Electronic mapping of the UniProt cilium subcellular-location keyword.
+      DYF-6 is directly observed within cilia, where it undergoes IFT.
+    action: ACCEPT
+    reason: &gt;-
+      Correct core ciliary location, corroborated by experimental IFT movement
+      within ciliated endings (PMID:16648645).
+    supported_by:
+    - reference_id: PMID:16648645
+      supporting_text: Movement of DYF-6::GFP within the ciliated endings of the
+        neurons indicates that DYF-6 is involved in IFT
+      reference_section_type: ABSTRACT
+- term:
+    id: GO:0030425
+    label: dendrite
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000044
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      DYF-6 is present in the sensory dendrites through which IFT cargo is
+      trafficked to the ciliated ending; UniProt curates dendrite localization
+      from PMID:16648645 and WormBase makes the same call by IDA.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Real localization (the dendritic route to the cilium) but not the core
+      site of DYF-6 function, which is the cilium/IFT machinery.
+- term:
+    id: GO:0042073
+    label: intraciliary transport
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      InterPro2GO transfer (IPR022088, IFT complex B) to intraciliary transport.
+      Duplicates the IBA/NAS/IDA intraciliary-transport annotations and is
+      correct.
+    action: ACCEPT
+    reason: &gt;-
+      Core biological process; redundant with experimental IDA (PMID:16648645)
+      but consistent.
+    supported_by:
+    - reference_id: PMID:16648645
+      supporting_text: Movement of DYF-6::GFP within the ciliated endings of the
+        neurons indicates that DYF-6 is involved in IFT
+      reference_section_type: ABSTRACT
+- term:
+    id: GO:0043204
+    label: perikaryon
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000044
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Electronic mapping of the UniProt perikaryon subcellular-location keyword,
+      the same call made experimentally (EXP) from PMID:16648645. DYF-6 is present
+      in the neuronal cell body/perikaryon in addition to the cilium.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Real localization but not the core functional site; the cell body reflects
+      the neuron of expression rather than DYF-6&#39;s IFT role.
+- term:
+    id: GO:0120025
+    label: plasma membrane bounded cell projection
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000117
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      ARBA machine-learning annotation to a high-level grouping term that is the
+      parent of both cilium and dendrite, which are already specifically
+      annotated for DYF-6.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      Over-general electronic grouping term; its informative descendants (cilium,
+      dendrite) are already annotated, so it adds no information.
+- term:
+    id: GO:0005929
+    label: cilium
+  evidence_type: NAS
+  original_reference_id: PMID:28479320
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      ComplexPortal (CPX-1290) assertion that DYF-6 localizes to the cilium,
+      consistent with the experimental observation that DYF-6 undergoes IFT
+      within cilia.
+    action: ACCEPT
+    reason: &gt;-
+      Correct core ciliary location.
+    supported_by:
+    - reference_id: PMID:16648645
+      supporting_text: Movement of DYF-6::GFP within the ciliated endings of the
+        neurons indicates that DYF-6 is involved in IFT
+      reference_section_type: ABSTRACT
+- term:
+    id: GO:0030992
+    label: intraciliary transport particle B
+  evidence_type: NAS
+  original_reference_id: PMID:28479320
+  qualifier: part_of
+  review:
+    summary: &gt;-
+      ComplexPortal (CPX-1290) assignment of DYF-6 to IFT complex B, based on the
+      affinity-purification / mass-spectrometry of the worm IFT-B complex in Yi
+      et al. 2017 and reflected in the UniProt SUBUNIT statement.
+    action: ACCEPT
+    reason: &gt;-
+      Core cellular-component identity; biochemically supported IFT-B membership.
+    supported_by:
+    - reference_id: PMID:28479320
+      supporting_text: intraflagellar transport (IFT)-B complex abolishes dynein-2&#39;s
+        ciliary localization
+      reference_section_type: ABSTRACT
+- term:
+    id: GO:0042073
+    label: intraciliary transport
+  evidence_type: NAS
+  original_reference_id: PMID:28479320
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      ComplexPortal assertion that DYF-6, as an IFT-B subunit, functions in
+      intraciliary transport, consistent with the worm experimental data.
+    action: ACCEPT
+    reason: &gt;-
+      Core biological process; consistent with IFT-B membership and experimental
+      IFT movement (PMID:16648645).
+    supported_by:
+    - reference_id: PMID:16648645
+      supporting_text: Movement of DYF-6::GFP within the ciliated endings of the
+        neurons indicates that DYF-6 is involved in IFT
+      reference_section_type: ABSTRACT
+- term:
+    id: GO:0060271
+    label: cilium assembly
+  evidence_type: NAS
+  original_reference_id: PMID:28479320
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      ComplexPortal assertion that DYF-6 functions in cilium assembly, consistent
+      with the foreshortened-cilia phenotype of dyf-6 mutants.
+    action: ACCEPT
+    reason: &gt;-
+      Core biological process; supported by the dyf-6 mutant cilium phenotype
+      (PMID:16648645).
+    supported_by:
+    - reference_id: PMID:16648645
+      supporting_text: the cilia of the amphid and phasmid dendritic endings are
+        foreshortened
+      reference_section_type: ABSTRACT
+- term:
+    id: GO:0043204
+    label: perikaryon
+  evidence_type: EXP
+  original_reference_id: PMID:16648645
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Experimental localization of DYF-6 to the neuronal perikaryon (cell body)
+      in addition to the cilium and dendrite. DYF-6::GFP is expressed throughout
+      the ciliated sensory neurons.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Real experimental localization but not DYF-6&#39;s core functional site; the
+      cell body reflects the site of expression rather than the IFT role.
+    supported_by:
+    - reference_id: PMID:16648645
+      supporting_text: DYF-6::GFP is expressed in amphid and phasmid neurons
+      reference_section_type: ABSTRACT
+- term:
+    id: GO:0030425
+    label: dendrite
+  evidence_type: IDA
+  original_reference_id: PMID:16648645
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      WormBase IDA localization of DYF-6 to the sensory dendrites, the route
+      along which IFT cargo travels between the cell body and the ciliated
+      ending.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Real localization along the trafficking route to the cilium, but not the
+      core functional site (the cilium/IFT machinery).
+- term:
+    id: GO:0042073
+    label: intraciliary transport
+  evidence_type: IDA
+  original_reference_id: PMID:16648645
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Direct observation that DYF-6::GFP moves within the ciliated endings of
+      amphid and phasmid neurons demonstrates that DYF-6 participates in
+      intraflagellar (intraciliary) transport. This is the primary experimental
+      basis for the core function.
+    action: ACCEPT
+    reason: &gt;-
+      Core biological process; strongest, directly observed evidence
+      (PMID:16648645).
+    supported_by:
+    - reference_id: PMID:16648645
+      supporting_text: Movement of DYF-6::GFP within the ciliated endings of the
+        neurons indicates that DYF-6 is involved in IFT
+      reference_section_type: ABSTRACT
+- term:
+    id: GO:0043025
+    label: neuronal cell body
+  evidence_type: IDA
+  original_reference_id: PMID:16648645
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      WormBase IDA localization of DYF-6 to the neuronal cell body, consistent
+      with the EXP perikaryon annotation and with expression throughout ciliated
+      sensory neurons.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Real localization but not the core functional site; reflects the neuron of
+      expression rather than the IFT role.
+    supported_by:
+    - reference_id: PMID:16648645
+      supporting_text: DYF-6::GFP is expressed in amphid and phasmid neurons
+      reference_section_type: ABSTRACT
+- term:
+    id: GO:1905515
+    label: non-motile cilium assembly
+  evidence_type: IMP
+  original_reference_id: PMID:16648645
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      C. elegans sensory cilia are non-motile, and DYF-6 is required to build
+      them: dyf-6 mutants have foreshortened amphid and phasmid ciliary endings.
+      This is the most specific and organism-appropriate biological-process term
+      for DYF-6.
+    action: ACCEPT
+    reason: &gt;-
+      Core biological process; the non-motile-cilium wording matches the worm
+      sensory cilium and is directly supported by the mutant phenotype
+      (PMID:16648645).
+    supported_by:
+    - reference_id: PMID:16648645
+      supporting_text: the cilia of the amphid and phasmid dendritic endings are
+        foreshortened
+      reference_section_type: ABSTRACT
+core_functions:
+- description: &gt;-
+    DYF-6/IFT46 is a structural subunit of intraflagellar transport (IFT) complex
+    B in ciliated sensory neurons. It localizes to the cilium and the ciliary base
+    (basal body / transition-zone region), undergoes bidirectional IFT movement
+    within the ciliated dendritic endings, and is required to build full-length
+    non-motile sensory cilia — dyf-6 loss foreshortens the amphid and phasmid
+    ciliary endings and produces the OSM-6 mislocalization pattern typical of IFT
+    complex B mutants. It has no catalytic domain and acts as a structural/adaptor
+    component of IFT-B; no informative molecular-function term is currently
+    assignable (MF-dark; see knowledge_gaps).
+  in_complex:
+    id: GO:0030992
+    label: intraciliary transport particle B
+  directly_involved_in:
+  - id: GO:0042073
+    label: intraciliary transport
+  - id: GO:1905515
+    label: non-motile cilium assembly
+  locations:
+  - id: GO:0005929
+    label: cilium
+  - id: GO:0036064
+    label: ciliary basal body
+  supported_by:
+  - reference_id: PMID:16648645
+    supporting_text: Movement of DYF-6::GFP within the ciliated endings of the
+      neurons indicates that DYF-6 is involved in IFT
+    reference_section_type: ABSTRACT
+  - reference_id: PMID:16648645
+    supporting_text: the cilia of the amphid and phasmid dendritic endings are
+      foreshortened
+    reference_section_type: ABSTRACT
+  - reference_id: PMID:28479320
+    supporting_text: intraflagellar transport (IFT)-B complex abolishes dynein-2&#39;s
+      ciliary localization
+    reference_section_type: ABSTRACT
+knowledge_gaps:
+- gap_statement: &gt;-
+    The molecular function of DYF-6/IFT46 is undefined. It has a large disordered
+    N-terminus and no recognizable catalytic domain, and no GO molecular-function
+    term is assigned to it in C. elegans. Whether it acts as a cargo adaptor
+    (Chlamydomonas IFT46 uses its N-terminal region to load outer dynein arms) or
+    purely as an IFT-B scaffold, and which IFT-B subunit(s) it directly contacts
+    in the worm, is not established.
+  boundary: &gt;-
+    DYF-6 is firmly established as an IFT complex B subunit that localizes to the
+    cilium and ciliary base, undergoes IFT movement, and is required to build
+    full-length non-motile sensory cilia. In other organisms the conserved
+    C-terminal IFT46_B_C domain mediates direct binding to IFT52 (and, via a
+    ternary module, IFT88) to build the IFT-B1 core, while the N-terminal region
+    binds the ODA16 cargo adaptor to load outer dynein arms — a role restricted
+    to motile cilia and therefore not expected in the worm. What is missing is a
+    GO molecular-function representation of this structural/scaffolding activity
+    (the MF aspect cannot express &#34;structural constituent of IFT particle B&#34;), and
+    the specific IFT-B contacts and any cargo-adaptor role of DYF-6 have not been
+    demonstrated for the C. elegans protein.
+  gap_kind:
+  - ONTOLOGY
+  - BIOLOGY
+  dark_aspect: MF_DARK
+  status: OPEN
+  significance: &gt;-
+    IFT46 is a conserved core IFT-B protein; defining its molecular activity
+    (scaffolding vs a specific cargo-adaptor interaction) is central to
+    understanding IFT-B architecture and cargo selection in cilia.
+  resolution: &gt;-
+    Map DYF-6&#39;s direct IFT-B interaction partners by biochemistry/structure;
+    test for cargo-adaptor activity; introduce a molecular-function term for an
+    IFT-particle structural/adaptor subunit activity.
+  provenance:
+  - reference_id: PMID:16648645
+    supporting_text: DYF-6, the product of a complex locus, lacks known motifs,
+      but orthologs are present in flies and mammals
+    reference_section_type: ABSTRACT
+  proposed_terms:
+  - proposed_name: structural constituent of intraflagellar transport particle B
+    proposed_definition: &gt;-
+      The action of a macromolecule that contributes to the structural integrity
+      or scaffolding of an intraflagellar transport particle B (IFT-B) complex,
+      as distinct from any catalytic or motor activity.
+    justification: &gt;-
+      IFT-B subunits such as DYF-6/IFT46 have a well-defined cellular role (be
+      part of, and maintain, the IFT-B particle) but no GO molecular-function term
+      can currently express this structural/scaffolding activity, leaving them
+      MF-dark despite complete BP/CC annotation.
+    proposed_parent:
+      id: GO:0005198
+      label: structural molecule activity
+- gap_statement: &gt;-
+    dyf-6 is a complex locus that, besides the short conserved IFT46 isoforms,
+    produces a longer nematode-specific transcript fusing the dyf-6 ORF to the
+    upstream gene F46F6.3; the biological role of this long product is
+    uncharacterized. All functional and rescue data derive from the short
+    isoforms, so whether the long isoform contributes anything beyond the
+    conserved IFT-B function is unknown.
+  boundary: &gt;-
+    The short (conserved) dyf-6 isoforms confer full dye-filling rescue and
+    undergo IFT; the F46F6.3-fused long transcript is nematode-specific and has no
+    assigned function, and existing alleles/reporters primarily report on the
+    short forms.
+  gap_kind:
+  - BIOLOGY
+  dark_aspect: RESIDUAL_SUBGAP
+  status: OPEN
+  significance: &gt;-
+    Establishing whether the nematode-specific long isoform has a distinct role
+    would clarify whether the dyf-6 locus encodes more than the conserved IFT-B
+    subunit function.
+  resolution: &gt;-
+    Isoform-specific knockouts/rescue and expression analysis of the long
+    dyf-6/F46F6.3 fusion product.
+  provenance:
+  - reference_id: PMID:16648645
+    supporting_text: DYF-6, the product of a complex locus, lacks known motifs,
+      but orthologs are present in flies and mammals
+    reference_section_type: ABSTRACT
+suggested_questions:
+- question: &gt;-
+    Does C. elegans DYF-6/IFT46 act as a cargo adaptor within IFT-B (as
+    Chlamydomonas IFT46 does for outer dynein arms), or purely as a structural
+    scaffold, and which IFT-B subunits does it directly contact?
+suggested_experiments:
+- description: &gt;-
+    Affinity purification / cross-linking mass spectrometry and structural
+    modeling of DYF-6 within the worm IFT-B complex to define its direct binding
+    partners and position in the particle.
+  experiment_type: interaction mapping
+- description: &gt;-
+    Isoform-specific rescue and separation-of-function alleles (including
+    N-terminal deletions) to test for a cargo-adaptor role and to determine
+    whether the long dyf-6/F46F6.3 fusion isoform has any distinct function.
+  experiment_type: genetics
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/genes/worm/klp-11/klp-11-ai-review.html
+++ b/genes/worm/klp-11/klp-11-ai-review.html
@@ -1,0 +1,4332 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>klp-11 - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        .propagation-review {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f8fafc;
+            border-left: 3px solid #64748b;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .propagation-title {
+            font-weight: 600;
+            color: #334155;
+            margin-bottom: 0.25rem;
+        }
+
+        .propagation-row {
+            margin-top: 0.25rem;
+        }
+
+        .propagation-source {
+            margin-top: 0.5rem;
+            padding-top: 0.5rem;
+            border-top: 1px solid #e5e7eb;
+        }
+
+        .propagation-source-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #1d4ed8;
+        }
+
+        .propagation-comment {
+            color: #4b5563;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>klp-11</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/Q19633" target="_blank" class="term-link">
+                        Q19633
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Caenorhabditis elegans</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-complete">
+                    COMPLETE
+                </span>
+            </div>
+
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "klp-11";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="Q19633" data-a="DESCRIPTION: KLP-11 is one of the two motor (heavy-chain) subun..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>KLP-11 is one of the two motor (heavy-chain) subunits of Caenorhabditis elegans heterotrimeric kinesin-II, a plus-end-directed microtubule motor of the kinesin-2 family. The holoenzyme is a heterotrimer of the two distinct motor subunits KLP-11 and KLP-20 together with the non-motor accessory subunit KAP-1 (kinesin-associated protein), and is the nematode orthologue of vertebrate KIF3A/KIF3B/KAP3 kinesin-II. KLP-11 is unprocessive as a homodimer; processive movement requires heterodimerization with its partner KLP-20, and heterodimerization is also required to bind the KAP-1 cargo-adaptor subunit. Within the assembled motor, KLP-11 contributes microtubule plus-end motor and ATPase activity. Functionally, kinesin-II is one of two anterograde intraflagellar transport (IFT) motors in worm sensory cilia; together with the faster homodimeric OSM-3 (KIF17) motor it drives IFT particles along the doublet microtubules of the ciliary middle (initial) segment, with the two motors acting partly redundantly to build the cilium foundation. Kinesin-II moves comparatively slowly (~0.5 um/s) and, through mechanical competition with OSM-3, contributes to the tension across IFT particles that is regulated by BBS proteins. KLP-11 localizes to sensory cilia of ciliated neurons.</p>
+    </div>
+
+
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003777" target="_blank" class="term-link">
+                                    GO:0003777
+                                </a>
+                            </span>
+                            <span class="term-label">microtubule motor activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q19633" data-a="GO:0003777" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> KLP-11 is a kinesin-2 motor subunit that, as part of the KLP-11/KLP-20/KAP-1 heterotrimer, is an active plus-end-directed microtubule motor. The phylogenetic (IBA) annotation is well supported and corroborated by direct C. elegans data.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Core molecular function. Kinesin-II motor activity is directly demonstrated for the purified holoenzyme containing KLP-11 (PMID:17000880). A more specific term (plus-end-directed microtubule motor activity) is captured in core_functions.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/17000880" target="_blank" class="term-link">
+                                        PMID:17000880
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">kinesin-II alone moved MTs at a maximal rate of 0.3 μm/s, and OSM-3 alone moved them at 0.7 μm/s</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
+                                    GO:0005737
+                                </a>
+                            </span>
+                            <span class="term-label">cytoplasm</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q19633" data-a="GO:0005737" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Generic cytoplasmic localization inferred phylogenetically. KLP-11 is present in the cytoplasm of ciliated neurons (cell bodies/dendrites) before and while operating in cilia, consistent with kinesin motors generally.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct but low-specificity parent. The informative localization for KLP-11 is the cilium and the axonemal kinesin-II complex; retained as accurate context.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008017" target="_blank" class="term-link">
+                                    GO:0008017
+                                </a>
+                            </span>
+                            <span class="term-label">microtubule binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q19633" data-a="GO:0008017" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Microtubule binding is an intrinsic property of the kinesin motor domain (FT 13..343) and is required for the motor activity of KLP-11-containing kinesin-II on axonemal microtubules.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Well-supported; microtubule binding is a defining feature of kinesin motors and underpins the demonstrated MT gliding activity of kinesin-II (PMID:17000880).
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/17000880" target="_blank" class="term-link">
+                                        PMID:17000880
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">the IFT particles assembling these sensory cilia are moved by the coordinate action of two anterograde IFT motors called kinesin-II and OSM-3, which are both members of the kinesin-2 family</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030705" target="_blank" class="term-link">
+                                    GO:0030705
+                                </a>
+                            </span>
+                            <span class="term-label">cytoskeleton-dependent intracellular transport</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-modify">
+                            MODIFY
+                        </span>
+                        <span class="vote-buttons" data-g="Q19633" data-a="GO:0030705" data-r="GO_REF:0000033" data-act="MODIFY">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> KLP-11 mediates microtubule-based (cytoskeleton-dependent) transport as part of kinesin-II. In the worm this is realized specifically as anterograde IFT within cilia.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct but too general. The specific, experimentally supported process for KLP-11 is intraciliary anterograde transport; generalize the annotation to that term.
+                        </div>
+
+
+
+                        <div class="propagation-review">
+                            <div class="propagation-title">Propagation Review</div>
+                            <div class="propagation-row">
+                                <strong>Root cause:</strong>
+                                <span class="badge">TERM SCOPING PROBLEM</span>
+                            </div>
+
+                            <div class="propagation-row">
+                                <strong>Failure modes:</strong>
+
+                                <span class="badge">GRANULARITY MISMATCH</span>
+
+                            </div>
+
+
+                            <div class="propagation-source">
+                                <strong>Sources checked:</strong>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">PANTHER:PTN009082057</span>
+
+                                    &middot; kinesin-2 / kinesin-II motor node
+
+
+                                    <span class="badge">SUPPORTS TRANSFER</span>
+
+
+                                </div>
+
+                            </div>
+
+                        </div>
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0035720" target="_blank" class="term-link">
+                                    intraciliary anterograde transport
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/17000880" target="_blank" class="term-link">
+                                        PMID:17000880
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">the IFT particles assembling these sensory cilia are moved by the coordinate action of two anterograde IFT motors called kinesin-II and OSM-3, which are both members of the kinesin-2 family</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0060271" target="_blank" class="term-link">
+                                    GO:0060271
+                                </a>
+                            </span>
+                            <span class="term-label">cilium assembly</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q19633" data-a="GO:0060271" data-r="GO_REF:0000033" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Kinesin-II contributes to sensory cilium assembly by delivering IFT cargo along the middle segment. However, klp-11 single mutants have near-full-length cilia because OSM-3 acts redundantly in the middle segment and builds the distal segment, so KLP-11 is individually dispensable for ciliogenesis.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The annotation is correct at the pathway level, but because of OSM-3 redundancy KLP-11 loss does not abolish cilium assembly; the sharpest core process is anterograde IFT. Retained as a real, non-core contribution.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/17000880" target="_blank" class="term-link">
+                                        PMID:17000880
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">These motors function redundantly to move the same IFT particles along the initial segment and build the cilium foundation, with either motor but not both being dispensable for this function</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/17000880" target="_blank" class="term-link">
+                                        PMID:17000880
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">OSM-6∷GFP moves at OSM-3&#39;s fast rate in klp-11 mutants</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005871" target="_blank" class="term-link">
+                                    GO:0005871
+                                </a>
+                            </span>
+                            <span class="term-label">kinesin complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q19633" data-a="GO:0005871" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> KLP-11 is a subunit of a kinesin complex, specifically the heterotrimeric kinesin-II (KLP-11/KLP-20/KAP-1). The generic kinesin complex annotation is correct.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct parent-level complex membership; the specific complex (kinesin II / axonemal heterotrimeric kinesin-II) is captured by the NAS/IPI annotations and core_functions.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/17000880" target="_blank" class="term-link">
+                                        PMID:17000880
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">consisting of 1 mol each of its subunits KLP-11, KLP-20, and KAP-1 with a native molecular mass of 287 kD</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005874" target="_blank" class="term-link">
+                                    GO:0005874
+                                </a>
+                            </span>
+                            <span class="term-label">microtubule</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q19633" data-a="GO:0005874" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> KLP-11 is active on microtubules; as part of kinesin-II it translocates along the axonemal (doublet) microtubules of the ciliary middle segment.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct localization/site-of-action for a microtubule motor, consistent with the demonstrated MT gliding activity of the holoenzyme.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/17000880" target="_blank" class="term-link">
+                                        PMID:17000880
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">kinesin-II alone moved MTs at a maximal rate of 0.3 μm/s, and OSM-3 alone moved them at 0.7 μm/s</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0007018" target="_blank" class="term-link">
+                                    GO:0007018
+                                </a>
+                            </span>
+                            <span class="term-label">microtubule-based movement</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q19633" data-a="GO:0007018" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> As a kinesin motor, KLP-11 drives microtubule-based movement. In the worm this is the anterograde movement of IFT particles within cilia.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct general process; the specific term (intraciliary anterograde transport) is also annotated (NAS) and captured in core_functions.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/17000880" target="_blank" class="term-link">
+                                        PMID:17000880
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">the IFT particles assembling these sensory cilia are moved by the coordinate action of two anterograde IFT motors called kinesin-II and OSM-3, which are both members of the kinesin-2 family</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016887" target="_blank" class="term-link">
+                                    GO:0016887
+                                </a>
+                            </span>
+                            <span class="term-label">ATP hydrolysis activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q19633" data-a="GO:0016887" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> KLP-11 contains a P-loop kinesin motor domain (ATP-binding site residues 99..106) and, as part of kinesin-II, hydrolyzes ATP to power motility; the holoenzyme uses Mg-ATP with Michaelis-Menten kinetics.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> ATP hydrolysis is essential for kinesin motor function and is directly evidenced by the ATP-dependent MT gliding kinetics of purified kinesin-II (PMID:17000880).
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/17000880" target="_blank" class="term-link">
+                                        PMID:17000880
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">indicating that Mg-ATP is the preferred substrate for kinesin-2 motors</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000166" target="_blank" class="term-link">
+                                    GO:0000166
+                                </a>
+                            </span>
+                            <span class="term-label">nucleotide binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000104
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q19633" data-a="GO:0000166" data-r="GO_REF:0000104" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Broad nucleotide-binding parent inferred from the kinesin P-loop motif. KLP-11 binds ATP/ADP during its mechanochemical cycle.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct but non-specific; the informative child (ATP binding) is separately annotated.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003774" target="_blank" class="term-link">
+                                    GO:0003774
+                                </a>
+                            </span>
+                            <span class="term-label">cytoskeletal motor activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000104
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q19633" data-a="GO:0003774" data-r="GO_REF:0000104" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Parent of microtubule motor activity; correct for KLP-11 as a cytoskeletal (kinesin) motor.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct but less specific than microtubule motor activity, which is separately annotated and refined in core_functions.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003777" target="_blank" class="term-link">
+                                    GO:0003777
+                                </a>
+                            </span>
+                            <span class="term-label">microtubule motor activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000120
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q19633" data-a="GO:0003777" data-r="GO_REF:0000120" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> InterPro/ARBA electronic assignment of microtubule motor activity based on the kinesin motor domain. Consistent with the IBA and IDA annotations.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct; duplicates the well-supported microtubule motor activity from an electronic pipeline.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005524" target="_blank" class="term-link">
+                                    GO:0005524
+                                </a>
+                            </span>
+                            <span class="term-label">ATP binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000120
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q19633" data-a="GO:0005524" data-r="GO_REF:0000120" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> ATP binding at the kinesin motor domain P-loop (BINDING 99..106) is required for the ATPase-driven motor cycle of KLP-11.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct and specific; supported by the conserved P-loop and the Mg-ATP kinetics of the holoenzyme (PMID:17000880).
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/17000880" target="_blank" class="term-link">
+                                        PMID:17000880
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">indicating that Mg-ATP is the preferred substrate for kinesin-2 motors</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005856" target="_blank" class="term-link">
+                                    GO:0005856
+                                </a>
+                            </span>
+                            <span class="term-label">cytoskeleton</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000120
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q19633" data-a="GO:0005856" data-r="GO_REF:0000120" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> KLP-11 localizes to the microtubule cytoskeleton (the ciliary axoneme). Broad but accurate.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct low-specificity localization for a microtubule motor; the informative site is the cilium/axoneme.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005929" target="_blank" class="term-link">
+                                    GO:0005929
+                                </a>
+                            </span>
+                            <span class="term-label">cilium</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000120
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q19633" data-a="GO:0005929" data-r="GO_REF:0000120" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> KLP-11 localizes to sensory cilia, where kinesin-II performs anterograde IFT along the middle segment.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Core localization, consistent with UniProt subcellular location and the cilia IFT role of kinesin-II (PMID:17000880).
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/17000880" target="_blank" class="term-link">
+                                        PMID:17000880
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">the IFT particles assembling these sensory cilia are moved by the coordinate action of two anterograde IFT motors called kinesin-II and OSM-3, which are both members of the kinesin-2 family</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0007018" target="_blank" class="term-link">
+                                    GO:0007018
+                                </a>
+                            </span>
+                            <span class="term-label">microtubule-based movement</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000120
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q19633" data-a="GO:0007018" data-r="GO_REF:0000120" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic assignment of microtubule-based movement, duplicating the IBA/IDA process annotation.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct; the more specific process (intraciliary anterograde transport) is also annotated.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008017" target="_blank" class="term-link">
+                                    GO:0008017
+                                </a>
+                            </span>
+                            <span class="term-label">microtubule binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q19633" data-a="GO:0008017" data-r="GO_REF:0000002" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> InterPro electronic assignment of microtubule binding via the kinesin motor domain; duplicates the IBA annotation.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct; microtubule binding is intrinsic to the kinesin motor domain.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0032991" target="_blank" class="term-link">
+                                    GO:0032991
+                                </a>
+                            </span>
+                            <span class="term-label">protein-containing complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000117
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-modify">
+                            MODIFY
+                        </span>
+                        <span class="vote-buttons" data-g="Q19633" data-a="GO:0032991" data-r="GO_REF:0000117" data-act="MODIFY">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Generic complex-membership assignment. KLP-11 is specifically a subunit of the heterotrimeric kinesin-II complex.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Too general. Replace with the specific kinesin II complex to convey the actual assembly KLP-11 belongs to.
+                        </div>
+
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016939" target="_blank" class="term-link">
+                                    kinesin II complex
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/17000880" target="_blank" class="term-link">
+                                        PMID:17000880
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">consisting of 1 mol each of its subunits KLP-11, KLP-20, and KAP-1 with a native molecular mass of 287 kD</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0007018" target="_blank" class="term-link">
+                                    GO:0007018
+                                </a>
+                            </span>
+                            <span class="term-label">microtubule-based movement</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">NAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/20498083" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:20498083
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Regulation of a heterodimeric kinesin-2 through an unprocess...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q19633" data-a="GO:0007018" data-r="PMID:20498083" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> ComplexPortal NAS annotation. KLP-11 (as the KLP-11/KLP-20 heterodimer, and within the kinesin-II holoenzyme) drives microtubule-based movement; heterodimerization confers the processivity needed for transport.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Author-stated (NAS) and consistent with the biochemistry: KLP-11 becomes a processive MT motor upon heterodimerization with KLP-20 (PMID:20498083).
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/20498083" target="_blank" class="term-link">
+                                        PMID:20498083
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">KLP11/KLP20 of Caenorhabditis elegans cilia</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016939" target="_blank" class="term-link">
+                                    GO:0016939
+                                </a>
+                            </span>
+                            <span class="term-label">kinesin II complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">NAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/20498083" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:20498083
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Regulation of a heterodimeric kinesin-2 through an unprocess...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q19633" data-a="GO:0016939" data-r="PMID:20498083" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> KLP-11 is a subunit of kinesin II. The heterodimer of the two motor subunits (KLP-11/KLP-20) plus KAP-1 constitutes the kinesin-II complex; heterodimerization is required for KAP-1 binding.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Core complex membership. Supported by both the ComplexPortal NAS record and the biochemistry of the KLP-11/KLP-20/KAP-1 assembly (PMID:20498083, PMID:17000880).
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/20498083" target="_blank" class="term-link">
+                                        PMID:20498083
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">heterodimerization is necessary to bind KAP1, the in vivo link between</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/17000880" target="_blank" class="term-link">
+                                        PMID:17000880
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">consisting of 1 mol each of its subunits KLP-11, KLP-20, and KAP-1 with a native molecular mass of 287 kD</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0035720" target="_blank" class="term-link">
+                                    GO:0035720
+                                </a>
+                            </span>
+                            <span class="term-label">intraciliary anterograde transport</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">NAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/20498083" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:20498083
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Regulation of a heterodimeric kinesin-2 through an unprocess...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q19633" data-a="GO:0035720" data-r="PMID:20498083" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> KLP-11-containing kinesin-II is an anterograde IFT motor of C. elegans cilia; the heterodimeric motor drives anterograde transport of IFT particles.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Core biological process for KLP-11. Author-stated (NAS) and corroborated by the cooperative anterograde IFT role of kinesin-II with OSM-3 (PMID:17000880).
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/17000880" target="_blank" class="term-link">
+                                        PMID:17000880
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">the IFT particles assembling these sensory cilia are moved by the coordinate action of two anterograde IFT motors called kinesin-II and OSM-3, which are both members of the kinesin-2 family</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003777" target="_blank" class="term-link">
+                                    GO:0003777
+                                </a>
+                            </span>
+                            <span class="term-label">microtubule motor activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/17000880" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:17000880
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Mechanism of transport of IFT particles in C. elegans cilia ...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q19633" data-a="GO:0003777" data-r="PMID:17000880" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct assay: purified recombinant C. elegans kinesin-II containing KLP-11 is an active microtubule motor in gliding assays, moving MTs at ~0.5 um/s.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Direct experimental evidence (IDA) for KLP-11&#39;s core molecular function as a component of the kinesin-II motor holoenzyme.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/17000880" target="_blank" class="term-link">
+                                        PMID:17000880
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">kinesin-II alone moved MTs at a maximal rate of 0.3 μm/s, and OSM-3 alone moved them at 0.7 μm/s</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0007018" target="_blank" class="term-link">
+                                    GO:0007018
+                                </a>
+                            </span>
+                            <span class="term-label">microtubule-based movement</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/17000880" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:17000880
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Mechanism of transport of IFT particles in C. elegans cilia ...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q19633" data-a="GO:0007018" data-r="PMID:17000880" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct in vitro demonstration that KLP-11-containing kinesin-II generates microtubule-based movement (MT gliding), the biochemical basis of its IFT role.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Direct experimental evidence (IDA). The specific process (intraciliary anterograde transport) is also annotated (NAS) and captured in core_functions.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/17000880" target="_blank" class="term-link">
+                                        PMID:17000880
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">kinesin-II alone moved MTs at a maximal rate of 0.3 μm/s, and OSM-3 alone moved them at 0.7 μm/s</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030993" target="_blank" class="term-link">
+                                    GO:0030993
+                                </a>
+                            </span>
+                            <span class="term-label">axonemal heterotrimeric kinesin-II complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/17000880" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:17000880
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Mechanism of transport of IFT particles in C. elegans cilia ...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q19633" data-a="GO:0030993" data-r="PMID:17000880" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> KLP-11 physically assembles into the axonemal heterotrimeric kinesin-II complex with KLP-20 (WBGene00002230) and KAP-1 (WBGene00002182), demonstrated as a monodisperse 1:1:1 (~287 kD) heterotrimer by sucrose gradients and gel filtration.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Direct physical-interaction evidence (IPI) for the most specific, experimentally grounded cellular-component annotation for KLP-11. This is a core annotation.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/17000880" target="_blank" class="term-link">
+                                        PMID:17000880
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">consisting of 1 mol each of its subunits KLP-11, KLP-20, and KAP-1 with a native molecular mass of 287 kD</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>As a motor subunit of the heterotrimeric kinesin-II holoenzyme (KLP-11/KLP-20/KAP-1), KLP-11 contributes plus-end-directed microtubule motor and ATPase activity. KLP-11 is unprocessive on its own (as a homodimer); processive plus-end movement is generated only by heterodimerization with the partner motor subunit KLP-20. The assembled motor drives relatively slow (~0.5 um/s) plus-end transport along axonemal microtubules.</h3>
+                <span class="vote-buttons" data-g="Q19633" data-a="FUNCTION: As a motor subunit of the heterotrimeric kinesin-I..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003777" target="_blank" class="term-link">
+                            microtubule motor activity
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0035720" target="_blank" class="term-link">
+                                intraciliary anterograde transport
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005929" target="_blank" class="term-link">
+                                cilium
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005874" target="_blank" class="term-link">
+                                microtubule
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">In Complex:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030993" target="_blank" class="term-link">
+                            axonemal heterotrimeric kinesin-II complex
+                        </a>
+                    </span>
+                </div>
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/17000880" target="_blank" class="term-link">
+                                PMID:17000880
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">consisting of 1 mol each of its subunits KLP-11, KLP-20, and KAP-1 with a native molecular mass of 287 kD</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/20498083" target="_blank" class="term-link">
+                                PMID:20498083
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">KLP11/KLP20 of Caenorhabditis elegans cilia</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>KLP-11-containing kinesin-II hydrolyzes ATP to power its motor cycle; the purified holoenzyme uses Mg-ATP as its preferred substrate with Michaelis-Menten kinetics, coupling ATP hydrolysis to microtubule-based movement.</h3>
+                <span class="vote-buttons" data-g="Q19633" data-a="FUNCTION: KLP-11-containing kinesin-II hydrolyzes ATP to pow..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016887" target="_blank" class="term-link">
+                            ATP hydrolysis activity
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0007018" target="_blank" class="term-link">
+                                microtubule-based movement
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">In Complex:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030993" target="_blank" class="term-link">
+                            axonemal heterotrimeric kinesin-II complex
+                        </a>
+                    </span>
+                </div>
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/17000880" target="_blank" class="term-link">
+                                PMID:17000880
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">indicating that Mg-ATP is the preferred substrate for kinesin-2 motors</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>Kinesin-II (with KLP-11) is one of two anterograde IFT motors that, together with the homodimeric OSM-3 motor, move IFT particles along the doublet microtubules of the ciliary middle segment. The two motors act partly redundantly to build the cilium foundation, and their mechanical competition contributes to IFT-particle tension regulated by BBS proteins.</h3>
+                <span class="vote-buttons" data-g="Q19633" data-a="FUNCTION: Kinesin-II (with KLP-11) is one of two anterograde..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003777" target="_blank" class="term-link">
+                            microtubule motor activity
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0035720" target="_blank" class="term-link">
+                                intraciliary anterograde transport
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005929" target="_blank" class="term-link">
+                                cilium
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">In Complex:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030993" target="_blank" class="term-link">
+                            axonemal heterotrimeric kinesin-II complex
+                        </a>
+                    </span>
+                </div>
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/17000880" target="_blank" class="term-link">
+                                PMID:17000880
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">These motors function redundantly to move the same IFT particles along the initial segment and build the cilium foundation, with either motor but not both being dispensable for this function</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000002.md" target="_blank" class="term-link">
+                            GO_REF:0000002
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation through association of InterPro records with GO terms</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
+                            GO_REF:0000033
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Annotation inferences using phylogenetic trees</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000104.md" target="_blank" class="term-link">
+                            GO_REF:0000104
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Electronic Gene Ontology annotations created by transferring manual GO annotations between related proteins based on shared sequence features</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000117.md" target="_blank" class="term-link">
+                            GO_REF:0000117
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Electronic Gene Ontology annotations created by ARBA machine learning models</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000120.md" target="_blank" class="term-link">
+                            GO_REF:0000120
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Combined Automated Annotation using Multiple IEA Methods</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/17000880" target="_blank" class="term-link">
+                            PMID:17000880
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Mechanism of transport of IFT particles in C. elegans cilia by the concerted action of kinesin-II and OSM-3 motors.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Purified C. elegans kinesin-II is a heterotrimer of KLP-11, KLP-20 and KAP-1 (1:1:1, ~287 kD).</div>
+
+                        <div class="finding-text">"consisting of 1 mol each of its subunits KLP-11, KLP-20, and KAP-1 with a native molecular mass of 287 kD"</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Kinesin-II is one of two anterograde IFT motors that move IFT particles along ciliary microtubules.</div>
+
+                        <div class="finding-text">"the IFT particles assembling these sensory cilia are moved by the coordinate action of two anterograde IFT motors called kinesin-II and OSM-3, which are both members of the kinesin-2 family"</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Kinesin-II and OSM-3 act redundantly along the initial (middle) segment to build the cilium foundation.</div>
+
+                        <div class="finding-text">"These motors function redundantly to move the same IFT particles along the initial segment and build the cilium foundation, with either motor but not both being dispensable for this function"</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Kinesin-II is a slow plus-end MT motor (~0.5 um/s) relative to OSM-3.</div>
+
+                        <div class="finding-text">"kinesin-II alone moved MTs at a maximal rate of 0.3 μm/s, and OSM-3 alone moved them at 0.7 μm/s"</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/20498083" target="_blank" class="term-link">
+                            PMID:20498083
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Regulation of a heterodimeric kinesin-2 through an unprocessive motor domain that is turned processive by its partner.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">KLP11/KLP20 is the C. elegans heterodimeric kinesin-2 studied here.</div>
+
+                        <div class="finding-text">"KLP11/KLP20 of Caenorhabditis elegans cilia"</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Heterodimerization is required to bind KAP1, the motor-cargo link.</div>
+
+                        <div class="finding-text">"heterodimerization is necessary to bind KAP1, the in vivo link between"</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Questions for Experts</h2>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> What is the distinct mechanochemical role of the KLP-11 motor head versus the KLP-20 head within the heterodimer, and why is an unprocessive subunit retained?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q19633" data-a="Q: What is the distinct mechanochemical role of the K..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Which IFT-particle cargoes are engaged by kinesin-II via KAP-1 in C. elegans cilia, and how is the kinesin-II-to-OSM-3 handoff regulated along the middle segment?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q19633" data-a="Q: Which IFT-particle cargoes are engaged by kinesin-..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Experiments</h2>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Reconstitute KLP-11/KLP-20 heterodimers and KLP-11 or KLP-20 homodimers and chimeras, and compare single-molecule processivity, velocity, and ATPase to dissect each head&#39;s contribution.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: KLP-11&#39;s head contributes asymmetric autoregulation but little autonomous processivity to kinesin-II.</em></p>
+
+
+                    <p style="margin-top: 0.5rem;">Type: single-molecule motility / biochemistry</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q19633" data-a="EXPERIMENT: Reconstitute KLP-11/KLP-20 heterodimers and KLP-11..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Determine the cryo-EM structure of the intact KLP-11/KLP-20/KAP-1 heterotrimer in different nucleotide states and on microtubules.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: Full-length assembled kinesin-II adopts nucleotide-dependent conformations that impose asymmetric autoregulation.</em></p>
+
+
+                    <p style="margin-top: 0.5rem;">Type: structural biology (cryo-EM)</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q19633" data-a="EXPERIMENT: Determine the cryo-EM structure of the intact KLP-..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Knowledge Gaps</h2>
+        <p style="color: #555; font-size: 0.92rem; margin-top: -0.3rem;">
+            What is <em>not</em> known — curated, literature-grounded statements of the open
+            unknowns (the inverse of core functions).
+        </p>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> No KLP-11 subunit-resolved in vivo molecular function is established independently of its partners: all motility, IFT and localization data are for the intact KLP-11/KLP-20/KAP-1 heterotrimer (or the KLP-11/KLP-20 heterodimer), and KLP-11 is unprocessive as a homodimer, so it has no demonstrated autonomous processive motor activity.</p>
+            <p style="margin-top: 0.4rem;">
+
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">MF_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> It is firmly established that KLP-11 is a subunit of the purified heterotrimeric kinesin-II holoenzyme, that the holoenzyme is an active plus-end MT motor, and that heterodimerization with KLP-20 is what confers processivity and enables KAP-1 binding.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Distinguishing the specific mechanochemical contribution of the KLP-11 head from that of KLP-20 is needed to understand why kinesin-II uses two distinct, asymmetric motor subunits.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Single-molecule and structural analysis of engineered KLP-11 vs KLP-20 heads and chimeras, building on the finding that KLP-11 mediates asymmetric autoregulation of the heterodimer.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"heterodimerization is necessary to bind KAP1, the in vivo link between"</em> — PMID:20498083</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The identity of the IFT cargo(es) directly engaged by KLP-11-containing kinesin-II via KAP-1 in C. elegans, and how cargo loading/unloading is regulated along the middle segment, are not resolved by the primary literature reviewed here.</p>
+            <p style="margin-top: 0.4rem;">
+
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">BP_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> Kinesin-II is established as an anterograde IFT motor that moves IFT particles (IFT-A/IFT-B subcomplexes) along the middle segment, and heterodimerization is required for KAP-1 (the motor-cargo link) binding.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Defining the kinesin-II-specific cargo interface would clarify the division of labor between kinesin-II and OSM-3 and the handoff of IFT trains between motors.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Proximity-labeling / cross-linking mass spectrometry of KAP-1 and KLP-11 in cilia, and cargo-selective transport assays.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"the IFT particles assembling these sensory cilia are moved by the coordinate action of two anterograde IFT motors called kinesin-II and OSM-3, which are both members of the kinesin-2 family"</em> — PMID:17000880</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The atomic structure of the fully assembled C. elegans kinesin-II heterotrimer and the structural basis of KLP-11-mediated asymmetric autoregulation of motor activity are unsolved.</p>
+            <p style="margin-top: 0.4rem;">
+
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">MF_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> Only a partial X-ray structure of the stalk/tail region (residues 537-782, PDB 9IKB, 3.54 A) of heterotrimeric kinesin-2 is available; the motor-domain interface and regulatory conformations are not resolved.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> A full structure would explain how an unprocessive subunit is converted to a processive heterodimer and how autoregulation is imposed asymmetrically.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Cryo-EM / higher-resolution crystallography of the intact KLP-11/KLP-20/KAP-1 holoenzyme in defined nucleotide states.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"KLP11/KLP20 of Caenorhabditis elegans cilia"</em> — PMID:20498083</li>
+
+            </ul>
+
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Tags</h2>
+        <div class="aliases">
+
+            <span class="badge">caeel-ciliopathy</span>
+
+        </div>
+    </div>
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Deep Research Sections -->
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(klp-11-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="Q19633" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="klp-11-c-elegans-gene-review-notes">klp-11 (C. elegans) — Gene Review Notes</h1>
+<h2 id="identity-verified-from-uniprot-q19633">Identity (verified from UniProt Q19633)</h2>
+<ul>
+<li>UniProt: Q19633 (Q19633_CAEEL), 782 aa, TrEMBL/unreviewed.</li>
+<li>Gene: klp-11; ORF F20C5.2; WormBase WBGene00002222; RefSeq NP_001369897.1.</li>
+<li>Chromosome IV. Taxon: C. elegans, NCBITaxon:6239.</li>
+<li>Family: TRAFAC class myosin-kinesin ATPase superfamily, kinesin family (PROSITE<br />
+  PRU00283; RuleBase RU000394). Kinesin motor domain FT 13..343; ATP-binding P-loop 99..106.</li>
+<li>ComplexPortal CPX-1208 "Kinesin II motor complex"; GO:0030993 axonemal heterotrimeric<br />
+  kinesin-II complex (IPI:WormBase).</li>
+<li>PDB 9IKB (X-ray 3.54 Å of residues 537-782): "Crystal structure of heterotrimeric Kinesin-2"<br />
+  (stalk/tail region), consistent with klp-11 being a subunit of a heterotrimer.</li>
+</ul>
+<p>klp-11 encodes one of the two motor (heavy-chain) subunits of C. elegans heterotrimeric<br />
+kinesin-II. The holoenzyme is a heterotrimer: KLP-11 + KLP-20 (the two distinct motor<br />
+subunits) + KAP-1 (the non-motor kinesin-associated protein / accessory subunit). This is the<br />
+orthologue of the vertebrate KIF3A/KIF3B/KAP3 kinesin-II. Kinesin-II is one of two<br />
+anterograde IFT motors in the worm; the other is homodimeric OSM-3 (KIF17 orthologue).</p>
+<h2 id="known-well-supported">KNOWN (well-supported)</h2>
+<h3 id="molecular-function-microtubule-plus-end-motor-atpase-as-part-of-the-heterotrimer">Molecular function: microtubule plus-end motor / ATPase, as part of the heterotrimer</h3>
+<ul>
+<li>Purified recombinant C. elegans kinesin-II (KLP-11/KLP-20/KAP-1) is an active<br />
+  plus-end-directed MT motor in gliding assays; it obeys Michaelis-Menten kinetics with<br />
+  Mg-ATP as preferred substrate.<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/17000880" title="In MT gliding assays, kinesin-II–driven motility conformed to Michaelis-Menten kinetics with a nucleotide profile very similar to that of kinesin-1 (Cohn et al., 1989), indicating that Mg-ATP is the preferred substrate for kinesin-2 motors">PMID:17000880</a></li>
+<li>Kinesin-II moves relatively slowly (~0.5 µm/s in vivo, ~0.3–0.5 µm/s in vitro), vs OSM-3 ~1.3 µm/s.<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/17000880" title="kinesin-II alone moved MTs at a maximal rate of 0.3 μm/s, and OSM-3 alone moved them at 0.7 μm/s">PMID:17000880</a><br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/17000880" title="kinesin-II alone moved at ∼0.5 μm/s, whereas OSM-3 alone (wild type or the G444E mutant) moved at ∼1.1 μm/s ... very close to the rates of transport driven by kinesin-II (0.5 μm/s) and OSM-3 (1.3 μm/s) in vivo">PMID:17000880</a></li>
+<li>The purified holoenzyme is a monodisperse heterotrimer of KLP-11, KLP-20 and KAP-1<br />
+  (1:1:1 stoichiometry; ~287 kD), matching native kinesin-II.<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/17000880" title="Purified kinesin-II behaved as a monodisperse, heterotrimeric complex on sucrose gradients (Fig. 1 F) and gel filtration columns (Fig. 1 G) consisting of 1 mol each of its subunits KLP-11, KLP-20, and KAP-1 with a native molecular mass of 287 kD">PMID:17000880</a></li>
+<li>WormBase makes an IDA microtubule motor activity annotation (GO:0003777) and an IDA<br />
+  microtubule-based movement annotation to klp-11 from PMID:17000880 (in vitro motility of the<br />
+  purified holoenzyme containing KLP-11).</li>
+</ul>
+<h3 id="heterodimerization-mechanism-why-two-distinct-motor-subunits">Heterodimerization mechanism (why two distinct motor subunits)</h3>
+<ul>
+<li>The KLP-11 motor domain is UNPROCESSIVE as a homodimer; heterodimerization with the<br />
+  processive KLP-20 partner generates processivity. The "unprocessive" KLP-11 subunit is<br />
+  retained because it mediates asymmetric autoregulation of motor activity, and<br />
+  heterodimerization is required to bind KAP-1 (the motor-cargo link).<br />
+  [PMID:20498083 "One motor domain is unprocessive as a homodimer, but heterodimerization with a processive partner generates processivity. The \"unprocessive\" subunit is kept in this partnership as it mediates an asymmetric autoregulation of the motor activity. Finally, heterodimerization is necessary to bind KAP1, the in vivo link between motor and cargo."]<br />
+  (Note: PMID:20498083 is abstract-only in cache; full_text_available: false. The abstract<br />
+  explicitly names KLP11/KLP20 of C. elegans, so the identity is certain.)</li>
+</ul>
+<h3 id="cellular-component-complex">Cellular component / complex</h3>
+<ul>
+<li>Subunit of the axonemal heterotrimeric kinesin-II complex (GO:0030993); IPI annotation by<br />
+  WormBase from PMID:17000880 with KLP-20 (WBGene00002230) and KAP-1 (WBGene00002182) as the<br />
+  with/from partners.</li>
+<li>Localizes to sensory cilia (UniProt: Cell projection, cilium; ARBA). C. elegans kinesin-II<br />
+  operates on axonemal microtubule doublets of the middle (initial) segment of amphid channel<br />
+  cilia.<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/17000880" title="C. elegans amphid channel ciliary axonemes are made up of two domains: an initial segment (called the middle segment) containing 4-μm–long MT doublets ... and a distal segment comprising 2.5-μm–long MT singlets">PMID:17000880</a></li>
+</ul>
+<h3 id="biological-process-anterograde-ift-of-the-ciliary-middle-segment-redundant-with-osm-3">Biological process: anterograde IFT of the ciliary middle segment (redundant with OSM-3)</h3>
+<ul>
+<li>Kinesin-II (with KLP-11) and OSM-3 are the two anterograde IFT motors; they act<br />
+  cooperatively/redundantly to move IFT particles along the middle segment and build the<br />
+  cilium foundation; either motor alone suffices for the middle segment (redundant), while<br />
+  OSM-3 alone extends the distal singlet segment.<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/17000880" title="These motors function redundantly to move the same IFT particles along the initial segment and build the cilium foundation, with either motor but not both being dispensable for this function">PMID:17000880</a><br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/17000880" title="the IFT particles assembling these sensory cilia are moved by the coordinate action of two anterograde IFT motors called kinesin-II and OSM-3, which are both members of the kinesin-2 family">PMID:17000880</a></li>
+<li>klp-11 single mutants have near full-length cilia (because OSM-3 compensates in the middle<br />
+  segment and builds the distal segment), unlike osm-3 mutants which lack distal segments.<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/17000880" title="the bbs-7/-8;klp-11 double mutants have almost full-length cilia, which is similar to the klp-11 mutants, and the bbs-7/-8;osm-3 double mutants have truncated cilia similar to the osm-3 mutants">PMID:17000880</a><br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/17000880" title="OSM-6∷GFP moves at OSM-3's fast rate in klp-11 mutants">PMID:17000880</a></li>
+<li>Motors coordinate by "mechanical competition": slow kinesin-II drags fast OSM-3 and vice<br />
+  versa; this tension, antagonized by BBS proteins, is what dissociates IFT-A/IFT-B in bbs<br />
+  mutants. This is a kinesin-II holoenzyme (KLP-11-containing) property.<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/17000880" title="the slower moving kinesin-II exerting drag on the faster moving OSM-3, whereas the faster moving OSM-3 tends to pull the slower moving kinesin-II along">PMID:17000880</a></li>
+</ul>
+<h2 id="not-known-gaps">NOT known / gaps</h2>
+<ul>
+<li>No klp-11-SPECIFIC (subunit-resolved) in vivo function beyond the holoenzyme: the motility,<br />
+  IFT, and localization data are for the intact KLP-11/KLP-20/KAP-1 heterotrimer or the<br />
+  KLP-11/KLP-20 heterodimer, not for a KLP-11 activity independent of its partners. Because<br />
+  KLP-11 is unprocessive as a homodimer (PMID:20498083), it does NOT have an autonomous<br />
+  processive motor activity — its motor role is realized only in the heterodimer/heterotrimer.</li>
+<li>The IFT cargo(es) directly linked to kinesin-II via KAP-1 in the worm, and how loading is<br />
+  regulated, are not resolved by the cached primary literature.</li>
+<li>Structure of the full assembled worm heterotrimer / the KLP-11 head–partner interface at<br />
+  atomic resolution: only a 3.54 Å partial (residues 537-782, stalk/tail) structure (PDB<br />
+  9IKB) is available; the mechanistic basis of asymmetric autoregulation is not solved.</li>
+<li>No evidence klp-11 acts outside cilia/IFT in the worm (no non-ciliary transport role<br />
+  established); vertebrate KIF3 paralogues have additional roles (melanosome transport,<br />
+  Hedgehog, left-right asymmetry) not demonstrated for C. elegans klp-11.</li>
+</ul>
+<h2 id="annotation-review-reasoning">Annotation review reasoning</h2>
+<ul>
+<li>Core (retain as core function): microtubule motor / plus-end motor activity and ATP<br />
+  hydrolysis contributed as part of the kinesin-II heterotrimer; membership of the axonemal<br />
+  heterotrimeric kinesin-II complex (GO:0030993) / kinesin II complex (GO:0016939); microtubule<br />
+  binding; anterograde IFT (GO:0035720) / microtubule-based movement; cilium localization.</li>
+<li>IBA/IEA generic parents (cytoplasm, cytoskeleton, microtubule, nucleotide binding,<br />
+  cytoskeletal motor activity, protein-containing complex) — ACCEPT as correct-but-general, or<br />
+  MODIFY where a more specific curated term is warranted; protein-containing complex → MODIFY to<br />
+  kinesin II complex.</li>
+<li>cilium assembly (GO:0060271, IBA): klp-11 single mutants have near-full-length cilia (OSM-3<br />
+  redundancy), so klp-11 contributes to but is individually dispensable for ciliogenesis; keep<br />
+  as involved (assembly is redundant), not the sharpest term — the sharpest is anterograde IFT.</li>
+<li>No REMOVE of the experimental IDA/IPI/NAS annotations — all are consistent with the<br />
+  holoenzyme evidence.</li>
+</ul>
+<h2 id="provenance-discipline">Provenance discipline</h2>
+<ul>
+<li>All supporting_text above are verbatim substrings of the cached publications<br />
+  (publications/PMID_17000880.md full text; publications/PMID_20498083.md abstract).</li>
+<li>PMID:20498083 is abstract-only in cache; NAS annotations from it (ComplexPortal) are<br />
+  supported by the abstract's explicit statements about KLP11/KLP20/KAP1.</li>
+</ul>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: Q19633
+gene_symbol: klp-11
+product_type: PROTEIN
+status: COMPLETE
+taxon:
+  id: NCBITaxon:6239
+  label: Caenorhabditis elegans
+description: &gt;-
+  KLP-11 is one of the two motor (heavy-chain) subunits of Caenorhabditis elegans
+  heterotrimeric kinesin-II, a plus-end-directed microtubule motor of the kinesin-2
+  family. The holoenzyme is a heterotrimer of the two distinct motor subunits KLP-11
+  and KLP-20 together with the non-motor accessory subunit KAP-1 (kinesin-associated
+  protein), and is the nematode orthologue of vertebrate KIF3A/KIF3B/KAP3 kinesin-II.
+  KLP-11 is unprocessive as a homodimer; processive movement requires heterodimerization
+  with its partner KLP-20, and heterodimerization is also required to bind the KAP-1
+  cargo-adaptor subunit. Within the assembled motor, KLP-11 contributes microtubule
+  plus-end motor and ATPase activity. Functionally, kinesin-II is one of two anterograde
+  intraflagellar transport (IFT) motors in worm sensory cilia; together with the faster
+  homodimeric OSM-3 (KIF17) motor it drives IFT particles along the doublet microtubules
+  of the ciliary middle (initial) segment, with the two motors acting partly redundantly
+  to build the cilium foundation. Kinesin-II moves comparatively slowly (~0.5 um/s) and,
+  through mechanical competition with OSM-3, contributes to the tension across IFT
+  particles that is regulated by BBS proteins. KLP-11 localizes to sensory cilia of
+  ciliated neurons.
+references:
+  - id: GO_REF:0000002
+    title: Gene Ontology annotation through association of InterPro records with GO terms
+    findings: []
+  - id: GO_REF:0000033
+    title: Annotation inferences using phylogenetic trees
+    findings: []
+  - id: GO_REF:0000104
+    title: Electronic Gene Ontology annotations created by transferring manual GO annotations
+      between related proteins based on shared sequence features
+    findings: []
+  - id: GO_REF:0000117
+    title: Electronic Gene Ontology annotations created by ARBA machine learning models
+    findings: []
+  - id: GO_REF:0000120
+    title: Combined Automated Annotation using Multiple IEA Methods
+    findings: []
+  - id: PMID:17000880
+    title: Mechanism of transport of IFT particles in C. elegans cilia by the concerted
+      action of kinesin-II and OSM-3 motors.
+    findings:
+      - statement: Purified C. elegans kinesin-II is a heterotrimer of KLP-11, KLP-20 and KAP-1 (1:1:1, ~287 kD).
+        supporting_text: consisting of 1 mol each of its subunits KLP-11, KLP-20, and KAP-1 with a native molecular mass of 287 kD
+      - statement: Kinesin-II is one of two anterograde IFT motors that move IFT particles along ciliary microtubules.
+        supporting_text: the IFT particles assembling these sensory cilia are moved by the coordinate action of two anterograde IFT motors called kinesin-II and OSM-3, which are both members of the kinesin-2 family
+      - statement: Kinesin-II and OSM-3 act redundantly along the initial (middle) segment to build the cilium foundation.
+        supporting_text: These motors function redundantly to move the same IFT particles along the initial segment and build the cilium foundation, with either motor but not both being dispensable for this function
+      - statement: Kinesin-II is a slow plus-end MT motor (~0.5 um/s) relative to OSM-3.
+        supporting_text: kinesin-II alone moved MTs at a maximal rate of 0.3 μm/s, and OSM-3 alone moved them at 0.7 μm/s
+    reference_review:
+      relevance: HIGH
+      correctness: VERIFIED
+      review_notes: &gt;-
+        Full text cached and PubMed-verified. Directly establishes KLP-11 as a subunit
+        of the purified heterotrimeric kinesin-II holoenzyme and its plus-end MT motility,
+        the source of the WormBase IDA (GO:0003777, GO:0007018) and IPI (GO:0030993)
+        annotations to klp-11.
+  - id: PMID:20498083
+    title: Regulation of a heterodimeric kinesin-2 through an unprocessive motor domain
+      that is turned processive by its partner.
+    findings:
+      - statement: KLP11/KLP20 is the C. elegans heterodimeric kinesin-2 studied here.
+        supporting_text: KLP11/KLP20 of Caenorhabditis elegans cilia
+      - statement: Heterodimerization is required to bind KAP1, the motor-cargo link.
+        supporting_text: heterodimerization is necessary to bind KAP1, the in vivo link between
+    reference_review:
+      relevance: HIGH
+      correctness: VERIFIED
+      review_notes: &gt;-
+        Abstract-only in cache (full_text_available: false), but the abstract explicitly
+        names KLP11/KLP20 of C. elegans and establishes that KLP-11 is unprocessive as a
+        homodimer, is turned processive by heterodimerization with KLP-20, and that
+        heterodimerization is required for KAP-1 binding. Supports the ComplexPortal NAS
+        annotations for kinesin II complex membership and anterograde IFT.
+existing_annotations:
+  - term:
+      id: GO:0003777
+      label: microtubule motor activity
+    evidence_type: IBA
+    original_reference_id: GO_REF:0000033
+    qualifier: enables
+    review:
+      summary: &gt;-
+        KLP-11 is a kinesin-2 motor subunit that, as part of the KLP-11/KLP-20/KAP-1
+        heterotrimer, is an active plus-end-directed microtubule motor. The phylogenetic
+        (IBA) annotation is well supported and corroborated by direct C. elegans data.
+      action: ACCEPT
+      reason: &gt;-
+        Core molecular function. Kinesin-II motor activity is directly demonstrated for the
+        purified holoenzyme containing KLP-11 (PMID:17000880). A more specific term
+        (plus-end-directed microtubule motor activity) is captured in core_functions.
+      supported_by:
+        - reference_id: PMID:17000880
+          supporting_text: kinesin-II alone moved MTs at a maximal rate of 0.3 μm/s, and OSM-3 alone moved them at 0.7 μm/s
+  - term:
+      id: GO:0005737
+      label: cytoplasm
+    evidence_type: IBA
+    original_reference_id: GO_REF:0000033
+    qualifier: is_active_in
+    review:
+      summary: &gt;-
+        Generic cytoplasmic localization inferred phylogenetically. KLP-11 is present in the
+        cytoplasm of ciliated neurons (cell bodies/dendrites) before and while operating in
+        cilia, consistent with kinesin motors generally.
+      action: ACCEPT
+      reason: &gt;-
+        Correct but low-specificity parent. The informative localization for KLP-11 is the
+        cilium and the axonemal kinesin-II complex; retained as accurate context.
+  - term:
+      id: GO:0008017
+      label: microtubule binding
+    evidence_type: IBA
+    original_reference_id: GO_REF:0000033
+    qualifier: enables
+    review:
+      summary: &gt;-
+        Microtubule binding is an intrinsic property of the kinesin motor domain (FT 13..343)
+        and is required for the motor activity of KLP-11-containing kinesin-II on axonemal
+        microtubules.
+      action: ACCEPT
+      reason: &gt;-
+        Well-supported; microtubule binding is a defining feature of kinesin motors and
+        underpins the demonstrated MT gliding activity of kinesin-II (PMID:17000880).
+      supported_by:
+        - reference_id: PMID:17000880
+          supporting_text: the IFT particles assembling these sensory cilia are moved by the coordinate action of two anterograde IFT motors called kinesin-II and OSM-3, which are both members of the kinesin-2 family
+  - term:
+      id: GO:0030705
+      label: cytoskeleton-dependent intracellular transport
+    evidence_type: IBA
+    original_reference_id: GO_REF:0000033
+    qualifier: involved_in
+    review:
+      summary: &gt;-
+        KLP-11 mediates microtubule-based (cytoskeleton-dependent) transport as part of
+        kinesin-II. In the worm this is realized specifically as anterograde IFT within cilia.
+      action: MODIFY
+      reason: &gt;-
+        Correct but too general. The specific, experimentally supported process for KLP-11 is
+        intraciliary anterograde transport; generalize the annotation to that term.
+      proposed_replacement_terms:
+        - id: GO:0035720
+          label: intraciliary anterograde transport
+      propagation_review:
+        root_cause: TERM_SCOPING_PROBLEM
+        failure_modes:
+          - GRANULARITY_MISMATCH
+        source_entities:
+          - source_id: PANTHER:PTN009082057
+            source_label: kinesin-2 / kinesin-II motor node
+            source_status: SUPPORTS_TRANSFER
+      supported_by:
+        - reference_id: PMID:17000880
+          supporting_text: the IFT particles assembling these sensory cilia are moved by the coordinate action of two anterograde IFT motors called kinesin-II and OSM-3, which are both members of the kinesin-2 family
+  - term:
+      id: GO:0060271
+      label: cilium assembly
+    evidence_type: IBA
+    original_reference_id: GO_REF:0000033
+    qualifier: involved_in
+    review:
+      summary: &gt;-
+        Kinesin-II contributes to sensory cilium assembly by delivering IFT cargo along the
+        middle segment. However, klp-11 single mutants have near-full-length cilia because
+        OSM-3 acts redundantly in the middle segment and builds the distal segment, so KLP-11
+        is individually dispensable for ciliogenesis.
+      action: KEEP_AS_NON_CORE
+      reason: &gt;-
+        The annotation is correct at the pathway level, but because of OSM-3 redundancy KLP-11
+        loss does not abolish cilium assembly; the sharpest core process is anterograde IFT.
+        Retained as a real, non-core contribution.
+      supported_by:
+        - reference_id: PMID:17000880
+          supporting_text: These motors function redundantly to move the same IFT particles along the initial segment and build the cilium foundation, with either motor but not both being dispensable for this function
+        - reference_id: PMID:17000880
+          supporting_text: OSM-6∷GFP moves at OSM-3&#39;s fast rate in klp-11 mutants
+  - term:
+      id: GO:0005871
+      label: kinesin complex
+    evidence_type: IBA
+    original_reference_id: GO_REF:0000033
+    qualifier: part_of
+    review:
+      summary: &gt;-
+        KLP-11 is a subunit of a kinesin complex, specifically the heterotrimeric kinesin-II
+        (KLP-11/KLP-20/KAP-1). The generic kinesin complex annotation is correct.
+      action: ACCEPT
+      reason: &gt;-
+        Correct parent-level complex membership; the specific complex (kinesin II /
+        axonemal heterotrimeric kinesin-II) is captured by the NAS/IPI annotations and
+        core_functions.
+      supported_by:
+        - reference_id: PMID:17000880
+          supporting_text: consisting of 1 mol each of its subunits KLP-11, KLP-20, and KAP-1 with a native molecular mass of 287 kD
+  - term:
+      id: GO:0005874
+      label: microtubule
+    evidence_type: IBA
+    original_reference_id: GO_REF:0000033
+    qualifier: is_active_in
+    review:
+      summary: &gt;-
+        KLP-11 is active on microtubules; as part of kinesin-II it translocates along the
+        axonemal (doublet) microtubules of the ciliary middle segment.
+      action: ACCEPT
+      reason: &gt;-
+        Correct localization/site-of-action for a microtubule motor, consistent with the
+        demonstrated MT gliding activity of the holoenzyme.
+      supported_by:
+        - reference_id: PMID:17000880
+          supporting_text: kinesin-II alone moved MTs at a maximal rate of 0.3 μm/s, and OSM-3 alone moved them at 0.7 μm/s
+  - term:
+      id: GO:0007018
+      label: microtubule-based movement
+    evidence_type: IBA
+    original_reference_id: GO_REF:0000033
+    qualifier: involved_in
+    review:
+      summary: &gt;-
+        As a kinesin motor, KLP-11 drives microtubule-based movement. In the worm this is the
+        anterograde movement of IFT particles within cilia.
+      action: ACCEPT
+      reason: &gt;-
+        Correct general process; the specific term (intraciliary anterograde transport) is
+        also annotated (NAS) and captured in core_functions.
+      supported_by:
+        - reference_id: PMID:17000880
+          supporting_text: the IFT particles assembling these sensory cilia are moved by the coordinate action of two anterograde IFT motors called kinesin-II and OSM-3, which are both members of the kinesin-2 family
+  - term:
+      id: GO:0016887
+      label: ATP hydrolysis activity
+    evidence_type: IBA
+    original_reference_id: GO_REF:0000033
+    qualifier: enables
+    review:
+      summary: &gt;-
+        KLP-11 contains a P-loop kinesin motor domain (ATP-binding site residues 99..106) and,
+        as part of kinesin-II, hydrolyzes ATP to power motility; the holoenzyme uses Mg-ATP
+        with Michaelis-Menten kinetics.
+      action: ACCEPT
+      reason: &gt;-
+        ATP hydrolysis is essential for kinesin motor function and is directly evidenced by
+        the ATP-dependent MT gliding kinetics of purified kinesin-II (PMID:17000880).
+      supported_by:
+        - reference_id: PMID:17000880
+          supporting_text: indicating that Mg-ATP is the preferred substrate for kinesin-2 motors
+  - term:
+      id: GO:0000166
+      label: nucleotide binding
+    evidence_type: IEA
+    original_reference_id: GO_REF:0000104
+    qualifier: enables
+    review:
+      summary: &gt;-
+        Broad nucleotide-binding parent inferred from the kinesin P-loop motif. KLP-11 binds
+        ATP/ADP during its mechanochemical cycle.
+      action: ACCEPT
+      reason: &gt;-
+        Correct but non-specific; the informative child (ATP binding) is separately annotated.
+  - term:
+      id: GO:0003774
+      label: cytoskeletal motor activity
+    evidence_type: IEA
+    original_reference_id: GO_REF:0000104
+    qualifier: enables
+    review:
+      summary: &gt;-
+        Parent of microtubule motor activity; correct for KLP-11 as a cytoskeletal (kinesin)
+        motor.
+      action: ACCEPT
+      reason: &gt;-
+        Correct but less specific than microtubule motor activity, which is separately
+        annotated and refined in core_functions.
+  - term:
+      id: GO:0003777
+      label: microtubule motor activity
+    evidence_type: IEA
+    original_reference_id: GO_REF:0000120
+    qualifier: enables
+    review:
+      summary: &gt;-
+        InterPro/ARBA electronic assignment of microtubule motor activity based on the kinesin
+        motor domain. Consistent with the IBA and IDA annotations.
+      action: ACCEPT
+      reason: &gt;-
+        Correct; duplicates the well-supported microtubule motor activity from an electronic
+        pipeline.
+  - term:
+      id: GO:0005524
+      label: ATP binding
+    evidence_type: IEA
+    original_reference_id: GO_REF:0000120
+    qualifier: enables
+    review:
+      summary: &gt;-
+        ATP binding at the kinesin motor domain P-loop (BINDING 99..106) is required for the
+        ATPase-driven motor cycle of KLP-11.
+      action: ACCEPT
+      reason: &gt;-
+        Correct and specific; supported by the conserved P-loop and the Mg-ATP kinetics of the
+        holoenzyme (PMID:17000880).
+      supported_by:
+        - reference_id: PMID:17000880
+          supporting_text: indicating that Mg-ATP is the preferred substrate for kinesin-2 motors
+  - term:
+      id: GO:0005856
+      label: cytoskeleton
+    evidence_type: IEA
+    original_reference_id: GO_REF:0000120
+    qualifier: located_in
+    review:
+      summary: &gt;-
+        KLP-11 localizes to the microtubule cytoskeleton (the ciliary axoneme). Broad but
+        accurate.
+      action: ACCEPT
+      reason: &gt;-
+        Correct low-specificity localization for a microtubule motor; the informative site is
+        the cilium/axoneme.
+  - term:
+      id: GO:0005929
+      label: cilium
+    evidence_type: IEA
+    original_reference_id: GO_REF:0000120
+    qualifier: located_in
+    review:
+      summary: &gt;-
+        KLP-11 localizes to sensory cilia, where kinesin-II performs anterograde IFT along the
+        middle segment.
+      action: ACCEPT
+      reason: &gt;-
+        Core localization, consistent with UniProt subcellular location and the cilia IFT role
+        of kinesin-II (PMID:17000880).
+      supported_by:
+        - reference_id: PMID:17000880
+          supporting_text: the IFT particles assembling these sensory cilia are moved by the coordinate action of two anterograde IFT motors called kinesin-II and OSM-3, which are both members of the kinesin-2 family
+  - term:
+      id: GO:0007018
+      label: microtubule-based movement
+    evidence_type: IEA
+    original_reference_id: GO_REF:0000120
+    qualifier: involved_in
+    review:
+      summary: &gt;-
+        Electronic assignment of microtubule-based movement, duplicating the IBA/IDA process
+        annotation.
+      action: ACCEPT
+      reason: &gt;-
+        Correct; the more specific process (intraciliary anterograde transport) is also
+        annotated.
+  - term:
+      id: GO:0008017
+      label: microtubule binding
+    evidence_type: IEA
+    original_reference_id: GO_REF:0000002
+    qualifier: enables
+    review:
+      summary: &gt;-
+        InterPro electronic assignment of microtubule binding via the kinesin motor domain;
+        duplicates the IBA annotation.
+      action: ACCEPT
+      reason: &gt;-
+        Correct; microtubule binding is intrinsic to the kinesin motor domain.
+  - term:
+      id: GO:0032991
+      label: protein-containing complex
+    evidence_type: IEA
+    original_reference_id: GO_REF:0000117
+    qualifier: part_of
+    review:
+      summary: &gt;-
+        Generic complex-membership assignment. KLP-11 is specifically a subunit of the
+        heterotrimeric kinesin-II complex.
+      action: MODIFY
+      reason: &gt;-
+        Too general. Replace with the specific kinesin II complex to convey the actual
+        assembly KLP-11 belongs to.
+      proposed_replacement_terms:
+        - id: GO:0016939
+          label: kinesin II complex
+      supported_by:
+        - reference_id: PMID:17000880
+          supporting_text: consisting of 1 mol each of its subunits KLP-11, KLP-20, and KAP-1 with a native molecular mass of 287 kD
+  - term:
+      id: GO:0007018
+      label: microtubule-based movement
+    evidence_type: NAS
+    original_reference_id: PMID:20498083
+    qualifier: involved_in
+    review:
+      summary: &gt;-
+        ComplexPortal NAS annotation. KLP-11 (as the KLP-11/KLP-20 heterodimer, and within the
+        kinesin-II holoenzyme) drives microtubule-based movement; heterodimerization confers
+        the processivity needed for transport.
+      action: ACCEPT
+      reason: &gt;-
+        Author-stated (NAS) and consistent with the biochemistry: KLP-11 becomes a processive
+        MT motor upon heterodimerization with KLP-20 (PMID:20498083).
+      supported_by:
+        - reference_id: PMID:20498083
+          supporting_text: KLP11/KLP20 of Caenorhabditis elegans cilia
+  - term:
+      id: GO:0016939
+      label: kinesin II complex
+    evidence_type: NAS
+    original_reference_id: PMID:20498083
+    qualifier: part_of
+    review:
+      summary: &gt;-
+        KLP-11 is a subunit of kinesin II. The heterodimer of the two motor subunits
+        (KLP-11/KLP-20) plus KAP-1 constitutes the kinesin-II complex; heterodimerization is
+        required for KAP-1 binding.
+      action: ACCEPT
+      reason: &gt;-
+        Core complex membership. Supported by both the ComplexPortal NAS record and the
+        biochemistry of the KLP-11/KLP-20/KAP-1 assembly (PMID:20498083, PMID:17000880).
+      supported_by:
+        - reference_id: PMID:20498083
+          supporting_text: heterodimerization is necessary to bind KAP1, the in vivo link between
+        - reference_id: PMID:17000880
+          supporting_text: consisting of 1 mol each of its subunits KLP-11, KLP-20, and KAP-1 with a native molecular mass of 287 kD
+  - term:
+      id: GO:0035720
+      label: intraciliary anterograde transport
+    evidence_type: NAS
+    original_reference_id: PMID:20498083
+    qualifier: involved_in
+    review:
+      summary: &gt;-
+        KLP-11-containing kinesin-II is an anterograde IFT motor of C. elegans cilia; the
+        heterodimeric motor drives anterograde transport of IFT particles.
+      action: ACCEPT
+      reason: &gt;-
+        Core biological process for KLP-11. Author-stated (NAS) and corroborated by the
+        cooperative anterograde IFT role of kinesin-II with OSM-3 (PMID:17000880).
+      supported_by:
+        - reference_id: PMID:17000880
+          supporting_text: the IFT particles assembling these sensory cilia are moved by the coordinate action of two anterograde IFT motors called kinesin-II and OSM-3, which are both members of the kinesin-2 family
+  - term:
+      id: GO:0003777
+      label: microtubule motor activity
+    evidence_type: IDA
+    original_reference_id: PMID:17000880
+    qualifier: enables
+    review:
+      summary: &gt;-
+        Direct assay: purified recombinant C. elegans kinesin-II containing KLP-11 is an active
+        microtubule motor in gliding assays, moving MTs at ~0.5 um/s.
+      action: ACCEPT
+      reason: &gt;-
+        Direct experimental evidence (IDA) for KLP-11&#39;s core molecular function as a component
+        of the kinesin-II motor holoenzyme.
+      supported_by:
+        - reference_id: PMID:17000880
+          supporting_text: kinesin-II alone moved MTs at a maximal rate of 0.3 μm/s, and OSM-3 alone moved them at 0.7 μm/s
+  - term:
+      id: GO:0007018
+      label: microtubule-based movement
+    evidence_type: IDA
+    original_reference_id: PMID:17000880
+    qualifier: involved_in
+    review:
+      summary: &gt;-
+        Direct in vitro demonstration that KLP-11-containing kinesin-II generates
+        microtubule-based movement (MT gliding), the biochemical basis of its IFT role.
+      action: ACCEPT
+      reason: &gt;-
+        Direct experimental evidence (IDA). The specific process (intraciliary anterograde
+        transport) is also annotated (NAS) and captured in core_functions.
+      supported_by:
+        - reference_id: PMID:17000880
+          supporting_text: kinesin-II alone moved MTs at a maximal rate of 0.3 μm/s, and OSM-3 alone moved them at 0.7 μm/s
+  - term:
+      id: GO:0030993
+      label: axonemal heterotrimeric kinesin-II complex
+    evidence_type: IPI
+    original_reference_id: PMID:17000880
+    qualifier: part_of
+    review:
+      summary: &gt;-
+        KLP-11 physically assembles into the axonemal heterotrimeric kinesin-II complex with
+        KLP-20 (WBGene00002230) and KAP-1 (WBGene00002182), demonstrated as a monodisperse
+        1:1:1 (~287 kD) heterotrimer by sucrose gradients and gel filtration.
+      action: ACCEPT
+      reason: &gt;-
+        Direct physical-interaction evidence (IPI) for the most specific, experimentally
+        grounded cellular-component annotation for KLP-11. This is a core annotation.
+      supported_by:
+        - reference_id: PMID:17000880
+          supporting_text: consisting of 1 mol each of its subunits KLP-11, KLP-20, and KAP-1 with a native molecular mass of 287 kD
+core_functions:
+  - description: &gt;-
+      As a motor subunit of the heterotrimeric kinesin-II holoenzyme (KLP-11/KLP-20/KAP-1),
+      KLP-11 contributes plus-end-directed microtubule motor and ATPase activity. KLP-11 is
+      unprocessive on its own (as a homodimer); processive plus-end movement is generated only
+      by heterodimerization with the partner motor subunit KLP-20. The assembled motor drives
+      relatively slow (~0.5 um/s) plus-end transport along axonemal microtubules.
+    molecular_function:
+      id: GO:0003777
+      label: microtubule motor activity
+    contributes_to_molecular_function:
+      id: GO:0008574
+      label: plus-end-directed microtubule motor activity
+    directly_involved_in:
+      - id: GO:0035720
+        label: intraciliary anterograde transport
+    locations:
+      - id: GO:0005929
+        label: cilium
+      - id: GO:0005874
+        label: microtubule
+    in_complex:
+      id: GO:0030993
+      label: axonemal heterotrimeric kinesin-II complex
+    supported_by:
+      - reference_id: PMID:17000880
+        supporting_text: consisting of 1 mol each of its subunits KLP-11, KLP-20, and KAP-1 with a native molecular mass of 287 kD
+      - reference_id: PMID:20498083
+        supporting_text: KLP11/KLP20 of Caenorhabditis elegans cilia
+  - description: &gt;-
+      KLP-11-containing kinesin-II hydrolyzes ATP to power its motor cycle; the purified
+      holoenzyme uses Mg-ATP as its preferred substrate with Michaelis-Menten kinetics,
+      coupling ATP hydrolysis to microtubule-based movement.
+    molecular_function:
+      id: GO:0016887
+      label: ATP hydrolysis activity
+    directly_involved_in:
+      - id: GO:0007018
+        label: microtubule-based movement
+    in_complex:
+      id: GO:0030993
+      label: axonemal heterotrimeric kinesin-II complex
+    supported_by:
+      - reference_id: PMID:17000880
+        supporting_text: indicating that Mg-ATP is the preferred substrate for kinesin-2 motors
+  - description: &gt;-
+      Kinesin-II (with KLP-11) is one of two anterograde IFT motors that, together with the
+      homodimeric OSM-3 motor, move IFT particles along the doublet microtubules of the ciliary
+      middle segment. The two motors act partly redundantly to build the cilium foundation, and
+      their mechanical competition contributes to IFT-particle tension regulated by BBS proteins.
+    molecular_function:
+      id: GO:0003777
+      label: microtubule motor activity
+    directly_involved_in:
+      - id: GO:0035720
+        label: intraciliary anterograde transport
+    locations:
+      - id: GO:0005929
+        label: cilium
+    in_complex:
+      id: GO:0030993
+      label: axonemal heterotrimeric kinesin-II complex
+    supported_by:
+      - reference_id: PMID:17000880
+        supporting_text: These motors function redundantly to move the same IFT particles along the initial segment and build the cilium foundation, with either motor but not both being dispensable for this function
+knowledge_gaps:
+  - gap_statement: &gt;-
+      No KLP-11 subunit-resolved in vivo molecular function is established independently of its
+      partners: all motility, IFT and localization data are for the intact KLP-11/KLP-20/KAP-1
+      heterotrimer (or the KLP-11/KLP-20 heterodimer), and KLP-11 is unprocessive as a homodimer,
+      so it has no demonstrated autonomous processive motor activity.
+    boundary: &gt;-
+      It is firmly established that KLP-11 is a subunit of the purified heterotrimeric kinesin-II
+      holoenzyme, that the holoenzyme is an active plus-end MT motor, and that heterodimerization
+      with KLP-20 is what confers processivity and enables KAP-1 binding.
+    gap_kind:
+      - BIOLOGY
+    dark_aspect: MF_DARK
+    significance: &gt;-
+      Distinguishing the specific mechanochemical contribution of the KLP-11 head from that of
+      KLP-20 is needed to understand why kinesin-II uses two distinct, asymmetric motor subunits.
+    resolution: &gt;-
+      Single-molecule and structural analysis of engineered KLP-11 vs KLP-20 heads and chimeras,
+      building on the finding that KLP-11 mediates asymmetric autoregulation of the heterodimer.
+    provenance:
+      - reference_id: PMID:20498083
+        supporting_text: heterodimerization is necessary to bind KAP1, the in vivo link between
+  - gap_statement: &gt;-
+      The identity of the IFT cargo(es) directly engaged by KLP-11-containing kinesin-II via
+      KAP-1 in C. elegans, and how cargo loading/unloading is regulated along the middle segment,
+      are not resolved by the primary literature reviewed here.
+    boundary: &gt;-
+      Kinesin-II is established as an anterograde IFT motor that moves IFT particles (IFT-A/IFT-B
+      subcomplexes) along the middle segment, and heterodimerization is required for KAP-1 (the
+      motor-cargo link) binding.
+    gap_kind:
+      - BIOLOGY
+    dark_aspect: BP_DARK
+    significance: &gt;-
+      Defining the kinesin-II-specific cargo interface would clarify the division of labor
+      between kinesin-II and OSM-3 and the handoff of IFT trains between motors.
+    resolution: &gt;-
+      Proximity-labeling / cross-linking mass spectrometry of KAP-1 and KLP-11 in cilia, and
+      cargo-selective transport assays.
+    provenance:
+      - reference_id: PMID:17000880
+        supporting_text: the IFT particles assembling these sensory cilia are moved by the coordinate action of two anterograde IFT motors called kinesin-II and OSM-3, which are both members of the kinesin-2 family
+  - gap_statement: &gt;-
+      The atomic structure of the fully assembled C. elegans kinesin-II heterotrimer and the
+      structural basis of KLP-11-mediated asymmetric autoregulation of motor activity are unsolved.
+    boundary: &gt;-
+      Only a partial X-ray structure of the stalk/tail region (residues 537-782, PDB 9IKB, 3.54 A)
+      of heterotrimeric kinesin-2 is available; the motor-domain interface and regulatory
+      conformations are not resolved.
+    gap_kind:
+      - BIOLOGY
+    dark_aspect: MF_DARK
+    significance: &gt;-
+      A full structure would explain how an unprocessive subunit is converted to a processive
+      heterodimer and how autoregulation is imposed asymmetrically.
+    resolution: &gt;-
+      Cryo-EM / higher-resolution crystallography of the intact KLP-11/KLP-20/KAP-1 holoenzyme in
+      defined nucleotide states.
+    provenance:
+      - reference_id: PMID:20498083
+        supporting_text: KLP11/KLP20 of Caenorhabditis elegans cilia
+suggested_questions:
+  - question: &gt;-
+      What is the distinct mechanochemical role of the KLP-11 motor head versus the KLP-20 head
+      within the heterodimer, and why is an unprocessive subunit retained?
+    experts: []
+  - question: &gt;-
+      Which IFT-particle cargoes are engaged by kinesin-II via KAP-1 in C. elegans cilia, and how
+      is the kinesin-II-to-OSM-3 handoff regulated along the middle segment?
+    experts: []
+suggested_experiments:
+  - hypothesis: &gt;-
+      KLP-11&#39;s head contributes asymmetric autoregulation but little autonomous processivity to
+      kinesin-II.
+    description: &gt;-
+      Reconstitute KLP-11/KLP-20 heterodimers and KLP-11 or KLP-20 homodimers and chimeras, and
+      compare single-molecule processivity, velocity, and ATPase to dissect each head&#39;s contribution.
+    experiment_type: single-molecule motility / biochemistry
+  - hypothesis: &gt;-
+      Full-length assembled kinesin-II adopts nucleotide-dependent conformations that impose
+      asymmetric autoregulation.
+    description: &gt;-
+      Determine the cryo-EM structure of the intact KLP-11/KLP-20/KAP-1 heterotrimer in different
+      nucleotide states and on microtubules.
+    experiment_type: structural biology (cryo-EM)
+tags:
+  - caeel-ciliopathy
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/genes/worm/klp-20/klp-20-ai-review.html
+++ b/genes/worm/klp-20/klp-20-ai-review.html
@@ -1,0 +1,4071 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>klp-20 - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        .propagation-review {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f8fafc;
+            border-left: 3px solid #64748b;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .propagation-title {
+            font-weight: 600;
+            color: #334155;
+            margin-bottom: 0.25rem;
+        }
+
+        .propagation-row {
+            margin-top: 0.25rem;
+        }
+
+        .propagation-source {
+            margin-top: 0.5rem;
+            padding-top: 0.5rem;
+            border-top: 1px solid #e5e7eb;
+        }
+
+        .propagation-source-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #1d4ed8;
+        }
+
+        .propagation-comment {
+            color: #4b5563;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>klp-20</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/Q965T6" target="_blank" class="term-link">
+                        Q965T6
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Caenorhabditis elegans</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-complete">
+                    COMPLETE
+                </span>
+            </div>
+
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "klp-20";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="Q965T6" data-a="DESCRIPTION: klp-20 encodes one of the two motor subunits of he..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>klp-20 encodes one of the two motor subunits of heterotrimeric kinesin-II, the anterograde intraflagellar transport (IFT) motor of Caenorhabditis elegans. It is a member of the kinesin-2 subfamily with an N-terminal kinesin motor domain (P-loop ATPase) and a C-terminal coiled-coil stalk. klp-20 does not act alone: it heterodimerizes through its C-terminal stalk with the second motor subunit klp-11, and this heterodimer associates with the non-motor accessory subunit kap-1 to form the heterotrimeric kinesin-II holoenzyme (klp-11/klp-20/kap-1). Heterodimerization with klp-11 is required to generate a processive motor and to bind kap-1, which links the motor to IFT cargo. As part of kinesin-II the protein is an ATP-driven, microtubule plus-end-directed motor that, together with the homodimeric kinesin-2 motor osm-3, powers anterograde IFT along the middle (doublet) segment of sensory-neuron cilia, building and maintaining the ciliary axoneme. It localizes to sensory cilia, including the ciliary base and transition zone.</p>
+    </div>
+
+
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003777" target="_blank" class="term-link">
+                                    GO:0003777
+                                </a>
+                            </span>
+                            <span class="term-label">microtubule motor activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q965T6" data-a="GO:0003777" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetic (IBA) support for microtubule motor activity, redundant with the experimental IDA below (PMID:17000880). Correct core molecular function of the kinesin motor domain. The more specific term is plus-end-directed microtubule motor activity (GO:0008574), captured in core_functions.
+                        </div>
+
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/17000880" target="_blank" class="term-link">
+                                        PMID:17000880
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">indicating that Mg-ATP is the preferred substrate for kinesin-2 motors</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
+                                    GO:0005737
+                                </a>
+                            </span>
+                            <span class="term-label">cytoplasm</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q965T6" data-a="GO:0005737" data-r="GO_REF:0000033" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Broad cytoplasmic localization consistent with UniProt (Cytoplasm, cytoskeleton by similarity), but uninformative relative to the specific ciliary localization. Keep as non-core context.
+                        </div>
+
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008017" target="_blank" class="term-link">
+                                    GO:0008017
+                                </a>
+                            </span>
+                            <span class="term-label">microtubule binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q965T6" data-a="GO:0008017" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Microtubule binding is intrinsic to the kinesin motor domain and required for the motor to engage its track. Correct and consistent with plus-end-directed motor activity; retained as a supporting molecular function.
+                        </div>
+
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0060271" target="_blank" class="term-link">
+                                    GO:0060271
+                                </a>
+                            </span>
+                            <span class="term-label">cilium assembly</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q965T6" data-a="GO:0060271" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Kinesin-II (with klp-20 as a motor subunit) and osm-3 move IFT particles that redundantly build the sensory cilium foundation, so involvement in cilium assembly is well supported. Accept as a core biological process.
+                        </div>
+
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/17000880" target="_blank" class="term-link">
+                                        PMID:17000880
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">either motor but not both being dispensable for this function</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005871" target="_blank" class="term-link">
+                                    GO:0005871
+                                </a>
+                            </span>
+                            <span class="term-label">kinesin complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q965T6" data-a="GO:0005871" data-r="GO_REF:0000033" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct but general parent of the specific complex membership. klp-20 is a subunit of the (axonemal heterotrimeric) kinesin-II complex; the specific terms GO:0016939/GO:0030993 are preferred. Keep as non-core.
+                        </div>
+
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005874" target="_blank" class="term-link">
+                                    GO:0005874
+                                </a>
+                            </span>
+                            <span class="term-label">microtubule</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q965T6" data-a="GO:0005874" data-r="GO_REF:0000033" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> The microtubule is the motor&#39;s track rather than a distinct cellular location of the protein. Consistent with function but non-core; the informative location is the cilium.
+                        </div>
+
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016887" target="_blank" class="term-link">
+                                    GO:0016887
+                                </a>
+                            </span>
+                            <span class="term-label">ATP hydrolysis activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q965T6" data-a="GO:0016887" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> ATP hydrolysis powers the kinesin motor; the motor domain of klp-20 contains the P-loop (Walker A) ATPase site, and purified kinesin-II shows Mg-ATP-dependent motility with Michaelis-Menten kinetics (PMID:17000880). Accept as part of the core motor mechanism.
+                        </div>
+
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/17000880" target="_blank" class="term-link">
+                                        PMID:17000880
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">kinesin-II–driven motility conformed to Michaelis-Menten kinetics</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008089" target="_blank" class="term-link">
+                                    GO:0008089
+                                </a>
+                            </span>
+                            <span class="term-label">anterograde axonal transport</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q965T6" data-a="GO:0008089" data-r="GO_REF:0000033" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> This term is a phylogenetic transfer from kinesin-II orthologs (KIF3) that act in neuronal axonal transport. In C. elegans the documented role of klp-20/kinesin-II is anterograde intraflagellar (ciliary) transport, not classical axonal cargo transport; there is no experimental evidence for a klp-20 axonal-transport role in worm. Treated as an over-propagated electronic inference; the accurate specific term is intraciliary anterograde transport (GO:0035720).
+                        </div>
+
+
+
+
+                        <div class="propagation-review">
+                            <div class="propagation-title">Propagation Review</div>
+                            <div class="propagation-row">
+                                <strong>Root cause:</strong>
+                                <span class="badge">TERM SCOPING PROBLEM</span>
+                            </div>
+
+                            <div class="propagation-row">
+                                <strong>Failure modes:</strong>
+
+                                <span class="badge">CONTEXT OR TISSUE MISMATCH</span>
+
+                                <span class="badge">GRANULARITY MISMATCH</span>
+
+                            </div>
+
+
+                            <div class="propagation-source">
+                                <strong>Sources checked:</strong>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">FB:FBgn0004380</span>
+
+                                    &middot; Klp64D (Drosophila kinesin-II KIF3A ortholog)
+
+
+                                    <span class="badge">SUPPORTS SOURCE BUT NOT TARGET</span>
+
+
+                                    <div class="propagation-comment">Kinesin-II orthologs act in neuronal anterograde axonal transport, but the documented C. elegans klp-20 role is anterograde intraciliary transport, not axonal cargo transport; the axon-specific term does not transfer.</div>
+
+                                </div>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">PANTHER:PTN000650181</span>
+
+                                    &middot; kinesin-2 anterograde-transport node
+
+
+                                    <span class="badge">SUPPORTS SOURCE BUT NOT TARGET</span>
+
+
+                                    <div class="propagation-comment">Node-level anterograde-transport inference; the ciliary (GO:0035720) rather than axonal (GO:0008089) child is the correct scoping for klp-20.</div>
+
+                                </div>
+
+                            </div>
+
+                        </div>
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003777" target="_blank" class="term-link">
+                                    GO:0003777
+                                </a>
+                            </span>
+                            <span class="term-label">microtubule motor activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000120
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q965T6" data-a="GO:0003777" data-r="GO_REF:0000120" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic (InterPro/ARBA) support for microtubule motor activity, redundant with the experimental IDA (PMID:17000880) and the IBA above. Correct core molecular function.
+                        </div>
+
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005524" target="_blank" class="term-link">
+                                    GO:0005524
+                                </a>
+                            </span>
+                            <span class="term-label">ATP binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q965T6" data-a="GO:0005524" data-r="GO_REF:0000002" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> ATP binding via the conserved P-loop/Walker A motif of the kinesin motor domain (UniProt BINDING 91..98). Correct molecular-mechanism support for the ATP-driven motor; retained as supporting.
+                        </div>
+
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005856" target="_blank" class="term-link">
+                                    GO:0005856
+                                </a>
+                            </span>
+                            <span class="term-label">cytoskeleton</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000120
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q965T6" data-a="GO:0005856" data-r="GO_REF:0000120" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> General cytoskeletal localization from an electronic subcellular-location rule. Consistent with a microtubule motor but non-specific; the informative location is the cilium.
+                        </div>
+
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005929" target="_blank" class="term-link">
+                                    GO:0005929
+                                </a>
+                            </span>
+                            <span class="term-label">cilium</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000120
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q965T6" data-a="GO:0005929" data-r="GO_REF:0000120" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Ciliary localization is well established: klp-20/kinesin-II functions in sensory cilia and UniProt records SUBCELLULAR LOCATION cilium (localizing to the base and transition zone; PMID:28479320). Accept as a core cellular location.
+                        </div>
+
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0007018" target="_blank" class="term-link">
+                                    GO:0007018
+                                </a>
+                            </span>
+                            <span class="term-label">microtubule-based movement</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000120
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q965T6" data-a="GO:0007018" data-r="GO_REF:0000120" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic support for microtubule-based movement, redundant with the experimental IDA (PMID:17000880). Correct but general; the specific process is intraciliary anterograde transport (GO:0035720). Accept.
+                        </div>
+
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008017" target="_blank" class="term-link">
+                                    GO:0008017
+                                </a>
+                            </span>
+                            <span class="term-label">microtubule binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q965T6" data-a="GO:0008017" data-r="GO_REF:0000002" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic (InterPro) support for microtubule binding, redundant with the IBA above and intrinsic to the motor domain. Accept as supporting molecular function.
+                        </div>
+
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0032991" target="_blank" class="term-link">
+                                    GO:0032991
+                                </a>
+                            </span>
+                            <span class="term-label">protein-containing complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000117
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q965T6" data-a="GO:0032991" data-r="GO_REF:0000117" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Root-level complex membership from an ARBA rule. True (klp-20 is part of kinesin-II) but uninformative; the specific complex terms GO:0016939 and GO:0030993 supersede it. Over-annotated at this level of generality.
+                        </div>
+
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1904115" target="_blank" class="term-link">
+                                    GO:1904115
+                                </a>
+                            </span>
+                            <span class="term-label">axon cytoplasm</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000108
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q965T6" data-a="GO:1904115" data-r="GO_REF:0000108" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Inferred logically (GO_REF:0000108) from the anterograde axonal transport annotation (GO:0008089), which is itself an over-propagated phylogenetic transfer. klp-20 acts in sensory cilia in C. elegans, not documented axoplasm; this location is a downstream consequence of the over-annotated axonal-transport term.
+                        </div>
+
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0007018" target="_blank" class="term-link">
+                                    GO:0007018
+                                </a>
+                            </span>
+                            <span class="term-label">microtubule-based movement</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">NAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/20498083" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:20498083
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Regulation of a heterodimeric kinesin-2 through an unprocess...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q965T6" data-a="GO:0007018" data-r="PMID:20498083" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> ComplexPortal NAS annotation for microtubule-based movement, supported by the biophysical characterization of the KLP-11/KLP-20 heterodimer motor. Correct but general relative to intraciliary anterograde transport; accept.
+                        </div>
+
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/20498083" target="_blank" class="term-link">
+                                        PMID:20498083
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">One motor domain is unprocessive as a homodimer</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016939" target="_blank" class="term-link">
+                                    GO:0016939
+                                </a>
+                            </span>
+                            <span class="term-label">kinesin II complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">NAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/20498083" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:20498083
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Regulation of a heterodimeric kinesin-2 through an unprocess...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q965T6" data-a="GO:0016939" data-r="PMID:20498083" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> klp-20 is a subunit of the kinesin II complex (the klp-11/klp-20/kap-1 heterotrimer). Directly supported: heterodimerization of klp-20 with klp-11 is required to bind kap-1 (PMID:20498083), and the purified heterotrimer was characterized in PMID:17000880. Accept as core complex membership; the axonemal term GO:0030993 is the most specific.
+                        </div>
+
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/20498083" target="_blank" class="term-link">
+                                        PMID:20498083
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">heterodimerization is necessary to bind KAP1, the in vivo link between motor and</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0035720" target="_blank" class="term-link">
+                                    GO:0035720
+                                </a>
+                            </span>
+                            <span class="term-label">intraciliary anterograde transport</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">NAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/20498083" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:20498083
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Regulation of a heterodimeric kinesin-2 through an unprocess...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q965T6" data-a="GO:0035720" data-r="PMID:20498083" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Anterograde IFT is the core biological process of kinesin-II. As a kinesin-II motor subunit, klp-20 drives base-to-tip transport of IFT particles along sensory cilia together with osm-3. Accept as a core process.
+                        </div>
+
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/17000880" target="_blank" class="term-link">
+                                        PMID:17000880
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">two anterograde IFT motors called kinesin-II and OSM-3</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003777" target="_blank" class="term-link">
+                                    GO:0003777
+                                </a>
+                            </span>
+                            <span class="term-label">microtubule motor activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/17000880" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:17000880
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Mechanism of transport of IFT particles in C. elegans cilia ...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q965T6" data-a="GO:0003777" data-r="PMID:17000880" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct experimental (IDA) annotation from characterization of purified kinesin-II, which contains klp-20 as one of its two motor subunits and moves microtubules in an ATP-dependent manner. This is the strongest evidence for the core molecular function. The most specific term is plus-end-directed microtubule motor activity (GO:0008574), used in core_functions.
+                        </div>
+
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/17000880" target="_blank" class="term-link">
+                                        PMID:17000880
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">the KLP-11, KAP-1, and KLP-20 subunits elute as a monodisperse heterotrimeric complex</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0007018" target="_blank" class="term-link">
+                                    GO:0007018
+                                </a>
+                            </span>
+                            <span class="term-label">microtubule-based movement</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/17000880" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:17000880
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Mechanism of transport of IFT particles in C. elegans cilia ...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q965T6" data-a="GO:0007018" data-r="PMID:17000880" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct experimental annotation for microtubule-based movement from the kinesin-II gliding assays. Correct; general relative to intraciliary anterograde transport but experimentally solid. Accept.
+                        </div>
+
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/17000880" target="_blank" class="term-link">
+                                        PMID:17000880
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">indicating that Mg-ATP is the preferred substrate for kinesin-2 motors</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030993" target="_blank" class="term-link">
+                                    GO:0030993
+                                </a>
+                            </span>
+                            <span class="term-label">axonemal heterotrimeric kinesin-II complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/17000880" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:17000880
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Mechanism of transport of IFT particles in C. elegans cilia ...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q965T6" data-a="GO:0030993" data-r="PMID:17000880" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct physical-interaction (IPI) evidence that klp-20 is a subunit of the axonemal heterotrimeric kinesin-II complex, purified as a monodisperse heterotrimer of KLP-11/KLP-20/KAP-1 (with WormBase klp-11 and kap-1 as the with/from partners). This is the most specific and best-supported complex-membership term and the core cellular-component annotation.
+                        </div>
+
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/17000880" target="_blank" class="term-link">
+                                        PMID:17000880
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">consisting of 1 mol each of its subunits KLP-11, KLP-20, and KAP-1 with a native molecular mass of 287 kD</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008574" target="_blank" class="term-link">
+                                    GO:0008574
+                                </a>
+                            </span>
+                            <span class="term-label">plus-end-directed microtubule motor activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/17000880" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:17000880
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Mechanism of transport of IFT particles in C. elegans cilia ...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-new">
+                            NEW
+                        </span>
+                        <span class="vote-buttons" data-g="Q965T6" data-a="GO:0008574" data-r="PMID:17000880" data-act="NEW">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Proposed refinement of the experimental microtubule motor activity annotation (GO:0003777, IDA, PMID:17000880) to the more specific plus-end-directed microtubule motor activity. Kinesins are plus-end-directed motors and kinesin-II (with klp-20) drives anterograde (base-to-tip, plus-end-directed) IFT; the purified motor moves microtubules in gliding assays. This is the primary core molecular function.
+                        </div>
+
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/17000880" target="_blank" class="term-link">
+                                        PMID:17000880
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">kinesin-II alone moved MTs at a maximal rate of 0.3</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>As one of the two motor subunits of heterotrimeric kinesin-II (klp-11/klp-20/kap-1), klp-20 contributes to the ATP-driven, microtubule plus-end-directed motor activity of the complex. klp-20 heterodimerizes with klp-11 through its C-terminal coiled-coil stalk; this heterodimer is processive and binds the accessory subunit kap-1, which couples the motor to IFT cargo. The motor moves along the doublet microtubules of the sensory-cilium middle segment.</h3>
+                <span class="vote-buttons" data-g="Q965T6" data-a="FUNCTION: As one of the two motor subunits of heterotrimeric..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008574" target="_blank" class="term-link">
+                            plus-end-directed microtubule motor activity
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0035720" target="_blank" class="term-link">
+                                intraciliary anterograde transport
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0060271" target="_blank" class="term-link">
+                                cilium assembly
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005929" target="_blank" class="term-link">
+                                cilium
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">In Complex:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030993" target="_blank" class="term-link">
+                            axonemal heterotrimeric kinesin-II complex
+                        </a>
+                    </span>
+                </div>
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/17000880" target="_blank" class="term-link">
+                                PMID:17000880
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">the KLP-11, KAP-1, and KLP-20 subunits elute as a monodisperse heterotrimeric complex</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/20498083" target="_blank" class="term-link">
+                                PMID:20498083
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">heterodimerization is necessary to bind KAP1, the in vivo link between motor and</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>The kinesin motor domain of klp-20 hydrolyzes ATP to power microtubule-based movement. Purified kinesin-II (containing klp-20) uses Mg-ATP as its preferred substrate with Michaelis-Menten kinetics, and klp-20 carries the conserved P-loop (Walker A) ATP-binding motif.</h3>
+                <span class="vote-buttons" data-g="Q965T6" data-a="FUNCTION: The kinesin motor domain of klp-20 hydrolyzes ATP ..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016887" target="_blank" class="term-link">
+                            ATP hydrolysis activity
+                        </a>
+                    </span>
+                </div>
+
+
+
+
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">In Complex:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030993" target="_blank" class="term-link">
+                            axonemal heterotrimeric kinesin-II complex
+                        </a>
+                    </span>
+                </div>
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/17000880" target="_blank" class="term-link">
+                                PMID:17000880
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">indicating that Mg-ATP is the preferred substrate for kinesin-2 motors</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000002.md" target="_blank" class="term-link">
+                            GO_REF:0000002
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation through association of InterPro records with GO terms</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
+                            GO_REF:0000033
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Annotation inferences using phylogenetic trees</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000108.md" target="_blank" class="term-link">
+                            GO_REF:0000108
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Automatic assignment of GO terms using logical inference, based on on inter-ontology links</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000117.md" target="_blank" class="term-link">
+                            GO_REF:0000117
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Electronic Gene Ontology annotations created by ARBA machine learning models</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000120.md" target="_blank" class="term-link">
+                            GO_REF:0000120
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Combined Automated Annotation using Multiple IEA Methods</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/17000880" target="_blank" class="term-link">
+                            PMID:17000880
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Mechanism of transport of IFT particles in C. elegans cilia by the concerted action of kinesin-II and OSM-3 motors.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Purified recombinant kinesin-II behaves as a monodisperse heterotrimer of the KLP-11, KLP-20 and KAP-1 subunits (native mass ~287 kD, 1:1:1 stoichiometry), establishing klp-20 as a subunit of the heterotrimeric kinesin-II complex.</div>
+
+                        <div class="finding-text">"the KLP-11, KAP-1, and KLP-20 subunits elute as a monodisperse heterotrimeric complex"</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Kinesin-II (containing klp-20) is an ATP-driven microtubule motor; in gliding assays it moves microtubules and uses Mg-ATP by Michaelis-Menten kinetics.</div>
+
+                        <div class="finding-text">"indicating that Mg-ATP is the preferred substrate for kinesin-2 motors"</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Kinesin-II and OSM-3 are the two anterograde IFT motors that redundantly move IFT particles to build the sensory cilium foundation.</div>
+
+                        <div class="finding-text">"two anterograde IFT motors called kinesin-II and OSM-3"</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/20498083" target="_blank" class="term-link">
+                            PMID:20498083
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Regulation of a heterodimeric kinesin-2 through an unprocessive motor domain that is turned processive by its partner.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">The KLP-11/KLP-20 heterodimer pairs an unprocessive with a processive motor domain; heterodimerization generates processivity.</div>
+
+                        <div class="finding-text">"One motor domain is unprocessive as a homodimer"</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Heterodimerization of klp-20 with klp-11 is required to bind KAP-1, the in vivo link between the motor and its cargo.</div>
+
+                        <div class="finding-text">"heterodimerization is necessary to bind KAP1, the in vivo link between motor and"</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Questions for Experts</h2>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Within the klp-11/klp-20 heterodimer, which motor domain is the processive one and which is unprocessive, and how do the two heads cooperate to set the ~0.5 um/s in vivo velocity of kinesin-II?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q965T6" data-a="Q: Within the klp-11/klp-20 heterodimer, which motor ..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> How does cargo binding to kap-1 relieve the tail-mediated autoinhibition of the klp-11/klp-20 heterodimer, and what is the specific contribution of the klp-20 tail (residues 444-445 and the 525-550 klp-11 interaction region)?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q965T6" data-a="Q: How does cargo binding to kap-1 relieve the tail-m..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Experiments</h2>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Single-molecule motility (TIRF) comparison of purified klp-20 homodimer, klp-11 homodimer, and klp-11/klp-20 heterodimer with subunit-specific fluorophores, to assign processivity and duty ratio to each subunit and test the asymmetric-autoregulation model.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: klp-20 and klp-11 have different intrinsic processivities, and one specific subunit is the unprocessive, autoregulatory head.</em></p>
+
+
+                </div>
+                <span class="vote-buttons" data-g="Q965T6" data-a="EXPERIMENT: Single-molecule motility (TIRF) comparison of puri..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> In vivo IFT imaging (kymography of fluorescently tagged IFT components) in klp-20 loss-of-function versus osm-3 loss-of-function animals to define the cargoes and axonemal segments whose transport specifically depends on the klp-20-containing kinesin-II motor.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: The klp-20-containing kinesin-II motor is specifically required for anterograde transport of a defined subset of IFT cargoes along the middle (doublet) segment.</em></p>
+
+
+                </div>
+                <span class="vote-buttons" data-g="Q965T6" data-a="EXPERIMENT: In vivo IFT imaging (kymography of fluorescently t..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Knowledge Gaps</h2>
+        <p style="color: #555; font-size: 0.92rem; margin-top: -0.3rem;">
+            What is <em>not</em> known — curated, literature-grounded statements of the open
+            unknowns (the inverse of core functions).
+        </p>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> Within the klp-11/klp-20 heterodimer it is not resolved which subunit is the &#34;unprocessive&#34; motor domain and which is the processive one — i.e. whether klp-20 itself is the processive or the autoinhibited/unprocessive head, and the residue-level basis of its individual duty ratio.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">RESIDUAL_SUBGAP</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> It is established that heterodimerization of the two distinct C. elegans kinesin-2 motor domains converts an otherwise unprocessive homodimer into a processive heterodimer, that the unprocessive subunit mediates an asymmetric autoregulation of motor activity, and that the heterodimer must form to bind kap-1 (the cargo link). UniProt annotates two klp-20 residues (444, 445) as possibly required for autoinhibition within the heterodimer.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Kinesin-2 heterodimerization is the paradigm for how obligate motor heterodimers tune processivity and autoregulation; assigning the processive vs unprocessive role to klp-20 vs klp-11 defines the mechanistic division of labor of the anterograde IFT motor.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Single-molecule processivity assays on defined homodimeric vs heterodimeric constructs of the klp-20 and klp-11 motor domains, with subunit-specific labeling and head-tracking to assign duty ratio to each subunit.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"One motor domain is unprocessive as a homodimer"</em> — PMID:20498083</li>
+
+                <li><em>"asymmetric autoregulation of the motor"</em> — PMID:20498083</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The direct, klp-20-motor-selected ciliary cargo repertoire is not enumerated: what cargoes the klp-20-containing kinesin-II specifically delivers is inferred through the IFT-A/IFT-B particle rather than measured for the motor itself.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span><span class="badge">CURATION</span>
+                <span class="badge">BP_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> Kinesin-II (with klp-20 as a motor subunit) and osm-3 are the two anterograde IFT motors that move IFT particles to build the sensory cilium foundation; kap-1 provides the in vivo link between the motor and cargo.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Defining the motor-specific cargo would clarify how the two anterograde IFT motors (kinesin-II vs osm-3) divide cargo responsibilities along the ciliary axoneme, which is central to understanding ciliogenesis and ciliopathy.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Proximity labeling or cargo-trapping proteomics on the klp-20/kap-1 motor in cilia, combined with klp-20 loss-of-function IFT imaging to identify cargoes whose ciliary delivery specifically requires the klp-20-containing motor.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"heterodimerization is necessary to bind KAP1, the in vivo link between motor and"</em> — PMID:20498083</li>
+
+            </ul>
+
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Tags</h2>
+        <div class="aliases">
+
+            <span class="badge">caeel-ciliopathy</span>
+
+        </div>
+    </div>
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Deep Research Sections -->
+
+    <div class="section">
+        <h2 class="section-title">Deep Research</h2>
+
+        <details class="deep-research-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; gap: 1rem;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Falcon</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(klp-20-deep-research-falcon.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="Q965T6" data-a="DEEP_RESEARCH: Falcon" data-r="" data-act="DEEP_RESEARCH" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This deep research is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This deep research needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+
+                <div class="report-meta">
+
+                    <span class="report-meta-text">Comprehensive Research Report: *klp-20* (Kinesin-Like Protein 20) in *Caenorhabditis elegans*</span>
+
+
+                    <span class="report-badge">Falcon</span>
+
+
+                    <span class="report-badge">Edison Scientific Literature</span>
+
+
+                    <span class="report-badge">15 citations</span>
+
+
+                    <span class="report-badge">1 artifacts</span>
+
+
+                    <span class="report-meta-text">2026-07-04T20:25:34.223036</span>
+
+
+
+                </div>
+
+
+                <div class="artifact-list">
+
+
+
+                    <div class="artifact-link">
+                        <a href="klp-20-deep-research-falcon_artifacts/artifact-00.md" class="term-link">Edison artifact artifact-00</a>
+                        <span>(text/markdown)</span>
+                    </div>
+
+
+                </div>
+
+                <p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h1 id="comprehensive-research-report-klp-20-kinesin-like-protein-20-in-caenorhabditis-elegans">Comprehensive Research Report: <em>klp-20</em> (Kinesin-Like Protein 20) in <em>Caenorhabditis elegans</em></h1>
+<h2 id="1-gene-and-protein-identity">1. Gene and Protein Identity</h2>
+<p>The gene <em>klp-20</em> (ORF name Y50D7A.6; UniProt accession Q965T6) encodes a kinesin-like protein in <em>Caenorhabditis elegans</em>. KLP-20 belongs to the TRAFAC class myosin-kinesin ATPase superfamily and contains a canonical kinesin motor domain (InterPro: IPR001752), a kinesin-like family domain (IPR027640), a P-loop NTPase domain (IPR027417), and a kinesin motor domain conserved site (IPR019821). These domains are diagnostic of a microtubule-dependent motor protein that couples ATP hydrolysis to directional movement along microtubule tracks.</p>
+<p>The summary of KLP-20's key properties is provided below:</p>
+<table>
+<thead>
+<tr>
+<th>Property</th>
+<th>Value</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Gene name</td>
+<td>klp-20 (maguire2015myristoylatedcil7is pages 13-17)</td>
+</tr>
+<tr>
+<td>ORF name</td>
+<td>Y50D7A.6</td>
+</tr>
+<tr>
+<td>UniProt accession</td>
+<td>Q965T6</td>
+</tr>
+<tr>
+<td>Protein family</td>
+<td>Kinesin-2 / heterotrimeric kinesin-II; TRAFAC-class myosin-kinesin ATPase superfamily (maguire2015myristoylatedcil7is pages 13-17, nakayama2018ciliaryproteintrafficking pages 4-5)</td>
+</tr>
+<tr>
+<td>Complex partners</td>
+<td>KLP-11 and KAP-1 form the heterotrimeric kinesin-II complex with KLP-20 (maguire2015myristoylatedcil7is pages 13-17, nakayama2018ciliaryproteintrafficking pages 4-5)</td>
+</tr>
+<tr>
+<td>Mammalian ortholog / counterpart</td>
+<td>Functional counterpart within the mammalian heterotrimeric kinesin-II complex: KIF3B (with KIF3A and KAP3/KIFAP3) (nakayama2018ciliaryproteintrafficking pages 4-5, verhey2011kinesinmotorsand pages 2-4)</td>
+</tr>
+<tr>
+<td>Molecular function</td>
+<td>ATP-dependent microtubule motor that drives anterograde intraflagellar transport (IFT) of IFT complexes/cargo during ciliogenesis and ciliary maintenance (maguire2015myristoylatedcil7is pages 13-17, maguire2015myristoylatedcil7is pages 7-13, verhey2011kinesinmotorsand pages 2-4)</td>
+</tr>
+<tr>
+<td>Subcellular localization</td>
+<td>Cilia of ciliated sensory neurons, including amphids, phasmids, IL2 neurons, and male-specific sensory neurons (maguire2015myristoylatedcil7is pages 13-17, maguire2015myristoylatedcil7is pages 7-13)</td>
+</tr>
+<tr>
+<td>Motor velocity alone</td>
+<td>~0.5 μm/s for kinesin-II anterograde movement in amphid channel cilia / transition zone loading phase (maguire2015myristoylatedcil7is pages 13-17, prevo2017intraflagellartransportmechanisms pages 33-35, prevo2017intraflagellartransportmechanisms pages 12-14)</td>
+</tr>
+<tr>
+<td>Motor velocity with OSM-3</td>
+<td>~0.7 μm/s when kinesin-II and OSM-3 co-transport IFT trains in the middle segment (maguire2015myristoylatedcil7is pages 13-17, prevo2017intraflagellartransportmechanisms pages 12-14)</td>
+</tr>
+<tr>
+<td>Key biological process</td>
+<td>Intraflagellar transport supporting cilia assembly, maintenance, and organization of middle/proximal ciliary segments (nakayama2018ciliaryproteintrafficking pages 4-5, li2024regulationofciliary pages 3-5)</td>
+</tr>
+<tr>
+<td>Functional division of labor</td>
+<td>Kinesin-II loads/navigates IFT trains through the transition zone and cooperates with OSM-3 in the middle segment; OSM-3 alone builds/transports in the distal segment (prevo2017intraflagellartransportmechanisms pages 33-35, maguire2015myristoylatedcil7is pages 13-17, prevo2017intraflagellartransportmechanisms pages 12-14)</td>
+</tr>
+<tr>
+<td>Mutant phenotype</td>
+<td>In single mutants of heterotrimeric kinesin-II genes including klp-20, amphid chemosensory cilia are maintained because OSM-3 compensates; thus klp-20 loss alone yields a relatively mild/partially redundant ciliary phenotype (verhey2011kinesinmotorsand pages 2-4)</td>
+</tr>
+</tbody>
+</table>
+<p><em>Table: This table summarizes the core annotated and literature-supported properties of C. elegans KLP-20, including its kinesin-II complex membership, ciliary localization, transport role, velocities, and mutant behavior. It is useful as a compact reference for functional annotation.</em></p>
+<h2 id="2-molecular-function-and-enzymatic-activity">2. Molecular Function and Enzymatic Activity</h2>
+<p>KLP-20 is one of the two motor subunits of the <em>C. elegans</em> heterotrimeric kinesin-II complex, a member of the kinesin-2 family (maguire2015myristoylatedcil7is pages 13-17, nakayama2018ciliaryproteintrafficking pages 4-5). The heterotrimeric kinesin-II complex consists of two distinct motor subunits, KLP-20 and KLP-11, plus the non-motor accessory subunit KAP-1 (maguire2015myristoylatedcil7is pages 13-17, maguire2015myristoylatedcil7is pages 7-13). This complex is the functional ortholog of the mammalian heterotrimeric kinesin-II comprising KIF3A, KIF3B, and KAP3/KIFAP3, with KLP-20 serving as the functional counterpart of KIF3B (nakayama2018ciliaryproteintrafficking pages 4-5, verhey2011kinesinmotorsand pages 2-4).</p>
+<p>As a kinesin motor protein, KLP-20 functions as an ATP-dependent microtubule-based motor. The enzymatic reaction catalyzed is the hydrolysis of ATP to ADP and inorganic phosphate (Pi), and this chemical energy is coupled to plus-end-directed translocation along microtubule tracks. The substrate is ATP (with Mg²⁺ as a cofactor), and the protein generates mechanical force through conformational changes in the motor domain upon nucleotide binding and hydrolysis. The kinesin motor domain contains a P-loop NTPase fold characteristic of this superfamily.</p>
+<h2 id="3-biological-function-intraflagellar-transport-ift">3. Biological Function: Intraflagellar Transport (IFT)</h2>
+<p>The primary biological function of KLP-20, as part of the heterotrimeric kinesin-II complex, is to drive anterograde intraflagellar transport (IFT) in the cilia of sensory neurons (maguire2015myristoylatedcil7is pages 13-17, maguire2015myristoylatedcil7is pages 7-13, nakayama2018ciliaryproteintrafficking pages 4-5). IFT is an essential, highly conserved mechanism for the assembly, maintenance, and function of cilia. During IFT, kinesin-II assembles with IFT particle complexes (IFT-A and IFT-B) and associated cargoes—including axoneme precursors, ciliary membrane proteins, signaling molecules, and retrograde motors—and drives their anterograde (base-to-tip) transport along axonemal microtubules (maguire2015myristoylatedcil7is pages 13-17, verhey2011kinesinmotorsand pages 2-4).</p>
+<h3 id="31-cooperation-with-osm-3">3.1 Cooperation with OSM-3</h3>
+<p>A distinguishing feature of IFT in <em>C. elegans</em> sensory cilia is the cooperative action of two kinesin-2 motors: the heterotrimeric kinesin-II (containing KLP-20/KLP-11/KAP-1) and the homodimeric kinesin-2 motor OSM-3 (the <em>C. elegans</em> ortholog of mammalian KIF17) (maguire2015myristoylatedcil7is pages 13-17, li2024regulationofciliary pages 3-5). These two motors have distinct velocities and roles:</p>
+<ul>
+<li><strong>Kinesin-II alone</strong> moves at approximately <strong>0.5 μm/s</strong> in the anterograde direction and functions as a "loader" and "navigator," loading IFT trains at the ciliary base and transporting them through the transition zone (maguire2015myristoylatedcil7is pages 13-17, prevo2017intraflagellartransportmechanisms pages 12-14).</li>
+<li><strong>OSM-3 alone</strong> moves at approximately <strong>1.3–1.5 μm/s</strong> and acts as the long-range transporter in the distal ciliary segment (prevo2017intraflagellartransportmechanisms pages 33-35, prevo2017intraflagellartransportmechanisms pages 12-14).</li>
+<li>When both motors are present on the same IFT train in the <strong>middle (proximal) segment</strong>, they produce an intermediate velocity of approximately <strong>0.7 μm/s</strong> (maguire2015myristoylatedcil7is pages 13-17, prevo2017intraflagellartransportmechanisms pages 12-14).</li>
+</ul>
+<p>This cooperation involves a coordinated motor handover mechanism: as IFT trains move distally along the middle segment, kinesin-II gradually undocks from the trains while OSM-3 motors simultaneously dock, causing progressive acceleration. In the distal segment, OSM-3 alone occupies the trains, reaching terminal velocity. During retrograde transport, IFT dynein returns the trains to the base while recycling OSM-3, and kinesin-II gradually re-docks along the proximal segment (prevo2017intraflagellartransportmechanisms pages 33-35).</p>
+<h3 id="32-role-in-ciliary-segment-assembly">3.2 Role in Ciliary Segment Assembly</h3>
+<p>The <em>C. elegans</em> amphid channel cilia exhibit a characteristic bipartite structure with a middle segment containing nine microtubule doublets and a distal segment containing nine microtubule singlets. Kinesin-II and OSM-3 work together redundantly to build the middle segment, while OSM-3 alone is responsible for constructing the distal segment (nakayama2018ciliaryproteintrafficking pages 4-5, maguire2015myristoylatedcil7is pages 13-17, li2024regulationofciliary pages 3-5, prevo2017intraflagellartransportmechanisms pages 15-17). The handover zone between kinesin-II and OSM-3 defines the boundary between proximal and distal ciliary compartments, and this boundary is regulated by kinases such as CDKL-1 (park2021cdklkinaseregulates pages 1-3, park2021cdklkinaseregulates pages 12-13).</p>
+<h2 id="4-subcellular-localization">4. Subcellular Localization</h2>
+<p>KLP-20, as part of the heterotrimeric kinesin-II complex, is expressed and functions within the cilia of all ciliated sensory neurons in <em>C. elegans</em> (maguire2015myristoylatedcil7is pages 13-17, maguire2015myristoylatedcil7is pages 7-13). In adult hermaphrodites, 60 of 302 neurons possess ciliated dendritic endings, including the amphid neurons (primary chemosensory organs in the head), phasmid neurons (chemosensory organs in the tail), inner labial neurons (IL1, IL2), and various other sensory neurons. Male <em>C. elegans</em> possess an additional ~50 ciliated sensory neurons involved in mating behaviors (maguire2015myristoylatedcil7is pages 7-13). Specifically, KLP-20 localizes to the ciliary compartment where it carries out anterograde IFT along the axoneme, with highest concentration in the transition zone and middle (proximal) segment of cilia (prevo2017intraflagellartransportmechanisms pages 33-35, prevo2017intraflagellartransportmechanisms pages 12-14).</p>
+<h2 id="5-mutant-phenotype-and-genetic-redundancy">5. Mutant Phenotype and Genetic Redundancy</h2>
+<p>A notable aspect of KLP-20 function in <em>C. elegans</em> is its partial redundancy with OSM-3. In single mutants of any of the heterotrimeric kinesin-II genes (<em>klp-11</em>, <em>klp-20</em>, or <em>kap-1</em>), the non-motile cilia at the dendritic endings of amphid chemosensory neurons are maintained, because OSM-3 compensates for the loss of kinesin-II function (verhey2011kinesinmotorsand pages 2-4). This contrasts sharply with the situation in most other organisms, where loss of heterotrimeric kinesin-II leads to a complete absence of cilia. In mammals, for example, deletion of either <em>Kif3a</em> or <em>Kif3b</em> results in a "no cilia" phenotype (nakayama2018ciliaryproteintrafficking pages 4-5). The unique redundancy in <em>C. elegans</em> was established through studies showing that kinesin-II and OSM-3 work cooperatively and redundantly in the middle region of ASH/ASI channel and AWC wing cilia, whereas OSM-3 works alone to build the distal region (verhey2011kinesinmotorsand pages 2-4). However, this compensation is not universal across all cilia types in <em>C. elegans</em>; the roles of kinesin-2 and OSM-3 differ across different chemosensory neuron types within the amphid organ (verhey2011kinesinmotorsand pages 2-4).</p>
+<h2 id="6-regulation-by-tubulin-post-translational-modifications">6. Regulation by Tubulin Post-Translational Modifications</h2>
+<p>The activity of kinesin motors in <em>C. elegans</em> cilia, including kinesin-II, is regulated by the "tubulin code"—a system of tubulin post-translational modifications (PTMs) including glutamylation. The glutamylase TTLL-11 and deglutamylase CCPP-1 fine-tune tubulin glutamylation levels in cilia, which in turn regulates motor protein activity and cargo transport (o’hagan2017glutamylationregulatestransport pages 4-5, o’hagan2017glutamylationregulatestransport pages 1-3). Interestingly, while CCPP-1-mediated regulation affects the velocities of OSM-3/KIF17 and KLP-6 (a kinesin-3 motor), it does not appear to directly affect the anterograde transport mediated by heterotrimeric kinesin-II (o’hagan2017glutamylationregulatestransport pages 4-5, o’hagan2017glutamylationregulatestransport pages 1-3). In vitro studies have shown that polyglutamylation of tubulin increases both the processivity and velocity of kinesin-2 motors (o’hagan2017glutamylationregulatestransport pages 7-8). The transport of the glutamylase TTLL-11 by ciliary kinesins creates a feedback mechanism whereby the motors transport the very enzyme that modifies the microtubule tracks on which they run (o’hagan2017glutamylationregulatestransport pages 9-10, o’hagan2017glutamylationregulatestransport pages 9-9).</p>
+<h2 id="7-pathway-context-and-broader-significance">7. Pathway Context and Broader Significance</h2>
+<p>KLP-20 functions within the intraflagellar transport pathway, which is central to ciliogenesis and ciliary homeostasis. The IFT pathway involves: (1) assembly of IFT trains (composed of IFT-A and IFT-B particle complexes) at the ciliary base; (2) anterograde transport by kinesin-2 motors (kinesin-II and OSM-3) delivering axonemal building blocks and signaling molecules to the ciliary tip; (3) cargo unloading and IFT train remodeling at the ciliary tip; and (4) retrograde transport by IFT dynein returning components to the base (prevo2017intraflagellartransportmechanisms pages 33-35, prevo2017intraflagellartransportmechanisms pages 15-17, verhey2011kinesinmotorsand pages 2-4). Heterotrimeric kinesin-II interacts with the IFT-B complex at the interface between the core and peripheral subcomplexes (nakayama2018ciliaryproteintrafficking pages 4-5).</p>
+<p>The conservation of the heterotrimeric kinesin-II complex from nematodes to mammals underscores its fundamental importance in cilia biology. Mutations in ciliary genes, including those encoding IFT motors and their regulators, cause a growing class of pleiotropic human diseases known as ciliopathies. While KLP-20 itself is a <em>C. elegans</em>-specific gene name, its mammalian counterpart KIF3B is essential for ciliogenesis, and loss of KIF3B in mice results in a complete absence of cilia (nakayama2018ciliaryproteintrafficking pages 4-5).</p>
+<h2 id="8-summary">8. Summary</h2>
+<p>KLP-20 is a kinesin-2 family motor protein that functions as one of the two motor subunits of the <em>C. elegans</em> heterotrimeric kinesin-II complex, together with KLP-11 and the accessory subunit KAP-1. Its primary molecular function is ATP-dependent, plus-end-directed translocation along ciliary microtubules, driving anterograde intraflagellar transport in all ciliated sensory neurons. KLP-20 cooperates with the homodimeric kinesin-2 motor OSM-3 to build the middle segments of sensory cilia, with a motor handover mechanism ensuring smooth cargo delivery along different ciliary compartments. The partial functional redundancy between kinesin-II and OSM-3 in <em>C. elegans</em> means that <em>klp-20</em> single mutants maintain cilia structure, a feature distinct from most other organisms. KLP-20's activity is influenced by the tubulin code, including glutamylation of axonemal microtubules, and it operates within the broader IFT pathway that is essential for cilia assembly, maintenance, and sensory signaling.</p>
+<p>References</p>
+<ol>
+<li>
+<p>(maguire2015myristoylatedcil7is pages 13-17): Julie Elizabeth Maguire. Myristoylated cil-7 is required for polycystin associated behaviors and extracellular vesicle biogenesis in c. elegans. ArXiv, Jan 2015. URL: https://doi.org/10.7282/t3cr5w7w, doi:10.7282/t3cr5w7w. This article has 0 citations.</p>
+</li>
+<li>
+<p>(nakayama2018ciliaryproteintrafficking pages 4-5): Kazuhisa Nakayama and Yohei Katoh. Ciliary protein trafficking mediated by ift and bbsome complexes with the aid of kinesin-2 and dynein-2 motors. Journal of biochemistry, 163 3:155-164, Mar 2018. URL: https://doi.org/10.1093/jb/mvx087, doi:10.1093/jb/mvx087. This article has 160 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(verhey2011kinesinmotorsand pages 2-4): Kristen J. Verhey, John Dishinger, and Hooi Lynn Kee. Kinesin motors and primary cilia. Biochemical Society transactions, 39 5:1120-5, Oct 2011. URL: https://doi.org/10.1042/bst0391120, doi:10.1042/bst0391120. This article has 108 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(maguire2015myristoylatedcil7is pages 7-13): Julie Elizabeth Maguire. Myristoylated cil-7 is required for polycystin associated behaviors and extracellular vesicle biogenesis in c. elegans. ArXiv, Jan 2015. URL: https://doi.org/10.7282/t3cr5w7w, doi:10.7282/t3cr5w7w. This article has 0 citations.</p>
+</li>
+<li>
+<p>(prevo2017intraflagellartransportmechanisms pages 33-35): Bram Prevo, Jonathan M. Scholey, and Erwin J. G. Peterman. Intraflagellar transport: mechanisms of motor action, cooperation, and cargo delivery. The FEBS Journal, 284:2905-2931, Sep 2017. URL: https://doi.org/10.1111/febs.14068, doi:10.1111/febs.14068. This article has 253 citations.</p>
+</li>
+<li>
+<p>(prevo2017intraflagellartransportmechanisms pages 12-14): Bram Prevo, Jonathan M. Scholey, and Erwin J. G. Peterman. Intraflagellar transport: mechanisms of motor action, cooperation, and cargo delivery. The FEBS Journal, 284:2905-2931, Sep 2017. URL: https://doi.org/10.1111/febs.14068, doi:10.1111/febs.14068. This article has 253 citations.</p>
+</li>
+<li>
+<p>(li2024regulationofciliary pages 3-5): Lin Li and Jie Ran. Regulation of ciliary homeostasis by intraflagellar transport-independent kinesins. Cell Death &amp; Disease, Jan 2024. URL: https://doi.org/10.1038/s41419-024-06428-9, doi:10.1038/s41419-024-06428-9. This article has 21 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(prevo2017intraflagellartransportmechanisms pages 15-17): Bram Prevo, Jonathan M. Scholey, and Erwin J. G. Peterman. Intraflagellar transport: mechanisms of motor action, cooperation, and cargo delivery. The FEBS Journal, 284:2905-2931, Sep 2017. URL: https://doi.org/10.1111/febs.14068, doi:10.1111/febs.14068. This article has 253 citations.</p>
+</li>
+<li>
+<p>(park2021cdklkinaseregulates pages 1-3): Kwangjin Park, Chunmei Li, Sofia Tsiropoulou, João Gonçalves, Christine Kondratev, Laurence Pelletier, Oliver E. Blacque, and Michel R. Leroux. Cdkl kinase regulates the length of the ciliary proximal segment. Current Biology, 31:2359-2373.e7, Jun 2021. URL: https://doi.org/10.1016/j.cub.2021.03.068, doi:10.1016/j.cub.2021.03.068. This article has 40 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(park2021cdklkinaseregulates pages 12-13): Kwangjin Park, Chunmei Li, Sofia Tsiropoulou, João Gonçalves, Christine Kondratev, Laurence Pelletier, Oliver E. Blacque, and Michel R. Leroux. Cdkl kinase regulates the length of the ciliary proximal segment. Current Biology, 31:2359-2373.e7, Jun 2021. URL: https://doi.org/10.1016/j.cub.2021.03.068, doi:10.1016/j.cub.2021.03.068. This article has 40 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(o’hagan2017glutamylationregulatestransport pages 4-5): Robert O’Hagan, Malan Silva, Ken C.Q. Nguyen, Winnie Zhang, Sebastian Bellotti, Yasmin H. Ramadan, David H. Hall, and Maureen M. Barr. Glutamylation regulates transport, specializes function, and sculpts the structure of cilia. Current biology : CB, 27:3430-3441.e6, Nov 2017. URL: https://doi.org/10.1016/j.cub.2017.09.066, doi:10.1016/j.cub.2017.09.066. This article has 119 citations.</p>
+</li>
+<li>
+<p>(o’hagan2017glutamylationregulatestransport pages 1-3): Robert O’Hagan, Malan Silva, Ken C.Q. Nguyen, Winnie Zhang, Sebastian Bellotti, Yasmin H. Ramadan, David H. Hall, and Maureen M. Barr. Glutamylation regulates transport, specializes function, and sculpts the structure of cilia. Current biology : CB, 27:3430-3441.e6, Nov 2017. URL: https://doi.org/10.1016/j.cub.2017.09.066, doi:10.1016/j.cub.2017.09.066. This article has 119 citations.</p>
+</li>
+<li>
+<p>(o’hagan2017glutamylationregulatestransport pages 7-8): Robert O’Hagan, Malan Silva, Ken C.Q. Nguyen, Winnie Zhang, Sebastian Bellotti, Yasmin H. Ramadan, David H. Hall, and Maureen M. Barr. Glutamylation regulates transport, specializes function, and sculpts the structure of cilia. Current biology : CB, 27:3430-3441.e6, Nov 2017. URL: https://doi.org/10.1016/j.cub.2017.09.066, doi:10.1016/j.cub.2017.09.066. This article has 119 citations.</p>
+</li>
+<li>
+<p>(o’hagan2017glutamylationregulatestransport pages 9-10): Robert O’Hagan, Malan Silva, Ken C.Q. Nguyen, Winnie Zhang, Sebastian Bellotti, Yasmin H. Ramadan, David H. Hall, and Maureen M. Barr. Glutamylation regulates transport, specializes function, and sculpts the structure of cilia. Current biology : CB, 27:3430-3441.e6, Nov 2017. URL: https://doi.org/10.1016/j.cub.2017.09.066, doi:10.1016/j.cub.2017.09.066. This article has 119 citations.</p>
+</li>
+<li>
+<p>(o’hagan2017glutamylationregulatestransport pages 9-9): Robert O’Hagan, Malan Silva, Ken C.Q. Nguyen, Winnie Zhang, Sebastian Bellotti, Yasmin H. Ramadan, David H. Hall, and Maureen M. Barr. Glutamylation regulates transport, specializes function, and sculpts the structure of cilia. Current biology : CB, 27:3430-3441.e6, Nov 2017. URL: https://doi.org/10.1016/j.cub.2017.09.066, doi:10.1016/j.cub.2017.09.066. This article has 119 citations.</p>
+</li>
+</ol>
+<h2 id="artifacts">Artifacts</h2>
+<ul>
+<li><a href="klp-20-deep-research-falcon_artifacts/artifact-00.md">Edison artifact artifact-00</a></li>
+</ul>
+<h2 id="citations">Citations</h2>
+<ol>
+<li>verhey2011kinesinmotorsand pages 2-4</li>
+<li>prevo2017intraflagellartransportmechanisms pages 33-35</li>
+<li>nakayama2018ciliaryproteintrafficking pages 4-5</li>
+<li>prevo2017intraflagellartransportmechanisms pages 12-14</li>
+<li>li2024regulationofciliary pages 3-5</li>
+<li>prevo2017intraflagellartransportmechanisms pages 15-17</li>
+<li>park2021cdklkinaseregulates pages 1-3</li>
+<li>park2021cdklkinaseregulates pages 12-13</li>
+<li>https://doi.org/10.7282/t3cr5w7w,</li>
+<li>https://doi.org/10.1093/jb/mvx087,</li>
+<li>https://doi.org/10.1042/bst0391120,</li>
+<li>https://doi.org/10.1111/febs.14068,</li>
+<li>https://doi.org/10.1038/s41419-024-06428-9,</li>
+<li>https://doi.org/10.1016/j.cub.2021.03.068,</li>
+<li>https://doi.org/10.1016/j.cub.2017.09.066,</li>
+</ol>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(klp-20-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="Q965T6" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="klp-20-c-elegans-gene-review-notes">klp-20 (C. elegans) — Gene Review Notes</h1>
+<h2 id="identity-verified-from-uniprot-q965t6">Identity (verified from UniProt Q965T6)</h2>
+<ul>
+<li>UniProt: <strong>Q965T6</strong> (KLP20_CAEEL), 646 aa, "Kinesin-like protein klp-20"</li>
+<li>WormBase: <strong>WBGene00002230</strong>, sequence name <strong>Y50D7A.6</strong>, on Chromosome III</li>
+<li>Family: TRAFAC class myosin-kinesin ATPase superfamily; Kinesin family; <strong>Kinesin II subfamily</strong></li>
+<li>Domain architecture (UniProt): N-terminal <strong>Kinesin motor domain (6–331)</strong> with the P-loop ATP-binding<br />
+  Walker A (BINDING 91..98, ATP); a long <strong>coiled coil (342–552)</strong> stalk; a <strong>klp-11 interaction region<br />
+  (525–550)</strong>; and a disordered C-terminal tail (623–646, basic).</li>
+<li>Structure: PDB <strong>9IKB</strong> (X-ray 3.54 Å) covers residues 527–646 (the C-terminal stalk/tail); AlphaFoldDB Q965T6;<br />
+  ComplexPortal <strong>CPX-1208 "Kinesin II motor complex"</strong>.</li>
+</ul>
+<p>klp-20 is <strong>one of the two motor subunits of heterotrimeric kinesin-II</strong> in <em>C. elegans</em>. Kinesin-II is the<br />
+heterotrimer <strong>KLP-11 + KLP-20 + KAP-1</strong> (two distinct motor polypeptides + one non-motor accessory subunit KAP).<br />
+This is distinct from <strong>OSM-3</strong>, the <em>homodimeric</em> kinesin-2 that is the second anterograde IFT motor. klp-20 must be<br />
+kept distinct from its heterodimer partner klp-11 (KLP11_CAEEL) — much of the biochemistry was done on the<br />
+KLP-11/KLP-20 heterodimer, and where a result is specific to klp-11 alone I note it.</p>
+<h2 id="known-well-supported">KNOWN (well supported)</h2>
+<h3 id="kinesin-ii-complex-membership-experimental-klp-20-specific">Kinesin-II complex membership (experimental, klp-20-specific)</h3>
+<ul>
+<li>klp-20 is a subunit of the heterotrimeric kinesin-II motor. Purified recombinant kinesin-II behaves as a<br />
+  monodisperse heterotrimer of the three named subunits:<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/17000880" title="the KLP-11, KAP-1, and KLP-20 subunits elute as a monodisperse heterotrimeric complex">PMID:17000880</a><br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/17000880" title="consisting of 1 mol each of its subunits KLP-11, KLP-20, and KAP-1 with a native molecular mass of 287 kD">PMID:17000880</a></li>
+<li>The complex is the <strong>axonemal heterotrimeric kinesin-II complex</strong> (GO:0030993). UniProt SUBUNIT: "Component of the<br />
+  kinesin II motor complex, a heterotrimeric complex composed of kap-1, klp-11 and klp-20" (UniProt Q965T6).</li>
+<li>ComplexPortal CPX-1208 records the "Kinesin II motor complex" (NAS, PMID:20498083).</li>
+</ul>
+<h3 id="microtubule-motor-atpase-activity-experimental-complex-level">Microtubule motor / ATPase activity (experimental, complex-level)</h3>
+<ul>
+<li>Purified recombinant kinesin-II (containing klp-20) is an <strong>ATP-driven, microtubule plus-end-directed motor</strong>:<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/17000880" title="kinesin-II alone moved MTs at a maximal rate of 0.3 μm/s">PMID:17000880</a><br />
+  and, under optimized conditions, <a href="https://pubmed.ncbi.nlm.nih.gov/17000880" title="kinesin-II alone moved at ∼0.5 μm/s">PMID:17000880</a>.</li>
+<li>Kinesin-II uses Mg-ATP by Michaelis–Menten kinetics:<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/17000880" title="kinesin-II–driven motility conformed to Michaelis-Menten kinetics">PMID:17000880</a> and<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/17000880" title="indicating that Mg-ATP is the preferred substrate for kinesin-2 motors">PMID:17000880</a>.</li>
+<li>Kinesins are plus-end directed motors; anterograde IFT (base→ciliary tip) is toward MT plus ends, so the specific<br />
+  MF is <strong>plus-end-directed microtubule motor activity (GO:0008574)</strong> rather than only the parent GO:0003777.<br />
+  WormBase made the IDA GO:0003777 "microtubule motor activity" annotation from PMID:17000880.</li>
+</ul>
+<h3 id="heterodimerization-confers-processivity-needed-for-cargo-coupling-klp-20klp-11-heterodimer">Heterodimerization confers processivity; needed for cargo coupling (klp-20/klp-11 heterodimer)</h3>
+<ul>
+<li>The KLP-11/KLP-20 heterodimer is the functional unit: one motor domain is unprocessive alone but becomes<br />
+  processive on heterodimerization:<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/20498083" title="One motor domain is unprocessive as a homodimer, but heterodimerization with a processive partner generates processivity.">PMID:20498083</a></li>
+<li>Heterodimerization is required to bind KAP-1, which links the motor to cargo:<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/20498083" title="heterodimerization is necessary to bind KAP1, the in vivo link between motor and cargo.">PMID:20498083</a></li>
+<li>The unprocessive subunit contributes asymmetric autoregulation of motor activity:<br />
+  [PMID:20498083 "The \"unprocessive\" subunit is kept in this partnership as it mediates an asymmetric autoregulation of the motor activity."]</li>
+<li>UniProt (from PMID:20498083, PMID:21917588) elaborates: the C-termini of klp-20 and klp-11 form a coiled-coil<br />
+  stalk necessary for association with kap-1, and prior to cargo binding the heterodimer is autoinhibited by its<br />
+  tail folding onto the motor domain; cargo binding relieves autoinhibition. Interaction region on klp-20 = 525–550<br />
+  (REGION, ECO:0000269|PubMed:21917588).</li>
+</ul>
+<h3 id="anterograde-ift-along-sensory-cilia-experimental-at-the-pathway-level">Anterograde IFT along sensory cilia (experimental at the pathway level)</h3>
+<ul>
+<li>In <em>C. elegans</em> amphid/phasmid sensory neuron cilia, kinesin-II and OSM-3 are the two anterograde IFT motors that<br />
+  redundantly build the cilium foundation (middle/initial segment, MT doublets); OSM-3 alone extends the distal<br />
+  singlet segment:<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/17000880" title="the IFT particles assembling these sensory cilia are moved by the coordinate action of two anterograde IFT motors called kinesin-II and OSM-3">PMID:17000880</a><br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/17000880" title="either motor but not both being dispensable for this function">PMID:17000880</a></li>
+<li>Kinesin-II is the slower motor (~0.5 µm/s in vivo) vs OSM-3 (~1.3 µm/s); the two act by mechanical competition,<br />
+  with BBS proteins holding IFT-A and IFT-B together against the tension:<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/17000880" title="the slower moving kinesin-II exerting drag on the faster moving OSM-3">PMID:17000880</a></li>
+<li>Subcellular location: UniProt SUBCELLULAR LOCATION = cilium (Cell projection), with a note that it localizes to the<br />
+  base and transition zone of cilia (ECO:0000269|PubMed:28479320); also Cytoplasm/cytoskeleton (by similarity).</li>
+</ul>
+<h2 id="not-established-knowledge-gaps-for-klp-20-specifically">NOT established / KNOWLEDGE GAPS (for klp-20 specifically)</h2>
+<ol>
+<li>
+<p><strong>Which subunit of the heterodimer is the "unprocessive" one?</strong> PMID:20498083 shows the KLP-11/KLP-20 heterodimer<br />
+   pairs a processive with an unprocessive motor domain and that the unprocessive subunit mediates asymmetric<br />
+   autoregulation, but the abstract (only the abstract is cached; full text not available from PMC) does not, in the<br />
+   cached text, assign the unprocessive/processive role to klp-20 vs klp-11 by name. So whether klp-20 itself is the<br />
+   processive or the unprocessive head — and thus the residue-level basis of its individual duty ratio — is not<br />
+   pinned down here. (Later biophysical work partly addresses this, but is not in our cache.)</p>
+</li>
+<li>
+<p><strong>klp-20-specific (vs klp-11-specific) contribution to autoinhibition / cargo release.</strong> UniProt annotates two<br />
+   sites on klp-20 (444, 445) as "May be required for autoinhibition within the klp-11/klp-20 heterodimer"<br />
+   (ECO:0000269|PubMed:20498083), but the mechanism by which klp-20 (as opposed to klp-11 or KAP-1) triggers<br />
+   release of autoinhibition upon cargo binding is not resolved.</p>
+</li>
+<li>
+<p><strong>Direct ciliary cargo of the klp-20-containing motor.</strong> UniProt notes the kinesin-II complex delivers specific<br />
+   ciliary cargo (e.g. che-3/dynein) to ciliary tips "likely mediated by IFT complexes A and B" (PMID:28479320) —<br />
+   i.e. the direct, klp-20-motor-selected cargo repertoire is inferred through the IFT particle, not directly<br />
+   enumerated for klp-20.</p>
+</li>
+</ol>
+<h2 id="annotation-review-plan-22-goa-rows">Annotation review plan (22 GOA rows)</h2>
+<p>MF:<br />
+- GO:0003777 microtubule motor activity — 3 rows (IBA GO_REF:0000033; IEA GO_REF:0000120; <strong>IDA PMID:17000880</strong>).<br />
+  Core. IDA is the strongest; MF is really plus-end-directed. ACCEPT the IDA as core; the IBA/IEA are redundant<br />
+  same-term support (KEEP_AS_NON_CORE / ACCEPT). Propose GO:0008574 as the more specific MF in core_functions.<br />
+- GO:0016887 ATP hydrolysis activity (IBA) — ACCEPT, part of motor mechanism (supported by PMID:17000880 kinetics).<br />
+- GO:0005524 ATP binding (IEA) — ACCEPT (Walker A motif present; molecular-mechanism support).<br />
+- GO:0008017 microtubule binding — 2 rows (IBA, IEA) — ACCEPT (motor must bind MT track).</p>
+<p>CC:<br />
+- GO:0030993 axonemal heterotrimeric kinesin-II complex (<strong>IPI PMID:17000880</strong>) — ACCEPT, core complex membership.<br />
+- GO:0016939 kinesin II complex (NAS PMID:20498083) — ACCEPT, complex membership (more general than 0030993).<br />
+- GO:0005871 kinesin complex (IBA) — ACCEPT/KEEP_AS_NON_CORE (general parent of the above).<br />
+- GO:0032991 protein-containing complex (IEA ARBA) — over-general; MARK_AS_OVER_ANNOTATED (root-level).<br />
+- GO:0005929 cilium (IEA) — ACCEPT, location (consistent with UniProt SUBCELLULAR LOCATION cilium).<br />
+- GO:0005874 microtubule (IBA) — KEEP_AS_NON_CORE (track, not really a "location" of the protein per se).<br />
+- GO:0005737 cytoplasm (IBA) — KEEP_AS_NON_CORE (broad; consistent with cytoplasm-by-similarity).<br />
+- GO:0005856 cytoskeleton (IEA) — KEEP_AS_NON_CORE (general).<br />
+- GO:1904115 axon cytoplasm (IEA GO_REF:0000108, inferred from GO:0008089) — this is inferred solely from the<br />
+  anterograde axonal transport BP, which itself is an IBA over-propagation (see below). klp-20 acts in sensory<br />
+  cilia, not documented axonal transport in worm. MARK_AS_OVER_ANNOTATED / KEEP_AS_NON_CORE.</p>
+<p>BP:<br />
+- GO:0035720 intraciliary anterograde transport (NAS PMID:20498083) — ACCEPT, core.<br />
+- GO:0060271 cilium assembly (IBA) — ACCEPT/KEEP_AS_NON_CORE (kinesin-II builds the cilium foundation; PMID:17000880).<br />
+- GO:0007018 microtubule-based movement — 3 rows (IBA; IEA; <strong>IDA PMID:17000880</strong>; NAS PMID:20498083 also) — ACCEPT<br />
+  (parent of the specific transport; IDA strongest). Somewhat general vs 0035720.<br />
+- GO:0008089 anterograde axonal transport (IBA) — the phylogenetic transfer from KIF3/kinesin-II in neurons brings<br />
+  in an axonal-transport term. In <em>C. elegans</em> the documented role is ciliary IFT, not classical axonal transport;<br />
+  this is a likely IBA over-propagation. MARK_AS_OVER_ANNOTATED (or KEEP_AS_NON_CORE) — but do NOT remove the<br />
+  underlying experimental terms; this is the electronic/IBA one only.</p>
+<p>Kinesin modeling (per task): model motor via in_complex (GO:0030993 axonemal heterotrimeric kinesin-II complex) +<br />
+contributes_to_molecular_function (GO:0008574 plus-end-directed MT motor / GO:0016887 ATP hydrolysis), keeping a<br />
+specific MT motor MF (not protein binding). Directly_involved_in: GO:0035720 intraciliary anterograde transport,<br />
+GO:0060271 cilium assembly.</p>
+<h2 id="deep-research">Deep research</h2>
+<ul>
+<li>falcon deep-research launched (foreground) with perplexity-lite fallback; see klp-20-deep-research-*.md if produced.<br />
+  Primary review rests on the cached full text of PMID:17000880 and the abstract of PMID:20498083 plus UniProt Q965T6.<br />
+</content></li>
+</ul>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: Q965T6
+gene_symbol: klp-20
+product_type: PROTEIN
+status: COMPLETE
+taxon:
+  id: NCBITaxon:6239
+  label: Caenorhabditis elegans
+description: &gt;-
+  klp-20 encodes one of the two motor subunits of heterotrimeric kinesin-II, the
+  anterograde intraflagellar transport (IFT) motor of Caenorhabditis elegans. It is a
+  member of the kinesin-2 subfamily with an N-terminal kinesin motor domain (P-loop
+  ATPase) and a C-terminal coiled-coil stalk. klp-20 does not act alone: it
+  heterodimerizes through its C-terminal stalk with the second motor subunit klp-11, and
+  this heterodimer associates with the non-motor accessory subunit kap-1 to form the
+  heterotrimeric kinesin-II holoenzyme (klp-11/klp-20/kap-1). Heterodimerization with
+  klp-11 is required to generate a processive motor and to bind kap-1, which links the
+  motor to IFT cargo. As part of kinesin-II the protein is an ATP-driven, microtubule
+  plus-end-directed motor that, together with the homodimeric kinesin-2 motor osm-3,
+  powers anterograde IFT along the middle (doublet) segment of sensory-neuron cilia,
+  building and maintaining the ciliary axoneme. It localizes to sensory cilia, including
+  the ciliary base and transition zone.
+references:
+  - id: GO_REF:0000002
+    title: Gene Ontology annotation through association of InterPro records with GO terms
+    findings: []
+  - id: GO_REF:0000033
+    title: Annotation inferences using phylogenetic trees
+    findings: []
+  - id: GO_REF:0000108
+    title: Automatic assignment of GO terms using logical inference, based on on inter-ontology links
+    findings: []
+  - id: GO_REF:0000117
+    title: Electronic Gene Ontology annotations created by ARBA machine learning models
+    findings: []
+  - id: GO_REF:0000120
+    title: Combined Automated Annotation using Multiple IEA Methods
+    findings: []
+  - id: PMID:17000880
+    title: Mechanism of transport of IFT particles in C. elegans cilia by the concerted action of kinesin-II and OSM-3 motors.
+    findings:
+      - statement: &gt;-
+          Purified recombinant kinesin-II behaves as a monodisperse heterotrimer of the
+          KLP-11, KLP-20 and KAP-1 subunits (native mass ~287 kD, 1:1:1 stoichiometry),
+          establishing klp-20 as a subunit of the heterotrimeric kinesin-II complex.
+        supporting_text: &#34;the KLP-11, KAP-1, and KLP-20 subunits elute as a monodisperse heterotrimeric complex&#34;
+        reference_section_type: RESULTS
+      - statement: &gt;-
+          Kinesin-II (containing klp-20) is an ATP-driven microtubule motor; in gliding
+          assays it moves microtubules and uses Mg-ATP by Michaelis-Menten kinetics.
+        supporting_text: &#34;indicating that Mg-ATP is the preferred substrate for kinesin-2 motors&#34;
+        reference_section_type: RESULTS
+      - statement: &gt;-
+          Kinesin-II and OSM-3 are the two anterograde IFT motors that redundantly move
+          IFT particles to build the sensory cilium foundation.
+        supporting_text: &#34;two anterograde IFT motors called kinesin-II and OSM-3&#34;
+        reference_section_type: INTRODUCTION
+    reference_review:
+      relevance: HIGH
+      correctness: VERIFIED
+      review_notes: &gt;-
+        Full text cached (PMC2064394). Directly names KLP-20 as a subunit of the purified
+        heterotrimeric kinesin-II holoenzyme and characterizes its motor/ATPase activity
+        and role in anterograde IFT. Source of the WormBase IDA (GO:0003777) and IPI
+        (GO:0030993) annotations.
+  - id: PMID:20498083
+    title: Regulation of a heterodimeric kinesin-2 through an unprocessive motor domain that is turned processive by its partner.
+    findings:
+      - statement: &gt;-
+          The KLP-11/KLP-20 heterodimer pairs an unprocessive with a processive motor
+          domain; heterodimerization generates processivity.
+        supporting_text: &#34;One motor domain is unprocessive as a homodimer&#34;
+        reference_section_type: ABSTRACT
+      - statement: &gt;-
+          Heterodimerization of klp-20 with klp-11 is required to bind KAP-1, the in vivo
+          link between the motor and its cargo.
+        supporting_text: &#34;heterodimerization is necessary to bind KAP1, the in vivo link between motor and&#34;
+        reference_section_type: ABSTRACT
+    reference_review:
+      relevance: HIGH
+      correctness: VERIFIED
+      review_notes: &gt;-
+        Abstract-only cache (full text not available from PMC2890855). Studies the
+        C. elegans KLP-11/KLP-20 heterodimer directly; establishes that processivity and
+        KAP-1 (cargo) binding require heterodimerization, and that the motor is
+        autoregulated. Source of the ComplexPortal NAS annotations.
+existing_annotations:
+  - term:
+      id: GO:0003777
+      label: microtubule motor activity
+    evidence_type: IBA
+    original_reference_id: GO_REF:0000033
+    qualifier: enables
+    review:
+      summary: &gt;-
+        Phylogenetic (IBA) support for microtubule motor activity, redundant with the
+        experimental IDA below (PMID:17000880). Correct core molecular function of the
+        kinesin motor domain. The more specific term is plus-end-directed microtubule
+        motor activity (GO:0008574), captured in core_functions.
+      action: ACCEPT
+      supported_by:
+        - reference_id: PMID:17000880
+          supporting_text: &#34;indicating that Mg-ATP is the preferred substrate for kinesin-2 motors&#34;
+          reference_section_type: RESULTS
+  - term:
+      id: GO:0005737
+      label: cytoplasm
+    evidence_type: IBA
+    original_reference_id: GO_REF:0000033
+    qualifier: is_active_in
+    review:
+      summary: &gt;-
+        Broad cytoplasmic localization consistent with UniProt (Cytoplasm, cytoskeleton by
+        similarity), but uninformative relative to the specific ciliary localization. Keep
+        as non-core context.
+      action: KEEP_AS_NON_CORE
+  - term:
+      id: GO:0008017
+      label: microtubule binding
+    evidence_type: IBA
+    original_reference_id: GO_REF:0000033
+    qualifier: enables
+    review:
+      summary: &gt;-
+        Microtubule binding is intrinsic to the kinesin motor domain and required for the
+        motor to engage its track. Correct and consistent with plus-end-directed motor
+        activity; retained as a supporting molecular function.
+      action: ACCEPT
+  - term:
+      id: GO:0060271
+      label: cilium assembly
+    evidence_type: IBA
+    original_reference_id: GO_REF:0000033
+    qualifier: involved_in
+    review:
+      summary: &gt;-
+        Kinesin-II (with klp-20 as a motor subunit) and osm-3 move IFT particles that
+        redundantly build the sensory cilium foundation, so involvement in cilium assembly
+        is well supported. Accept as a core biological process.
+      action: ACCEPT
+      supported_by:
+        - reference_id: PMID:17000880
+          supporting_text: &#34;either motor but not both being dispensable for this function&#34;
+          reference_section_type: INTRODUCTION
+  - term:
+      id: GO:0005871
+      label: kinesin complex
+    evidence_type: IBA
+    original_reference_id: GO_REF:0000033
+    qualifier: part_of
+    review:
+      summary: &gt;-
+        Correct but general parent of the specific complex membership. klp-20 is a subunit
+        of the (axonemal heterotrimeric) kinesin-II complex; the specific terms
+        GO:0016939/GO:0030993 are preferred. Keep as non-core.
+      action: KEEP_AS_NON_CORE
+  - term:
+      id: GO:0005874
+      label: microtubule
+    evidence_type: IBA
+    original_reference_id: GO_REF:0000033
+    qualifier: is_active_in
+    review:
+      summary: &gt;-
+        The microtubule is the motor&#39;s track rather than a distinct cellular location of
+        the protein. Consistent with function but non-core; the informative location is the
+        cilium.
+      action: KEEP_AS_NON_CORE
+  - term:
+      id: GO:0016887
+      label: ATP hydrolysis activity
+    evidence_type: IBA
+    original_reference_id: GO_REF:0000033
+    qualifier: enables
+    review:
+      summary: &gt;-
+        ATP hydrolysis powers the kinesin motor; the motor domain of klp-20 contains the
+        P-loop (Walker A) ATPase site, and purified kinesin-II shows Mg-ATP-dependent
+        motility with Michaelis-Menten kinetics (PMID:17000880). Accept as part of the
+        core motor mechanism.
+      action: ACCEPT
+      supported_by:
+        - reference_id: PMID:17000880
+          supporting_text: &#34;kinesin-II–driven motility conformed to Michaelis-Menten kinetics&#34;
+          reference_section_type: RESULTS
+  - term:
+      id: GO:0008089
+      label: anterograde axonal transport
+    evidence_type: IBA
+    original_reference_id: GO_REF:0000033
+    qualifier: involved_in
+    review:
+      summary: &gt;-
+        This term is a phylogenetic transfer from kinesin-II orthologs (KIF3) that act in
+        neuronal axonal transport. In C. elegans the documented role of klp-20/kinesin-II
+        is anterograde intraflagellar (ciliary) transport, not classical axonal cargo
+        transport; there is no experimental evidence for a klp-20 axonal-transport role in
+        worm. Treated as an over-propagated electronic inference; the accurate specific
+        term is intraciliary anterograde transport (GO:0035720).
+      action: MARK_AS_OVER_ANNOTATED
+      propagation_review:
+        root_cause: TERM_SCOPING_PROBLEM
+        failure_modes:
+          - CONTEXT_OR_TISSUE_MISMATCH
+          - GRANULARITY_MISMATCH
+        source_entities:
+          - source_id: FB:FBgn0004380
+            source_label: Klp64D (Drosophila kinesin-II KIF3A ortholog)
+            source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
+            comment: &gt;-
+              Kinesin-II orthologs act in neuronal anterograde axonal transport, but the
+              documented C. elegans klp-20 role is anterograde intraciliary transport, not
+              axonal cargo transport; the axon-specific term does not transfer.
+          - source_id: PANTHER:PTN000650181
+            source_label: kinesin-2 anterograde-transport node
+            source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
+            comment: &gt;-
+              Node-level anterograde-transport inference; the ciliary (GO:0035720) rather
+              than axonal (GO:0008089) child is the correct scoping for klp-20.
+  - term:
+      id: GO:0003777
+      label: microtubule motor activity
+    evidence_type: IEA
+    original_reference_id: GO_REF:0000120
+    qualifier: enables
+    review:
+      summary: &gt;-
+        Electronic (InterPro/ARBA) support for microtubule motor activity, redundant with
+        the experimental IDA (PMID:17000880) and the IBA above. Correct core molecular
+        function.
+      action: ACCEPT
+  - term:
+      id: GO:0005524
+      label: ATP binding
+    evidence_type: IEA
+    original_reference_id: GO_REF:0000002
+    qualifier: enables
+    review:
+      summary: &gt;-
+        ATP binding via the conserved P-loop/Walker A motif of the kinesin motor domain
+        (UniProt BINDING 91..98). Correct molecular-mechanism support for the ATP-driven
+        motor; retained as supporting.
+      action: ACCEPT
+  - term:
+      id: GO:0005856
+      label: cytoskeleton
+    evidence_type: IEA
+    original_reference_id: GO_REF:0000120
+    qualifier: located_in
+    review:
+      summary: &gt;-
+        General cytoskeletal localization from an electronic subcellular-location rule.
+        Consistent with a microtubule motor but non-specific; the informative location is
+        the cilium.
+      action: KEEP_AS_NON_CORE
+  - term:
+      id: GO:0005929
+      label: cilium
+    evidence_type: IEA
+    original_reference_id: GO_REF:0000120
+    qualifier: located_in
+    review:
+      summary: &gt;-
+        Ciliary localization is well established: klp-20/kinesin-II functions in sensory
+        cilia and UniProt records SUBCELLULAR LOCATION cilium (localizing to the base and
+        transition zone; PMID:28479320). Accept as a core cellular location.
+      action: ACCEPT
+  - term:
+      id: GO:0007018
+      label: microtubule-based movement
+    evidence_type: IEA
+    original_reference_id: GO_REF:0000120
+    qualifier: involved_in
+    review:
+      summary: &gt;-
+        Electronic support for microtubule-based movement, redundant with the experimental
+        IDA (PMID:17000880). Correct but general; the specific process is intraciliary
+        anterograde transport (GO:0035720). Accept.
+      action: ACCEPT
+  - term:
+      id: GO:0008017
+      label: microtubule binding
+    evidence_type: IEA
+    original_reference_id: GO_REF:0000002
+    qualifier: enables
+    review:
+      summary: &gt;-
+        Electronic (InterPro) support for microtubule binding, redundant with the IBA
+        above and intrinsic to the motor domain. Accept as supporting molecular function.
+      action: ACCEPT
+  - term:
+      id: GO:0032991
+      label: protein-containing complex
+    evidence_type: IEA
+    original_reference_id: GO_REF:0000117
+    qualifier: part_of
+    review:
+      summary: &gt;-
+        Root-level complex membership from an ARBA rule. True (klp-20 is part of
+        kinesin-II) but uninformative; the specific complex terms GO:0016939 and GO:0030993
+        supersede it. Over-annotated at this level of generality.
+      action: MARK_AS_OVER_ANNOTATED
+  - term:
+      id: GO:1904115
+      label: axon cytoplasm
+    evidence_type: IEA
+    original_reference_id: GO_REF:0000108
+    qualifier: located_in
+    review:
+      summary: &gt;-
+        Inferred logically (GO_REF:0000108) from the anterograde axonal transport
+        annotation (GO:0008089), which is itself an over-propagated phylogenetic transfer.
+        klp-20 acts in sensory cilia in C. elegans, not documented axoplasm; this location
+        is a downstream consequence of the over-annotated axonal-transport term.
+      action: MARK_AS_OVER_ANNOTATED
+  - term:
+      id: GO:0007018
+      label: microtubule-based movement
+    evidence_type: NAS
+    original_reference_id: PMID:20498083
+    qualifier: involved_in
+    review:
+      summary: &gt;-
+        ComplexPortal NAS annotation for microtubule-based movement, supported by the
+        biophysical characterization of the KLP-11/KLP-20 heterodimer motor. Correct but
+        general relative to intraciliary anterograde transport; accept.
+      action: ACCEPT
+      supported_by:
+        - reference_id: PMID:20498083
+          supporting_text: &#34;One motor domain is unprocessive as a homodimer&#34;
+          reference_section_type: ABSTRACT
+  - term:
+      id: GO:0016939
+      label: kinesin II complex
+    evidence_type: NAS
+    original_reference_id: PMID:20498083
+    qualifier: part_of
+    review:
+      summary: &gt;-
+        klp-20 is a subunit of the kinesin II complex (the klp-11/klp-20/kap-1
+        heterotrimer). Directly supported: heterodimerization of klp-20 with klp-11 is
+        required to bind kap-1 (PMID:20498083), and the purified heterotrimer was
+        characterized in PMID:17000880. Accept as core complex membership; the axonemal
+        term GO:0030993 is the most specific.
+      action: ACCEPT
+      supported_by:
+        - reference_id: PMID:20498083
+          supporting_text: &#34;heterodimerization is necessary to bind KAP1, the in vivo link between motor and&#34;
+          reference_section_type: ABSTRACT
+  - term:
+      id: GO:0035720
+      label: intraciliary anterograde transport
+    evidence_type: NAS
+    original_reference_id: PMID:20498083
+    qualifier: involved_in
+    review:
+      summary: &gt;-
+        Anterograde IFT is the core biological process of kinesin-II. As a kinesin-II motor
+        subunit, klp-20 drives base-to-tip transport of IFT particles along sensory cilia
+        together with osm-3. Accept as a core process.
+      action: ACCEPT
+      supported_by:
+        - reference_id: PMID:17000880
+          supporting_text: &#34;two anterograde IFT motors called kinesin-II and OSM-3&#34;
+          reference_section_type: INTRODUCTION
+  - term:
+      id: GO:0003777
+      label: microtubule motor activity
+    evidence_type: IDA
+    original_reference_id: PMID:17000880
+    qualifier: enables
+    review:
+      summary: &gt;-
+        Direct experimental (IDA) annotation from characterization of purified kinesin-II,
+        which contains klp-20 as one of its two motor subunits and moves microtubules in an
+        ATP-dependent manner. This is the strongest evidence for the core molecular
+        function. The most specific term is plus-end-directed microtubule motor activity
+        (GO:0008574), used in core_functions.
+      action: ACCEPT
+      supported_by:
+        - reference_id: PMID:17000880
+          supporting_text: &#34;the KLP-11, KAP-1, and KLP-20 subunits elute as a monodisperse heterotrimeric complex&#34;
+          reference_section_type: RESULTS
+  - term:
+      id: GO:0007018
+      label: microtubule-based movement
+    evidence_type: IDA
+    original_reference_id: PMID:17000880
+    qualifier: involved_in
+    review:
+      summary: &gt;-
+        Direct experimental annotation for microtubule-based movement from the kinesin-II
+        gliding assays. Correct; general relative to intraciliary anterograde transport but
+        experimentally solid. Accept.
+      action: ACCEPT
+      supported_by:
+        - reference_id: PMID:17000880
+          supporting_text: &#34;indicating that Mg-ATP is the preferred substrate for kinesin-2 motors&#34;
+          reference_section_type: RESULTS
+  - term:
+      id: GO:0030993
+      label: axonemal heterotrimeric kinesin-II complex
+    evidence_type: IPI
+    original_reference_id: PMID:17000880
+    qualifier: part_of
+    review:
+      summary: &gt;-
+        Direct physical-interaction (IPI) evidence that klp-20 is a subunit of the axonemal
+        heterotrimeric kinesin-II complex, purified as a monodisperse heterotrimer of
+        KLP-11/KLP-20/KAP-1 (with WormBase klp-11 and kap-1 as the with/from partners).
+        This is the most specific and best-supported complex-membership term and the core
+        cellular-component annotation.
+      action: ACCEPT
+      supported_by:
+        - reference_id: PMID:17000880
+          supporting_text: &#34;consisting of 1 mol each of its subunits KLP-11, KLP-20, and KAP-1 with a native molecular mass of 287 kD&#34;
+          reference_section_type: RESULTS
+  - term:
+      id: GO:0008574
+      label: plus-end-directed microtubule motor activity
+    evidence_type: IDA
+    original_reference_id: PMID:17000880
+    qualifier: enables
+    review:
+      summary: &gt;-
+        Proposed refinement of the experimental microtubule motor activity annotation
+        (GO:0003777, IDA, PMID:17000880) to the more specific plus-end-directed microtubule
+        motor activity. Kinesins are plus-end-directed motors and kinesin-II (with klp-20)
+        drives anterograde (base-to-tip, plus-end-directed) IFT; the purified motor moves
+        microtubules in gliding assays. This is the primary core molecular function.
+      action: NEW
+      supported_by:
+        - reference_id: PMID:17000880
+          supporting_text: &#34;kinesin-II alone moved MTs at a maximal rate of 0.3&#34;
+          reference_section_type: RESULTS
+core_functions:
+  - description: &gt;-
+      As one of the two motor subunits of heterotrimeric kinesin-II (klp-11/klp-20/kap-1),
+      klp-20 contributes to the ATP-driven, microtubule plus-end-directed motor activity of
+      the complex. klp-20 heterodimerizes with klp-11 through its C-terminal coiled-coil
+      stalk; this heterodimer is processive and binds the accessory subunit kap-1, which
+      couples the motor to IFT cargo. The motor moves along the doublet microtubules of the
+      sensory-cilium middle segment.
+    molecular_function:
+      id: GO:0008574
+      label: plus-end-directed microtubule motor activity
+    contributes_to_molecular_function:
+      id: GO:0008574
+      label: plus-end-directed microtubule motor activity
+    in_complex:
+      id: GO:0030993
+      label: axonemal heterotrimeric kinesin-II complex
+    directly_involved_in:
+      - id: GO:0035720
+        label: intraciliary anterograde transport
+      - id: GO:0060271
+        label: cilium assembly
+    locations:
+      - id: GO:0005929
+        label: cilium
+    supported_by:
+      - reference_id: PMID:17000880
+        supporting_text: &#34;the KLP-11, KAP-1, and KLP-20 subunits elute as a monodisperse heterotrimeric complex&#34;
+        reference_section_type: RESULTS
+      - reference_id: PMID:20498083
+        supporting_text: &#34;heterodimerization is necessary to bind KAP1, the in vivo link between motor and&#34;
+        reference_section_type: ABSTRACT
+  - description: &gt;-
+      The kinesin motor domain of klp-20 hydrolyzes ATP to power microtubule-based
+      movement. Purified kinesin-II (containing klp-20) uses Mg-ATP as its preferred
+      substrate with Michaelis-Menten kinetics, and klp-20 carries the conserved P-loop
+      (Walker A) ATP-binding motif.
+    molecular_function:
+      id: GO:0016887
+      label: ATP hydrolysis activity
+    contributes_to_molecular_function:
+      id: GO:0016887
+      label: ATP hydrolysis activity
+    in_complex:
+      id: GO:0030993
+      label: axonemal heterotrimeric kinesin-II complex
+    supported_by:
+      - reference_id: PMID:17000880
+        supporting_text: &#34;indicating that Mg-ATP is the preferred substrate for kinesin-2 motors&#34;
+        reference_section_type: RESULTS
+knowledge_gaps:
+  - gap_statement: &gt;-
+      Within the klp-11/klp-20 heterodimer it is not resolved which subunit is the
+      &#34;unprocessive&#34; motor domain and which is the processive one — i.e. whether klp-20
+      itself is the processive or the autoinhibited/unprocessive head, and the
+      residue-level basis of its individual duty ratio.
+    boundary: &gt;-
+      It is established that heterodimerization of the two distinct C. elegans kinesin-2
+      motor domains converts an otherwise unprocessive homodimer into a processive
+      heterodimer, that the unprocessive subunit mediates an asymmetric autoregulation of
+      motor activity, and that the heterodimer must form to bind kap-1 (the cargo link).
+      UniProt annotates two klp-20 residues (444, 445) as possibly required for
+      autoinhibition within the heterodimer.
+    gap_kind:
+      - BIOLOGY
+    dark_aspect: RESIDUAL_SUBGAP
+    status: OPEN
+    significance: &gt;-
+      Kinesin-2 heterodimerization is the paradigm for how obligate motor heterodimers
+      tune processivity and autoregulation; assigning the processive vs unprocessive role
+      to klp-20 vs klp-11 defines the mechanistic division of labor of the anterograde IFT
+      motor.
+    resolution: &gt;-
+      Single-molecule processivity assays on defined homodimeric vs heterodimeric
+      constructs of the klp-20 and klp-11 motor domains, with subunit-specific labeling and
+      head-tracking to assign duty ratio to each subunit.
+    provenance:
+      - reference_id: PMID:20498083
+        supporting_text: &#34;One motor domain is unprocessive as a homodimer&#34;
+        reference_section_type: ABSTRACT
+      - reference_id: PMID:20498083
+        supporting_text: &#34;asymmetric autoregulation of the motor&#34;
+        reference_section_type: ABSTRACT
+  - gap_statement: &gt;-
+      The direct, klp-20-motor-selected ciliary cargo repertoire is not enumerated: what
+      cargoes the klp-20-containing kinesin-II specifically delivers is inferred through the
+      IFT-A/IFT-B particle rather than measured for the motor itself.
+    boundary: &gt;-
+      Kinesin-II (with klp-20 as a motor subunit) and osm-3 are the two anterograde IFT
+      motors that move IFT particles to build the sensory cilium foundation; kap-1 provides
+      the in vivo link between the motor and cargo.
+    gap_kind:
+      - BIOLOGY
+      - CURATION
+    dark_aspect: BP_DARK
+    status: OPEN
+    significance: &gt;-
+      Defining the motor-specific cargo would clarify how the two anterograde IFT motors
+      (kinesin-II vs osm-3) divide cargo responsibilities along the ciliary axoneme, which
+      is central to understanding ciliogenesis and ciliopathy.
+    resolution: &gt;-
+      Proximity labeling or cargo-trapping proteomics on the klp-20/kap-1 motor in cilia,
+      combined with klp-20 loss-of-function IFT imaging to identify cargoes whose ciliary
+      delivery specifically requires the klp-20-containing motor.
+    provenance:
+      - reference_id: PMID:20498083
+        supporting_text: &#34;heterodimerization is necessary to bind KAP1, the in vivo link between motor and&#34;
+        reference_section_type: ABSTRACT
+suggested_questions:
+  - question: &gt;-
+      Within the klp-11/klp-20 heterodimer, which motor domain is the processive one and
+      which is unprocessive, and how do the two heads cooperate to set the ~0.5 um/s in vivo
+      velocity of kinesin-II?
+  - question: &gt;-
+      How does cargo binding to kap-1 relieve the tail-mediated autoinhibition of the
+      klp-11/klp-20 heterodimer, and what is the specific contribution of the klp-20 tail
+      (residues 444-445 and the 525-550 klp-11 interaction region)?
+suggested_experiments:
+  - description: &gt;-
+      Single-molecule motility (TIRF) comparison of purified klp-20 homodimer, klp-11
+      homodimer, and klp-11/klp-20 heterodimer with subunit-specific fluorophores, to
+      assign processivity and duty ratio to each subunit and test the
+      asymmetric-autoregulation model.
+    hypothesis: &gt;-
+      klp-20 and klp-11 have different intrinsic processivities, and one specific subunit
+      is the unprocessive, autoregulatory head.
+  - description: &gt;-
+      In vivo IFT imaging (kymography of fluorescently tagged IFT components) in klp-20
+      loss-of-function versus osm-3 loss-of-function animals to define the cargoes and
+      axonemal segments whose transport specifically depends on the klp-20-containing
+      kinesin-II motor.
+    hypothesis: &gt;-
+      The klp-20-containing kinesin-II motor is specifically required for anterograde
+      transport of a defined subset of IFT cargoes along the middle (doublet) segment.
+tags:
+  - caeel-ciliopathy
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/genes/worm/lys-1/lys-1-ai-review.html
+++ b/genes/worm/lys-1/lys-1-ai-review.html
@@ -1,0 +1,3577 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>lys-1 - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        .propagation-review {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f8fafc;
+            border-left: 3px solid #64748b;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .propagation-title {
+            font-weight: 600;
+            color: #334155;
+            margin-bottom: 0.25rem;
+        }
+
+        .propagation-row {
+            margin-top: 0.25rem;
+        }
+
+        .propagation-source {
+            margin-top: 0.5rem;
+            padding-top: 0.5rem;
+            border-top: 1px solid #e5e7eb;
+        }
+
+        .propagation-source-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #1d4ed8;
+        }
+
+        .propagation-comment {
+            color: #4b5563;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>lys-1</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/O62415" target="_blank" class="term-link">
+                        O62415
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Caenorhabditis elegans</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-complete">
+                    COMPLETE
+                </span>
+            </div>
+
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "lys-1";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="O62415" data-a="DESCRIPTION: LYS-1 is one of the protist-type (Entamoeba-type) ..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>LYS-1 is one of the protist-type (Entamoeba-type) lysozymes of Caenorhabditis elegans, a nematode that carries an unusually large and divergent lysozyme family (15 genes split into protist-type lys and invertebrate-type ilys classes). Structurally it is a glycoside hydrolase family 25 (GH25) protein with an N-terminal signal peptide. LYS-1 functions as an infection-inducible antibacterial effector of the intestinal innate immune response: it is one of the most strongly induced genes upon infection by the Gram-negative bacterium Serratia marcescens, and its overexpression increases resistance to that pathogen, while RNAi knockdown reduces survival on the Gram-positive bacterium Staphylococcus aureus. It is also transcriptionally upregulated by Bacillus thuringiensis and is part of the ELT-2/GATA-controlled intestinal infection-response program, and it is a DAF-16/FOXO target that links the immune response to the dauer developmental decision. The protein localizes to vesicles in the apical region of intestinal cells and is expressed in the intestine and a subset of head neurons. Although the GH25 fold implies muramidase (peptidoglycan-hydrolysing) activity, this catalytic activity has never been demonstrated for LYS-1 at the protein level, and the sequence lacks the conserved active-site residues, so its actual enzymatic function is uncertain.</p>
+    </div>
+
+
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0007165" target="_blank" class="term-link">
+                                    GO:0007165
+                                </a>
+                            </span>
+                            <span class="term-label">signal transduction</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-remove">
+                            REMOVE
+                        </span>
+                        <span class="vote-buttons" data-g="O62415" data-a="GO:0007165" data-r="GO_REF:0000033" data-act="REMOVE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> This IBA is a phylogenetic propagation from a PANTHER subfamily seeded by non-lysozyme members (including a Dictyostelium protein). Lysozymes are secreted antibacterial hydrolases/effectors, not signal-transducing proteins, and there is no evidence that LYS-1 transduces any signal.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Over-broad phylogenetic inference inconsistent with the biology of a lysozyme-family antibacterial effector. No experimental or sequence feature supports a signal transduction role for LYS-1; the specific, experimentally supported role is antibacterial defense (captured by the defense-response terms below).
+                        </div>
+
+
+
+                        <div class="propagation-review">
+                            <div class="propagation-title">Propagation Review</div>
+                            <div class="propagation-row">
+                                <strong>Root cause:</strong>
+                                <span class="badge">PROPAGATION BAD</span>
+                            </div>
+
+                            <div class="propagation-row">
+                                <strong>Failure modes:</strong>
+
+                                <span class="badge">FUNCTIONAL DIVERGENCE</span>
+
+                                <span class="badge">GRANULARITY MISMATCH</span>
+
+                            </div>
+
+
+                            <div class="propagation-source">
+                                <strong>Sources checked:</strong>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">PANTHER:PTN000574946</span>
+
+                                    &middot; PTN000574946 (PANTHER ancestral node)
+
+
+                                    <span class="badge">SOURCE WEAK OR INFERRED</span>
+
+
+                                    <div class="propagation-comment">Ancestral node whose GO:0007165 assignment was seeded from dictyBase:DDB_G0273175 (a Dictyostelium protein). &#34;Signal transduction&#34; is not a function of a GH25 lysozyme-family antibacterial effector; the propagation transfers an unrelated, overly generic process to LYS-1.</div>
+
+                                </div>
+
+                            </div>
+
+                        </div>
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0045087" target="_blank" class="term-link">
+                                    GO:0045087
+                                </a>
+                            </span>
+                            <span class="term-label">innate immune response</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="O62415" data-a="GO:0045087" data-r="GO_REF:0000033" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> The innate-immune-response assignment is correct for LYS-1, but this IBA is redundant with the stronger experimental IMP (PMID:21209831) and HEP (PMID:16968778) annotations to the same term. Retained as valid biological process context rather than as a distinct line of evidence.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct process but redundant with experimental annotations to the same term; the more specific defense-response-to-Gram-positive/Gram-negative terms carry the core biology.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003796" target="_blank" class="term-link">
+                                    GO:0003796
+                                </a>
+                            </span>
+                            <span class="term-label">lysozyme activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-undecided">
+                            UNDECIDED
+                        </span>
+                        <span class="vote-buttons" data-g="O62415" data-a="GO:0003796" data-r="GO_REF:0000002" data-act="UNDECIDED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> This is a family/domain-based (InterPro IPR002053, GH25) inference of muramidase activity. It has never been demonstrated for LYS-1: no C. elegans lysozyme has been characterized at the protein level, and UniProt flags a CAUTION that LYS-1 &#34;Lacks conserved active site residues, suggesting it has no catalytic activity.&#34; The activity therefore cannot be confirmed, and there is positive sequence evidence that it may be absent.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Cannot verify: no biochemical/enzymatic assay of purified LYS-1 exists, and the UniProt active-site CAUTION suggests possible loss of catalytic activity. Per guidelines this is an author-flagged unresolved MF, not a confident REMOVE (family activity cannot be definitively excluded without biochemistry). This is the central molecular-function knowledge gap for this gene.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/21931778" target="_blank" class="term-link">
+                                        PMID:21931778
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">All available data is based on genetic analysis, whereas none of the lysozymes have been characterized at the protein level.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006950" target="_blank" class="term-link">
+                                    GO:0006950
+                                </a>
+                            </span>
+                            <span class="term-label">response to stress</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000117
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="O62415" data-a="GO:0006950" data-r="GO_REF:0000117" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> A very generic ARBA machine-learned assignment. The specific infection/defense-response terms below describe LYS-1&#39;s biology far more informatively; a bare response-to-stress term adds little.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Too general to be informative and subsumed by the specific defense response / innate immune response annotations that are experimentally supported.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0009253" target="_blank" class="term-link">
+                                    GO:0009253
+                                </a>
+                            </span>
+                            <span class="term-label">peptidoglycan catabolic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-undecided">
+                            UNDECIDED
+                        </span>
+                        <span class="vote-buttons" data-g="O62415" data-a="GO:0009253" data-r="GO_REF:0000002" data-act="UNDECIDED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> The biological-process counterpart of the unverified lysozyme activity (InterPro/GH25 inference). Because peptidoglycan hydrolysis by LYS-1 has not been demonstrated and the sequence may lack catalytic residues, this process cannot be confirmed for this paralog.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Depends on an unverified catalytic (muramidase) activity; no direct evidence LYS-1 cleaves peptidoglycan. Tied to the lysozyme-activity knowledge gap.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/21931778" target="_blank" class="term-link">
+                                        PMID:21931778
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">All available data is based on genetic analysis, whereas none of the lysozymes have been characterized at the protein level.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016998" target="_blank" class="term-link">
+                                    GO:0016998
+                                </a>
+                            </span>
+                            <span class="term-label">cell wall macromolecule catabolic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-undecided">
+                            UNDECIDED
+                        </span>
+                        <span class="vote-buttons" data-g="O62415" data-a="GO:0016998" data-r="GO_REF:0000002" data-act="UNDECIDED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> A more general parent of peptidoglycan catabolism, from the same family-based InterPro inference; same caveat that the underlying catalytic activity is undemonstrated for LYS-1.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Same unverified-catalysis basis as the peptidoglycan/lysozyme-activity annotations; cannot confirm cell-wall macromolecule catabolism for LYS-1.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0060205" target="_blank" class="term-link">
+                                    GO:0060205
+                                </a>
+                            </span>
+                            <span class="term-label">cytoplasmic vesicle lumen</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000044
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="O62415" data-a="GO:0060205" data-r="GO_REF:0000044" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> UniProt Subcellular Location keyword propagation matching the curated localization of LYS-1 to the lumen of apical intestinal vesicles. Redundant with the EXP annotation from PMID:12176330.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct location but electronically propagated and redundant with the experimental EXP/IDA vesicle annotations.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0060205" target="_blank" class="term-link">
+                                    GO:0060205
+                                </a>
+                            </span>
+                            <span class="term-label">cytoplasmic vesicle lumen</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">EXP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/12176330" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:12176330
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Inducible antibacterial defense system in C. elegans.
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O62415" data-a="GO:0060205" data-r="PMID:12176330" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Experimentally curated localization of LYS-1 to the lumen of vesicles in the apical region of intestinal cells, from the primary characterization of the inducible antibacterial defense system.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Curator-assigned experimental localization consistent with a secreted intestinal antibacterial effector stored in apical vesicles.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0045087" target="_blank" class="term-link">
+                                    GO:0045087
+                                </a>
+                            </span>
+                            <span class="term-label">innate immune response</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">HEP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/16968778" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:16968778
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    A conserved role for a GATA transcription factor in regulati...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="O62415" data-a="GO:0045087" data-r="PMID:16968778" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> High-throughput expression evidence: lys-1 is part of the intestinal ELT-2/GATA-regulated infection-response gene program identified in a genome-wide study of epithelial innate immunity. Consistent with its infection-inducible antibacterial role.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Expression-based support for involvement in the innate immune response; corroborates the experimental IMP annotation but is itself expression- level evidence.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0045087" target="_blank" class="term-link">
+                                    GO:0045087
+                                </a>
+                            </span>
+                            <span class="term-label">innate immune response</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/21209831" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:21209831
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    RNAi screen of DAF-16/FOXO target genes in C. elegans links ...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O62415" data-a="GO:0045087" data-r="PMID:21209831" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> RNAi knockdown of lys-1 significantly reduces C. elegans survival on the pathogen Staphylococcus aureus (TD50 4.7 vs 6.8 days for control, p&lt;0.0001), demonstrating that lys-1 is required for a normal innate immune/pathogen-resistance response.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Direct loss-of-function (RNAi) phenotype establishing a functional role in the innate immune response; core immune-defense biology of the gene.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/21209831" target="_blank" class="term-link">
+                                        PMID:21209831
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Two genes, lys-1 and clc-1, were required for normal resistance to S. aureus.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0050830" target="_blank" class="term-link">
+                                    GO:0050830
+                                </a>
+                            </span>
+                            <span class="term-label">defense response to Gram-positive bacterium</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/21209831" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:21209831
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    RNAi screen of DAF-16/FOXO target genes in C. elegans links ...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O62415" data-a="GO:0050830" data-r="PMID:21209831" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Staphylococcus aureus is a Gram-positive bacterium, and lys-1 RNAi reduces survival on it (TD50 4.7 vs 6.8 days, p&lt;0.0001), directly supporting a role in defense against Gram-positive bacteria. This is the most specific, experimentally supported process term for the gene.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Specific, experimentally demonstrated defense function against a Gram-positive pathogen; a core biological process of LYS-1.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/21209831" target="_blank" class="term-link">
+                                        PMID:21209831
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The TD50 (time required for 50% of the nematodes to die) for lys-1 was 4.7 days (p&lt;0.0001)</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031410" target="_blank" class="term-link">
+                                    GO:0031410
+                                </a>
+                            </span>
+                            <span class="term-label">cytoplasmic vesicle</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/12176330" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:12176330
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Inducible antibacterial defense system in C. elegans.
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O62415" data-a="GO:0031410" data-r="PMID:12176330" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct-assay localization of LYS-1 to cytoplasmic vesicles in intestinal cells, from the primary characterization paper.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Experimentally observed subcellular localization consistent with storage of the effector in intestinal vesicles.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0045177" target="_blank" class="term-link">
+                                    GO:0045177
+                                </a>
+                            </span>
+                            <span class="term-label">apical part of cell</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/12176330" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:12176330
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Inducible antibacterial defense system in C. elegans.
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O62415" data-a="GO:0045177" data-r="PMID:12176330" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> LYS-1 localizes to the apical region of intestinal cells (apically positioned vesicles), consistent with secretion toward the gut lumen where ingested bacteria are encountered.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Experimentally supported apical localization appropriate for a gut-luminal antibacterial effector.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0050829" target="_blank" class="term-link">
+                                    GO:0050829
+                                </a>
+                            </span>
+                            <span class="term-label">defense response to Gram-negative bacterium</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/12176330" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:12176330
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Inducible antibacterial defense system in C. elegans.
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O62415" data-a="GO:0050829" data-r="PMID:12176330" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> lys-1 is among the most robustly induced genes upon infection by the Gram-negative bacterium Serratia marcescens, and its overexpression augments resistance to that pathogen, supporting a role in defense against Gram-negative bacteria. The evidence code is IEP (expression), reinforced by the overexpression gain-of-resistance phenotype.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Infection-inducible expression plus overexpression-conferred resistance establish a defense role against a Gram-negative pathogen; a core biological process of LYS-1.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12176330" target="_blank" class="term-link">
+                                        PMID:12176330
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">overexpression of the lysozyme gene lys-1 augments the resistance of C. elegans to S. marcescens.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>Infection-inducible antibacterial effector of the C. elegans intestinal innate immune response, acting against both Gram-negative (S. marcescens) and Gram-positive (S. aureus) bacteria. LYS-1 is stored in the lumen of apical intestinal vesicles, positioned for release toward ingested bacteria in the gut. It is a GH25 protist-type lysozyme; a muramidase (peptidoglycan-hydrolysing) molecular function is implied by the fold but has not been demonstrated and may be absent (no conserved active-site residues), so no specific molecular_function is asserted here.</h3>
+                <span class="vote-buttons" data-g="O62415" data-a="FUNCTION: Infection-inducible antibacterial effector of the ..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0050829" target="_blank" class="term-link">
+                                defense response to Gram-negative bacterium
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0050830" target="_blank" class="term-link">
+                                defense response to Gram-positive bacterium
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0045087" target="_blank" class="term-link">
+                                innate immune response
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0060205" target="_blank" class="term-link">
+                                cytoplasmic vesicle lumen
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0045177" target="_blank" class="term-link">
+                                apical part of cell
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/12176330" target="_blank" class="term-link">
+                                PMID:12176330
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">overexpression of the lysozyme gene lys-1 augments the resistance of C. elegans to S. marcescens.</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/21209831" target="_blank" class="term-link">
+                                PMID:21209831
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">Two genes, lys-1 and clc-1, were required for normal resistance to S. aureus.</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000002.md" target="_blank" class="term-link">
+                            GO_REF:0000002
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation through association of InterPro records with GO terms</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
+                            GO_REF:0000033
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Annotation inferences using phylogenetic trees</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
+                            GO_REF:0000044
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000117.md" target="_blank" class="term-link">
+                            GO_REF:0000117
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Electronic Gene Ontology annotations created by ARBA machine learning models</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/12176330" target="_blank" class="term-link">
+                            PMID:12176330
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Inducible antibacterial defense system in C. elegans.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">lys-1 is among the most robustly infection-induced genes and its overexpression augments resistance to the Gram-negative bacterium Serratia marcescens; the protein localizes to apical intestinal vesicles.</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/16968778" target="_blank" class="term-link">
+                            PMID:16968778
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">A conserved role for a GATA transcription factor in regulating epithelial innate immune responses.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Genome-wide study establishing the intestinal ELT-2/GATA-regulated epithelial infection-response gene program of which lys-1 is a member (basis of the HEP innate-immune-response annotation).</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/21209831" target="_blank" class="term-link">
+                            PMID:21209831
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">RNAi screen of DAF-16/FOXO target genes in C. elegans links pathogenesis and dauer formation.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">lys-1 RNAi significantly reduces survival on Staphylococcus aureus (TD50 4.7 vs 6.8 days, p&lt;0.0001), showing lys-1 is required for normal resistance; lys-1 is a DAF-16/FOXO target with a synthetic dauer-formation phenotype.</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/21931778" target="_blank" class="term-link">
+                            PMID:21931778
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Protist-type lysozymes of the nematode Caenorhabditis elegans contribute to resistance against pathogenic Bacillus thuringiensis.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Classifies lys-1 as a chromosome V protist-type lysozyme within the 15-gene C. elegans lysozyme family, shows lys-1 is transcriptionally upregulated by B. thuringiensis in all tested strains, and states explicitly that no C. elegans lysozyme has been characterized at the protein level (basis of the muramidase-activity knowledge gap).</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Questions for Experts</h2>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Does purified LYS-1 protein possess muramidase/bacteriolytic activity, or has this GH25 protist-type lysozyme lost catalytic function and act by a non-enzymatic antibacterial mechanism?</p>
+
+                    <p style="margin-top: 0.5rem;"><em>Suggested experts: Schulenburg H</em></p>
+
+                </div>
+                <span class="vote-buttons" data-g="O62415" data-a="Q: Does purified LYS-1 protein possess muramidase/bac..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> What is the phenotype of a lys-1 loss-of-function null, and to what extent is lys-1 redundant with other protist-type lysozymes in defense against ingested pathogens?</p>
+
+                    <p style="margin-top: 0.5rem;"><em>Suggested experts: Schulenburg H, Ewbank JJ</em></p>
+
+                </div>
+                <span class="vote-buttons" data-g="O62415" data-a="Q: What is the phenotype of a lys-1 loss-of-function ..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Experiments</h2>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Express and purify recombinant LYS-1, then assay (i) muramidase activity on Micrococcus luteus cell walls and defined peptidoglycan substrates, (ii) bacteriolytic/growth-inhibitory activity against S. aureus and S. marcescens, and (iii) direct binding to bacterial cell-surface components; pair with active-site mutagenesis and, if possible, structure determination.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: LYS-1 either hydrolyzes bacterial peptidoglycan (canonical lysozyme mechanism) or, lacking active-site residues, kills/inhibits bacteria by a non-catalytic binding/permeabilizing mechanism.</em></p>
+
+
+                    <p style="margin-top: 0.5rem;">Type: biochemistry / enzymology / structural biology</p>
+
+                </div>
+                <span class="vote-buttons" data-g="O62415" data-a="EXPERIMENT: Express and purify recombinant LYS-1, then assay (..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Generate a lys-1 null allele (CRISPR) and test survival and intestinal pathogen load on a panel of Gram-negative and Gram-positive pathogens (S. marcescens, S. aureus, B. thuringiensis, P. aeruginosa), comparing single mutant, paralog combinations, and rescue/overexpression lines.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: lys-1 contributes non-redundantly to intestinal antibacterial defense in vivo.</em></p>
+
+
+                    <p style="margin-top: 0.5rem;">Type: genetics / host-pathogen survival and CFU assays</p>
+
+                </div>
+                <span class="vote-buttons" data-g="O62415" data-a="EXPERIMENT: Generate a lys-1 null allele (CRISPR) and test sur..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Knowledge Gaps</h2>
+        <p style="color: #555; font-size: 0.92rem; margin-top: -0.3rem;">
+            What is <em>not</em> known — curated, literature-grounded statements of the open
+            unknowns (the inverse of core functions).
+        </p>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> It is not known whether LYS-1 has any muramidase / lysozyme (peptidoglycan-hydrolysing) enzymatic activity. All functional evidence is genetic (infection-inducible expression, RNAi, overexpression); the protein has never been purified or assayed, and its sequence lacks the conserved GH25 active-site residues, raising the possibility that it is a pseudo-muramidase.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">MF_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> What is firmly established is that LYS-1 is a GH25 protist-type lysozyme whose gene is infection-inducible and functionally required for normal antibacterial defense (S. marcescens, S. aureus). What is unknown is the biochemical activity of the protein: whether it cleaves peptidoglycan, permeabilizes/agglutinates bacteria by another mechanism, or acts non-catalytically.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Whether LYS-1 kills bacteria enzymatically (like canonical lysozymes) or by a non-catalytic mechanism determines the correct molecular-function annotation and whether the current InterPro-based lysozyme-activity / peptidoglycan-catabolism annotations should stand. This is a recurring issue across the expanded, divergent C. elegans lysozyme family.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Express and purify recombinant LYS-1 and assay muramidase / bacteriolytic activity (e.g. on Micrococcus cell walls and defined peptidoglycan) and its ability to bind/permeabilize target bacteria; complement with active-site residue mutagenesis and structural analysis.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"All available data is based on genetic analysis, whereas none of the lysozymes have been characterized at the protein level."</em> — PMID:21931778</li>
+
+                <li><em>"our study (and most previous studies) only indicates, but does not strictly prove a defence function of these enzymes. Unequivocal evidence would require analysis of the purified protein, especially its ability to interact with the pathogen at the molecular level."</em> — PMID:21931778</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The molecular substrate or microbial target of LYS-1 is undefined: it is unknown which bacterial surface molecule(s) LYS-1 acts on, and whether its antibacterial spectrum extends beyond S. marcescens, S. aureus and B. thuringiensis.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">MF_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> LYS-1 is known to be required for resistance to S. aureus and to protect against S. marcescens when overexpressed, and it is transcriptionally induced by these plus B. thuringiensis. What is unknown is the direct biochemical target/substrate and the full microbial spectrum.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Identifying the target molecule would clarify the mechanism (enzymatic versus binding/permeabilizing) and the range of pathogens LYS-1 counters, informing both its MF annotation and its place in the surveillance-immunity effector repertoire.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Biochemical target/substrate identification with purified protein (peptidoglycan/cell-wall degradation assays, pull-downs of bacterial ligands) and broader pathogen-panel survival/CFU assays with defined lys-1 loss- and gain-of-function strains.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"Unequivocal evidence would require analysis of the purified protein, especially its ability to interact with the pathogen at the molecular level."</em> — PMID:21931778</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> Whether lys-1 is individually necessary in vivo or is functionally redundant within the 15-member C. elegans lysozyme family is unresolved. The defense phenotypes rest on RNAi knockdown and overexpression rather than a characterized single-gene null, and many lysozyme paralogs share overlapping infection-induction profiles.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">BP_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> lys-1 RNAi reduces S. aureus survival and lys-1 overexpression increases S. marcescens resistance, establishing a contribution to defense. What is unknown is the phenotype of a clean lys-1 loss-of-function null and the degree of redundancy with paralogs such as lys-2, lys-3 and lys-7.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Redundancy determines whether lys-1 is a non-redundant defense gene or one of several partially interchangeable effectors, which affects how strongly its individual loss impacts host survival and how its biological role should be weighted.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Generate and phenotype a lys-1 null allele (and higher-order lysozyme combinatorial mutants) across a pathogen panel, quantifying survival and pathogen load relative to wild type and to single-paralog mutants.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"the nematode Caenorhabditis elegans harbours 15 phylogenetically diverse lysozyme genes"</em> — PMID:21931778</li>
+
+                <li><em>"Whether lys-1 is individually necessary in vivo, or redundant within the 15-member lysozyme family, is not resolved."</em> — file:worm/lys-1/lys-1-notes.md</li>
+
+            </ul>
+
+
+        </div>
+
+    </div>
+
+
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Deep Research Sections -->
+
+    <div class="section">
+        <h2 class="section-title">Deep Research</h2>
+
+        <details class="deep-research-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; gap: 1rem;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Falcon</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(lys-1-deep-research-falcon.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="O62415" data-a="DEEP_RESEARCH: Falcon" data-r="" data-act="DEEP_RESEARCH" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This deep research is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This deep research needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+
+                <div class="report-meta">
+
+                    <span class="report-meta-text">this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</span>
+
+
+                    <span class="report-badge">Falcon</span>
+
+
+                    <span class="report-badge">Edison Scientific Literature</span>
+
+
+                    <span class="report-badge">26 citations</span>
+
+
+                    <span class="report-badge">1 artifacts</span>
+
+
+                    <span class="report-meta-text">2026-07-04T21:01:44.126493</span>
+
+
+
+                </div>
+
+
+                <div class="artifact-list">
+
+
+
+                    <div class="artifact-link">
+                        <a href="lys-1-deep-research-falcon_artifacts/artifact-00.md" class="term-link">Edison artifact artifact-00</a>
+                        <span>(text/markdown)</span>
+                    </div>
+
+
+                </div>
+
+                <p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h2 id="comprehensive-research-report-c-elegans-lys-1-lysozyme-like-protein-1-y22f5a4-uniprot-o62415">Comprehensive Research Report: <em>C. elegans</em> lys-1 (Lysozyme-Like Protein 1, Y22F5A.4, UniProt: O62415)</h2>
+<h3 id="1-gene-identity-and-protein-classification">1. Gene Identity and Protein Classification</h3>
+<p>The <em>lys-1</em> gene (ORF Y22F5A.4) in <em>Caenorhabditis elegans</em> encodes Lysozyme-Like Protein 1 (LYS-1), a member of the glycosyl hydrolase family 25 (GH25). The <em>C. elegans</em> genome encodes 10 protist-type lysozymes (lys-1 through lys-10), all belonging to the GH25 family, as well as six invertebrate-type lysozymes (ilys-1 through ilys-6) (simonsen2012strengthinnumbers pages 4-5, schulenburg2004evolutionofthe pages 7-8). The protist-type lysozymes in <em>C. elegans</em> are structurally most similar to lysozymes found in the amoeboid protozoon <em>Entamoeba histolytica</em>, rather than to the chicken-type (GH22) or insect-type lysozyme families that are well-characterized in vertebrates and arthropods (schulenburg2004evolutionofthe pages 7-8, mallo2002inducibleantibacterialdefense pages 2-3). This phylogenetic relationship suggests an ancient protist-type lysozyme lineage retained in nematodes.</p>
+<h3 id="2-enzymatic-function-and-substrate-specificity">2. Enzymatic Function and Substrate Specificity</h3>
+<p>LYS-1 is classified as a muramidase (EC 3.2.1.17) based on its membership in the GH25 family. GH25 muramidases catalyze the hydrolysis of the β-1,4-glycosidic bond between <em>N</em>-acetylmuramic acid (MurNAc/NAM) and <em>N</em>-acetylglucosamine (GlcNAc/NAG) in the carbohydrate backbone of bacterial peptidoglycan (moroz2021fungalgh25muramidases pages 1-2). Characterized GH25 enzymes exhibit both β-1,4-<em>N</em>-acetyl- and β-1,4-<em>N</em>,6-<em>O</em>-diacetylmuramidase activities (moroz2021fungalgh25muramidases pages 1-2). The catalytic mechanism of GH25 muramidases involves substrate-assisted catalysis: an aspartate residue acts as a general acid, donating a proton to the glycosidic oxygen, while the <em>N</em>-acetyl group of the substrate itself acts as the enzymatic nucleophile to stabilize the oxocarbenium ion-like transition state (moroz2021fungalgh25muramidases pages 13-16). This mechanism is shared with family GH20 chitobiases.</p>
+<p>While no direct biochemical characterization of recombinant LYS-1 has been published, its enzymatic activity as a peptidoglycan-degrading muramidase is strongly inferred from its GH25 family membership and conserved domain architecture (simonsen2012strengthinnumbers pages 4-5, moroz2021fungalgh25muramidases pages 1-2). As antimicrobial proteins, lysozymes function by breaking down peptidoglycan, the major structural component of bacterial cell walls, causing bacterial cell lysis (simonsen2012strengthinnumbers pages 4-5). In <em>E. histolytica</em>, the related protist-type lysozymes are known to act synergistically with amoebapores to break up bacteria, and a similar synergistic action with <em>C. elegans</em> amoebapore-like peptides (SPP family) has been hypothesized (mallo2002inducibleantibacterialdefense pages 2-3).</p>
+<h3 id="3-tissue-expression-and-subcellular-localization">3. Tissue Expression and Subcellular Localization</h3>
+<p>LYS-1 is primarily expressed in intestinal cells throughout the length of the nematode body, consistent with its role as an antimicrobial effector at the primary site of pathogen encounter (mallo2002inducibleantibacterialdefense pages 3-4, alper2007specificityandcomplexity pages 3-4). Using <em>lys-1::GFP</em> reporter constructs, expression has been detected at multiple positions along the intestine, including mid-body, anterior-to-mid-body, and posterior regions (alper2007specificityandcomplexity pages 3-4). In addition to intestinal expression, <em>lys-1::GFP</em> is also expressed in specific neuronal populations, including the six IL1 and six IL2 neurons, a few additional neurons in the head ganglia, and two posterior phasmid chemosensory neurons (mallo2002inducibleantibacterialdefense pages 3-4, alper2007specificityandcomplexity pages 3-4, mallo2002inducibleantibacterialdefense pages 2-3). The functional significance of neuronal expression remains unclear.</p>
+<p>At the subcellular level, LYS-1::GFP localizes to vesicles within intestinal cells. These vesicles are distinct from secondary lysosomes and show a high concentration at the apical surface of intestinal cells, suggesting trafficking toward the intestinal lumen (mallo2002inducibleantibacterialdefense pages 3-4, schulenburg2004evolutionofthe pages 7-8). This localization pattern is reminiscent of the granular exocytosis mechanisms described in <em>E. histolytica</em> and secretory lysosomes in cytotoxic T lymphocytes (schulenburg2004evolutionofthe pages 7-8). The apical/luminal secretion is consistent with LYS-1 acting directly on bacteria present in the intestinal lumen, the primary site where <em>S. marcescens</em> and other pathogens colonize (mallo2002inducibleantibacterialdefense pages 3-4).</p>
+<h3 id="4-signaling-pathways-regulating-lys-1-expression">4. Signaling Pathways Regulating lys-1 Expression</h3>
+<p>The expression of <em>lys-1</em> is regulated by multiple conserved innate immune signaling pathways:</p>
+<p><strong>TIR-1/NSY-1 (SARM-MAPKKK) pathway:</strong> RNAi-mediated knockdown of either <em>nsy-1</em> (a MAPKKK) or <em>tir-1</em> (a TIR domain adaptor protein upstream of NSY-1) leads to strong reduction of <em>lys-1</em> expression, demonstrating that this pathway is a major positive regulator of constitutive <em>lys-1</em> transcription (alper2007specificityandcomplexity pages 5-7, alper2007specificityandcomplexity pages 4-5). The effects of <em>tir-1</em> and <em>nsy-1</em> knockdown on <em>lys-1</em> are nearly identical, consistent with their action in the same signaling cascade.</p>
+<p><strong>PMK-1/p38 MAPK pathway:</strong> Several studies have confirmed that <em>lys-1</em> is a PMK-1-dependent immune gene. In studies of probiotic-mediated immune stimulation, upregulation of <em>lys-1</em> by heat-inactivated <em>Lactobacillus curvatus</em> was abolished in <em>pmk-1</em> mutants, demonstrating PMK-1 dependence (dinic2021probioticmediatedp38mapk pages 4-5). Additionally, the bZIP transcription factor ZIP-11, which acts in a feedback loop with the PMK-1/p38 pathway, was shown to regulate <em>lys-1</em> among other PMK-1-dependent immune genes (zheng2021thebziptranscription pages 6-8).</p>
+<p><strong>TGF-β/DBL-1 pathway and PMK-1 dual regulation:</strong> One study explicitly noted that "the lysozyme-like protein Lys-1 is regulated by both TGF-β and PMK-1 signaling pathways" (liu2013componentsofthe pages 4-5, liu2013componentsofthe pages 2-2).</p>
+<p><strong>DAF-2/DAF-16 insulin-like signaling pathway:</strong> <em>lys-1</em> has been identified as a putative target of the DAF-16/FOXO transcription factor. In a genetic screen for DAF-16 target genes, RNAi knockdown of <em>lys-1</em> resulted in a synthetic dauer-constitutive (SynDaf) phenotype in a sensitized background, linking <em>lys-1</em> to the insulin-like signaling network that regulates both immunity and dauer formation (jensen2010rnaiscreenof pages 2-3, jensen2010rnaiscreenof pages 4-5).</p>
+<h3 id="5-pathogen-specific-induction">5. Pathogen-Specific Induction</h3>
+<p>The transcriptional induction of <em>lys-1</em> exhibits pathogen specificity. In the original study by Mallo et al. (2002), <em>lys-1</em> was identified as one of the most robustly induced genes following infection with the Gram-negative bacterium <em>Serratia marcescens</em>, confirmed by both microarray and Northern blot analyses at 24 and 48 hours post-infection (mallo2002inducibleantibacterialdefense pages 2-3, mallo2002inducibleantibacterialdefense pages 1-2). Subsequent work by Alper et al. (2007) found that <em>lys-1</em> was induced by <em>Pseudomonas aeruginosa</em> but not by <em>S. marcescens</em> in their experimental conditions, highlighting that quantitative differences in induction can depend on experimental context, timing, and bacterial strain (alper2007specificityandcomplexity pages 5-7). More recent studies have confirmed <em>lys-1</em> upregulation in the context of <em>Staphylococcus aureus</em> infection (jensen2010rnaiscreenof pages 2-3) and various other pathogenic and probiotic bacterial challenges (dinic2021probioticmediatedp38mapk pages 4-5).</p>
+<h3 id="6-functional-evidence-from-genetic-experiments">6. Functional Evidence from Genetic Experiments</h3>
+<p><strong>Overexpression:</strong> Transgenic <em>C. elegans</em> overexpressing the <em>lys-1::GFP</em> fusion construct showed significantly increased survival when challenged with the protease-deficient <em>S. marcescens</em> strain Db1140, providing direct evidence that LYS-1 contributes to antibacterial defense (mallo2002inducibleantibacterialdefense pages 1-2, mallo2002inducibleantibacterialdefense pages 3-4). Importantly, overexpression did not confer protection against the more virulent wild-type Db11 strain, likely because bacterial proteases produced by virulent <em>S. marcescens</em> can counteract LYS-1's protective effects (mallo2002inducibleantibacterialdefense pages 3-4, schulenburg2004evolutionofthe pages 6-7). Overexpression of <em>lys-1</em> has also been noted to augment resistance to <em>S. marcescens</em> in other reports (mallo2002inducibleantibacterialdefense pages 1-2).</p>
+<p><strong>Knockdown:</strong> RNAi knockdown of <em>lys-1</em> in wild-type worms had little effect on survival against <em>S. marcescens</em>, suggesting that multiple redundant defense factors contribute to antibacterial immunity in <em>C. elegans</em> (mallo2002inducibleantibacterialdefense pages 3-4, schulenburg2004evolutionofthe pages 6-7). However, in a sensitized RNAi-hypersensitive background (<em>rrf-3</em>), <em>lys-1</em> RNAi significantly reduced survival upon <em>S. aureus</em> challenge, indicating that LYS-1 does contribute to pathogen resistance when other defense mechanisms are limiting (jensen2010rnaiscreenof pages 2-3, jensen2010rnaiscreenof pages 4-5).</p>
+<h3 id="7-broader-biological-context-innate-immunity-and-dauer-formation">7. Broader Biological Context: Innate Immunity and Dauer Formation</h3>
+<p>An intriguing link has been established between <em>lys-1</em>-mediated innate immunity and the developmental decision to enter the dauer larval stage. Jensen et al. (2010) showed that <em>lys-1</em> knockdown causes a synthetic dauer-constitutive phenotype when combined with the <em>sdf-9</em> mutation, suggesting that infection-induced stress or compromised immunity can feed back into the dauer signaling circuit (jensen2010rnaiscreenof pages 2-3, jensen2010rnaiscreenof pages 4-5). This is consistent with the broader model that pathogen exposure increases dauer pheromone production and promotes dauer entry as a behavioral response to pathogenic environments (jensen2010rnaiscreenof pages 3-4).</p>
+<h3 id="8-summary">8. Summary</h3>
+<p>The following table summarizes the key properties of LYS-1:</p>
+<table>
+<thead>
+<tr>
+<th>Property</th>
+<th>Summary</th>
+<th>Evidence</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Gene name</td>
+<td><strong>lys-1</strong>; encodes lysozyme-like protein 1 in <em>Caenorhabditis elegans</em></td>
+<td>(mallo2002inducibleantibacterialdefense pages 2-3, alper2007specificityandcomplexity pages 1-2)</td>
+</tr>
+<tr>
+<td>ORF</td>
+<td><strong>Y22F5A.4</strong></td>
+<td>(mallo2002inducibleantibacterialdefense pages 2-3)</td>
+</tr>
+<tr>
+<td>UniProt ID</td>
+<td><strong>O62415</strong></td>
+<td>(mallo2002inducibleantibacterialdefense pages 2-3)</td>
+</tr>
+<tr>
+<td>Protein family</td>
+<td>Protist-type lysozyme; glycosyl hydrolase family 25 (<strong>GH25</strong>), one of 10 <em>C. elegans</em> protist-type lysozymes (lys-1 to lys-10)</td>
+<td>(simonsen2012strengthinnumbers pages 4-5, schulenburg2004evolutionofthe pages 7-8, mallo2002inducibleantibacterialdefense pages 2-3)</td>
+</tr>
+<tr>
+<td>Enzymatic activity</td>
+<td>Predicted <strong>muramidase/lysozyme</strong> that hydrolyzes bacterial peptidoglycan; direct biochemical activity has not been shown for LYS-1 itself, but inferred from GH25 family membership</td>
+<td>(simonsen2012strengthinnumbers pages 4-5, moroz2021fungalgh25muramidases pages 1-2, moroz2021fungalgh25muramidases pages 13-16)</td>
+</tr>
+<tr>
+<td>Substrate</td>
+<td>Bacterial <strong>peptidoglycan</strong>, specifically the β-1,4 glycosidic bond between <strong>MurNAc/NAM</strong> and <strong>GlcNAc/NAG</strong> in the glycan backbone</td>
+<td>(vollmer2008bacterialpeptidoglycan(murein) pages 6-7, moroz2021fungalgh25muramidases pages 1-2)</td>
+</tr>
+<tr>
+<td>Catalytic mechanism</td>
+<td>Inferred GH25 mechanism: substrate-assisted catalysis with an <strong>Asp</strong> acting as general acid; the substrate N-acetyl group contributes to catalysis</td>
+<td>(moroz2021fungalgh25muramidases pages 13-16)</td>
+</tr>
+<tr>
+<td>Tissue expression</td>
+<td>Strongly expressed in <strong>intestinal cells</strong>; also reported in <strong>IL1/IL2 neurons</strong>, head ganglia neurons, and posterior <strong>phasmid chemosensory neurons</strong> in reporter analyses</td>
+<td>(mallo2002inducibleantibacterialdefense pages 2-3, mallo2002inducibleantibacterialdefense pages 3-4, alper2007specificityandcomplexity pages 3-4)</td>
+</tr>
+<tr>
+<td>Subcellular localization</td>
+<td><strong>Vesicular</strong> localization in intestinal cells, with vesicles concentrated near the <strong>apical surface</strong>; distinct from secondary lysosomes and suggestive of trafficking toward the <strong>intestinal lumen</strong></td>
+<td>(schulenburg2004evolutionofthe pages 7-8, mallo2002inducibleantibacterialdefense pages 3-4)</td>
+</tr>
+<tr>
+<td>Likely site of action</td>
+<td>Likely acts in or toward the <strong>intestinal lumen</strong>, consistent with defense against ingested bacteria and luminal pathogens</td>
+<td>(schulenburg2004evolutionofthe pages 7-8, mallo2002inducibleantibacterialdefense pages 3-4)</td>
+</tr>
+<tr>
+<td>Signaling pathways regulating expression</td>
+<td>Expression requires <strong>TIR-1/NSY-1</strong> innate immune signaling; lys-1 is also reported to be regulated by <strong>PMK-1/p38 MAPK</strong> and <strong>TGF-β/DBL-1</strong> pathways; lys-1 is additionally described as a <strong>DAF-16/FOXO target</strong> in the insulin-like signaling network</td>
+<td>(alper2007specificityandcomplexity pages 5-7, alper2007specificityandcomplexity pages 4-5, liu2013componentsofthe pages 4-5, jensen2010rnaiscreenof pages 2-3, dinic2021probioticmediatedp38mapk pages 4-5)</td>
+</tr>
+<tr>
+<td>Pathogen induction</td>
+<td>Reported as induced during infection by <strong>Serratia marcescens</strong> and <strong>Pseudomonas aeruginosa</strong>; one study found induction by <strong>P. aeruginosa but not S. marcescens</strong>, indicating pathogen- and condition-specific regulation across assays</td>
+<td>(mallo2002inducibleantibacterialdefense pages 2-3, mallo2002inducibleantibacterialdefense pages 1-2, alper2007specificityandcomplexity pages 5-7)</td>
+</tr>
+<tr>
+<td>Functional evidence: overexpression</td>
+<td>Transgenic overexpression/lys-1::GFP animals showed <strong>increased resistance</strong> to the less virulent <em>S. marcescens</em> strain <strong>Db1140</strong>, but not to the more virulent strain <strong>Db11</strong></td>
+<td>(mallo2002inducibleantibacterialdefense pages 1-2, mallo2002inducibleantibacterialdefense pages 3-4)</td>
+</tr>
+<tr>
+<td>Functional evidence: knockdown</td>
+<td><strong>lys-1 RNAi</strong> abolished reporter expression but had little effect on survival against <em>S. marcescens</em> Db1140, suggesting redundancy; in a separate study, <strong>lys-1 RNAi increased sensitivity to Staphylococcus aureus</strong> and promoted dauer-related phenotypes in a sensitized background</td>
+<td>(schulenburg2004evolutionofthe pages 6-7, jensen2010rnaiscreenof pages 2-3, jensen2010rnaiscreenof pages 4-5, mallo2002inducibleantibacterialdefense pages 3-4)</td>
+</tr>
+<tr>
+<td>Biological role</td>
+<td>Antibacterial <strong>innate immune effector</strong> positioned at host-environment interfaces, especially the intestine; likely contributes to bacterial cell-wall degradation and host defense in combination with other effectors</td>
+<td>(schulenburg2004evolutionofthe pages 7-8, alper2007specificityandcomplexity pages 1-2, simonsen2012strengthinnumbers pages 4-5)</td>
+</tr>
+<tr>
+<td>Evolutionary relationships</td>
+<td>LYS-1 is evolutionarily closer to <strong>protist/Entamoeba histolytica</strong> lysozymes than to classical vertebrate chicken-type or insect lysozymes; this supports an ancient <strong>protist-type</strong> lysozyme lineage in nematodes</td>
+<td>(mallo2002inducibleantibacterialdefense pages 2-3, schulenburg2004evolutionofthe pages 7-8)</td>
+</tr>
+</tbody>
+</table>
+<p><em>Table: This table summarizes the main annotated and experimentally supported properties of C. elegans LYS-1, including molecular identity, inferred enzymatic activity, localization, regulation, pathogen responsiveness, and functional evidence. It is useful as a compact evidence map for gene functional annotation.</em></p>
+<p>In summary, <em>C. elegans</em> LYS-1 is a protist-type lysozyme of the glycosyl hydrolase family 25 that functions as an antimicrobial effector in the nematode's innate immune system. Based on its GH25 family membership, LYS-1 is predicted to catalyze the hydrolysis of the β-1,4-glycosidic bond between MurNAc and GlcNAc in bacterial peptidoglycan, using a substrate-assisted catalytic mechanism (moroz2021fungalgh25muramidases pages 1-2, moroz2021fungalgh25muramidases pages 13-16). The protein is expressed constitutively in intestinal cells, where it localizes to vesicles that traffic toward the apical surface for likely secretion into the intestinal lumen—the primary site of bacterial encounter (mallo2002inducibleantibacterialdefense pages 3-4, schulenburg2004evolutionofthe pages 7-8). Its expression is transcriptionally regulated by the TIR-1/NSY-1 SARM-MAPKKK pathway and the PMK-1/p38 MAPK cascade, as well as by the TGF-β/DBL-1 and DAF-2/DAF-16 insulin-like signaling pathways (alper2007specificityandcomplexity pages 5-7, alper2007specificityandcomplexity pages 4-5, liu2013componentsofthe pages 4-5, jensen2010rnaiscreenof pages 2-3, dinic2021probioticmediatedp38mapk pages 4-5). Functionally, overexpression of LYS-1 enhances resistance to bacterial pathogens, while its knockdown increases susceptibility, particularly to <em>Staphylococcus aureus</em> (mallo2002inducibleantibacterialdefense pages 1-2, jensen2010rnaiscreenof pages 2-3, mallo2002inducibleantibacterialdefense pages 3-4). The redundancy of the lysozyme family in <em>C. elegans</em>, with at least 16 lysozyme genes across two distinct families, likely reflects the central importance of peptidoglycan degradation in the nematode's bacterivorous lifestyle and innate immune defense (simonsen2012strengthinnumbers pages 4-5, schulenburg2004evolutionofthe pages 7-8).</p>
+<p>References</p>
+<ol>
+<li>
+<p>(simonsen2012strengthinnumbers pages 4-5): Karina T. Simonsen, Sandra F. Gallego, Nils J. Færgeman, and Birgitte H. Kallipolitis. Strength in numbers. Virulence, 3:477-484, Oct 2012. URL: https://doi.org/10.4161/viru.21906, doi:10.4161/viru.21906. This article has 36 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(schulenburg2004evolutionofthe pages 7-8): Hinrich Schulenburg, C. Léopold Kurz, and Jonathan J. Ewbank. Evolution of the innate immune system: the worm perspective. Immunological Reviews, 198:36-58, Apr 2004. URL: https://doi.org/10.1111/j.0105-2896.2004.0125.x, doi:10.1111/j.0105-2896.2004.0125.x. This article has 317 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(mallo2002inducibleantibacterialdefense pages 2-3): Gustavo V. Mallo, C.Léopold Kurz, Carole Couillault, Nathalie Pujol, Samuel Granjeaud, Yuji Kohara, and Jonathan J. Ewbank. Inducible antibacterial defense system in c. elegans. Current Biology, 12:1209-1214, Jul 2002. URL: https://doi.org/10.1016/s0960-9822(02)00928-4, doi:10.1016/s0960-9822(02)00928-4. This article has 614 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(moroz2021fungalgh25muramidases pages 1-2): Olga V. Moroz, Elena Blagova, Edward Taylor, Johan P. Turkenburg, Lars K. Skov, Garry P. Gippert, Kirk M. Schnorr, Li Ming, Liu Ye, Mikkel Klausen, Marianne T. Cohn, Esben G. W. Schmidt, Søren Nymand-Grarup, Gideon J. Davies, and Keith S. Wilson. Fungal gh25 muramidases: new family members with applications in animal nutrition and a crystal structure at 0.78å resolution. PLOS ONE, 16:e0248190, Mar 2021. URL: https://doi.org/10.1371/journal.pone.0248190, doi:10.1371/journal.pone.0248190. This article has 12 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(moroz2021fungalgh25muramidases pages 13-16): Olga V. Moroz, Elena Blagova, Edward Taylor, Johan P. Turkenburg, Lars K. Skov, Garry P. Gippert, Kirk M. Schnorr, Li Ming, Liu Ye, Mikkel Klausen, Marianne T. Cohn, Esben G. W. Schmidt, Søren Nymand-Grarup, Gideon J. Davies, and Keith S. Wilson. Fungal gh25 muramidases: new family members with applications in animal nutrition and a crystal structure at 0.78å resolution. PLOS ONE, 16:e0248190, Mar 2021. URL: https://doi.org/10.1371/journal.pone.0248190, doi:10.1371/journal.pone.0248190. This article has 12 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(mallo2002inducibleantibacterialdefense pages 3-4): Gustavo V. Mallo, C.Léopold Kurz, Carole Couillault, Nathalie Pujol, Samuel Granjeaud, Yuji Kohara, and Jonathan J. Ewbank. Inducible antibacterial defense system in c. elegans. Current Biology, 12:1209-1214, Jul 2002. URL: https://doi.org/10.1016/s0960-9822(02)00928-4, doi:10.1016/s0960-9822(02)00928-4. This article has 614 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(alper2007specificityandcomplexity pages 3-4): Scott Alper, Sandra J. McBride, Brad Lackford, Jonathan H. Freedman, and David A. Schwartz. Specificity and complexity of the <i>caenorhabditis elegans</i> innate immune response. Aug 2007. URL: https://doi.org/10.1128/mcb.02070-06, doi:10.1128/mcb.02070-06. This article has 232 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(alper2007specificityandcomplexity pages 5-7): Scott Alper, Sandra J. McBride, Brad Lackford, Jonathan H. Freedman, and David A. Schwartz. Specificity and complexity of the <i>caenorhabditis elegans</i> innate immune response. Aug 2007. URL: https://doi.org/10.1128/mcb.02070-06, doi:10.1128/mcb.02070-06. This article has 232 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(alper2007specificityandcomplexity pages 4-5): Scott Alper, Sandra J. McBride, Brad Lackford, Jonathan H. Freedman, and David A. Schwartz. Specificity and complexity of the <i>caenorhabditis elegans</i> innate immune response. Aug 2007. URL: https://doi.org/10.1128/mcb.02070-06, doi:10.1128/mcb.02070-06. This article has 232 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(dinic2021probioticmediatedp38mapk pages 4-5): Miroslav Dinić, Stefan Jakovljević, Jelena Đokić, Nikola Popović, Dušan Radojević, Ivana Strahinić, and Nataša Golić. Probiotic-mediated p38 mapk immune signaling prolongs the survival of caenorhabditis elegans exposed to pathogenic bacteria. Scientific Reports, Oct 2021. URL: https://doi.org/10.1038/s41598-021-00698-5, doi:10.1038/s41598-021-00698-5. This article has 45 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(zheng2021thebziptranscription pages 6-8): Zhongfan Zheng, Yilixiati Aihemaiti, Junqiang Liu, Muhammad Irfan Afridi, Shengmei Yang, Xiumei Zhang, Yongfu Xu, Chunhong Chen, and Haijun Tu. The bzip transcription factor zip-11 is required for the innate immune regulation in caenorhabditis elegans. Frontiers in Immunology, Nov 2021. URL: https://doi.org/10.3389/fimmu.2021.744454, doi:10.3389/fimmu.2021.744454. This article has 8 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(liu2013componentsofthe pages 4-5): Jinghua Liu, Jeff Hafting, Alan T. Critchley, Arjun H. Banskota, and Balakrishnan Prithiviraj. Components of the cultivated red seaweed chondrus crispus enhance the immune response of caenorhabditis elegans to pseudomonas aeruginosa through the <i>pmk-1</i> , <i>daf-2/daf-16</i> , and <i>skn-1</i> pathways. Applied and Environmental Microbiology, 79:7343-7350, Dec 2013. URL: https://doi.org/10.1128/aem.01927-13, doi:10.1128/aem.01927-13. This article has 85 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(liu2013componentsofthe pages 2-2): Jinghua Liu, Jeff Hafting, Alan T. Critchley, Arjun H. Banskota, and Balakrishnan Prithiviraj. Components of the cultivated red seaweed chondrus crispus enhance the immune response of caenorhabditis elegans to pseudomonas aeruginosa through the <i>pmk-1</i> , <i>daf-2/daf-16</i> , and <i>skn-1</i> pathways. Applied and Environmental Microbiology, 79:7343-7350, Dec 2013. URL: https://doi.org/10.1128/aem.01927-13, doi:10.1128/aem.01927-13. This article has 85 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(jensen2010rnaiscreenof pages 2-3): Victor L. Jensen, Karina T. Simonsen, Yu-Hui Lee, Donha Park, and Donald L. Riddle. Rnai screen of daf-16/foxo target genes in c. elegans links pathogenesis and dauer formation. PLoS ONE, 5:e15902, Dec 2010. URL: https://doi.org/10.1371/journal.pone.0015902, doi:10.1371/journal.pone.0015902. This article has 37 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(jensen2010rnaiscreenof pages 4-5): Victor L. Jensen, Karina T. Simonsen, Yu-Hui Lee, Donha Park, and Donald L. Riddle. Rnai screen of daf-16/foxo target genes in c. elegans links pathogenesis and dauer formation. PLoS ONE, 5:e15902, Dec 2010. URL: https://doi.org/10.1371/journal.pone.0015902, doi:10.1371/journal.pone.0015902. This article has 37 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(mallo2002inducibleantibacterialdefense pages 1-2): Gustavo V. Mallo, C.Léopold Kurz, Carole Couillault, Nathalie Pujol, Samuel Granjeaud, Yuji Kohara, and Jonathan J. Ewbank. Inducible antibacterial defense system in c. elegans. Current Biology, 12:1209-1214, Jul 2002. URL: https://doi.org/10.1016/s0960-9822(02)00928-4, doi:10.1016/s0960-9822(02)00928-4. This article has 614 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(schulenburg2004evolutionofthe pages 6-7): Hinrich Schulenburg, C. Léopold Kurz, and Jonathan J. Ewbank. Evolution of the innate immune system: the worm perspective. Immunological Reviews, 198:36-58, Apr 2004. URL: https://doi.org/10.1111/j.0105-2896.2004.0125.x, doi:10.1111/j.0105-2896.2004.0125.x. This article has 317 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(jensen2010rnaiscreenof pages 3-4): Victor L. Jensen, Karina T. Simonsen, Yu-Hui Lee, Donha Park, and Donald L. Riddle. Rnai screen of daf-16/foxo target genes in c. elegans links pathogenesis and dauer formation. PLoS ONE, 5:e15902, Dec 2010. URL: https://doi.org/10.1371/journal.pone.0015902, doi:10.1371/journal.pone.0015902. This article has 37 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(alper2007specificityandcomplexity pages 1-2): Scott Alper, Sandra J. McBride, Brad Lackford, Jonathan H. Freedman, and David A. Schwartz. Specificity and complexity of the <i>caenorhabditis elegans</i> innate immune response. Aug 2007. URL: https://doi.org/10.1128/mcb.02070-06, doi:10.1128/mcb.02070-06. This article has 232 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(vollmer2008bacterialpeptidoglycan(murein) pages 6-7): Waldemar Vollmer, Bernard Joris, Paulette Charlier, and Simon Foster. Bacterial peptidoglycan (murein) hydrolases. FEMS microbiology reviews, 32 2:259-86, Mar 2008. URL: https://doi.org/10.1111/j.1574-6976.2007.00099.x, doi:10.1111/j.1574-6976.2007.00099.x. This article has 1226 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+</ol>
+<h2 id="artifacts">Artifacts</h2>
+<ul>
+<li><a href="lys-1-deep-research-falcon_artifacts/artifact-00.md">Edison artifact artifact-00</a></li>
+</ul>
+<h2 id="citations">Citations</h2>
+<ol>
+<li>simonsen2012strengthinnumbers pages 4-5</li>
+<li>mallo2002inducibleantibacterialdefense pages 2-3</li>
+<li>alper2007specificityandcomplexity pages 3-4</li>
+<li>schulenburg2004evolutionofthe pages 7-8</li>
+<li>mallo2002inducibleantibacterialdefense pages 3-4</li>
+<li>zheng2021thebziptranscription pages 6-8</li>
+<li>alper2007specificityandcomplexity pages 5-7</li>
+<li>jensen2010rnaiscreenof pages 2-3</li>
+<li>mallo2002inducibleantibacterialdefense pages 1-2</li>
+<li>jensen2010rnaiscreenof pages 3-4</li>
+<li>alper2007specificityandcomplexity pages 4-5</li>
+<li>liu2013componentsofthe pages 4-5</li>
+<li>liu2013componentsofthe pages 2-2</li>
+<li>jensen2010rnaiscreenof pages 4-5</li>
+<li>schulenburg2004evolutionofthe pages 6-7</li>
+<li>alper2007specificityandcomplexity pages 1-2</li>
+<li>https://doi.org/10.4161/viru.21906,</li>
+<li>https://doi.org/10.1111/j.0105-2896.2004.0125.x,</li>
+<li>https://doi.org/10.1016/s0960-9822(02</li>
+<li>https://doi.org/10.1371/journal.pone.0248190,</li>
+<li>https://doi.org/10.1128/mcb.02070-06,</li>
+<li>https://doi.org/10.1038/s41598-021-00698-5,</li>
+<li>https://doi.org/10.3389/fimmu.2021.744454,</li>
+<li>https://doi.org/10.1128/aem.01927-13,</li>
+<li>https://doi.org/10.1371/journal.pone.0015902,</li>
+<li>https://doi.org/10.1111/j.1574-6976.2007.00099.x,</li>
+</ol>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(lys-1-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="O62415" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="lys-1-caenorhabditis-elegans-research-notes">lys-1 (Caenorhabditis elegans) — research notes</h1>
+<p>UniProt: O62415 (LYS1_CAEEL) · WormBase: WBGene00003090 / Y22F5A.4 · Chromosome V<br />
+Gene product: Lysozyme-like protein 1 (LYS-1). Precursor with N-terminal signal peptide.</p>
+<h2 id="summary-of-what-is-known-vs-not-known">Summary of what is KNOWN vs NOT KNOWN</h2>
+<h3 id="known">KNOWN</h3>
+<ul>
+<li>lys-1 is a member of the C. elegans <strong>protist-type (Entamoeba-type)</strong> lysozyme family<br />
+  (<code>lys</code> genes), one of two lysozyme classes in the worm (the other being the<br />
+  invertebrate-type <code>ilys</code> genes). C. elegans has an unusually large, divergent lysozyme<br />
+  family: <a href="https://pubmed.ncbi.nlm.nih.gov/21931778" title="the nematode Caenorhabditis elegans harbours 15 phylogenetically   diverse lysozyme genes, belonging to two distinct types, the protist- or Entamoeba-type   (lys genes) and the invertebrate-type (ilys genes) lysozymes.">PMID:21931778</a>. lys-1 is one of the<br />
+  chromosome V protist-type lysozymes: <a href="https://pubmed.ncbi.nlm.nih.gov/21931778" title="Reddish/yellowish bar colours refer   to the lysozymes from chromosome V (lys-1, lys-2, lys-3, and lys-7)">PMID:21931778</a>.</li>
+<li>Structurally it belongs to the <strong>glycosyl hydrolase family 25 (GH25)</strong> (UniProt SIMILARITY:<br />
+  "Belongs to the glycosyl hydrolase 25 family."; InterPro Glyco_hydro_25 IPR002053; PROSITE<br />
+  Ch-type lysozyme domain PS51904; CDD cd06416 GH25_Lys1-like; PANTHER PTHR23208:SF41).</li>
+<li>lys-1 is an <strong>infection-inducible antibacterial effector</strong>. It is among the most strongly<br />
+  induced genes upon infection with the Gram-negative bacterium <em>Serratia marcescens</em>:<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/12176330" title="Among the most robustly induced are genes encoding lectins and lysozymes,   known to be involved in immune responses in other organisms.">PMID:12176330</a>. Overexpression is<br />
+  protective: <a href="https://pubmed.ncbi.nlm.nih.gov/12176330" title="overexpression of the lysozyme gene lys-1 augments the   resistance of C. elegans to S. marcescens.">PMID:12176330</a>.</li>
+<li>lys-1 is required for normal resistance to the Gram-positive bacterium <em>Staphylococcus<br />
+  aureus</em>. RNAi knockdown reduces survival on S. aureus:<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/21209831" title="we show that two of these genes, lys-1 and clc-1, are required for normal   resistance to Staphylococcus aureus.">PMID:21209831</a>; <a href="https://pubmed.ncbi.nlm.nih.gov/21209831" title="The TD50 (time required for 50% of   the nematodes to die) for lys-1 was 4.7 days (p&lt;0.0001) ... compared to 6.8 days for the   GFP RNAi control.">PMID:21209831</a>.</li>
+<li>lys-1 is a <strong>DAF-16/FOXO transcriptional target</strong> and behaves as a synthetic dauer-formation<br />
+  (SynDaf) gene, linking innate immunity to the insulin/IGF-1 signalling (dauer) axis:<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/21209831" title="Two of the latter genes, lys-1 and cpr-1, are known to participate in innate   immunity">PMID:21209831</a> (the whole screen was of DAF-16 targets; lys-1 gave a SynDaf phenotype, Table 1,<br />
+  19.1% dauer).</li>
+<li>lys-1 is induced by additional pathogens. It is transcriptionally upregulated by<br />
+<em>Bacillus thuringiensis</em> in all three tested C. elegans strains:<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/21931778" title="significant upregulation was found for lys-1 and lys-2 in all three C.   elegans strains">PMID:21931778</a>. It is also part of the intestinal ELT-2/GATA-regulated infection response<br />
+  program (HEP annotation, PMID:16968778 genome-wide study of intestinal innate immune genes).</li>
+<li>Expression / localization (from the UniProt curated summary of PMID:12176330 full text; the<br />
+  cached publication is abstract-only, so these come from the curator who read the full paper):<br />
+  expressed in intestine and in a subset of head neurons (IL2, IL6 and other head ganglia<br />
+  neurons); the protein localizes to vesicles in the apical region of intestinal cells<br />
+  (cytoplasmic vesicle / cytoplasmic vesicle lumen; apical part of cell).</li>
+<li>Direct genetic/overexpression evidence links lys-1 to defence against two pathogens:<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/21931778" title="four lysozyme genes were directly shown by overexpression and mutant or   RNAi-knock down analysis to contribute to the nematode's defence against pathogens: lys-1   against Serratia marcescens and Staphylococcus aureus">PMID:21931778</a>.</li>
+</ul>
+<h3 id="not-known-knowledge-gaps">NOT KNOWN (knowledge gaps)</h3>
+<ul>
+<li><strong>Whether LYS-1 actually has muramidase / lysozyme enzymatic (peptidoglycan-hydrolysing)<br />
+  activity is NOT demonstrated.</strong> All functional data are genetic (expression, RNAi,<br />
+  overexpression); the protein has never been purified or assayed biochemically:<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/21931778" title="All available data is based on genetic analysis, whereas none of the   lysozymes have been characterized at the protein level.">PMID:21931778</a>;<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/21931778" title="our study (and most previous studies) only indicates, but does not strictly   prove a defence function of these enzymes. Unequivocal evidence would require analysis of   the purified protein, especially its ability to interact with the pathogen at the molecular   level.">PMID:21931778</a>.<br />
+  Critically, UniProt flags a <strong>CAUTION</strong> on the sequence itself:<br />
+  "Lacks conserved active site residues, suggesting it has no catalytic activity."<br />
+  (UniProt O62415, CC CAUTION line, ECO:0000305). So the <code>lysozyme activity</code> and<br />
+<code>peptidoglycan catabolic process</code> / <code>cell wall macromolecule catabolic process</code> annotations<br />
+  are family-level IEA (InterPro) inferences that may not hold for this specific paralog.</li>
+<li>The <strong>molecular substrate / target microbe surface molecule</strong> of LYS-1 (if any) is unknown;<br />
+  no biochemical demonstration of peptidoglycan cleavage or bacteriolysis by LYS-1 exists.</li>
+<li>Whether lys-1 is <strong>individually necessary</strong> in vivo, or <strong>redundant</strong> within the 15-member<br />
+  lysozyme family, is not resolved. The evidence for a defence role is RNAi/overexpression, not<br />
+  a clean single-gene loss-of-function null; the large paralog family and overlapping infection<br />
+  induction profiles suggest possible redundancy <a href="https://pubmed.ncbi.nlm.nih.gov/21931778" title="the encountered genetic   diversity may reflect functional diversity">PMID:21931778</a>.</li>
+<li>Whether lys-1 has a <strong>digestive / nutritional (non-immune)</strong> role, as lysozymes do in some<br />
+  organisms <a href="https://pubmed.ncbi.nlm.nih.gov/21931778" title="They ... play important roles in both immunity and digestion">PMID:21931778</a>, is<br />
+  untested in C. elegans.</li>
+</ul>
+<h2 id="per-annotation-reasoning-goa">Per-annotation reasoning (GOA)</h2>
+<ol>
+<li>GO:0007165 signal transduction (IBA, GO_REF:0000033) — This IBA is propagated from a<br />
+   PANTHER subfamily (PTN000574946, seeded from <em>Dictyostelium</em>). Lysozymes are secreted<br />
+   antibacterial hydrolases / effectors, not signalling proteins; there is no evidence LYS-1<br />
+   transduces a signal. This is a spurious/over-broad phylogenetic propagation. → REMOVE.</li>
+<li>GO:0045087 innate immune response (IBA, GO_REF:0000033) — supported by whole picture and by<br />
+   the experimental IMP/HEP annotations below; but IBA here is redundant with the stronger<br />
+   experimental annotations. Keep as non-core (BP context). → KEEP_AS_NON_CORE.</li>
+<li>GO:0003796 lysozyme activity (IEA, InterPro IPR002053) — family/domain-based MF inference.<br />
+   NOT experimentally demonstrated for LYS-1, and UniProt CAUTION says it lacks conserved<br />
+   active-site residues. This is the central MF uncertainty. → UNDECIDED / MARK_AS_OVER_ANNOTATED<br />
+   (I will use UNDECIDED: cannot verify demonstrated activity, and cannot definitively rule out<br />
+   family activity without biochemistry; the CAUTION suggests possible pseudo-muramidase).</li>
+<li>GO:0006950 response to stress (IEA, ARBA GO_REF:0000117) — extremely generic; ARBA<br />
+   machine-learned. The specific defense-response terms below capture the biology far better.<br />
+   → MARK_AS_OVER_ANNOTATED (too generic to be informative).</li>
+<li>GO:0009253 peptidoglycan catabolic process (IEA, InterPro) — the BP counterpart of the<br />
+   unverified lysozyme MF; same caveat. → UNDECIDED.</li>
+<li>GO:0016998 cell wall macromolecule catabolic process (IEA, InterPro) — same family-inference<br />
+   caveat, and it is a more general parent of peptidoglycan catabolism. → UNDECIDED.</li>
+<li>GO:0060205 cytoplasmic vesicle lumen (IEA, UniProtKB-SubCell GO_REF:0000044) — SubCell<br />
+   propagation matching the curated location. Redundant with the EXP annotation; keep non-core.<br />
+   → KEEP_AS_NON_CORE.</li>
+<li>GO:0060205 cytoplasmic vesicle lumen (EXP, PMID:12176330) — curated location from the<br />
+   primary paper (apical intestinal vesicles). → ACCEPT (CC location).</li>
+<li>GO:0045087 innate immune response (HEP, PMID:16968778) — expression-based (ELT-2/GATA<br />
+   intestinal infection-response program). Consistent. → KEEP_AS_NON_CORE.</li>
+<li>GO:0045087 innate immune response (IMP, PMID:21209831) — RNAi reduces S. aureus survival;<br />
+    solid experimental BP. → ACCEPT.</li>
+<li>GO:0050830 defense response to Gram-positive bacterium (IMP, PMID:21209831) — S. aureus is<br />
+    Gram-positive; RNAi reduces survival on it. Directly supported and specific. → ACCEPT (core).</li>
+<li>GO:0031410 cytoplasmic vesicle (IDA, PMID:12176330) — curated location. → ACCEPT (CC).</li>
+<li>GO:0045177 apical part of cell (IDA, PMID:12176330) — apical intestinal localization.<br />
+    → ACCEPT (CC).</li>
+<li>GO:0050829 defense response to Gram-negative bacterium (IEP, PMID:12176330) — induced by<br />
+    S. marcescens (Gram-negative) and overexpression protects. IEP = expression-based; the<br />
+    overexpression protection strengthens it. → ACCEPT (core BP).</li>
+</ol>
+<h2 id="family-paralog-context-do-not-confuse-lys-1-with-paralogs">Family / paralog context (do not confuse lys-1 with paralogs)</h2>
+<ul>
+<li>lys-1, lys-2, lys-3, lys-7 are chromosome V protist-type lysozymes; lys-4/5/6/10 chr IV;<br />
+  lys-8 chr II [PMID:21931778 Figure 1 legend].</li>
+<li>Functionally characterized paralogs by genetics: lys-2 (P. aeruginosa, B. thuringiensis),<br />
+  lys-5 &amp; lys-7 (B. thuringiensis and others), ilys-3 (M. nematophilum) <a href="https://pubmed.ncbi.nlm.nih.gov/21931778">PMID:21931778</a>.<br />
+  These are DIFFERENT genes; lys-1's own direct evidence is S. marcescens + S. aureus.</li>
+</ul>
+<h2 id="provenance-notes">Provenance notes</h2>
+<ul>
+<li>PMID:12176330 (Mallo et al., Curr Biol 2002) — cached copy is ABSTRACT-ONLY<br />
+  (full_text_available: false). Localization/tissue-specificity claims (apical intestinal<br />
+  vesicles; IL2/IL6 neurons) are in the UniProt curated record from the full text, not in the<br />
+  cached abstract. Do not quote those as verbatim supporting_text from the cache.</li>
+<li>PMID:21209831 (Jensen et al., PLoS ONE 2010) — FULL TEXT cached. Strong source for S. aureus<br />
+  RNAi phenotype and DAF-16/dauer link.</li>
+<li>PMID:21931778 (Boehnisch et al., PLoS ONE 2011) — FULL TEXT cached. Best source for<br />
+  protist-type classification, B. thuringiensis induction of lys-1, and the explicit "no<br />
+  protein-level characterization" statements underpinning the knowledge gaps.</li>
+<li>PMID:16968778 (Shapira et al., PNAS 2006) — ABSTRACT-ONLY. ELT-2/GATA intestinal<br />
+  infection-response program; source of the HEP innate-immune-response annotation.</li>
+</ul>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: O62415
+gene_symbol: lys-1
+product_type: PROTEIN
+status: COMPLETE
+taxon:
+  id: NCBITaxon:6239
+  label: Caenorhabditis elegans
+description: &gt;-
+  LYS-1 is one of the protist-type (Entamoeba-type) lysozymes of Caenorhabditis
+  elegans, a nematode that carries an unusually large and divergent lysozyme
+  family (15 genes split into protist-type lys and invertebrate-type ilys
+  classes). Structurally it is a glycoside hydrolase family 25 (GH25) protein
+  with an N-terminal signal peptide. LYS-1 functions as an infection-inducible
+  antibacterial effector of the intestinal innate immune response: it is one of
+  the most strongly induced genes upon infection by the Gram-negative bacterium
+  Serratia marcescens, and its overexpression increases resistance to that
+  pathogen, while RNAi knockdown reduces survival on the Gram-positive bacterium
+  Staphylococcus aureus. It is also transcriptionally upregulated by Bacillus
+  thuringiensis and is part of the ELT-2/GATA-controlled intestinal
+  infection-response program, and it is a DAF-16/FOXO target that links the
+  immune response to the dauer developmental decision. The protein localizes to
+  vesicles in the apical region of intestinal cells and is expressed in the
+  intestine and a subset of head neurons. Although the GH25 fold implies
+  muramidase (peptidoglycan-hydrolysing) activity, this catalytic activity has
+  never been demonstrated for LYS-1 at the protein level, and the sequence lacks
+  the conserved active-site residues, so its actual enzymatic function is
+  uncertain.
+existing_annotations:
+  - term:
+      id: GO:0007165
+      label: signal transduction
+    evidence_type: IBA
+    original_reference_id: GO_REF:0000033
+    qualifier: involved_in
+    review:
+      summary: &gt;-
+        This IBA is a phylogenetic propagation from a PANTHER subfamily seeded
+        by non-lysozyme members (including a Dictyostelium protein). Lysozymes
+        are secreted antibacterial hydrolases/effectors, not signal-transducing
+        proteins, and there is no evidence that LYS-1 transduces any signal.
+      action: REMOVE
+      reason: &gt;-
+        Over-broad phylogenetic inference inconsistent with the biology of a
+        lysozyme-family antibacterial effector. No experimental or sequence
+        feature supports a signal transduction role for LYS-1; the specific,
+        experimentally supported role is antibacterial defense (captured by the
+        defense-response terms below).
+      propagation_review:
+        root_cause: PROPAGATION_BAD
+        failure_modes:
+          - FUNCTIONAL_DIVERGENCE
+          - GRANULARITY_MISMATCH
+        source_entities:
+          - source_id: PANTHER:PTN000574946
+            source_label: PTN000574946 (PANTHER ancestral node)
+            source_status: SOURCE_WEAK_OR_INFERRED
+            comment: &gt;-
+              Ancestral node whose GO:0007165 assignment was seeded from
+              dictyBase:DDB_G0273175 (a Dictyostelium protein). &#34;Signal
+              transduction&#34; is not a function of a GH25 lysozyme-family
+              antibacterial effector; the propagation transfers an unrelated,
+              overly generic process to LYS-1.
+  - term:
+      id: GO:0045087
+      label: innate immune response
+    evidence_type: IBA
+    original_reference_id: GO_REF:0000033
+    qualifier: involved_in
+    review:
+      summary: &gt;-
+        The innate-immune-response assignment is correct for LYS-1, but this IBA
+        is redundant with the stronger experimental IMP (PMID:21209831) and HEP
+        (PMID:16968778) annotations to the same term. Retained as valid biological
+        process context rather than as a distinct line of evidence.
+      action: KEEP_AS_NON_CORE
+      reason: &gt;-
+        Correct process but redundant with experimental annotations to the same
+        term; the more specific defense-response-to-Gram-positive/Gram-negative
+        terms carry the core biology.
+  - term:
+      id: GO:0003796
+      label: lysozyme activity
+    evidence_type: IEA
+    original_reference_id: GO_REF:0000002
+    qualifier: enables
+    review:
+      summary: &gt;-
+        This is a family/domain-based (InterPro IPR002053, GH25) inference of
+        muramidase activity. It has never been demonstrated for LYS-1: no C.
+        elegans lysozyme has been characterized at the protein level, and UniProt
+        flags a CAUTION that LYS-1 &#34;Lacks conserved active site residues,
+        suggesting it has no catalytic activity.&#34; The activity therefore cannot
+        be confirmed, and there is positive sequence evidence that it may be
+        absent.
+      action: UNDECIDED
+      reason: &gt;-
+        Cannot verify: no biochemical/enzymatic assay of purified LYS-1 exists,
+        and the UniProt active-site CAUTION suggests possible loss of catalytic
+        activity. Per guidelines this is an author-flagged unresolved MF, not a
+        confident REMOVE (family activity cannot be definitively excluded without
+        biochemistry). This is the central molecular-function knowledge gap for
+        this gene.
+      supported_by:
+        - reference_id: PMID:21931778
+          supporting_text: &gt;-
+            All available data is based on genetic analysis, whereas none of the
+            lysozymes have been characterized at the protein level.
+  - term:
+      id: GO:0006950
+      label: response to stress
+    evidence_type: IEA
+    original_reference_id: GO_REF:0000117
+    qualifier: involved_in
+    review:
+      summary: &gt;-
+        A very generic ARBA machine-learned assignment. The specific
+        infection/defense-response terms below describe LYS-1&#39;s biology far more
+        informatively; a bare response-to-stress term adds little.
+      action: MARK_AS_OVER_ANNOTATED
+      reason: &gt;-
+        Too general to be informative and subsumed by the specific defense
+        response / innate immune response annotations that are experimentally
+        supported.
+  - term:
+      id: GO:0009253
+      label: peptidoglycan catabolic process
+    evidence_type: IEA
+    original_reference_id: GO_REF:0000002
+    qualifier: involved_in
+    review:
+      summary: &gt;-
+        The biological-process counterpart of the unverified lysozyme activity
+        (InterPro/GH25 inference). Because peptidoglycan hydrolysis by LYS-1 has
+        not been demonstrated and the sequence may lack catalytic residues, this
+        process cannot be confirmed for this paralog.
+      action: UNDECIDED
+      reason: &gt;-
+        Depends on an unverified catalytic (muramidase) activity; no direct
+        evidence LYS-1 cleaves peptidoglycan. Tied to the lysozyme-activity
+        knowledge gap.
+      supported_by:
+        - reference_id: PMID:21931778
+          supporting_text: &gt;-
+            All available data is based on genetic analysis, whereas none of the
+            lysozymes have been characterized at the protein level.
+  - term:
+      id: GO:0016998
+      label: cell wall macromolecule catabolic process
+    evidence_type: IEA
+    original_reference_id: GO_REF:0000002
+    qualifier: involved_in
+    review:
+      summary: &gt;-
+        A more general parent of peptidoglycan catabolism, from the same
+        family-based InterPro inference; same caveat that the underlying
+        catalytic activity is undemonstrated for LYS-1.
+      action: UNDECIDED
+      reason: &gt;-
+        Same unverified-catalysis basis as the peptidoglycan/lysozyme-activity
+        annotations; cannot confirm cell-wall macromolecule catabolism for LYS-1.
+  - term:
+      id: GO:0060205
+      label: cytoplasmic vesicle lumen
+    evidence_type: IEA
+    original_reference_id: GO_REF:0000044
+    qualifier: located_in
+    review:
+      summary: &gt;-
+        UniProt Subcellular Location keyword propagation matching the curated
+        localization of LYS-1 to the lumen of apical intestinal vesicles.
+        Redundant with the EXP annotation from PMID:12176330.
+      action: KEEP_AS_NON_CORE
+      reason: &gt;-
+        Correct location but electronically propagated and redundant with the
+        experimental EXP/IDA vesicle annotations.
+  - term:
+      id: GO:0060205
+      label: cytoplasmic vesicle lumen
+    evidence_type: EXP
+    original_reference_id: PMID:12176330
+    qualifier: located_in
+    review:
+      summary: &gt;-
+        Experimentally curated localization of LYS-1 to the lumen of vesicles in
+        the apical region of intestinal cells, from the primary characterization
+        of the inducible antibacterial defense system.
+      action: ACCEPT
+      reason: &gt;-
+        Curator-assigned experimental localization consistent with a secreted
+        intestinal antibacterial effector stored in apical vesicles.
+  - term:
+      id: GO:0045087
+      label: innate immune response
+    evidence_type: HEP
+    original_reference_id: PMID:16968778
+    qualifier: involved_in
+    review:
+      summary: &gt;-
+        High-throughput expression evidence: lys-1 is part of the intestinal
+        ELT-2/GATA-regulated infection-response gene program identified in a
+        genome-wide study of epithelial innate immunity. Consistent with its
+        infection-inducible antibacterial role.
+      action: KEEP_AS_NON_CORE
+      reason: &gt;-
+        Expression-based support for involvement in the innate immune response;
+        corroborates the experimental IMP annotation but is itself expression-
+        level evidence.
+  - term:
+      id: GO:0045087
+      label: innate immune response
+    evidence_type: IMP
+    original_reference_id: PMID:21209831
+    qualifier: involved_in
+    review:
+      summary: &gt;-
+        RNAi knockdown of lys-1 significantly reduces C. elegans survival on the
+        pathogen Staphylococcus aureus (TD50 4.7 vs 6.8 days for control,
+        p&lt;0.0001), demonstrating that lys-1 is required for a normal innate
+        immune/pathogen-resistance response.
+      action: ACCEPT
+      reason: &gt;-
+        Direct loss-of-function (RNAi) phenotype establishing a functional role
+        in the innate immune response; core immune-defense biology of the gene.
+      supported_by:
+        - reference_id: PMID:21209831
+          supporting_text: &gt;-
+            Two genes, lys-1 and clc-1, were required for normal resistance to S.
+            aureus.
+  - term:
+      id: GO:0050830
+      label: defense response to Gram-positive bacterium
+    evidence_type: IMP
+    original_reference_id: PMID:21209831
+    qualifier: involved_in
+    review:
+      summary: &gt;-
+        Staphylococcus aureus is a Gram-positive bacterium, and lys-1 RNAi
+        reduces survival on it (TD50 4.7 vs 6.8 days, p&lt;0.0001), directly
+        supporting a role in defense against Gram-positive bacteria. This is the
+        most specific, experimentally supported process term for the gene.
+      action: ACCEPT
+      reason: &gt;-
+        Specific, experimentally demonstrated defense function against a
+        Gram-positive pathogen; a core biological process of LYS-1.
+      supported_by:
+        - reference_id: PMID:21209831
+          supporting_text: &gt;-
+            The TD50 (time required for 50% of the nematodes to die) for lys-1
+            was 4.7 days (p&lt;0.0001)
+  - term:
+      id: GO:0031410
+      label: cytoplasmic vesicle
+    evidence_type: IDA
+    original_reference_id: PMID:12176330
+    qualifier: located_in
+    review:
+      summary: &gt;-
+        Direct-assay localization of LYS-1 to cytoplasmic vesicles in intestinal
+        cells, from the primary characterization paper.
+      action: ACCEPT
+      reason: &gt;-
+        Experimentally observed subcellular localization consistent with storage
+        of the effector in intestinal vesicles.
+  - term:
+      id: GO:0045177
+      label: apical part of cell
+    evidence_type: IDA
+    original_reference_id: PMID:12176330
+    qualifier: located_in
+    review:
+      summary: &gt;-
+        LYS-1 localizes to the apical region of intestinal cells (apically
+        positioned vesicles), consistent with secretion toward the gut lumen
+        where ingested bacteria are encountered.
+      action: ACCEPT
+      reason: &gt;-
+        Experimentally supported apical localization appropriate for a
+        gut-luminal antibacterial effector.
+  - term:
+      id: GO:0050829
+      label: defense response to Gram-negative bacterium
+    evidence_type: IEP
+    original_reference_id: PMID:12176330
+    qualifier: involved_in
+    review:
+      summary: &gt;-
+        lys-1 is among the most robustly induced genes upon infection by the
+        Gram-negative bacterium Serratia marcescens, and its overexpression
+        augments resistance to that pathogen, supporting a role in defense
+        against Gram-negative bacteria. The evidence code is IEP (expression),
+        reinforced by the overexpression gain-of-resistance phenotype.
+      action: ACCEPT
+      reason: &gt;-
+        Infection-inducible expression plus overexpression-conferred resistance
+        establish a defense role against a Gram-negative pathogen; a core
+        biological process of LYS-1.
+      supported_by:
+        - reference_id: PMID:12176330
+          supporting_text: &gt;-
+            overexpression of the lysozyme gene lys-1 augments the resistance of
+            C. elegans to S. marcescens.
+core_functions:
+  - description: &gt;-
+      Infection-inducible antibacterial effector of the C. elegans intestinal
+      innate immune response, acting against both Gram-negative (S. marcescens)
+      and Gram-positive (S. aureus) bacteria. LYS-1 is stored in the lumen of
+      apical intestinal vesicles, positioned for release toward ingested
+      bacteria in the gut. It is a GH25 protist-type lysozyme; a muramidase
+      (peptidoglycan-hydrolysing) molecular function is implied by the fold but
+      has not been demonstrated and may be absent (no conserved active-site
+      residues), so no specific molecular_function is asserted here.
+    directly_involved_in:
+      - id: GO:0050829
+        label: defense response to Gram-negative bacterium
+      - id: GO:0050830
+        label: defense response to Gram-positive bacterium
+      - id: GO:0045087
+        label: innate immune response
+    locations:
+      - id: GO:0060205
+        label: cytoplasmic vesicle lumen
+      - id: GO:0045177
+        label: apical part of cell
+    supported_by:
+      - reference_id: PMID:12176330
+        supporting_text: &gt;-
+          overexpression of the lysozyme gene lys-1 augments the resistance of
+          C. elegans to S. marcescens.
+      - reference_id: PMID:21209831
+        supporting_text: &gt;-
+          Two genes, lys-1 and clc-1, were required for normal resistance to S.
+          aureus.
+knowledge_gaps:
+  - gap_statement: &gt;-
+      It is not known whether LYS-1 has any muramidase / lysozyme
+      (peptidoglycan-hydrolysing) enzymatic activity. All functional evidence is
+      genetic (infection-inducible expression, RNAi, overexpression); the protein
+      has never been purified or assayed, and its sequence lacks the conserved
+      GH25 active-site residues, raising the possibility that it is a
+      pseudo-muramidase.
+    boundary: &gt;-
+      What is firmly established is that LYS-1 is a GH25 protist-type lysozyme
+      whose gene is infection-inducible and functionally required for normal
+      antibacterial defense (S. marcescens, S. aureus). What is unknown is the
+      biochemical activity of the protein: whether it cleaves peptidoglycan,
+      permeabilizes/agglutinates bacteria by another mechanism, or acts
+      non-catalytically.
+    gap_kind:
+      - BIOLOGY
+    dark_aspect: MF_DARK
+    status: OPEN
+    significance: &gt;-
+      Whether LYS-1 kills bacteria enzymatically (like canonical lysozymes) or by
+      a non-catalytic mechanism determines the correct molecular-function
+      annotation and whether the current InterPro-based lysozyme-activity /
+      peptidoglycan-catabolism annotations should stand. This is a recurring issue
+      across the expanded, divergent C. elegans lysozyme family.
+    resolution: &gt;-
+      Express and purify recombinant LYS-1 and assay muramidase / bacteriolytic
+      activity (e.g. on Micrococcus cell walls and defined peptidoglycan) and its
+      ability to bind/permeabilize target bacteria; complement with active-site
+      residue mutagenesis and structural analysis.
+    provenance:
+      - reference_id: PMID:21931778
+        supporting_text: &gt;-
+          All available data is based on genetic analysis, whereas none of the
+          lysozymes have been characterized at the protein level.
+      - reference_id: PMID:21931778
+        supporting_text: &gt;-
+          our study (and most previous studies) only indicates, but does not
+          strictly prove a defence function of these enzymes. Unequivocal
+          evidence would require analysis of the purified protein, especially its
+          ability to interact with the pathogen at the molecular level.
+  - gap_statement: &gt;-
+      The molecular substrate or microbial target of LYS-1 is undefined: it is
+      unknown which bacterial surface molecule(s) LYS-1 acts on, and whether its
+      antibacterial spectrum extends beyond S. marcescens, S. aureus and B.
+      thuringiensis.
+    boundary: &gt;-
+      LYS-1 is known to be required for resistance to S. aureus and to protect
+      against S. marcescens when overexpressed, and it is transcriptionally
+      induced by these plus B. thuringiensis. What is unknown is the direct
+      biochemical target/substrate and the full microbial spectrum.
+    gap_kind:
+      - BIOLOGY
+    dark_aspect: MF_DARK
+    status: OPEN
+    significance: &gt;-
+      Identifying the target molecule would clarify the mechanism (enzymatic
+      versus binding/permeabilizing) and the range of pathogens LYS-1 counters,
+      informing both its MF annotation and its place in the surveillance-immunity
+      effector repertoire.
+    resolution: &gt;-
+      Biochemical target/substrate identification with purified protein
+      (peptidoglycan/cell-wall degradation assays, pull-downs of bacterial
+      ligands) and broader pathogen-panel survival/CFU assays with defined lys-1
+      loss- and gain-of-function strains.
+    provenance:
+      - reference_id: PMID:21931778
+        supporting_text: &gt;-
+          Unequivocal evidence would require analysis of the purified protein,
+          especially its ability to interact with the pathogen at the molecular
+          level.
+  - gap_statement: &gt;-
+      Whether lys-1 is individually necessary in vivo or is functionally
+      redundant within the 15-member C. elegans lysozyme family is unresolved.
+      The defense phenotypes rest on RNAi knockdown and overexpression rather
+      than a characterized single-gene null, and many lysozyme paralogs share
+      overlapping infection-induction profiles.
+    boundary: &gt;-
+      lys-1 RNAi reduces S. aureus survival and lys-1 overexpression increases S.
+      marcescens resistance, establishing a contribution to defense. What is
+      unknown is the phenotype of a clean lys-1 loss-of-function null and the
+      degree of redundancy with paralogs such as lys-2, lys-3 and lys-7.
+    gap_kind:
+      - BIOLOGY
+    dark_aspect: BP_DARK
+    status: OPEN
+    significance: &gt;-
+      Redundancy determines whether lys-1 is a non-redundant defense gene or one
+      of several partially interchangeable effectors, which affects how strongly
+      its individual loss impacts host survival and how its biological role should
+      be weighted.
+    resolution: &gt;-
+      Generate and phenotype a lys-1 null allele (and higher-order lysozyme
+      combinatorial mutants) across a pathogen panel, quantifying survival and
+      pathogen load relative to wild type and to single-paralog mutants.
+    provenance:
+      - reference_id: PMID:21931778
+        supporting_text: &gt;-
+          the nematode Caenorhabditis elegans harbours 15 phylogenetically
+          diverse lysozyme genes
+      - reference_id: file:worm/lys-1/lys-1-notes.md
+        supporting_text: &gt;-
+          Whether lys-1 is individually necessary in vivo, or redundant within
+          the 15-member lysozyme family, is not resolved.
+suggested_questions:
+  - question: &gt;-
+      Does purified LYS-1 protein possess muramidase/bacteriolytic activity, or
+      has this GH25 protist-type lysozyme lost catalytic function and act by a
+      non-enzymatic antibacterial mechanism?
+    experts:
+      - Schulenburg H
+  - question: &gt;-
+      What is the phenotype of a lys-1 loss-of-function null, and to what extent
+      is lys-1 redundant with other protist-type lysozymes in defense against
+      ingested pathogens?
+    experts:
+      - Schulenburg H
+      - Ewbank JJ
+suggested_experiments:
+  - hypothesis: &gt;-
+      LYS-1 either hydrolyzes bacterial peptidoglycan (canonical lysozyme
+      mechanism) or, lacking active-site residues, kills/inhibits bacteria by a
+      non-catalytic binding/permeabilizing mechanism.
+    description: &gt;-
+      Express and purify recombinant LYS-1, then assay (i) muramidase activity on
+      Micrococcus luteus cell walls and defined peptidoglycan substrates, (ii)
+      bacteriolytic/growth-inhibitory activity against S. aureus and S.
+      marcescens, and (iii) direct binding to bacterial cell-surface components;
+      pair with active-site mutagenesis and, if possible, structure
+      determination.
+    experiment_type: biochemistry / enzymology / structural biology
+  - hypothesis: &gt;-
+      lys-1 contributes non-redundantly to intestinal antibacterial defense in
+      vivo.
+    description: &gt;-
+      Generate a lys-1 null allele (CRISPR) and test survival and intestinal
+      pathogen load on a panel of Gram-negative and Gram-positive pathogens (S.
+      marcescens, S. aureus, B. thuringiensis, P. aeruginosa), comparing single
+      mutant, paralog combinations, and rescue/overexpression lines.
+    experiment_type: genetics / host-pathogen survival and CFU assays
+references:
+  - id: GO_REF:0000002
+    title: Gene Ontology annotation through association of InterPro records with GO terms
+    findings: []
+  - id: GO_REF:0000033
+    title: Annotation inferences using phylogenetic trees
+    findings: []
+  - id: GO_REF:0000044
+    title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary
+      mapping, accompanied by conservative changes to GO terms applied by UniProt
+    findings: []
+  - id: GO_REF:0000117
+    title: Electronic Gene Ontology annotations created by ARBA machine learning models
+    findings: []
+  - id: PMID:12176330
+    title: Inducible antibacterial defense system in C. elegans.
+    findings:
+      - statement: &gt;-
+          lys-1 is among the most robustly infection-induced genes and its
+          overexpression augments resistance to the Gram-negative bacterium
+          Serratia marcescens; the protein localizes to apical intestinal
+          vesicles.
+        reference_section_type: RESULTS
+    reference_review:
+      relevance: HIGH
+      correctness: VERIFIED
+      review_notes: &gt;-
+        Primary characterization of the inducible antibacterial defense system;
+        directly establishes lys-1 induction and overexpression-conferred
+        resistance to S. marcescens. Cached copy is abstract-only, so localization
+        details derive from the UniProt-curated full text; the overexpression
+        claim is a verbatim quote from the cached abstract.
+  - id: PMID:16968778
+    title: A conserved role for a GATA transcription factor in regulating epithelial innate
+      immune responses.
+    findings:
+      - statement: &gt;-
+          Genome-wide study establishing the intestinal ELT-2/GATA-regulated
+          epithelial infection-response gene program of which lys-1 is a member
+          (basis of the HEP innate-immune-response annotation).
+        reference_section_type: ABSTRACT
+    reference_review:
+      relevance: MEDIUM
+      correctness: VERIFIED
+      review_notes: &gt;-
+        Abstract-only cache. Establishes the ELT-2/GATA intestinal innate-immunity
+        program; supports lys-1&#39;s expression-based innate-immune-response
+        annotation as a program member rather than as a directly assayed gene here.
+  - id: PMID:21209831
+    title: RNAi screen of DAF-16/FOXO target genes in C. elegans links pathogenesis and dauer
+      formation.
+    findings:
+      - statement: &gt;-
+          lys-1 RNAi significantly reduces survival on Staphylococcus aureus
+          (TD50 4.7 vs 6.8 days, p&lt;0.0001), showing lys-1 is required for normal
+          resistance; lys-1 is a DAF-16/FOXO target with a synthetic
+          dauer-formation phenotype.
+        reference_section_type: RESULTS
+    reference_review:
+      relevance: HIGH
+      correctness: VERIFIED
+      review_notes: &gt;-
+        Full text cached and verified. Strong experimental support for the S.
+        aureus (Gram-positive) defense and innate-immune-response IMP annotations,
+        and for the DAF-16/dauer link.
+  - id: PMID:21931778
+    title: Protist-type lysozymes of the nematode Caenorhabditis elegans contribute to resistance
+      against pathogenic Bacillus thuringiensis.
+    findings:
+      - statement: &gt;-
+          Classifies lys-1 as a chromosome V protist-type lysozyme within the
+          15-gene C. elegans lysozyme family, shows lys-1 is transcriptionally
+          upregulated by B. thuringiensis in all tested strains, and states
+          explicitly that no C. elegans lysozyme has been characterized at the
+          protein level (basis of the muramidase-activity knowledge gap).
+        reference_section_type: RESULTS
+    reference_review:
+      relevance: HIGH
+      correctness: VERIFIED
+      review_notes: &gt;-
+        Full text cached and verified. Key source for the protist-type
+        classification, B. thuringiensis induction of lys-1, and the field&#39;s
+        explicit admission that lysozyme enzymatic function is undemonstrated at
+        the protein level.
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/genes/worm/mff-1/mff-1-ai-review.html
+++ b/genes/worm/mff-1/mff-1-ai-review.html
@@ -1,0 +1,2741 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>mff-1 - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        .propagation-review {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f8fafc;
+            border-left: 3px solid #64748b;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .propagation-title {
+            font-weight: 600;
+            color: #334155;
+            margin-bottom: 0.25rem;
+        }
+
+        .propagation-row {
+            margin-top: 0.25rem;
+        }
+
+        .propagation-source {
+            margin-top: 0.5rem;
+            padding-top: 0.5rem;
+            border-top: 1px solid #e5e7eb;
+        }
+
+        .propagation-source-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #1d4ed8;
+        }
+
+        .propagation-comment {
+            color: #4b5563;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>mff-1</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/Q19343" target="_blank" class="term-link">
+                        Q19343
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Caenorhabditis elegans</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-draft">
+                    DRAFT
+                </span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Aliases:</span>
+                <div class="aliases">
+
+                    <span class="badge">F11C1.2</span>
+
+                    <span class="badge">Mitochondrial fission factor</span>
+
+                </div>
+            </div>
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "mff-1";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="Q19343" data-a="DESCRIPTION: MFF-1 is one of two Caenorhabditis elegans ortholo..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>MFF-1 is one of two Caenorhabditis elegans orthologs of mammalian mitochondrial fission factor (MFF), a tail-anchored mitochondrial outer membrane protein. It is a short (158 aa) protein with a cytosol-facing N-terminal domain and a single C-terminal transmembrane anchor, embedded in the mitochondrial outer membrane with part of the protein exposed to the cytosol. Together with its paralog MFF-2, MFF-1 is required for normal mitochondrial and peroxisomal fission; single mff-1 or mff-2 mutants have only weak defects, whereas the mff-1 mff-2 double mutant shows a strong mitochondrial fission defect approaching that of the fission dynamin drp-1, and tubular (unfission) peroxisomes. In this respect the worm Mff proteins differ markedly from the two worm Fis1 homologs (fis-1, fis-2), which have no obvious effect on fission. In mammals MFF is the principal receptor that recruits the dynamin-related GTPase DRP1/DNM1L to the mitochondrial surface; the worm proteins promote fission and contribute to stress-induced mitophagy, acting upstream of the Fis1-dependent step, but Mff is not strictly required for DRP-1 recruitment to worm mitochondria.</p>
+    </div>
+
+
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000266" target="_blank" class="term-link">
+                                    GO:0000266
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial fission</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000104
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q19343" data-a="GO:0000266" data-r="GO_REF:0000104" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Mitochondrial fission is the core biological process for MFF-1. This UniRule IEA annotation is transferred from the characterized mammalian MFF ortholog and is directly supported by C. elegans genetics. Single mff-1 (and mff-2) mutants have weak effects owing to redundancy, but the mff-1 mff-2 double mutant has a strong mitochondrial fission defect approaching that of drp-1.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Genuine, experimentally supported core function in worm. Unlike the worm Fis1 homologs (fis-1, fis-2), the Mff homologs have a real fission role. The IEA term is corroborated by direct mutant analysis (PMID:24196833).
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/24196833" target="_blank" class="term-link">
+                                        PMID:24196833
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">mff-1 and mff-2 single mutants have weak effects, and that the Mff double mutant has a mitochondrial fission defect similar to but not as strong as the drp-1 defect</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005741" target="_blank" class="term-link">
+                                    GO:0005741
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial outer membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000044
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q19343" data-a="GO:0005741" data-r="GO_REF:0000044" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> MFF-1 is a tail-anchored mitochondrial outer membrane protein (single C-terminal transmembrane helix, aa 139-156; cytosol-facing N-terminus). This SubCell IEA annotation is experimentally supported in worm, where anti-MFF-1 antibody serves as a mitochondrial outer membrane marker and MFF-1 is digested in protease-protection assays on intact mitochondria without detergent.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Core localization, experimentally confirmed in C. elegans (PMID:21248201) and consistent with the canonical MFF topology and UniProt SubCell annotation.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/21248201" target="_blank" class="term-link">
+                                        PMID:21248201
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">MOMA-1 is digested when no detergent is added, like MFF-1, while EAT-3 and F1β are protease protected</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005777" target="_blank" class="term-link">
+                                    GO:0005777
+                                </a>
+                            </span>
+                            <span class="term-label">peroxisome</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000120
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q19343" data-a="GO:0005777" data-r="GO_REF:0000120" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> MFF mediates peroxisomal as well as mitochondrial fission. In worm, the mff-1 mff-2 double mutant shows tubular (un-divided) peroxisomes, indicating a peroxisome fission defect, which supports a functional MFF role at peroxisomes. This IEA localization annotation is consistent with the peroxisome fission function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Supported by worm genetics (Mff double mutant to tubular peroxisomes, PMID:24196833) and by ortholog function, but peroxisome fission is a secondary role relative to the dominant mitochondrial fission function; retained as non-core.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/24196833" target="_blank" class="term-link">
+                                        PMID:24196833
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">We conclude that C. elegans Mff homologues affect mitochondrial and peroxisome fission, whereas Fis1 homologues have no obvious effects.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0090141" target="_blank" class="term-link">
+                                    GO:0090141
+                                </a>
+                            </span>
+                            <span class="term-label">positive regulation of mitochondrial fission</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000104
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q19343" data-a="GO:0090141" data-r="GO_REF:0000104" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> MFF-1 promotes mitochondrial fission; its loss reduces fission (double mutant fission defect) and its function acts upstream in the fission pathway. This UniRule IEA annotation captures the positive-regulatory nature of the MFF receptor/adaptor role in driving fission.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Consistent with the experimentally supported pro-fission role in worm (PMID:24196833). Appropriately specific positive-regulation term for a fission factor that promotes rather than executes membrane scission.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/24196833" target="_blank" class="term-link">
+                                        PMID:24196833
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">the Mff double mutant has a mitochondrial fission defect similar to but not as strong as the drp-1 defect</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0090314" target="_blank" class="term-link">
+                                    GO:0090314
+                                </a>
+                            </span>
+                            <span class="term-label">positive regulation of protein targeting to membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000104
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q19343" data-a="GO:0090314" data-r="GO_REF:0000104" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> This UniRule IEA term encodes the mammalian MFF function of recruiting the fission dynamin DRP1/DNM1L to the mitochondrial outer membrane. In C. elegans, however, Mff (mff-1/mff-2) is NOT strictly required for DRP-1 recruitment - CFP::DRP-1 still forms fission-marking spots and fractionates to mitochondria normally in Mff double and quadruple mutants, and worm lacks the MiD49/MiD51 receptors.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The annotation is inferred from mammalian orthology and is only partially supported in worm. Because DRP-1 reaches worm mitochondria without Mff, this recruitment function is not firmly established as a worm activity; retained as non-core with an explicit caveat rather than removed (the mammalian ortholog function and the pro-fission role make it plausible, and it is not contradicted as a contributory rather than essential recruitment role).
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/24196833" target="_blank" class="term-link">
+                                        PMID:24196833
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Mff and Fis1 are not essential for fission or for Drp1 recruitment to mitochondria in C. elegans</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:worm/mff-1/mff-1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">MFF-1 functions as a membrane-anchored receptor/adaptor protein that recruits the dynamin-related GTPase DRP-1 from the cytosol to the mitochondrial outer membrane, thereby promoting mitochondrial fission</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>MFF-1 is a tail-anchored mitochondrial outer membrane adaptor that, redundantly with its paralog MFF-2, promotes mitochondrial (and peroxisomal) fission - the mff-1 mff-2 double mutant has a strong fission defect approaching that of the fission dynamin drp-1.</h3>
+                <span class="vote-buttons" data-g="Q19343" data-a="FUNCTION: MFF-1 is a tail-anchored mitochondrial outer membr..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0060090" target="_blank" class="term-link">
+                            molecular adaptor activity
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000266" target="_blank" class="term-link">
+                                mitochondrial fission
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005741" target="_blank" class="term-link">
+                                mitochondrial outer membrane
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/24196833" target="_blank" class="term-link">
+                                PMID:24196833
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">mff-1 and mff-2 single mutants have weak effects, and that the Mff double mutant has a mitochondrial fission defect similar to but not as strong as the drp-1 defect</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/21248201" target="_blank" class="term-link">
+                                PMID:21248201
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">antibodies for EAT-3 (an inner membrane marker), MOMA-1, MFF-1 (an outer membrane marker), and F1β subunit of the ATP synthase complex</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
+                            GO_REF:0000044
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000104.md" target="_blank" class="term-link">
+                            GO_REF:0000104
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Electronic Gene Ontology annotations created by transferring manual GO annotations between related proteins based on shared sequence features</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000120.md" target="_blank" class="term-link">
+                            GO_REF:0000120
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Combined Automated Annotation using Multiple IEA Methods</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/24196833" target="_blank" class="term-link">
+                            PMID:24196833
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Mutations in Fis1 disrupt orderly disposal of defective mitochondria.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">C. elegans has two Mff homologues (mff-1, mff-2); the Mff double mutant has a mitochondrial fission defect approaching that of drp-1, whereas single mutants are weak (indicating functional redundancy between mff-1 and mff-2)</div>
+
+                        <div class="finding-text">"mff-1 and mff-2 single mutants have weak effects, and that the Mff double mutant has a mitochondrial fission defect similar to but not as strong as the drp-1 defect"</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Worm Mff homologues affect both mitochondrial and peroxisome fission, unlike the Fis1 homologues</div>
+
+                        <div class="finding-text">"We conclude that C. elegans Mff homologues affect mitochondrial and peroxisome fission, whereas Fis1 homologues have no obvious effects."</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <div class="finding-statement">In worm, Mff is not essential for DRP-1 recruitment to mitochondria (a divergence from the mammalian paradigm)</div>
+
+                        <div class="finding-text">"We conclude that Mff affects fission, but Mff and Fis1 are not essential for fission or for Drp1 recruitment to mitochondria in C. elegans."</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Loss of Mff reduces the number of mitophagosomes; Mff acts upstream of the Fis1-dependent step in the fission-mitophagy sequence</div>
+
+                        <div class="finding-text">"significantly reduced number of spots in Mff double and Fis1 Mff quadruple mutant strains"</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/21248201" target="_blank" class="term-link">
+                            PMID:21248201
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">A novel mitochondrial outer membrane protein, MOMA-1, that affects cristae morphology in Caenorhabditis elegans.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">mff-1 corresponds to ORF F11C1.2; C. elegans has two Mff homologues encoded by mff-1(F11C1.2) and mff-2(F55F8.6)</div>
+
+                        <div class="finding-text">"two Mff homologues, encoded by mff-1(F11C1.2) and mff-2(F55F8.6)"</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <div class="finding-statement">MFF-1 is a mitochondrial outer membrane protein, used as an outer membrane marker</div>
+
+                        <div class="finding-text">"antibodies for EAT-3 (an inner membrane marker), MOMA-1, MFF-1 (an outer membrane marker), and F1β subunit of the ATP synthase complex"</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <div class="finding-statement">In protease-protection of intact mitochondria, MFF-1 is digested without detergent, i.e. it is exposed to the cytosol / anchored in the outer membrane</div>
+
+                        <div class="finding-text">"MOMA-1 is digested when no detergent is added, like MFF-1, while EAT-3 and F1β are protease protected"</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        file:worm/mff-1/mff-1-deep-research-falcon.md
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Deep research report for C. elegans mff-1 (falcon/Edison)</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">By orthology to the well-characterized mammalian MFF, MFF-1 is a membrane-anchored receptor/adaptor that recruits DRP-1 to the mitochondrial outer membrane to promote fission; direct functional tests in worm are limited</div>
+
+                        <div class="finding-text">"MFF-1 functions as a membrane-anchored receptor/adaptor protein that recruits the dynamin-related GTPase DRP-1 from the cytosol to the mitochondrial outer membrane, thereby promoting mitochondrial fission"</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Questions for Experts</h2>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Does C. elegans MFF-1 physically bind DRP-1, and is it a functional DRP-1 receptor given that DRP-1 recruitment to mitochondria is Mff-independent in worm?</p>
+
+                    <p style="margin-top: 0.5rem;"><em>Suggested experts: Alexander M. van der Bliek</em></p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q19343" data-a="Q: Does C. elegans MFF-1 physically bind DRP-1, and i..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> What is the functional division of labor between mff-1 and mff-2 (and relative to fis-1/fis-2) in worm mitochondrial versus peroxisomal fission?</p>
+
+                    <p style="margin-top: 0.5rem;"><em>Suggested experts: Alexander M. van der Bliek</em></p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q19343" data-a="Q: What is the functional division of labor between m..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Experiments</h2>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Co-immunoprecipitation and in vitro binding assays between MFF-1 (cytosolic domain) and DRP-1, combined with structure-guided mutagenesis and rescue of the mff-1 mff-2 double mutant.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: MFF-1 promotes fission by recruiting or organizing DRP-1 at the outer membrane even though DRP-1 can reach mitochondria independently of Mff.</em></p>
+
+
+                    <p style="margin-top: 0.5rem;">Type: protein interaction / genetic rescue</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q19343" data-a="EXPERIMENT: Co-immunoprecipitation and in vitro binding assays..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Paralog-specific fluorescent reporters and tissue-restricted rescue of the mff-1 mff-2 double mutant to dissect individual contributions at mitochondria versus peroxisomes.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: mff-1 and mff-2 have distinct tissue or organelle preferences.</em></p>
+
+
+                    <p style="margin-top: 0.5rem;">Type: reporter expression / genetic rescue</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q19343" data-a="EXPERIMENT: Paralog-specific fluorescent reporters and tissue-..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Knowledge Gaps</h2>
+        <p style="color: #555; font-size: 0.92rem; margin-top: -0.3rem;">
+            What is <em>not</em> known — curated, literature-grounded statements of the open
+            unknowns (the inverse of core functions).
+        </p>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The specific molecular activity of C. elegans MFF-1 is uncharacterized: whether worm MFF-1 physically binds DRP-1 (and via which surface), whether it acts as a receptor/adaptor that recruits DRP-1 as in mammals, and whether it has any activity beyond scaffolding, are all undetermined. The GO molecular function is captured only by orthology-based IEA (positive regulation of protein targeting to membrane), not by a demonstrated worm activity.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">MF_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> It is firmly established that MFF-1 is a tail-anchored mitochondrial outer membrane protein (PMID:21248201) and that mff-1, redundantly with mff-2, is required for normal mitochondrial and peroxisomal fission (PMID:24196833). What is NOT established is the direct biochemical mechanism by which MFF-1 promotes fission in worm, because DRP-1 still localizes to mitochondria without Mff.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> In mammals MFF is the principal DRP1 receptor, but the worm data show DRP-1 recruitment is Mff-independent, so the worm MFF-1 mechanism may differ from the textbook receptor model. Resolving it would clarify how metazoan fission-factor function is (or is not) conserved.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Direct MFF-1-DRP-1 interaction assays (co-IP, in vitro binding), structure-guided mutagenesis of the cytosolic domain, and rescue of the mff-1 mff-2 double mutant with wild-type vs interaction-defective MFF-1.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"Mff and Fis1 are not essential for fission or for Drp1 recruitment to mitochondria in C. elegans"</em> — PMID:24196833</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The division of labor between mff-1 and mff-2 is unresolved: which paralog dominates, whether they are functionally interchangeable, whether they act in different tissues or at different targets (mitochondria vs peroxisomes), and whether they hetero-oligomerize are all unknown. Single-mutant phenotypes are weak, so the individual contribution of mff-1 has not been isolated.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">RESIDUAL_SUBGAP</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> It is established that single mff-1 and single mff-2 mutants have only weak fission defects while the double mutant is strong, indicating substantial redundancy (PMID:24196833). The relative and tissue-specific contributions of each paralog are the gap.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Understanding mff-1 vs mff-2 (and their relation to fis-1/fis-2) division of labor is needed to build an accurate model of worm DRP-1 recruitment and mitochondrial fission, and to interpret single-gene perturbations in the mitophagy/aging pathway.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Paralog-specific tagged reporters and tissue-restricted rescue of the mff-1 mff-2 double mutant, plus mff-1 vs mff-2 single- and cross-rescue experiments.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"mff-1 and mff-2 single mutants have weak effects, and that the Mff double mutant has a mitochondrial fission defect similar to but not as strong as the drp-1 defect"</em> — PMID:24196833</li>
+
+            </ul>
+
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Tags</h2>
+        <div class="aliases">
+
+            <span class="badge">caeel-mitophagy</span>
+
+        </div>
+    </div>
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Deep Research Sections -->
+
+    <div class="section">
+        <h2 class="section-title">Deep Research</h2>
+
+        <details class="deep-research-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; gap: 1rem;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Falcon</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(mff-1-deep-research-falcon.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="Q19343" data-a="DEEP_RESEARCH: Falcon" data-r="" data-act="DEEP_RESEARCH" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This deep research is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This deep research needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+
+                <div class="report-meta">
+
+                    <span class="report-meta-text">this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</span>
+
+
+                    <span class="report-badge">Falcon</span>
+
+
+                    <span class="report-badge">Edison Scientific Literature</span>
+
+
+                    <span class="report-badge">26 citations</span>
+
+
+                    <span class="report-badge">1 artifacts</span>
+
+
+                    <span class="report-meta-text">2026-07-04T21:01:43.492177</span>
+
+
+
+                </div>
+
+
+                <div class="artifact-list">
+
+
+
+                    <div class="artifact-link">
+                        <a href="mff-1-deep-research-falcon_artifacts/artifact-00.md" class="term-link">Edison artifact artifact-00</a>
+                        <span>(text/markdown)</span>
+                    </div>
+
+
+                </div>
+
+                <p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h2 id="comprehensive-research-report-c-elegans-mff-1-mitochondrial-fission-factor-uniprot-q19343">Comprehensive Research Report: <em>C. elegans</em> mff-1 (Mitochondrial Fission Factor, UniProt Q19343)</h2>
+<h3 id="1-gene-identity-and-protein-family">1. Gene Identity and Protein Family</h3>
+<p>The gene <em>mff-1</em> (ORF name F11C1.2, CELE_F11C1.2) in <em>Caenorhabditis elegans</em> encodes Mitochondrial Fission Factor (MFF-1), a member of the Tango11 protein family containing the Mff/Tango-11 domain (InterPro IPR008518). <em>C. elegans</em> possesses two paralogs of this family: <em>mff-1</em> (F11C1.2) and <em>mff-2</em>, both of which have been proposed as candidate DRP-1 receptors on the mitochondrial outer membrane (lu2011amolecularswitch pages 7-8). The protein is the <em>C. elegans</em> ortholog of mammalian MFF and <em>Drosophila</em> Tango11 (CG3404), which was originally identified through siRNA screening for genes that affect mitochondrial morphology in <em>Drosophila</em> S2 cells (singh2023mechanisticanalysisof pages 28-32). Importantly, the MFF/Tango11 family is metazoan-specific and absent in yeast, which instead utilizes a different set of adaptor proteins (Fis1/Mdv1/Caf4) for Dnm1-mediated mitochondrial fission (yu2020regulationofmammalian pages 6-7, singh2023mechanisticanalysisof pages 28-32).</p>
+<h3 id="2-primary-molecular-function">2. Primary Molecular Function</h3>
+<p>MFF-1 functions as a membrane-anchored receptor/adaptor protein that recruits the dynamin-related GTPase DRP-1 from the cytosol to the mitochondrial outer membrane, thereby promoting mitochondrial fission. This function is conserved from the well-characterized mammalian ortholog MFF. In mammalian cells, MFF is the principal DRP1 receptor and is essential for mitochondrial recruitment of DRP1; depletion of MFF severely inhibits mitochondrial fission and DRP1 recruitment, while overexpression extensively recruits DRP1 and induces mitochondrial fragmentation (otera2011discoveryofthe pages 1-3, yu2020regulationofmammalian pages 6-7). MFF binds DRP1 directly, although this interaction is transient and detectable only after chemical crosslinking (singh2023mechanisticanalysisof pages 28-32, singh2023mechanisticanalysisof pages 32-35). The interaction occurs through N-terminal repeat motifs (R1 and R2) in the first ~50 amino acids of MFF, which are essential for DRP1 binding (otera2011discoveryofthe pages 1-3, yu2020regulationofmammalian pages 6-7). Notably, MFF selectively recruits oligomerized, active forms of DRP1, distinguishing it from alternative DRP1 receptors such as MiD49/MiD51, which bind a wider range of DRP1 assembly states (yu2020regulationofmammalian pages 6-7).</p>
+<p>In <em>C. elegans</em>, Lu et al. (2011) proposed that MFF-1 and MFF-2 serve as mitochondrial receptors for DRP-1, alongside the EGL-1–CED-9 complex. The rationale is that loss of <em>egl-1</em> function only causes an approximately 20% increase in mitochondrial length, far less severe than the hyperfusion phenotype of <em>drp-1</em> mutants, implying the existence of additional DRP-1 receptors such as MFF-1 and MFF-2 (lu2011amolecularswitch pages 7-8). Similarly, Qin et al. (2020) listed <em>fis-2</em>, <em>mff-1</em>, and <em>mff-2</em> as candidate DRP-1 recruiters in <em>C. elegans</em> neurons (qin2020anendoplasmicreticulum pages 5-7).</p>
+<p>MFF-1 is not an enzyme and does not catalyze a biochemical reaction. Rather, it functions as a structural adaptor that physically links cytosolic DRP-1 to the mitochondrial membrane, enabling the mechanochemical GTPase activity of DRP-1 to constrict and sever the outer mitochondrial membrane.</p>
+<h3 id="3-subcellular-localization">3. Subcellular Localization</h3>
+<p>MFF-1 localizes to the mitochondrial outer membrane (MOM). This was directly demonstrated in <em>C. elegans</em> by Head et al. (2011), who used MFF-1 as an outer membrane marker in protease protection experiments on isolated mitochondria. They showed that MFF-1 is digested by proteinase K in intact mitochondria (similar to other cytoplasmically exposed MOM proteins), whereas inner membrane protein EAT-3 and matrix protein F1β remain protease-protected. This confirms that MFF-1 is embedded in the mitochondrial outer membrane with a substantial portion of the protein exposed to the cytosol (head2011anovelmitochondrial pages 5-6). This topology is fully consistent with the mammalian ortholog, which is a C-tail-anchored MOM protein with its N-terminal functional domain facing the cytosol (singh2023mechanisticanalysisof pages 28-32, otera2011discoveryofthe pages 1-3).</p>
+<h3 id="4-domain-architecture-and-structural-features">4. Domain Architecture and Structural Features</h3>
+<p>Based on conserved domain architecture from the mammalian ortholog, the MFF/Tango-11 domain (IPR008518) protein is predicted to contain: (1) N-terminal repeat regions that serve as the DRP1-binding interface; (2) a coiled-coil domain that mediates protein oligomerization; and (3) a C-terminal transmembrane domain that anchors the protein in the outer mitochondrial membrane in a tail-anchored configuration (singh2023mechanisticanalysisof pages 28-32). In mammalian MFF, the coiled-coil domain enables oligomerization, most likely as a trimer with a dissociation constant of approximately 10 μM in solution. This dynamic oligomerization is essential for DRP1 activation and is significantly more favorable when the protein is membrane-anchored (liu2021mffoligomerizationis pages 7-8, liu2021mffoligomerizationis pages 1-2). Oligomerization-defective MFF mutants fail to rescue mitochondrial division, DRP1 recruitment to mitochondria, and peroxisome division in MFF-knockout cells (liu2021mffoligomerizationis pages 1-2, liu2021mffoligomerizationis pages 6-7).</p>
+<h3 id="5-biochemical-pathway-and-mechanism-of-mitochondrial-fission">5. Biochemical Pathway and Mechanism of Mitochondrial Fission</h3>
+<p>MFF-1 participates in the DRP1-mediated mitochondrial fission pathway. The current model, derived primarily from mammalian studies, proceeds as follows:</p>
+<ol>
+<li><strong>DRP1 recruitment</strong>: Cytosolic DRP1 exists as a mixture of dimers and higher-order oligomers. MFF on the outer mitochondrial membrane selectively binds pre-formed DRP1 oligomers through its N-terminal repeat motifs (singh2023mechanisticanalysisof pages 32-35, yu2020regulationofmammalian pages 6-7).</li>
+<li><strong>MFF oligomerization and Drp1 activation</strong>: MFF trimers assemble into higher-order puncta on the MOM. Actin filaments synergize with MFF by lowering the effective MFF concentration required for DRP1 activation by approximately 10-fold (liu2021mffoligomerizationis pages 7-8, liu2021mffoligomerizationis pages 1-2).</li>
+<li><strong>Membrane constriction and scission</strong>: Once recruited and activated, DRP1 self-assembles into ring-like oligomeric structures around mitochondria and hydrolyzes GTP, driving constriction and ultimately severing the outer mitochondrial membrane (otera2011discoveryofthe pages 1-3).</li>
+</ol>
+<p>In <em>C. elegans</em>, the mitochondrial fission pathway additionally involves the EGL-1–CED-9 complex as a parallel DRP-1 receptor system. The BCL-2-like protein CED-9 can act as a molecular switch: in complex with the BH3-only protein EGL-1, it recruits GTP-bound DRP-1 to mitochondria and promotes fission, whereas CED-9 alone promotes FZO-1/EAT-3-dependent mitochondrial fusion (lu2011amolecularswitch pages 6-7, lu2011amolecularswitch pages 4-6, lu2011amolecularswitch pages 7-8). This dual-receptor system (EGL-1/CED-9 plus MFF-1/MFF-2) explains why loss of <em>egl-1</em> alone only partially phenocopies <em>drp-1</em> loss-of-function (lu2011amolecularswitch pages 7-8).</p>
+<h3 id="6-role-in-peroxisomal-fission">6. Role in Peroxisomal Fission</h3>
+<p>In mammalian cells, MFF is the sole DRP1 receptor essential for peroxisomal division. MFF-knockout cells display enlarged, elongated peroxisomes, and only wild-type MFF (but not oligomerization-deficient mutants) can rescue this phenotype (liu2021mffoligomerizationis pages 1-2, liu2021mffoligomerizationis pages 6-7, carmichael2022fissionimpossible(?)—new pages 9-10). Whether MFF-1 similarly participates in peroxisomal fission in <em>C. elegans</em> has not been directly tested in the retrieved literature, but this dual role is likely conserved given the family membership and the shared DRP1/MFF fission machinery.</p>
+<h3 id="7-regulation-by-ampk-phosphorylation">7. Regulation by AMPK Phosphorylation</h3>
+<p>Mammalian MFF is regulated by phosphorylation by AMP-activated protein kinase (AMPK), the master cellular energy sensor. Key phosphorylation sites include Ser146 (involved in regulating MAVS-mediated innate immune responses), as well as Ser155, Ser172, and Ser275, which collectively link energy status to mitochondrial fission activity (hanada2021mavsisenergized pages 9-10, hanada2021mavsisenergized pages 7-8, tabara2025molecularmechanismsof pages 9-10). Under conditions of mitochondrial dysfunction or energy stress, AMPK phosphorylates MFF to promote mitochondrial fission, thereby facilitating the segregation and removal of damaged mitochondria via mitophagy (hanada2021mavsisenergized pages 1-2, carmichael2022fissionimpossible(?)—new pages 9-10). Additionally, protein kinase D (PKD) phosphorylates MFF during mitosis to coordinate mitochondrial division with cell division (tabara2025molecularmechanismsof pages 9-10). Whether AMPK-mediated regulation of MFF-1 is conserved in <em>C. elegans</em> remains to be determined experimentally.</p>
+<h3 id="8-non-canonical-function-in-innate-immunity">8. Non-Canonical Function in Innate Immunity</h3>
+<p>A remarkable non-canonical function of MFF was discovered in its regulation of mitochondrial antiviral signaling (MAVS). Hanada et al. (2020) demonstrated that MFF is required for the formation of active MAVS clusters on mitochondria, independent of its role in mitochondrial fission and independent of DRP1. Under energy-replete conditions, MFF promotes MAVS cluster formation and a robust antiviral response. Under energy-depleted conditions, AMPK phosphorylates MFF at Ser146, leading to disorganization of MAVS clusters and suppression of the acute antiviral response (hanada2021mavsisenergized pages 9-10, hanada2021mavsisenergized pages 7-8, hanada2021mavsisenergized pages 1-2). This dual role positions MFF as a critical link between mitochondrial metabolism and innate immunity.</p>
+<h3 id="9-evolutionary-conservation-and-the-tango11-family">9. Evolutionary Conservation and the Tango11 Family</h3>
+<p>The Tango11/MFF family is conserved across metazoa but absent from yeast. The <em>Drosophila</em> ortholog, Tango11 (CG3404), was identified through genome-wide siRNA screening, and its knockdown causes perinuclear clustering of mitochondria similar to DRP1 knockdown, confirming a conserved fission function (singh2023mechanisticanalysisof pages 28-32). <em>C. elegans</em> has expanded this family to include two paralogs, <em>mff-1</em> and <em>mff-2</em>, possibly reflecting functional diversification or partial redundancy in DRP-1 recruitment (lu2011amolecularswitch pages 7-8). In mammals, the single MFF gene generates at least nine splice variants through alternative exon usage, producing proteins of 25.1–38.5 kDa (singh2023mechanisticanalysisof pages 28-32).</p>
+<h3 id="10-disease-relevance-of-the-mammalian-ortholog">10. Disease Relevance of the Mammalian Ortholog</h3>
+<p>Loss-of-function mutations in human MFF cause encephalopathy due to mitochondrial and peroxisomal fission defect (OMIM 617086), an autosomal recessive disorder. Clinical features include Leigh-like encephalopathy, developmental delay, epileptic seizures, optic atrophy, peripheral neuropathy, microcephaly, and intellectual disability (carmichael2022fissionimpossible(?)—new pages 22-23, carmichael2022fissionimpossible(?)—new pages 9-10, carmichael2022fissionimpossible(?)—new pages 21-22, OpenTargets Search: -MFF). Mutations are typically nonsense mutations that cause truncation before the C-terminal transmembrane domain. At the cellular level, patient fibroblasts show elongated, hyper-fused mitochondria and peroxisomes, reflecting impaired organellar fission, while metabolic functions of these organelles often remain surprisingly normal (carmichael2022fissionimpossible(?)—new pages 9-10, carmichael2022fissionimpossible(?)—new pages 10-12). This underscores that the primary pathology derives from disrupted organellar dynamics and distribution rather than metabolic failure per se.</p>
+<h3 id="summary">Summary</h3>
+<p>The following table provides a cross-species comparison of MFF-1/MFF/Tango11:</p>
+<table>
+<thead>
+<tr>
+<th>Feature</th>
+<th><em>C. elegans</em> mff-1</th>
+<th>Human MFF</th>
+<th><em>Drosophila</em> Tango11</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Gene name</td>
+<td><strong>mff-1</strong>; ORF <strong>F11C1.2</strong>; UniProt <strong>Q19343</strong></td>
+<td><strong>MFF</strong> (<em>mitochondrial fission factor</em>)</td>
+<td><strong>Tango11</strong> / <strong>CG3404</strong>; described as the <em>Drosophila</em> ortholog of MFF (lu2011amolecularswitch pages 7-8, singh2023mechanisticanalysisof pages 28-32)</td>
+</tr>
+<tr>
+<td>Protein family</td>
+<td>Tango11/MFF family; one of two <em>C. elegans</em> MFF paralogs (<strong>mff-1</strong>, <strong>mff-2</strong>) (lu2011amolecularswitch pages 7-8, singh2023mechanisticanalysisof pages 28-32)</td>
+<td>Metazoan MFF/Tango11 family; major DRP1 receptor in mammals (otera2011discoveryofthe pages 1-3, yu2020regulationofmammalian pages 6-7)</td>
+<td>Tango11/MFF family; conserved metazoan ortholog of mammalian MFF (singh2023mechanisticanalysisof pages 28-32)</td>
+</tr>
+<tr>
+<td>Domain (IPR008518)</td>
+<td>Mff/Tango-11 domain (IPR008518); consistent with assignment as mitochondrial fission factor family member</td>
+<td>Mff/Tango-11 family domain with N-terminal DRP1-binding repeat region, coiled-coil segment, and C-terminal transmembrane anchor (singh2023mechanisticanalysisof pages 28-32, yu2020regulationofmammalian pages 6-7)</td>
+<td>Conserved Tango11/MFF family domain inferred from orthology to mammalian MFF (singh2023mechanisticanalysisof pages 28-32)</td>
+</tr>
+<tr>
+<td>Subcellular localization</td>
+<td>Mitochondrial outer membrane; MFF-1 behaves as an outer membrane marker and is protease-sensitive in intact mitochondria, consistent with cytosolic exposure (head2011anovelmitochondrial pages 5-6)</td>
+<td>C-tail-anchored outer mitochondrial membrane protein; also present on peroxisomal membranes (singh2023mechanisticanalysisof pages 28-32, otera2011discoveryofthe pages 1-3, liu2021mffoligomerizationis pages 1-2)</td>
+<td>Functional ortholog implicated in mitochondrial morphology control; specific localization not directly shown in retrieved evidence, but inferred to act at mitochondria from orthology and phenotype (singh2023mechanisticanalysisof pages 28-32)</td>
+</tr>
+<tr>
+<td>Primary function</td>
+<td>Candidate DRP-1 receptor/adaptor for mitochondrial fission in worms; proposed to act alongside <strong>mff-2</strong> as an additional DRP-1 receptor beyond EGL-1/CED-9 (lu2011amolecularswitch pages 7-8, qin2020anendoplasmicreticulum pages 5-7)</td>
+<td>Core membrane adaptor/receptor that recruits cytosolic DRP1 to mitochondrial constriction sites and promotes mitochondrial division (otera2011discoveryofthe pages 1-3, singh2023mechanisticanalysisof pages 32-35, yu2020regulationofmammalian pages 6-7)</td>
+<td>Required for normal mitochondrial morphology; knockdown causes perinuclear mitochondrial clustering similar to <strong>Drp1</strong> knockdown, supporting a conserved fission role (singh2023mechanisticanalysisof pages 28-32)</td>
+</tr>
+<tr>
+<td>DRP1 interaction</td>
+<td>Proposed DRP-1 recruiter in <em>C. elegans</em> based on homology to mammalian MFF and worm mitochondrial dynamics studies (lu2011amolecularswitch pages 7-8, qin2020anendoplasmicreticulum pages 5-7)</td>
+<td>Direct but transient DRP1-binding receptor; N-terminal repeats are required for recruitment, and MFF preferentially recruits oligomerized/active DRP1 (otera2011discoveryofthe pages 1-3, singh2023mechanisticanalysisof pages 32-35, yu2020regulationofmammalian pages 6-7)</td>
+<td>Conserved Drp1-pathway component inferred from orthology and mitochondrial morphology phenotype after knockdown (singh2023mechanisticanalysisof pages 28-32)</td>
+</tr>
+<tr>
+<td>Oligomerization</td>
+<td>No direct oligomerization data found in retrieved worm-specific literature</td>
+<td>Oligomerizes via coiled-coil domain, likely as a trimer; oligomerization is required for DRP1 activation, puncta formation, mitochondrial division, and peroxisomal division (liu2021mffoligomerizationis pages 7-8, liu2021mffoligomerizationis pages 1-2, liu2021mffoligomerizationis pages 6-7)</td>
+<td>No direct oligomerization data found in retrieved evidence; likely conserved by family membership (singh2023mechanisticanalysisof pages 28-32)</td>
+</tr>
+<tr>
+<td>Peroxisomal fission role</td>
+<td>No direct worm-specific evidence found in retrieved literature</td>
+<td>Essential for peroxisomal as well as mitochondrial fission; loss causes elongated/tubular peroxisomes (singh2023mechanisticanalysisof pages 28-32, liu2021mffoligomerizationis pages 1-2, carmichael2022fissionimpossible(?)—new pages 9-10)</td>
+<td>No direct evidence found in retrieved literature</td>
+</tr>
+<tr>
+<td>Key regulators (e.g., AMPK)</td>
+<td>No direct worm-specific regulators identified in retrieved evidence</td>
+<td>Regulated by AMPK phosphorylation; sites reported include <strong>S146</strong> in innate immunity studies and <strong>S155, S172, S275</strong> in broader mitochondrial dynamics reviews; phosphorylation links energy status to fission and MAVS signaling (hanada2021mavsisenergized pages 9-10, hanada2021mavsisenergized pages 7-8, tabara2025molecularmechanismsof pages 9-10, carmichael2022fissionimpossible(?)—new pages 9-10)</td>
+<td>No direct regulator identified in retrieved evidence</td>
+</tr>
+<tr>
+<td>Disease association</td>
+<td>No specific disease association expected for worm gene</td>
+<td>Biallelic loss-of-function mutations cause <strong>encephalopathy due to mitochondrial and peroxisomal fission defect / lethal encephalopathy</strong>, with developmental delay, optic atrophy, peripheral neuropathy, microcephaly, seizures, and elongated mitochondria/peroxisomes in patient cells (carmichael2022fissionimpossible(?)—new pages 22-23, carmichael2022fissionimpossible(?)—new pages 9-10, carmichael2022fissionimpossible(?)—new pages 21-22, OpenTargets Search: -MFF)</td>
+<td>No human disease association applicable; useful as a comparative model gene (singh2023mechanisticanalysisof pages 28-32)</td>
+</tr>
+</tbody>
+</table>
+<p><em>Table: This table compares the key features of worm mff-1, human MFF, and Drosophila Tango11 to support functional annotation by orthology. It highlights what is directly shown in C. elegans versus what is inferred from better-characterized metazoan orthologs.</em></p>
+<p>In summary, <em>C. elegans</em> MFF-1 (F11C1.2, UniProt Q19343) is a mitochondrial outer membrane protein belonging to the metazoan-specific Tango11/MFF family. It functions as a receptor/adaptor for the dynamin-related GTPase DRP-1, recruiting it from the cytosol to the mitochondrial surface to promote organellar fission. While direct functional studies on <em>mff-1</em> in <em>C. elegans</em> are limited, its identification as a protease-sensitive outer mitochondrial membrane protein (head2011anovelmitochondrial pages 5-6), its classification within the Tango11 family (singh2023mechanisticanalysisof pages 28-32), and its proposal as a DRP-1 receptor alongside its paralog MFF-2 (lu2011amolecularswitch pages 7-8) strongly support functional conservation with the well-characterized mammalian MFF, which serves as the principal DRP1 adaptor for both mitochondrial and peroxisomal fission.</p>
+<p>References</p>
+<ol>
+<li>
+<p>(lu2011amolecularswitch pages 7-8): Yun Lu, Stéphane G. Rolland, and Barbara Conradt. A molecular switch that governs mitochondrial fusion and fission mediated by the bcl2-like protein ced-9 of caenorhabditis elegans. Proceedings of the National Academy of Sciences, 108:E813-E822, Sep 2011. URL: https://doi.org/10.1073/pnas.1103218108, doi:10.1073/pnas.1103218108. This article has 48 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(singh2023mechanisticanalysisof pages 28-32): Abeer Prakash Singh. Mechanistic analysis of mitochondrial fission mediators. Text, Jan 2023. URL: https://doi.org/10.26181/21844440.v1, doi:10.26181/21844440.v1. This article has 0 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(yu2020regulationofmammalian pages 6-7): Rong Yu, Urban Lendahl, Monica Nistér, and Jian Zhao. Regulation of mammalian mitochondrial dynamics: opportunities and challenges. Frontiers in Endocrinology, Jun 2020. URL: https://doi.org/10.3389/fendo.2020.00374, doi:10.3389/fendo.2020.00374. This article has 222 citations.</p>
+</li>
+<li>
+<p>(otera2011discoveryofthe pages 1-3): Hidenori Otera and Katsuyoshi Mihara. Discovery of the membrane receptor for mitochondrial fission gtpase drp1. Small GTPases, 2:167-172-51, May 2011. URL: https://doi.org/10.4161/sgtp.2.3.16486, doi:10.4161/sgtp.2.3.16486. This article has 108 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(singh2023mechanisticanalysisof pages 32-35): Abeer Prakash Singh. Mechanistic analysis of mitochondrial fission mediators. Text, Jan 2023. URL: https://doi.org/10.26181/21844440.v1, doi:10.26181/21844440.v1. This article has 0 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(qin2020anendoplasmicreticulum pages 5-7): Qing Qin, Ting Zhao, Wei Zou, Kang Shen, and Xiangming Wang. An endoplasmic reticulum atpase safeguards endoplasmic reticulum identity by removing ectopically localized mitochondrial proteins. Cell reports, 33 6:108363, Nov 2020. URL: https://doi.org/10.1016/j.celrep.2020.108363, doi:10.1016/j.celrep.2020.108363. This article has 48 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(head2011anovelmitochondrial pages 5-6): Brian P. Head, Miren Zulaika, Sergey Ryazantsev, and Alexander M. van der Bliek. A novel mitochondrial outer membrane protein, moma-1, that affects cristae morphology in caenorhabditis elegans. Molecular Biology of the Cell, 22:831-841, Mar 2011. URL: https://doi.org/10.1091/mbc.e10-07-0600, doi:10.1091/mbc.e10-07-0600. This article has 95 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(liu2021mffoligomerizationis pages 7-8): Ao Liu, Frieda Kage, and Henry N. Higgs. Mff oligomerization is required for drp1 activation and synergy with actin filaments during mitochondrial division. Oct 2021. URL: https://doi.org/10.1091/mbc.e21-04-0224, doi:10.1091/mbc.e21-04-0224. This article has 41 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(liu2021mffoligomerizationis pages 1-2): Ao Liu, Frieda Kage, and Henry N. Higgs. Mff oligomerization is required for drp1 activation and synergy with actin filaments during mitochondrial division. Oct 2021. URL: https://doi.org/10.1091/mbc.e21-04-0224, doi:10.1091/mbc.e21-04-0224. This article has 41 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(liu2021mffoligomerizationis pages 6-7): Ao Liu, Frieda Kage, and Henry N. Higgs. Mff oligomerization is required for drp1 activation and synergy with actin filaments during mitochondrial division. Oct 2021. URL: https://doi.org/10.1091/mbc.e21-04-0224, doi:10.1091/mbc.e21-04-0224. This article has 41 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(lu2011amolecularswitch pages 6-7): Yun Lu, Stéphane G. Rolland, and Barbara Conradt. A molecular switch that governs mitochondrial fusion and fission mediated by the bcl2-like protein ced-9 of caenorhabditis elegans. Proceedings of the National Academy of Sciences, 108:E813-E822, Sep 2011. URL: https://doi.org/10.1073/pnas.1103218108, doi:10.1073/pnas.1103218108. This article has 48 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(lu2011amolecularswitch pages 4-6): Yun Lu, Stéphane G. Rolland, and Barbara Conradt. A molecular switch that governs mitochondrial fusion and fission mediated by the bcl2-like protein ced-9 of caenorhabditis elegans. Proceedings of the National Academy of Sciences, 108:E813-E822, Sep 2011. URL: https://doi.org/10.1073/pnas.1103218108, doi:10.1073/pnas.1103218108. This article has 48 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(carmichael2022fissionimpossible(?)—new pages 9-10): Ruth E. Carmichael, Markus Islinger, and Michael Schrader. Fission impossible (?)—new insights into disorders of peroxisome dynamics. Cells, 11:1922, Jun 2022. URL: https://doi.org/10.3390/cells11121922, doi:10.3390/cells11121922. This article has 28 citations.</p>
+</li>
+<li>
+<p>(hanada2021mavsisenergized pages 9-10): Yuki Hanada, Naotada Ishihara, Lixiang Wang, Hidenori Otera, Takaya Ishihara, Takumi Koshiba, Katsuyoshi Mihara, Yoshihiro Ogawa, and Masatoshi Nomura. Mavs is energized by mff which senses mitochondrial metabolism via ampk for acute antiviral immunity. Nature Communications, Nov 2020. URL: https://doi.org/10.1038/s41467-020-19287-7, doi:10.1038/s41467-020-19287-7. This article has 79 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(hanada2021mavsisenergized pages 7-8): Yuki Hanada, Naotada Ishihara, Lixiang Wang, Hidenori Otera, Takaya Ishihara, Takumi Koshiba, Katsuyoshi Mihara, Yoshihiro Ogawa, and Masatoshi Nomura. Mavs is energized by mff which senses mitochondrial metabolism via ampk for acute antiviral immunity. Nature Communications, Nov 2020. URL: https://doi.org/10.1038/s41467-020-19287-7, doi:10.1038/s41467-020-19287-7. This article has 79 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(tabara2025molecularmechanismsof pages 9-10): Luis-Carlos Tábara, Mayuko Segawa, and Julien Prudent. Molecular mechanisms of mitochondrial dynamics. Nature reviews. Molecular cell biology, 26:123-146, Oct 2025. URL: https://doi.org/10.1038/s41580-024-00785-1, doi:10.1038/s41580-024-00785-1. This article has 390 citations.</p>
+</li>
+<li>
+<p>(hanada2021mavsisenergized pages 1-2): Yuki Hanada, Naotada Ishihara, Lixiang Wang, Hidenori Otera, Takaya Ishihara, Takumi Koshiba, Katsuyoshi Mihara, Yoshihiro Ogawa, and Masatoshi Nomura. Mavs is energized by mff which senses mitochondrial metabolism via ampk for acute antiviral immunity. Nature Communications, Nov 2020. URL: https://doi.org/10.1038/s41467-020-19287-7, doi:10.1038/s41467-020-19287-7. This article has 79 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(carmichael2022fissionimpossible(?)—new pages 22-23): Ruth E. Carmichael, Markus Islinger, and Michael Schrader. Fission impossible (?)—new insights into disorders of peroxisome dynamics. Cells, 11:1922, Jun 2022. URL: https://doi.org/10.3390/cells11121922, doi:10.3390/cells11121922. This article has 28 citations.</p>
+</li>
+<li>
+<p>(carmichael2022fissionimpossible(?)—new pages 21-22): Ruth E. Carmichael, Markus Islinger, and Michael Schrader. Fission impossible (?)—new insights into disorders of peroxisome dynamics. Cells, 11:1922, Jun 2022. URL: https://doi.org/10.3390/cells11121922, doi:10.3390/cells11121922. This article has 28 citations.</p>
+</li>
+<li>
+<p>(OpenTargets Search: -MFF): Open Targets Query (-MFF, 5 results). Buniello, A. et al. (2025). Open Targets Platform: facilitating therapeutic hypotheses building in drug discovery. Nucleic Acids Research.</p>
+</li>
+<li>
+<p>(carmichael2022fissionimpossible(?)—new pages 10-12): Ruth E. Carmichael, Markus Islinger, and Michael Schrader. Fission impossible (?)—new insights into disorders of peroxisome dynamics. Cells, 11:1922, Jun 2022. URL: https://doi.org/10.3390/cells11121922, doi:10.3390/cells11121922. This article has 28 citations.</p>
+</li>
+</ol>
+<h2 id="artifacts">Artifacts</h2>
+<ul>
+<li><a href="mff-1-deep-research-falcon_artifacts/artifact-00.md">Edison artifact artifact-00</a></li>
+</ul>
+<h2 id="citations">Citations</h2>
+<ol>
+<li>lu2011amolecularswitch pages 7-8</li>
+<li>singh2023mechanisticanalysisof pages 28-32</li>
+<li>yu2020regulationofmammalian pages 6-7</li>
+<li>qin2020anendoplasmicreticulum pages 5-7</li>
+<li>head2011anovelmitochondrial pages 5-6</li>
+<li>otera2011discoveryofthe pages 1-3</li>
+<li>tabara2025molecularmechanismsof pages 9-10</li>
+<li>singh2023mechanisticanalysisof pages 32-35</li>
+<li>liu2021mffoligomerizationis pages 7-8</li>
+<li>liu2021mffoligomerizationis pages 1-2</li>
+<li>liu2021mffoligomerizationis pages 6-7</li>
+<li>lu2011amolecularswitch pages 6-7</li>
+<li>lu2011amolecularswitch pages 4-6</li>
+<li>hanada2021mavsisenergized pages 9-10</li>
+<li>hanada2021mavsisenergized pages 7-8</li>
+<li>hanada2021mavsisenergized pages 1-2</li>
+<li>https://doi.org/10.1073/pnas.1103218108,</li>
+<li>https://doi.org/10.26181/21844440.v1,</li>
+<li>https://doi.org/10.3389/fendo.2020.00374,</li>
+<li>https://doi.org/10.4161/sgtp.2.3.16486,</li>
+<li>https://doi.org/10.1016/j.celrep.2020.108363,</li>
+<li>https://doi.org/10.1091/mbc.e10-07-0600,</li>
+<li>https://doi.org/10.1091/mbc.e21-04-0224,</li>
+<li>https://doi.org/10.3390/cells11121922,</li>
+<li>https://doi.org/10.1038/s41467-020-19287-7,</li>
+<li>https://doi.org/10.1038/s41580-024-00785-1,</li>
+</ol>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(mff-1-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="Q19343" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="mff-1-c-elegans-research-notes">mff-1 (C. elegans) research notes</h1>
+<p>UniProt: Q19343 (Q19343_CAEEL, unreviewed/TrEMBL). WormBase: WBGene00008691, F11C1.2.<br />
+Gene: mff-1. Human ortholog: MFF (mitochondrial fission factor). 158 aa.</p>
+<h2 id="identity-confirmation">Identity confirmation</h2>
+<ul>
+<li>UniProt Q19343 is <code>mff-1 {ECO:0000313|WormBase:F11C1.2}</code>, ORF F11C1.2, "Mitochondrial fission factor",<br />
+  family Tango11 (Mff/Tango-11, IPR008518). TCDB 8.A.166.1.1 "mitochondrial fission factor (mff) family".</li>
+<li>Primary literature explicitly identifies this gene:<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/21248201" title="C. elegans has two Fis1 homologues, encoded by fis-1 and fis-2, and two Mff homologues, encoded by mff-1(F11C1.2) and mff-2(F55F8.6)">PMID:21248201</a>.<br />
+  So F11C1.2 = mff-1 is confirmed by ORF name in the primary literature. mff-2 = F55F8.6 is the paralog.</li>
+</ul>
+<h2 id="protein-architecture">Protein architecture</h2>
+<ul>
+<li>158 aa, single C-terminal predicted transmembrane helix (UniProt FT TRANSMEM 139..156), consistent<br />
+  with a tail-anchored (type IV / single-pass) mitochondrial outer-membrane protein — the canonical MFF<br />
+  topology (cytosol-facing N-terminal domain, C-terminal TM anchor).</li>
+<li>UniProt FUNCTION (RuleBase, electronic): "Plays a role in mitochondrial and peroxisomal fission.<br />
+  Promotes the recruitment and association of the fission mediator dynamin-related protein 1 (DNM1L)<br />
+  to the mitochondrial surface."</li>
+<li>UniProt SUBCELLULAR LOCATION (RuleBase): Mitochondrion outer membrane; Single-pass type IV membrane<br />
+  protein. Peroxisome.</li>
+</ul>
+<h2 id="known-experimental-c-elegans-specific">KNOWN (experimental, C. elegans-specific)</h2>
+<h3 id="mitochondrial-and-peroxisome-fission-genuine-role-redundant-with-mff-2">Mitochondrial and peroxisome fission — genuine role, redundant with mff-2</h3>
+<ul>
+<li><a href="https://pubmed.ncbi.nlm.nih.gov/24196833" title="mff-1 and mff-2 single mutants have weak effects, and that the Mff double mutant has a   mitochondrial fission defect similar to but not as strong as the drp-1 defect">PMID:24196833</a> — direct genetic<br />
+  evidence that mff-1 (with mff-2) is required for normal mitochondrial fission. Single mff-1 mutant =<br />
+  weak (redundancy with mff-2); Mff double mutant = strong fission defect (approaching drp-1).</li>
+<li><a href="https://pubmed.ncbi.nlm.nih.gov/24196833" title="Analogous results were obtained with a peroxisome marker, showing punctate peroxisomes   in wild-type and Fis1 mutants and tubular peroxisomes in drp-1 mutant and Mff double mutants">PMID:24196833</a> and<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/24196833" title="We conclude that C. elegans Mff homologues affect mitochondrial and peroxisome fission,   whereas Fis1 homologues have no obvious effects">PMID:24196833</a> — supports both mitochondrial fission AND peroxisome<br />
+  localization/peroxisome fission for MFF (worm), and contrasts sharply with fis-1/fis-2 (no obvious<br />
+  fission role).</li>
+<li>Alleles: mff-1(tm2955), mff-2(tm3041) (Mitani/NBRP); quadruple fis-1 fis-2 mff-1 mff-2 mutant made.</li>
+</ul>
+<h3 id="mitochondrial-outer-membrane-localization-experimentally-supported">Mitochondrial outer membrane localization — experimentally supported</h3>
+<ul>
+<li><a href="https://pubmed.ncbi.nlm.nih.gov/21248201" title="Blots were probed with antibodies for EAT-3 (an inner membrane marker), MOMA-1, MFF-1   (an outer membrane marker), and F1β subunit of the ATP synthase complex (a mitochondrial matrix   marker)">PMID:21248201</a> — MFF-1 is used as a bona fide mitochondrial outer membrane marker (anti-MFF-1 antibody).</li>
+<li><a href="https://pubmed.ncbi.nlm.nih.gov/21248201" title="MOMA-1 is digested when no detergent is added, like MFF-1, while EAT-3 and F1β are   protease protected">PMID:21248201</a> — in a protease-protection assay on intact mitochondria, MFF-1 is digested without<br />
+  detergent, i.e. it is exposed to the cytosol / anchored in the OM (consistent with tail-anchored OM<br />
+  topology, N-terminus cytosol-facing).</li>
+<li>GFP/CFP-tagged mff-1 expressed in muscle cells <a href="https://pubmed.ncbi.nlm.nih.gov/24196833" title="Full-length fis-1, fis-2, mff-1, and   mff-2 cDNAs were cloned in the pPD96.52 expression vector">PMID:24196833</a>.</li>
+</ul>
+<h3 id="mitophagy-stress-induced-fission-non-core-downstream">Mitophagy / stress-induced fission (non-core, downstream)</h3>
+<ul>
+<li><a href="https://pubmed.ncbi.nlm.nih.gov/24196833" title="significantly reduced number of spots in Mff double and Fis1 Mff quadruple mutant   strains">PMID:24196833</a> and <a href="https://pubmed.ncbi.nlm.nih.gov/24196833" title="their number is reduced by Mff mutations and eliminated by the Pink1   mutation">PMID:24196833</a> — Mff (mff-1/mff-2) contributes to formation of mitophagosomes (LGG-1/mito colocalizing<br />
+  spots); loss of Mff reduces (but does not abolish) mitophagosome number. This is a downstream<br />
+  consequence of the fission role, not a distinct molecular function.</li>
+<li><a href="https://pubmed.ncbi.nlm.nih.gov/24196833" title="Mff acts upstream of the Fis1-dependent step in this process">PMID:24196833</a> — places Mff early in<br />
+  the fission→mitophagy sequence (Drp1 first binds Mff, then Fis1).</li>
+</ul>
+<h2 id="not-known-important-worm-specific-nuances">NOT known / important worm-specific nuances</h2>
+<ul>
+<li><strong>DRP-1 recruitment in worm is NOT strictly Mff-dependent</strong> (unlike mammals). This is the key divergence<br />
+  from the mammalian paradigm and from the UniProt RuleBase "promotes recruitment of DNM1L" statement:<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/24196833" title="We conclude that Mff affects fission, but Mff and Fis1 are not essential for fission or   for Drp1 recruitment to mitochondria in C. elegans">PMID:24196833</a>. CFP::DRP-1 still forms fission-marking spots and<br />
+  fractionates to mitochondria normally in Mff double/quadruple mutants. Worm lacks MiD49/MiD51.<br />
+  =&gt; The "positive regulation of protein targeting to membrane" (DRP-1 recruitment) annotation is<br />
+  inferred from mammalian orthology (UniRule) and is only partially supported in worm — DRP-1 can reach<br />
+  mitochondria without Mff, though Mff still promotes efficient fission. Keep as non-core / note the<br />
+  caveat; do not assert as a firmly established worm function.</li>
+<li>No experimental characterization of a direct MFF-1–DRP-1 physical interaction in worm.</li>
+<li>Relative division of labor between mff-1 and mff-2 (which paralog dominates, tissue specificity,<br />
+  whether they heterooligomerize) is not resolved — single mutants are "weak", implicating redundancy,<br />
+  but the individual contribution of mff-1 vs mff-2 is not dissected.</li>
+<li>No worm data on peroxisome-specific vs mitochondria-specific pools of MFF-1, or on regulation<br />
+  (mammalian MFF is phospho-regulated by AMPK; not tested in worm).</li>
+</ul>
+<h2 id="annotation-assessment-summary-all-5-goa-annotations-are-iea">Annotation assessment summary (all 5 GOA annotations are IEA)</h2>
+<ol>
+<li>GO:0000266 mitochondrial fission (IEA, UniRule) — ACCEPT (core). Now backed by worm experimental<br />
+   genetics (Mff double mutant fission defect, PMID:24196833). Genuine fission role expected for MFF and<br />
+   confirmed in worm — unlike fis-1/fis-2.</li>
+<li>GO:0005741 mitochondrial outer membrane (IEA, SubCell) — ACCEPT (core). Experimentally supported in<br />
+   worm (MFF-1 OM marker + protease protection, PMID:21248201).</li>
+<li>GO:0005777 peroxisome (IEA, SubCell/UniRule) — ACCEPT / KEEP_AS_NON_CORE. Supported by worm data<br />
+   (Mff double mutant → tubular peroxisomes, i.e. peroxisome fission defect, PMID:24196833) plus ortholog.</li>
+<li>GO:0090141 positive regulation of mitochondrial fission (IEA, UniRule) — ACCEPT (core). MFF promotes<br />
+   fission; loss reduces fission. Consistent with worm genetics.</li>
+<li>GO:0090314 positive regulation of protein targeting to membrane (IEA, UniRule) = DRP-1 recruitment.<br />
+   MODIFY/KEEP_AS_NON_CORE with caveat — in worm, Mff is NOT essential for DRP-1 recruitment<br />
+   (PMID:24196833). Inferred from mammalian orthology; only partially holds in worm. Keep but flag.</li>
+</ol>
+<h2 id="deep-research">Deep research</h2>
+<ul>
+<li>falcon deep-research launched (<code>just deep-research-falcon worm mff-1 --fallback perplexity-lite</code>).<br />
+  Falcon can take 20+ min. drp-1 falcon research already cites worm FIS-1/FIS-2 and MFF-1/MFF-2 as<br />
+  DRP-1 recruitment factors (Traa et al. GeroScience 2025; Kamerkar et al. Nat Commun 2018) — background<br />
+  cross-species context only, not worm mff-1-specific mechanism.</li>
+</ul>
+<h2 id="falcon-deep-research-completed-1059s-26-citations-mff-1-deep-research-falconmd">Falcon deep research (completed, 1059s, 26 citations) — mff-1-deep-research-falcon.md</h2>
+<p>Genuine falcon report. Confirms and extends the primary-literature picture. Key points:<br />
+- Confirms identity: mff-1 = ORF F11C1.2, UniProt Q19343, Tango11/MFF family (metazoan-specific, absent<br />
+  in yeast). Two worm paralogs mff-1 and mff-2.<br />
+- Cites Head et al. 2011 (PMID:21248201) for the OM/protease-protection localization result (matches my<br />
+  read of that paper).<br />
+- Cites Lu, Rolland, Conradt 2011 (PNAS; = PMID:21949250, already cached) proposing MFF-1/MFF-2 as<br />
+  candidate DRP-1 receptors alongside the EGL-1–CED-9 complex — this is a PROPOSAL/inference, not a<br />
+  direct MFF-1 mechanism test.<br />
+- Mammalian MFF biology (by orthology only, NOT worm): N-terminal R1/R2 repeats bind DRP1; MFF is the<br />
+  principal DRP1 receptor; MFF mediates peroxisome fission; AMPK phosphorylates MFF (S146, S155, S172,<br />
+  S275); MFF-MAVS/innate-immunity role; human MFF LoF → encephalopathy (OMIM 617086). None of these are<br />
+  demonstrated for worm mff-1.<br />
+- Falcon did NOT retrieve Shen et al. 2014 (PMID:24196833) — so it states worm peroxisome fission "has<br />
+  not been directly tested". My review has the stronger direct evidence (Shen 2014: Mff double mutant →<br />
+  tubular peroxisomes), so I rely on the primary paper, not the falcon inference, for the peroxisome and<br />
+  the Mff-independent-DRP-1-recruitment points.</p>
+<p>Net: my review is anchored on the two direct experimental worm papers (PMID:24196833, PMID:21248201).<br />
+Falcon confirms identity + localization and provides mammalian/ortholog context. No falcon-only claim is<br />
+used as primary evidence; all supporting_text quotes are from cached PMIDs.</p>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: Q19343
+gene_symbol: mff-1
+aliases:
+- F11C1.2
+- Mitochondrial fission factor
+product_type: PROTEIN
+status: DRAFT
+taxon:
+  id: NCBITaxon:6239
+  label: Caenorhabditis elegans
+description: &gt;-
+  MFF-1 is one of two Caenorhabditis elegans orthologs of mammalian mitochondrial
+  fission factor (MFF), a tail-anchored mitochondrial outer membrane protein. It is
+  a short (158 aa) protein with a cytosol-facing N-terminal domain and a single
+  C-terminal transmembrane anchor, embedded in the mitochondrial outer membrane with
+  part of the protein exposed to the cytosol. Together with its paralog MFF-2, MFF-1
+  is required for normal mitochondrial and peroxisomal fission; single mff-1 or mff-2
+  mutants have only weak defects, whereas the mff-1 mff-2 double mutant shows a strong
+  mitochondrial fission defect approaching that of the fission dynamin drp-1, and
+  tubular (unfission) peroxisomes. In this respect the worm Mff proteins differ
+  markedly from the two worm Fis1 homologs (fis-1, fis-2), which have no obvious effect
+  on fission. In mammals MFF is the principal receptor that recruits the
+  dynamin-related GTPase DRP1/DNM1L to the mitochondrial surface; the worm proteins
+  promote fission and contribute to stress-induced mitophagy, acting upstream of the
+  Fis1-dependent step, but Mff is not strictly required for DRP-1 recruitment to worm
+  mitochondria.
+references:
+- id: GO_REF:0000044
+  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location
+    vocabulary mapping, accompanied by conservative changes to GO terms applied by
+    UniProt
+  findings: []
+- id: GO_REF:0000104
+  title: Electronic Gene Ontology annotations created by transferring manual GO annotations
+    between related proteins based on shared sequence features
+  findings: []
+- id: GO_REF:0000120
+  title: Combined Automated Annotation using Multiple IEA Methods
+  findings: []
+- id: PMID:24196833
+  title: Mutations in Fis1 disrupt orderly disposal of defective mitochondria.
+  findings:
+  - statement: &gt;-
+      C. elegans has two Mff homologues (mff-1, mff-2); the Mff double mutant has a
+      mitochondrial fission defect approaching that of drp-1, whereas single mutants
+      are weak (indicating functional redundancy between mff-1 and mff-2)
+    supporting_text: mff-1 and mff-2 single mutants have weak effects, and that the
+      Mff double mutant has a mitochondrial fission defect similar to but not as strong
+      as the drp-1 defect
+  - statement: &gt;-
+      Worm Mff homologues affect both mitochondrial and peroxisome fission, unlike the
+      Fis1 homologues
+    supporting_text: We conclude that C. elegans Mff homologues affect mitochondrial
+      and peroxisome fission, whereas Fis1 homologues have no obvious effects.
+  - statement: &gt;-
+      In worm, Mff is not essential for DRP-1 recruitment to mitochondria (a divergence
+      from the mammalian paradigm)
+    supporting_text: We conclude that Mff affects fission, but Mff and Fis1 are not
+      essential for fission or for Drp1 recruitment to mitochondria in C. elegans.
+  - statement: &gt;-
+      Loss of Mff reduces the number of mitophagosomes; Mff acts upstream of the
+      Fis1-dependent step in the fission-mitophagy sequence
+    supporting_text: significantly reduced number of spots in Mff double and Fis1 Mff
+      quadruple mutant strains
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Full-text PMC paper (van der Bliek lab). Directly assays C. elegans mff-1 (allele
+      tm2955) with its paralog mff-2 (tm3041): establishes the fission role, peroxisome
+      fission role, mitophagy contribution, and the worm-specific finding that Mff is
+      not required for DRP-1 recruitment. Primary experimental source for this gene.
+- id: PMID:21248201
+  title: A novel mitochondrial outer membrane protein, MOMA-1, that affects cristae
+    morphology in Caenorhabditis elegans.
+  findings:
+  - statement: &gt;-
+      mff-1 corresponds to ORF F11C1.2; C. elegans has two Mff homologues encoded by
+      mff-1(F11C1.2) and mff-2(F55F8.6)
+    supporting_text: two Mff homologues, encoded by mff-1(F11C1.2) and mff-2(F55F8.6)
+  - statement: &gt;-
+      MFF-1 is a mitochondrial outer membrane protein, used as an outer membrane marker
+    supporting_text: antibodies for EAT-3 (an inner membrane marker), MOMA-1, MFF-1
+      (an outer membrane marker), and F1β subunit of the ATP synthase complex
+  - statement: &gt;-
+      In protease-protection of intact mitochondria, MFF-1 is digested without
+      detergent, i.e. it is exposed to the cytosol / anchored in the outer membrane
+    supporting_text: MOMA-1 is digested when no detergent is added, like MFF-1, while
+      EAT-3 and F1β are protease protected
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Full-text PMC paper (van der Bliek lab). Confirms gene identity (mff-1 = F11C1.2)
+      and provides experimental support for mitochondrial outer membrane localization
+      of MFF-1 (used as OM marker; digested in protease protection without detergent,
+      indicating cytosol-exposed OM anchoring).
+- id: file:worm/mff-1/mff-1-deep-research-falcon.md
+  title: Deep research report for C. elegans mff-1 (falcon/Edison)
+  findings:
+  - statement: &gt;-
+      By orthology to the well-characterized mammalian MFF, MFF-1 is a membrane-anchored
+      receptor/adaptor that recruits DRP-1 to the mitochondrial outer membrane to promote
+      fission; direct functional tests in worm are limited
+    supporting_text: MFF-1 functions as a membrane-anchored receptor/adaptor protein
+      that recruits the dynamin-related GTPase DRP-1 from the cytosol to the mitochondrial
+      outer membrane, thereby promoting mitochondrial fission
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Genuine falcon/Edison deep-research report (1059 s, 26 citations). Confirms gene
+      identity (mff-1 = F11C1.2, Q19343) and the Head et al. 2011 OM localization result,
+      and supplies mammalian/ortholog context (DRP1 receptor role, peroxisome fission,
+      AMPK regulation, disease). The receptor/adaptor claim for worm is orthology-based
+      inference, not a direct worm assay; used only as supporting/contextual evidence.
+existing_annotations:
+- term:
+    id: GO:0000266
+    label: mitochondrial fission
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000104
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Mitochondrial fission is the core biological process for MFF-1. This UniRule IEA
+      annotation is transferred from the characterized mammalian MFF ortholog and is
+      directly supported by C. elegans genetics. Single mff-1 (and mff-2) mutants have
+      weak effects owing to redundancy, but the mff-1 mff-2 double mutant has a strong
+      mitochondrial fission defect approaching that of drp-1.
+    action: ACCEPT
+    reason: &gt;-
+      Genuine, experimentally supported core function in worm. Unlike the worm Fis1
+      homologs (fis-1, fis-2), the Mff homologs have a real fission role. The IEA term
+      is corroborated by direct mutant analysis (PMID:24196833).
+    supported_by:
+    - reference_id: PMID:24196833
+      supporting_text: mff-1 and mff-2 single mutants have weak effects, and that the
+        Mff double mutant has a mitochondrial fission defect similar to but not as strong
+        as the drp-1 defect
+- term:
+    id: GO:0005741
+    label: mitochondrial outer membrane
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000044
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      MFF-1 is a tail-anchored mitochondrial outer membrane protein (single C-terminal
+      transmembrane helix, aa 139-156; cytosol-facing N-terminus). This SubCell IEA
+      annotation is experimentally supported in worm, where anti-MFF-1 antibody serves
+      as a mitochondrial outer membrane marker and MFF-1 is digested in
+      protease-protection assays on intact mitochondria without detergent.
+    action: ACCEPT
+    reason: &gt;-
+      Core localization, experimentally confirmed in C. elegans (PMID:21248201) and
+      consistent with the canonical MFF topology and UniProt SubCell annotation.
+    supported_by:
+    - reference_id: PMID:21248201
+      supporting_text: MOMA-1 is digested when no detergent is added, like MFF-1, while
+        EAT-3 and F1β are protease protected
+- term:
+    id: GO:0005777
+    label: peroxisome
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000120
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      MFF mediates peroxisomal as well as mitochondrial fission. In worm, the mff-1
+      mff-2 double mutant shows tubular (un-divided) peroxisomes, indicating a
+      peroxisome fission defect, which supports a functional MFF role at peroxisomes.
+      This IEA localization annotation is consistent with the peroxisome fission
+      function.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Supported by worm genetics (Mff double mutant to tubular peroxisomes,
+      PMID:24196833) and by ortholog function, but peroxisome fission is a secondary
+      role relative to the dominant mitochondrial fission function; retained as non-core.
+    supported_by:
+    - reference_id: PMID:24196833
+      supporting_text: We conclude that C. elegans Mff homologues affect mitochondrial
+        and peroxisome fission, whereas Fis1 homologues have no obvious effects.
+- term:
+    id: GO:0090141
+    label: positive regulation of mitochondrial fission
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000104
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      MFF-1 promotes mitochondrial fission; its loss reduces fission (double mutant
+      fission defect) and its function acts upstream in the fission pathway. This
+      UniRule IEA annotation captures the positive-regulatory nature of the MFF
+      receptor/adaptor role in driving fission.
+    action: ACCEPT
+    reason: &gt;-
+      Consistent with the experimentally supported pro-fission role in worm
+      (PMID:24196833). Appropriately specific positive-regulation term for a fission
+      factor that promotes rather than executes membrane scission.
+    supported_by:
+    - reference_id: PMID:24196833
+      supporting_text: the Mff double mutant has a mitochondrial fission defect similar
+        to but not as strong as the drp-1 defect
+- term:
+    id: GO:0090314
+    label: positive regulation of protein targeting to membrane
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000104
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      This UniRule IEA term encodes the mammalian MFF function of recruiting the fission
+      dynamin DRP1/DNM1L to the mitochondrial outer membrane. In C. elegans, however,
+      Mff (mff-1/mff-2) is NOT strictly required for DRP-1 recruitment - CFP::DRP-1
+      still forms fission-marking spots and fractionates to mitochondria normally in
+      Mff double and quadruple mutants, and worm lacks the MiD49/MiD51 receptors.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      The annotation is inferred from mammalian orthology and is only partially
+      supported in worm. Because DRP-1 reaches worm mitochondria without Mff, this
+      recruitment function is not firmly established as a worm activity; retained as
+      non-core with an explicit caveat rather than removed (the mammalian ortholog
+      function and the pro-fission role make it plausible, and it is not contradicted
+      as a contributory rather than essential recruitment role).
+    supported_by:
+    - reference_id: PMID:24196833
+      supporting_text: Mff and Fis1 are not essential for fission or for Drp1 recruitment
+        to mitochondria in C. elegans
+    - reference_id: file:worm/mff-1/mff-1-deep-research-falcon.md
+      supporting_text: MFF-1 functions as a membrane-anchored receptor/adaptor protein
+        that recruits the dynamin-related GTPase DRP-1 from the cytosol to the mitochondrial
+        outer membrane, thereby promoting mitochondrial fission
+core_functions:
+- description: &gt;-
+    MFF-1 is a tail-anchored mitochondrial outer membrane adaptor that, redundantly
+    with its paralog MFF-2, promotes mitochondrial (and peroxisomal) fission - the
+    mff-1 mff-2 double mutant has a strong fission defect approaching that of the
+    fission dynamin drp-1.
+  molecular_function:
+    id: GO:0060090
+    label: molecular adaptor activity
+  directly_involved_in:
+  - id: GO:0000266
+    label: mitochondrial fission
+  locations:
+  - id: GO:0005741
+    label: mitochondrial outer membrane
+  supported_by:
+  - reference_id: PMID:24196833
+    supporting_text: mff-1 and mff-2 single mutants have weak effects, and that the
+      Mff double mutant has a mitochondrial fission defect similar to but not as strong
+      as the drp-1 defect
+  - reference_id: PMID:21248201
+    supporting_text: antibodies for EAT-3 (an inner membrane marker), MOMA-1, MFF-1
+      (an outer membrane marker), and F1β subunit of the ATP synthase complex
+knowledge_gaps:
+- gap_statement: &gt;-
+    The specific molecular activity of C. elegans MFF-1 is uncharacterized: whether
+    worm MFF-1 physically binds DRP-1 (and via which surface), whether it acts as a
+    receptor/adaptor that recruits DRP-1 as in mammals, and whether it has any activity
+    beyond scaffolding, are all undetermined. The GO molecular function is captured
+    only by orthology-based IEA (positive regulation of protein targeting to membrane),
+    not by a demonstrated worm activity.
+  boundary: &gt;-
+    It is firmly established that MFF-1 is a tail-anchored mitochondrial outer membrane
+    protein (PMID:21248201) and that mff-1, redundantly with mff-2, is required for
+    normal mitochondrial and peroxisomal fission (PMID:24196833). What is NOT
+    established is the direct biochemical mechanism by which MFF-1 promotes fission in
+    worm, because DRP-1 still localizes to mitochondria without Mff.
+  gap_kind:
+  - BIOLOGY
+  dark_aspect: MF_DARK
+  status: OPEN
+  significance: &gt;-
+    In mammals MFF is the principal DRP1 receptor, but the worm data show DRP-1
+    recruitment is Mff-independent, so the worm MFF-1 mechanism may differ from the
+    textbook receptor model. Resolving it would clarify how metazoan fission-factor
+    function is (or is not) conserved.
+  resolution: &gt;-
+    Direct MFF-1-DRP-1 interaction assays (co-IP, in vitro binding), structure-guided
+    mutagenesis of the cytosolic domain, and rescue of the mff-1 mff-2 double mutant
+    with wild-type vs interaction-defective MFF-1.
+  provenance:
+  - reference_id: PMID:24196833
+    supporting_text: Mff and Fis1 are not essential for fission or for Drp1 recruitment
+      to mitochondria in C. elegans
+- gap_statement: &gt;-
+    The division of labor between mff-1 and mff-2 is unresolved: which paralog dominates,
+    whether they are functionally interchangeable, whether they act in different tissues
+    or at different targets (mitochondria vs peroxisomes), and whether they
+    hetero-oligomerize are all unknown. Single-mutant phenotypes are weak, so the
+    individual contribution of mff-1 has not been isolated.
+  boundary: &gt;-
+    It is established that single mff-1 and single mff-2 mutants have only weak fission
+    defects while the double mutant is strong, indicating substantial redundancy
+    (PMID:24196833). The relative and tissue-specific contributions of each paralog are
+    the gap.
+  gap_kind:
+  - BIOLOGY
+  dark_aspect: RESIDUAL_SUBGAP
+  status: OPEN
+  significance: &gt;-
+    Understanding mff-1 vs mff-2 (and their relation to fis-1/fis-2) division of labor
+    is needed to build an accurate model of worm DRP-1 recruitment and mitochondrial
+    fission, and to interpret single-gene perturbations in the mitophagy/aging pathway.
+  resolution: &gt;-
+    Paralog-specific tagged reporters and tissue-restricted rescue of the mff-1 mff-2
+    double mutant, plus mff-1 vs mff-2 single- and cross-rescue experiments.
+  provenance:
+  - reference_id: PMID:24196833
+    supporting_text: mff-1 and mff-2 single mutants have weak effects, and that the
+      Mff double mutant has a mitochondrial fission defect similar to but not as strong
+      as the drp-1 defect
+proposed_new_terms: []
+suggested_questions:
+- question: &gt;-
+    Does C. elegans MFF-1 physically bind DRP-1, and is it a functional DRP-1 receptor
+    given that DRP-1 recruitment to mitochondria is Mff-independent in worm?
+  experts:
+  - Alexander M. van der Bliek
+- question: &gt;-
+    What is the functional division of labor between mff-1 and mff-2 (and relative to
+    fis-1/fis-2) in worm mitochondrial versus peroxisomal fission?
+  experts:
+  - Alexander M. van der Bliek
+suggested_experiments:
+- hypothesis: &gt;-
+    MFF-1 promotes fission by recruiting or organizing DRP-1 at the outer membrane even
+    though DRP-1 can reach mitochondria independently of Mff.
+  description: &gt;-
+    Co-immunoprecipitation and in vitro binding assays between MFF-1 (cytosolic domain)
+    and DRP-1, combined with structure-guided mutagenesis and rescue of the mff-1 mff-2
+    double mutant.
+  experiment_type: protein interaction / genetic rescue
+- hypothesis: mff-1 and mff-2 have distinct tissue or organelle preferences.
+  description: &gt;-
+    Paralog-specific fluorescent reporters and tissue-restricted rescue of the mff-1
+    mff-2 double mutant to dissect individual contributions at mitochondria versus
+    peroxisomes.
+  experiment_type: reporter expression / genetic rescue
+tags:
+- caeel-mitophagy
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/genes/worm/mksr-1/mksr-1-ai-review.html
+++ b/genes/worm/mksr-1/mksr-1-ai-review.html
@@ -1,0 +1,4200 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>mksr-1 - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        .propagation-review {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f8fafc;
+            border-left: 3px solid #64748b;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .propagation-title {
+            font-weight: 600;
+            color: #334155;
+            margin-bottom: 0.25rem;
+        }
+
+        .propagation-row {
+            margin-top: 0.25rem;
+        }
+
+        .propagation-source {
+            margin-top: 0.5rem;
+            padding-top: 0.5rem;
+            border-top: 1px solid #e5e7eb;
+        }
+
+        .propagation-source-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #1d4ed8;
+        }
+
+        .propagation-comment {
+            color: #4b5563;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>mksr-1</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/Q21191" target="_blank" class="term-link">
+                        Q21191
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Caenorhabditis elegans</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-complete">
+                    COMPLETE
+                </span>
+            </div>
+
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "mksr-1";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="Q21191" data-a="DESCRIPTION: MKSR-1 (MKS-1-related protein 1) is the Caenorhabd..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>MKSR-1 (MKS-1-related protein 1) is the Caenorhabditis elegans ortholog of human B9D1, one of the three B9-domain proteins (with MKS-1/MKS1 and MKSR-2/B9D2). It is a small, soluble B9/C2-domain protein and a core component of the MKS module, one of the two protein modules (MKS and NPHP) that together assemble the ciliary transition zone (TZ) at the base of sensory cilia. The TZ builds the Y-link connectors that tether the axoneme doublet microtubules to the ciliary membrane and forms the ciliary gate, a membrane diffusion barrier that restricts entry of non-ciliary membrane proteins into the cilium. MKSR-1 localizes to the TZ of ciliated sensory neurons; its localization is co-dependent with the other B9 proteins and requires the upstream scaffold MKS-5/RPGRIP1L. MKSR-1 in turn is required for the TZ localization of other MKS-module proteins (e.g. MKS-6/CC2D2A and MKS-3/meckelin) and forms a heterodimer with MKSR-2/B9D2. Consistent with the strong redundancy among transition-zone genes, mksr-1 single mutants have no overt defect in cilium structure or intraflagellar transport, whereas mksr-1;nphp-4 double mutants disrupt TZ membrane anchoring and Y-links; even in the single mutant, however, the ciliary gate leaks, allowing membrane proteins such as TRAM-1a and RPI-2 to enter the cilium. In humans, B9D1 is a Meckel-Gruber syndrome/nephronophthisis-spectrum ciliopathy gene.</p>
+    </div>
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Proposed New Ontology Terms</h2>
+
+        <div class="proposed-term">
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>structural constituent of ciliary transition zone</h3>
+                <span class="vote-buttons" data-g="Q21191" data-a="structural constituent of ciliary transition zone" data-r="" data-act="NEW">
+                    <button class="vote-btn" data-v="up" title="Agree this term should be created">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with creating this term">👎</button>
+                </span>
+            </div>
+
+
+            <p><strong>Definition:</strong> The action of a protein that contributes to the structural integrity of the ciliary transition zone, for example by acting as a scaffold or B9/C2-domain subunit of the MKS or NPHP module that helps build the Y-link connectors and the membrane diffusion barrier at the ciliary base, without itself catalyzing a biochemical reaction.</p>
+
+
+
+
+
+            <p><strong>Parent term:</strong>
+                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005198" target="_blank" class="term-link">
+                    structural molecule activity
+                </a>
+            </p>
+
+
+
+
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0036038" target="_blank" class="term-link">
+                                    GO:0036038
+                                </a>
+                            </span>
+                            <span class="term-label">MKS complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q21191" data-a="GO:0036038" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> MKSR-1/B9D1 is a core B9-domain subunit of the MKS module (MKS complex) at the ciliary transition zone. The phylogenetic (IBA) inference is directly corroborated by experimental work in C. elegans placing MKSR-1 in the MKS/MKSR module together with MKS-1, MKSR-2, MKS-3 and MKS-6.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Core cellular-component/complex annotation. The IBA inference from the B9D1 PANTHER family is consistent with direct C. elegans genetics and imaging, so it is retained as a core annotation.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/21422230" target="_blank" class="term-link">
+                                        PMID:21422230
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">MKS/MKSR module ... consisting of MKS-1/MKSR-1/MKSR-2/MKS-3/MKS-6</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0060271" target="_blank" class="term-link">
+                                    GO:0060271
+                                </a>
+                            </span>
+                            <span class="term-label">cilium assembly</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-modify">
+                            MODIFY
+                        </span>
+                        <span class="vote-buttons" data-g="Q21191" data-a="GO:0060271" data-r="GO_REF:0000033" data-act="MODIFY">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> As a core MKS-module subunit, MKSR-1 participates (redundantly with the NPHP module) in building the transition zone during assembly of the non-motile sensory cilia of C. elegans. The generic &#39;cilium assembly&#39; term is correct but less precise than &#39;non-motile cilium assembly&#39;, which is already experimentally annotated for this gene and matches the fact that all worm cilia are non-motile sensory cilia.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The essence (a role in cilium assembly) is right, but a more specific term is available and better supported. C. elegans sensory cilia are non-motile, and the gene already carries experimental IGI annotations to non-motile cilium assembly; generalize the IBA to the same specific process.
+                        </div>
+
+
+
+                        <div class="propagation-review">
+                            <div class="propagation-title">Propagation Review</div>
+                            <div class="propagation-row">
+                                <strong>Root cause:</strong>
+                                <span class="badge">TERM SCOPING PROBLEM</span>
+                            </div>
+
+                            <div class="propagation-row">
+                                <strong>Failure modes:</strong>
+
+                                <span class="badge">GRANULARITY MISMATCH</span>
+
+                            </div>
+
+
+                            <div class="propagation-source">
+                                <strong>Sources checked:</strong>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">PANTHER:PTN000311628</span>
+
+                                    &middot; PANTHER PTHR12968 B9 domain-containing family node
+
+
+                                    <span class="badge">SUPPORTS TRANSFER</span>
+
+
+                                    <div class="propagation-comment">The B9D1 family node correctly propagates a cilium-assembly role, but in C. elegans all cilia are non-motile sensory cilia, so the more specific child term (non-motile cilium assembly) applies and is already supported by experimental IGI annotations for mksr-1. This is a granularity refinement, not an erroneous propagation.</div>
+
+                                </div>
+
+                            </div>
+
+                        </div>
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1905515" target="_blank" class="term-link">
+                                    non-motile cilium assembly
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/18337471" target="_blank" class="term-link">
+                                        PMID:18337471
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">regulate the formation and/or maintenance of cilia and dendrites in the amphid and phasmid ciliated sensory neurons</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005929" target="_blank" class="term-link">
+                                    GO:0005929
+                                </a>
+                            </span>
+                            <span class="term-label">cilium</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000117
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-modify">
+                            MODIFY
+                        </span>
+                        <span class="vote-buttons" data-g="Q21191" data-a="GO:0005929" data-r="GO_REF:0000117" data-act="MODIFY">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> The ARBA electronic annotation places MKSR-1 in the cilium. This is correct at a coarse level but far less informative than the experimentally established ciliary transition-zone localization; MKSR-1 concentrates specifically at the TZ at the ciliary base, not along the ciliary axoneme.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The generic &#39;cilium&#39; location is subsumed by the specific, experimentally supported &#39;ciliary transition zone&#39; localization (IDA, PMID:21422230). Replace with the more informative and accurate compartment term.
+                        </div>
+
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0035869" target="_blank" class="term-link">
+                                    ciliary transition zone
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/21422230" target="_blank" class="term-link">
+                                        PMID:21422230
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">This is evident for MKS-1, MKS-1 related-1 (MKSR-1)/B9D1</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/14704431" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:14704431
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    A map of the interactome network of the metazoan C. elegans.
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q21191" data-a="GO:0005515" data-r="PMID:14704431" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IntAct-curated binary interaction between MKSR-1 (Q21191) and MKSR-2/B9D2 (Q9N423) from the C. elegans interactome map. The interaction is real and biologically meaningful (the B9D1-B9D2 heterodimer is a substructure of the MKS module), but the generic &#39;protein binding&#39; term conveys no specific molecular function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Experimental (IPI) interaction data should not be removed. However, &#39;protein binding&#39; is uninformative and is not the core function; the meaningful fact (MKSR-1-MKSR-2/B9D1-B9D2 heterodimer within the MKS module) is captured by the MKS-complex membership and the structural role in core_functions. Retained as a non-core supporting annotation.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/21422230" target="_blank" class="term-link">
+                                        PMID:21422230
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">MKS/MKSR module ... consisting of MKS-1/MKSR-1/MKSR-2/MKS-3/MKS-6</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/19123269" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:19123269
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Empirically controlled mapping of the Caenorhabditis elegans...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q21191" data-a="GO:0005515" data-r="PMID:19123269" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> A second IntAct-curated MKSR-1-MKSR-2 binary interaction, from the empirically-controlled C. elegans interactome. As above, the interaction is genuine but &#39;protein binding&#39; is uninformative.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Do not remove experimental interaction evidence. &#39;Protein binding&#39; is a low-information term; the MKSR-1-MKSR-2 heterodimer is represented by the MKS-complex membership and structural role. Retained as non-core.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/21422230" target="_blank" class="term-link">
+                                        PMID:21422230
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">MKS/MKSR module ... consisting of MKS-1/MKSR-1/MKSR-2/MKS-3/MKS-6</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1905515" target="_blank" class="term-link">
+                                    GO:1905515
+                                </a>
+                            </span>
+                            <span class="term-label">non-motile cilium assembly</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IGI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/18337471" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:18337471
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Functional redundancy of the B9 proteins and nephrocystins i...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q21191" data-a="GO:1905515" data-r="PMID:18337471" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Williams et al. showed the C. elegans B9 proteins (including MKSR-1) function redundantly with the nephrocystins: B9-gene mutations do not overtly affect cilia unless combined with a mutation in nph-1 or nph-4, revealing a (redundant) requirement of MKSR-1 for assembly of the non-motile sensory cilia. Reflected by the genetic interaction with the NPHP module.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Well-supported IGI annotation capturing the canonical MKS/NPHP redundancy. The synthetic ciliary phenotype with nphp genes is the standard genetic signature placing MKSR-1 in the MKS module and demonstrating its redundant role in cilium assembly. Core module-level function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/18337471" target="_blank" class="term-link">
+                                        PMID:18337471
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Mutations in the B9 genes do not overtly affect cilia formation unless they are in combination with a mutation in nph-1 or nph-4</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1904491" target="_blank" class="term-link">
+                                    GO:1904491
+                                </a>
+                            </span>
+                            <span class="term-label">protein localization to ciliary transition zone</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/26595381" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:26595381
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    TMEM107 recruits ciliopathy proteins to subdomains of the ci...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q21191" data-a="GO:1904491" data-r="PMID:26595381" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> WormBase IMP annotation from the TMEM107 study, which dissected MKS-module recruitment/organization at the TZ. The cached record is abstract-only; the abstract establishes that TMEM-107 organizes recruitment of MKS-module ciliopathy proteins to TZ subdomains, and the curator assigned the IMP for MKSR-1&#39;s role in TZ protein localization from the full text.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Experimental (IMP) annotation by a WormBase curator; the full text (not in cache) contains the direct evidence. Concordant with PMID:21422230, which directly shows MKSR-1 is required for TZ localization of MKS-6 and MKS-3. Per curation guidance the experimental annotation is retained rather than second-guessed from an abstract-only cache.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/26595381" target="_blank" class="term-link">
+                                        PMID:26595381
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">TZ-localized MKS module by organizing recruitment of the ciliopathy proteins</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1904491" target="_blank" class="term-link">
+                                    GO:1904491
+                                </a>
+                            </span>
+                            <span class="term-label">protein localization to ciliary transition zone</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/21422230" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:21422230
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    MKS and NPHP modules cooperate to establish basal body/trans...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q21191" data-a="GO:1904491" data-r="PMID:21422230" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Williams et al. directly show that disrupting MKSR-1 causes TZ delocalization of other MKS-module proteins: MKS-6 and MKS-3 fail to localize to the TZ in mksr-1 mutants (MKS-3 additionally accumulates along the axoneme). This defines MKSR-1 as required for correct protein localization to the transition zone.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Directly supported experimental (IMP) annotation. Loss of mksr-1 mislocalizes downstream TZ proteins, demonstrating a role in establishing protein localization to the transition zone. Core function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/21422230" target="_blank" class="term-link">
+                                        PMID:21422230
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">disrupting MKSR-1, MKSR-2, or MKS-5 results in TZ delocalization of MKS-6</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/21422230" target="_blank" class="term-link">
+                                        PMID:21422230
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">MKSR-1, MKSR-2, and MKS-5 restrict MKS-3 to the TZ membrane</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1905515" target="_blank" class="term-link">
+                                    GO:1905515
+                                </a>
+                            </span>
+                            <span class="term-label">non-motile cilium assembly</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IGI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/21422230" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:21422230
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    MKS and NPHP modules cooperate to establish basal body/trans...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q21191" data-a="GO:1905515" data-r="PMID:21422230" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> The genetic-interaction (IGI) evidence captures the MKS/NPHP redundancy in cilium assembly: the mksr-1;nphp-4 double mutant produces severe TZ ultrastructure defects (TZ not anchored to membrane, missing Y-links) nearly identical to mks-6;nphp-4, whereas the mksr-1 single mutant is structurally near-normal. WITH values reference the NPHP-module genes nphp-4/nphp-1.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Well-supported IGI annotation. The synthetic ultrastructural phenotype with the NPHP module is the standard genetic signature placing mksr-1 in the MKS module and demonstrating its (redundant) requirement for TZ/cilium assembly.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/21422230" target="_blank" class="term-link">
+                                        PMID:21422230
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Phenotypes nearly identical to mks-6;nphp-4 mutants were observed in the mksr-1;nphp-4 strain</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0035869" target="_blank" class="term-link">
+                                    GO:0035869
+                                </a>
+                            </span>
+                            <span class="term-label">ciliary transition zone</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/21422230" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:21422230
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    MKS and NPHP modules cooperate to establish basal body/trans...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q21191" data-a="GO:0035869" data-r="PMID:21422230" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct imaging of GFP/tdTomato-tagged MKSR-1 (B9D1) shows it concentrates at the ciliary transition zone in C. elegans sensory neurons, adjacent to and distinct from the basal body/transition-fibre region where IFT proteins peak. This is the core experimentally-established localization.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Experimental (IDA) localization to the transition zone, concordant with the IBA annotation and with the conserved TZ localization of B9D1 across metazoans. Core cellular-component annotation.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/21422230" target="_blank" class="term-link">
+                                        PMID:21422230
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">This is evident for MKS-1, MKS-1 related-1 (MKSR-1)/B9D1</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008340" target="_blank" class="term-link">
+                                    GO:0008340
+                                </a>
+                            </span>
+                            <span class="term-label">determination of adult lifespan</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IGI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/19208769" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:19208769
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Functional interactions between the ciliopathy-associated Me...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q21191" data-a="GO:0008340" data-r="PMID:19208769" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Bialas et al. found that all double mks/mksr mutant combinations (including those involving mksr-1) show an increased-lifespan phenotype caused by abnormal insulin-IGF-I signaling. This is an indirect, downstream consequence of compromised ciliary signaling under module redundancy, not a direct molecular function of MKSR-1.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Valid experimental (IGI) genetic-interaction annotation, but lifespan determination is a pleiotropic downstream effect of impaired cilium/sensory signaling rather than a core function of a transition-zone scaffold subunit. Retained as a non-core annotation.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/19208769" target="_blank" class="term-link">
+                                        PMID:19208769
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">increased lifespan phenotype, which is due to abnormal insulin-IGF-I signaling</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/18337471" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:18337471
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Functional redundancy of the B9 proteins and nephrocystins i...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q21191" data-a="GO:0005515" data-r="PMID:18337471" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> WormBase IPI annotation for a physical interaction of MKSR-1 with another B9 protein (WITH/FROM WBGene00021416 = mksr-2/B9D2), consistent with the co-dependent B9-protein complex at the ciliary base. As with the IntAct IPIs, the interaction is real but &#39;protein binding&#39; is uninformative.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Do not remove experimental interaction evidence. The MKSR-1-MKSR-2 heterodimer it captures is represented by MKS-complex membership and the structural role in core_functions; the generic term itself is non-core and low-information.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/18337471" target="_blank" class="term-link">
+                                        PMID:18337471
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">the C. elegans B9 proteins form a complex that localizes to the base of cilia</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008104" target="_blank" class="term-link">
+                                    GO:0008104
+                                </a>
+                            </span>
+                            <span class="term-label">intracellular protein localization</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/18337471" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:18337471
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Functional redundancy of the B9 proteins and nephrocystins i...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-modify">
+                            MODIFY
+                        </span>
+                        <span class="vote-buttons" data-g="Q21191" data-a="GO:0008104" data-r="PMID:18337471" data-act="MODIFY">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> This generic &#39;intracellular protein localization&#39; IMP reflects MKSR-1&#39;s role in localizing other ciliary/TZ proteins (the B9 proteins localize co-dependently at the ciliary base, and MKSR-1 is required for TZ localization of MKS-module proteins). A far more specific and better-supported term exists: protein localization to the ciliary transition zone.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The essence is right (MKSR-1 governs the localization of specific proteins), but &#39;intracellular protein localization&#39; is over-general. Replace with the specific process protein localization to ciliary transition zone, which is directly documented and already annotated for this gene.
+                        </div>
+
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1904491" target="_blank" class="term-link">
+                                    protein localization to ciliary transition zone
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/18337471" target="_blank" class="term-link">
+                                        PMID:18337471
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">the C. elegans B9 proteins form a complex that localizes to the base of cilia</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0035177" target="_blank" class="term-link">
+                                    GO:0035177
+                                </a>
+                            </span>
+                            <span class="term-label">larval foraging behavior</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IGI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/18337471" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:18337471
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Functional redundancy of the B9 proteins and nephrocystins i...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q21191" data-a="GO:0035177" data-r="PMID:18337471" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> WormBase IGI annotation linking mksr-1 (redundantly with the NPHP module) to larval foraging behavior. Foraging/roaming in C. elegans depends on functional sensory cilia, so a B9-gene x nphp genetic interaction that compromises cilia would be expected to affect foraging. The cached record is abstract-only and does not itself state &#39;foraging&#39;, so this rests on the curator&#39;s reading of the full text.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Downstream sensory-behavior phenotype rather than a core molecular/cellular function of a TZ scaffold subunit. The experimental IGI annotation is retained (not overruled from an abstract-only cache) but marked non-core.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/18337471" target="_blank" class="term-link">
+                                        PMID:18337471
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">regulate the formation and/or maintenance of cilia and dendrites in the amphid and phasmid ciliated sensory neurons</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1903565" target="_blank" class="term-link">
+                                    GO:1903565
+                                </a>
+                            </span>
+                            <span class="term-label">negative regulation of protein localization to cilium</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/21422230" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:21422230
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    MKS and NPHP modules cooperate to establish basal body/trans...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-new">
+                            NEW
+                        </span>
+                        <span class="vote-buttons" data-g="Q21191" data-a="GO:1903565" data-r="PMID:21422230" data-act="NEW">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> MKSR-1 is required for ciliary-gate (diffusion-barrier) function. In the mksr-1 single mutant, membrane-associated proteins that are normally excluded from cilia accumulate inside them: TRAM-1a and RPI-2 (RP2 ortholog) both accumulate within cilia of mksr-1 mutants, and MKS-3 abnormally accumulates inside cilia. This gate/barrier activity is the central function of the TZ and is not otherwise captured in GOA for mksr-1.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> New annotation proposed to capture MKSR-1&#39;s ciliary-gate role, directly demonstrated in the mksr-1 single mutant (leak of TRAM-1a, RPI-2 and MKS-3 into cilia). This mirrors the curated gate-function annotation modeled for the sibling gene mks-2 and represents a core function currently missing from mksr-1&#39;s GOA record.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/21422230" target="_blank" class="term-link">
+                                        PMID:21422230
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">accumulates within cilia of mksr-1, mksr-2, mks-5, mks-6, nphp-1, and nphp-4 mutants</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/21422230" target="_blank" class="term-link">
+                                        PMID:21422230
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">TZ proteins normally function to maintain a boundary at the cilium base, establishing the TZ as a bona fide ciliary gate</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>MKSR-1/B9D1 acts as a structural/scaffolding subunit of the MKS module of the ciliary transition zone. As a soluble B9/C2-domain protein it localizes to the TZ (dependent on MKS-5) and contributes to assembly and integrity of the TZ (Y-link connectors and basal body/TZ membrane anchoring) and to the ciliary gate - the membrane diffusion barrier that restricts non-ciliary membrane proteins (e.g. TRAM-1a, RPI-2) from entering the cilium. It is required to recruit/retain other MKS-module proteins (MKS-6, MKS-3) at the TZ and forms a heterodimer with MKSR-2/B9D2. There is no GO molecular-function term that precisely describes a transition-zone diffusion-barrier scaffold subunit; &#39;structural molecule activity&#39; is used here as the closest available placeholder.</h3>
+                <span class="vote-buttons" data-g="Q21191" data-a="FUNCTION: MKSR-1/B9D1 acts as a structural/scaffolding subun..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005198" target="_blank" class="term-link">
+                            structural molecule activity
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1905515" target="_blank" class="term-link">
+                                non-motile cilium assembly
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1904491" target="_blank" class="term-link">
+                                protein localization to ciliary transition zone
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1903565" target="_blank" class="term-link">
+                                negative regulation of protein localization to cilium
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0035869" target="_blank" class="term-link">
+                                ciliary transition zone
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">In Complex:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0036038" target="_blank" class="term-link">
+                            MKS complex
+                        </a>
+                    </span>
+                </div>
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/21422230" target="_blank" class="term-link">
+                                PMID:21422230
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">MKSR-1, MKSR-2, and MKS-5 restrict MKS-3 to the TZ membrane</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/21422230" target="_blank" class="term-link">
+                                PMID:21422230
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">accumulates within cilia of mksr-1, mksr-2, mks-5, mks-6, nphp-1, and nphp-4 mutants</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
+                            GO_REF:0000033
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Annotation inferences using phylogenetic trees</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000117.md" target="_blank" class="term-link">
+                            GO_REF:0000117
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Electronic Gene Ontology annotations created by ARBA machine learning models</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/14704431" target="_blank" class="term-link">
+                            PMID:14704431
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">A map of the interactome network of the metazoan C. elegans.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/18337471" target="_blank" class="term-link">
+                            PMID:18337471
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Functional redundancy of the B9 proteins and nephrocystins in Caenorhabditis elegans ciliogenesis.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">The C. elegans B9 proteins (MKS-1/MKSR-1/MKSR-2) form a complex at the base of cilia and function redundantly with the nephrocystins (nph-1/nph-4); B9-gene mutations do not overtly affect cilia unless combined with a nph mutation.</div>
+
+                        <div class="finding-text">"Mutations in the B9 genes do not overtly affect cilia formation unless they are in combination with a mutation in nph-1 or nph-4"</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/19123269" target="_blank" class="term-link">
+                            PMID:19123269
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Empirically controlled mapping of the Caenorhabditis elegans protein-protein interactome network.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/19208769" target="_blank" class="term-link">
+                            PMID:19208769
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Functional interactions between the ciliopathy-associated Meckel syndrome 1 (MKS1) protein and two novel MKS1-related (MKSR) proteins.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">The B9 domain defines a family of three proteins (MKS-1, MKSR-1, MKSR-2) in ciliated organisms; all three localize co-dependently to transition zones/basal bodies of C. elegans sensory cilia. Double mks/mksr mutants show an increased-lifespan phenotype due to abnormal insulin-IGF-I signaling.</div>
+
+                        <div class="finding-text">"increased lifespan phenotype, which is due to abnormal insulin-IGF-I signaling"</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/21422230" target="_blank" class="term-link">
+                            PMID:21422230
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">MKS and NPHP modules cooperate to establish basal body/transition zone membrane associations and ciliary gate function during ciliogenesis.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">MKSR-1/B9D1 localizes to the ciliary transition zone and is a member of the MKS/MKSR module (with MKS-1, MKSR-2, MKS-3, MKS-6); the mksr-1;nphp-4 double mutant disrupts TZ membrane anchoring and Y-links.</div>
+
+                        <div class="finding-text">"Phenotypes nearly identical to mks-6;nphp-4 mutants were observed in the mksr-1;nphp-4 strain"</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <div class="finding-statement">MKSR-1 is required for the transition-zone localization of other MKS-module proteins (MKS-6 and MKS-3), restricting MKS-3 to the TZ membrane.</div>
+
+                        <div class="finding-text">"MKSR-1, MKSR-2, and MKS-5 restrict MKS-3 to the TZ membrane"</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <div class="finding-statement">MKSR-1 contributes to ciliary-gate function; in mksr-1 mutants the normally-excluded membrane proteins TRAM-1a and RPI-2 accumulate inside cilia.</div>
+
+                        <div class="finding-text">"accumulates within cilia of mksr-1, mksr-2, mks-5, mks-6, nphp-1, and nphp-4 mutants"</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/26595381" target="_blank" class="term-link">
+                            PMID:26595381
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">TMEM107 recruits ciliopathy proteins to subdomains of the ciliary transition zone and causes Joubert syndrome.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">TMEM-107 organizes recruitment of MKS-module ciliopathy proteins to subdomains of the ciliary transition zone; MKS-module membrane proteins are immobile and periodically arranged within the TZ.</div>
+
+                        <div class="finding-text">"TZ-localized MKS module by organizing recruitment of the ciliopathy proteins"</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Questions for Experts</h2>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Does the MKSR-1/B9D1 B9/C2 domain bind Ca2+ and/or membrane lipids in vitro, as predicted from its synaptotagmin-like C2 fold, and is any such activity required for its transition-zone function?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q21191" data-a="Q: Does the MKSR-1/B9D1 B9/C2 domain bind Ca2+ and/or..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Beyond the MKSR-1-MKSR-2 (B9D1-B9D2) heterodimer, what are MKSR-1&#39;s direct contacts within the MKS module, and does it occupy a discrete sub-position in the transition-zone architecture?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q21191" data-a="Q: Beyond the MKSR-1-MKSR-2 (B9D1-B9D2) heterodimer, ..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Experiments</h2>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> In vitro biochemistry of the recombinant MKSR-1 B9/C2 domain (Ca2+ and phospholipid binding assays), complemented by structure-guided mutagenesis of candidate Ca2+/lipid-binding residues assayed in vivo for TZ localization and gate function.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: The MKSR-1 B9/C2 domain binds Ca2+/membrane lipids and this contributes to its anchoring or barrier role at the transition zone.</em></p>
+
+
+                </div>
+                <span class="vote-buttons" data-g="Q21191" data-a="EXPERIMENT: In vitro biochemistry of the recombinant MKSR-1 B9..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Proximity labelling (TurboID/BioID) or affinity purification of tagged MKSR-1 in C. elegans ciliated neurons to map its direct transition-zone interaction partners, and separation-of-function alleles tested for TRAM-1a exclusion (gate), MKS-6/MKS-3 recruitment, and Y-link ultrastructure by TEM.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: MKSR-1 occupies a specific position in the MKS-module interaction network with a defined set of direct partners and separable recruitment vs barrier functions.</em></p>
+
+
+                </div>
+                <span class="vote-buttons" data-g="Q21191" data-a="EXPERIMENT: Proximity labelling (TurboID/BioID) or affinity pu..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Knowledge Gaps</h2>
+        <p style="color: #555; font-size: 0.92rem; margin-top: -0.3rem;">
+            What is <em>not</em> known — curated, literature-grounded statements of the open
+            unknowns (the inverse of core functions).
+        </p>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> MKSR-1 has no assigned molecular function and there is no GO term to express one. Its role is to be a structural/diffusion-barrier scaffold subunit of the ciliary transition-zone MKS module, but GO has no molecular-function term such as &#34;structural constituent of the ciliary transition zone&#34; (or &#34;diffusion barrier component&#34;), so the gene reads as MF-dark despite a well-understood cellular-component and biological-process role.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">ONTOLOGY</span><span class="badge">CURATION</span>
+                <span class="badge">MF_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> It is firmly established that MKSR-1 = B9D1 is a B9/C2-domain protein of the TZ, a core MKS-module component required (redundantly with the NPHP module) for cilium/TZ assembly, for the ciliary gate, and for recruiting other MKS-module proteins (MKS-6, MKS-3). What is missing is a molecular-function representation: the worm GOA record carries only cellular-component and biological-process terms plus an uninformative &#39;protein binding&#39;, and no informative molecular_function annotation.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> This is the canonical &#34;structural subunit&#34; ontology gap shared across the transition-zone/ciliopathy gene set (cf. the mks-2 review): a mechanistically well-placed protein that cannot be given an informative MF term, contributing to apparent molecular-function darkness across MKS/NPHP-module genes.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Develop/adopt a molecular-function term for a structural constituent of the ciliary transition zone (analogous to &#34;structural constituent of ribosome&#34;), then annotate MKSR-1 and the other core MKS/NPHP-module subunits to it.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"MKSR-1, MKSR-2, and MKS-5 restrict MKS-3 to the TZ membrane"</em> — PMID:21422230</li>
+
+            </ul>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Proposed term (ontology gap):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><strong>structural constituent of ciliary transition zone</strong></li>
+
+            </ul>
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The specific, non-redundant molecular contribution of MKSR-1/B9D1 within the MKS module is undetermined: whether its predicted C2/B9 Ca2+/lipid-binding activity is real, its direct binding partners in the worm TZ beyond MKSR-2/B9D2, and whether MKSR-1 provides a discrete sub-function or is largely interchangeable with the other core MKS-module proteins.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">RESIDUAL_SUBGAP</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> Genetics and imaging establish that MKSR-1 is a core MKS-module protein whose TZ localization depends on MKS-5, that it is required to recruit MKS-6/MKS-3, that it forms a heterodimer with MKSR-2, and that it contributes to the gate. The predicted C2/B9 fold suggests Ca2+/lipid binding, but this has not been assayed for MKSR-1. mksr-1 single mutants are structurally near-normal (defects emerge in mksr-1;nphp-4 doubles), yet the single mutant already leaks TRAM-1a/RPI-2 into cilia, indicating at least a partial non-redundant barrier contribution.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Distinguishing a genuine non-redundant role (and testing the predicted C2/B9 membrane-binding activity) from full module redundancy is the load-bearing question for interpreting B9D1 ciliopathy alleles and for understanding how individual MKS-module subunits partition the barrier-building task.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Direct biochemistry of MKSR-1&#39;s B9/C2 domain (Ca2+/lipid binding), proximity labelling/affinity purification of tagged MKSR-1 in ciliated neurons to map its direct TZ partners, and separation-of-function alleles assayed for gate, Y-link, and recruitment phenotypes.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"This motif is predicted to bind Ca2+/lipids and participate—similar to synaptotagmin—in membrane/vesicle trafficking and fusion"</em> — PMID:21422230</li>
+
+            </ul>
+
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Tags</h2>
+        <div class="aliases">
+
+            <span class="badge">caeel-ciliopathy</span>
+
+        </div>
+    </div>
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Deep Research Sections -->
+
+    <div class="section">
+        <h2 class="section-title">Deep Research</h2>
+
+        <details class="deep-research-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; gap: 1rem;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Falcon</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(mksr-1-deep-research-falcon.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="Q21191" data-a="DEEP_RESEARCH: Falcon" data-r="" data-act="DEEP_RESEARCH" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This deep research is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This deep research needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+
+                <div class="report-meta">
+
+                    <span class="report-meta-text">Comprehensive Research Report: *mksr-1* (B9 Domain-Containing Protein 1) in *Caenorhabditis elegans*</span>
+
+
+                    <span class="report-badge">Falcon</span>
+
+
+                    <span class="report-badge">Edison Scientific Literature</span>
+
+
+                    <span class="report-badge">32 citations</span>
+
+
+                    <span class="report-badge">2 artifacts</span>
+
+
+                    <span class="report-meta-text">2026-07-04T20:28:12.708027</span>
+
+
+
+                </div>
+
+
+                <div class="artifact-list">
+
+
+
+                    <div class="artifact-link">
+                        <a href="mksr-1-deep-research-falcon_artifacts/artifact-00.md" class="term-link">Edison artifact artifact-00</a>
+                        <span>(text/markdown)</span>
+                    </div>
+
+
+
+
+                    <div class="artifact-link">
+                        <a href="mksr-1-deep-research-falcon_artifacts/artifact-01.md" class="term-link">Edison artifact artifact-01</a>
+                        <span>(text/markdown)</span>
+                    </div>
+
+
+                </div>
+
+                <p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h1 id="comprehensive-research-report-mksr-1-b9-domain-containing-protein-1-in-caenorhabditis-elegans">Comprehensive Research Report: <em>mksr-1</em> (B9 Domain-Containing Protein 1) in <em>Caenorhabditis elegans</em></h1>
+<h2 id="1-gene-and-protein-identity">1. Gene and Protein Identity</h2>
+<p>The gene <em>mksr-1</em> (MKS1-Related, also designated K03E6.4) encodes a B9 domain-containing protein 1 (UniProt: Q21191) in <em>Caenorhabditis elegans</em>. The name "MKSR" stands for Meckel Syndrome 1-Related, reflecting its evolutionary and functional relationship to the ciliopathy-associated protein MKS1. MKSR-1 is the <em>C. elegans</em> ortholog of mammalian B9D1 (also known as MKS9), a soluble protein containing a single B9 domain that spans nearly the entire length of the protein (bialas2009functionalinteractionsbetween pages 5-6, okazaki2020formationofthe pages 5-7). MKSR-1 belongs to a small family of three B9 domain-containing proteins—MKS-1, MKSR-1, and MKSR-2 (ortholog of B9D2)—that are evolutionarily conserved across ciliated organisms and always co-occur in the proteome, suggesting they function as an obligate complex (zhang2010identificationofnovel pages 8-9, bialas2009functionalinteractionsbetween pages 5-6).</p>
+<p>The following table summarizes the key molecular and functional properties of MKSR-1/B9D1:</p>
+<table>
+<thead>
+<tr>
+<th>Property</th>
+<th>Summary</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Gene / protein name</td>
+<td><strong>C. elegans:</strong> <strong>mksr-1</strong> (MKSR-1), UniProt Q21191, annotated as <strong>B9 domain-containing protein 1</strong>; <strong>human ortholog:</strong> <strong>B9D1</strong> (also called MKS9 in some literature) (bialas2009functionalinteractionsbetween pages 5-6, li2016mks5andcep290 pages 9-11, okazaki2020formationofthe pages 1-5)</td>
+</tr>
+<tr>
+<td>Protein family / domain</td>
+<td>Member of the <strong>B9 domain protein family</strong>; contains a <strong>B9-C2 / C2_B9-type domain</strong>, a specialized C2-domain family associated with ciliary proteins and inferred membrane/lipid interaction functions (zhang2010identificationofnovel pages 8-9, zhang2010identificationofnovel pages 5-6, okazaki2020formationofthe pages 1-5)</td>
+</tr>
+<tr>
+<td>Subcellular localization</td>
+<td>Localizes specifically to the <strong>ciliary transition zone (TZ)</strong> at the base of <strong>sensory cilia</strong> in <em>C. elegans</em> amphid and phasmid neurons; mammalian B9D1 is also a TZ protein (bialas2009functionalinteractionsbetween pages 5-6, li2016mks5andcep290 pages 9-11, bialas2009functionalinteractionsbetween pages 3-5)</td>
+</tr>
+<tr>
+<td>Molecular complex</td>
+<td>Core component of the <strong>MKS/B9 transition-zone complex</strong>; in vertebrates the B9 subcomplex is organized as <strong>MKS1–B9D2–B9D1</strong>, with B9D2 bridging MKS1 and B9D1 (okazaki2020formationofthe pages 1-5, okazaki2020formationofthe pages 5-7, okazaki2020formationofthe pages 21-27)</td>
+</tr>
+<tr>
+<td>Functional role</td>
+<td>Functions in <strong>ciliary gate / diffusion barrier</strong> activity at the TZ, helping maintain selective ciliary membrane protein composition and compartmentalization rather than acting as a classical enzyme or transporter; broadly supports TZ organization and ciliary signaling homeostasis (okazaki2020formationofthe pages 1-5, jensen2015formationofthe pages 14-15, jensen2015formationofthe pages 12-14)</td>
+</tr>
+<tr>
+<td>Genetic / pathway module</td>
+<td>Belongs to the <strong>MKS module</strong> of TZ proteins; specifically behaves as a <strong>core MKS module protein</strong> in the hierarchical assembly pathway downstream of <strong>MKS-5/RPGRIP1L</strong> and <strong>CEP-290</strong>, and is genetically separable from the <strong>NPHP module</strong> while functionally redundant with it during ciliogenesis/barrier formation (li2016mks5andcep290 pages 18-20, li2016mks5andcep290 pages 9-11, li2016mks5andcep290 pages 16-18, li2016mks5andcep290 pages 3-5)</td>
+</tr>
+<tr>
+<td>Key interacting partners</td>
+<td>Strongly linked with <strong>MKSR-2/B9D2</strong> and <strong>MKS-1</strong> through interdependent localization in worms; mammalian interaction mapping supports a linear <strong>MKS1–B9D2–B9D1</strong> arrangement. As a core MKS protein, its proper TZ localization also depends on <strong>CEP-290</strong> and upstream <strong>MKS-5</strong>-dependent assembly. Core/peripheral MKS relationships place it functionally alongside <strong>MKS-2/TMEM216</strong>, <strong>TMEM-231</strong>, <strong>TMEM-17</strong>, <strong>TMEM-67</strong>, <strong>TMEM-218</strong>, and <strong>TMEM-237</strong> (bialas2009functionalinteractionsbetween pages 5-6, okazaki2020formationofthe pages 5-7, li2016mks5andcep290 pages 18-20, li2016mks5andcep290 pages 9-11, li2016mks5andcep290 pages 16-18)</td>
+</tr>
+<tr>
+<td>Single-mutant phenotype in <em>C. elegans</em></td>
+<td><strong>mksr-1 single mutants</strong> are generally <strong>non-Dyf</strong> (no obvious dye-filling defect) and do not show major defects in gross ciliogenesis, intraflagellar transport, or chemosensation, indicating MKSR-1 is not absolutely required for basal cilium assembly on its own (bialas2009functionalinteractionsbetween pages 1-2, bialas2009functionalinteractionsbetween pages 6-7, bialas2009functionalinteractionsbetween pages 7-9, warburtonpitt2012ciliogenesisincaenorhabditis pages 3-4)</td>
+</tr>
+<tr>
+<td>Double-mutant / synthetic phenotype</td>
+<td>Stronger phenotypes emerge in combination with other TZ genes. <strong>MKS/NPHP double mutants</strong> reveal redundant function in ciliogenesis and membrane anchoring, with synthetic defects including <strong>dye-filling defects</strong>, <strong>loss of TZ ultrastructure/Y-links</strong>, <strong>axoneme malformations</strong>, <strong>cilium shortening</strong>, and <strong>TZ displacement</strong>. Genetic interactions are especially evident with <strong>nphp-1</strong>, <strong>nphp-4</strong>, and sensillum-specific interactions with <strong>nphp-2</strong> (jensen2015formationofthe pages 1-2, li2016mks5andcep290 pages 18-20, jensen2015formationofthe pages 14-15, bialas2009functionalinteractionsbetween pages 7-9, warburtonpitt2012ciliogenesisincaenorhabditis pages 4-6, warburtonpitt2015theciliopathygene pages 95-99)</td>
+</tr>
+<tr>
+<td>Assembly-dependence / localization dependencies</td>
+<td>MKSR-1 localization is <strong>interdependent</strong> with other core MKS proteins and is disrupted when <strong>MKSR-2</strong>, <strong>MKS-1</strong>, or <strong>CEP-290</strong> are absent; <strong>MKS-5</strong> acts further upstream as a foundational TZ assembly factor (bialas2009functionalinteractionsbetween pages 5-6, li2016mks5andcep290 pages 18-20, li2016mks5andcep290 pages 9-11, li2016mks5andcep290 pages 16-18, li2016mks5andcep290 pages 3-5)</td>
+</tr>
+<tr>
+<td>Human disease associations of ortholog</td>
+<td><strong>B9D1</strong> is associated with <strong>Meckel syndrome / Meckel syndrome type 9</strong> and <strong>Joubert syndrome / Joubert syndrome 27</strong> in human disease databases and primary literature (OpenTargets Search: -B9D1)</td>
+</tr>
+</tbody>
+</table>
+<p><em>Table: This table summarizes the main molecular, cellular, genetic, and disease-related properties of C. elegans MKSR-1 and its human ortholog B9D1. It is useful as a compact reference linking transition-zone localization, MKS-module function, mutant phenotypes, and ciliopathy associations.</em></p>
+<h2 id="2-structural-and-domain-features">2. Structural and Domain Features</h2>
+<p>MKSR-1 contains a single <strong>B9 domain</strong> (IPR010796; PF07162), which is classified as a specialized member of the <strong>C2 domain superfamily</strong> based on profile-profile comparisons and fold recognition analyses (zhang2010identificationofnovel pages 8-9, zhang2010identificationofnovel pages 5-6). C2 domains are typically β-sandwich structures that mediate calcium-dependent or calcium-independent membrane binding through interactions with phospholipids. The B9-type C2 domain, however, represents a distinct evolutionary branch: it occurs as a standalone domain (i.e., not fused with other functional domains) and contains conserved hydrophobic residues on its β-sheet that create a concave ligand-binding surface, consistent with lipid interaction capability (zhang2010identificationofnovel pages 8-9). Structural analyses of related ciliary C2 domains indicate that B9 domains are not expected to bind Ca²⁺ and instead may function primarily as protein-protein interaction modules within the transition zone (zhang2010identificationofnovel pages 8-9).</p>
+<p>Studies on the related B9 domain protein B9D2 have demonstrated strong binding affinity to specific phosphoinositides, including PI4P and PI(3,4,5)P3, with lesser binding to PI(4,5)P2 (caenenbraz2024newfunctionsof pages 8-10). Given the high structural similarity within the B9 family, MKSR-1's B9 domain is inferred to possess analogous lipid-interaction properties, which may facilitate its anchoring to specific membrane microdomains at the ciliary transition zone.</p>
+<h2 id="3-primary-function-structural-component-of-the-ciliary-transition-zone-gate">3. Primary Function: Structural Component of the Ciliary Transition Zone Gate</h2>
+<p>MKSR-1 is <strong>not an enzyme, transporter, or classical signaling molecule</strong>. Rather, it functions as a <strong>structural/adapter protein</strong> within the ciliary transition zone (TZ), where it serves as a core component of the <strong>MKS (Meckel syndrome) module</strong>—a multiprotein complex that constitutes part of the <strong>ciliary diffusion barrier or "gate"</strong> (jensen2015formationofthe pages 1-2, okazaki2020formationofthe pages 1-5).</p>
+<h3 id="31-the-transition-zone-as-a-ciliary-gate">3.1 The Transition Zone as a Ciliary Gate</h3>
+<p>The transition zone is a specialized ~0.8 μm region at the base of the cilium, located between the basal body and the axoneme proper. It contains characteristic Y-shaped linkers that connect the axonemal microtubule doublets to the ciliary membrane and functions as a selective barrier controlling which proteins and lipids can enter or exit the ciliary compartment (jensen2015formationofthe pages 14-15, jensen2015formationofthe pages 1-2, jensen2015formationofthe pages 2-4). This barrier is essential for maintaining the unique protein and lipid composition of cilia, which is required for their sensory and signaling functions.</p>
+<h3 id="32-the-b9-protein-complex-as-a-diffusion-barrier">3.2 The B9 Protein Complex as a Diffusion Barrier</h3>
+<p>In mammalian cells, the three B9 domain proteins form a linear tripartite complex with the interaction mode <strong>MKS1–B9D2–B9D1</strong>, where B9D2 serves as a bridge between MKS1 and B9D1, as demonstrated by visible immunoprecipitation and three-hybrid assays (okazaki2020formationofthe pages 5-7, okazaki2020formationofthe pages 21-27). MKS1 and B9D1 do not directly interact with each other (okazaki2020formationofthe pages 5-7). The formation of this complex is essential for creating a functional diffusion barrier for ciliary membrane proteins: loss of MKS1 or B9D2 results in failure of transmembrane proteins (such as GPCRs GPR161 and Smoothened) and lipidated membrane proteins (ARL13B, INPP5E) to properly localize to the ciliary membrane (okazaki2020formationofthe pages 5-7, okazaki2020formationofthe pages 21-27). Importantly, the B9 proteins are involved in, but not absolutely essential for, normal cilia biogenesis; rather, their complex formation is specifically crucial for the barrier/gating function (okazaki2020formationofthe pages 1-5).</p>
+<h3 id="33-recent-advances-b9-complex-interactions-with-tmem67-and-microtubule-modifications">3.3 Recent Advances: B9 Complex Interactions with TMEM67 and Microtubule Modifications</h3>
+<p>Recent work has revealed additional functions of the B9 complex beyond its role as a passive diffusion barrier. The B9D1-B9D2-MKS1 complex interacts with and anchors the transmembrane protein TMEM67 to the TZ membrane. Disruption of this B9-TMEM67 complex reduces posttranslational modifications (acetylation and polyglutamylation) of axonemal microtubules due to deregulation of tubulin-modifying enzymes within cilia (he2026ciliopathyrelatedb9protein pages 1-2, he2026ciliopathyrelatedb9protein pages 4-5). Furthermore, B9 proteins have been found to localize to centrioles prior to ciliogenesis, where they facilitate initiation of ciliary assembly by promoting membrane vesicle docking to distal appendages and CP110 removal from the mother centriole (he2026ciliopathyrelatedb9protein pages 2-4, he2026ciliopathyrelatedb9protein pages 1-2).</p>
+<h2 id="4-subcellular-localization">4. Subcellular Localization</h2>
+<p>In <em>C. elegans</em>, MKSR-1 localizes specifically to the <strong>transition zone at the base of sensory cilia</strong> in ciliated neurons. Fluorescent reporter studies have demonstrated MKSR-1 localization at transition zones of amphid cilia near the head and phasmid cilia near the tail (bialas2009functionalinteractionsbetween pages 3-5, bialas2009functionalinteractionsbetween pages 5-6). This localization pattern is shared with MKS-1 and MKSR-2, and the three B9 proteins show <strong>co-dependent localization</strong>: when any one is mutated, the other two show reduced or mislocalized signals at transition zones, with abnormal accumulations in dendrites (bialas2009functionalinteractionsbetween pages 5-6, bialas2009functionalinteractionsbetween pages 6-7). MKSR-1 localization also depends on CEP-290 and MKS-5, the upstream assembly factors of the TZ (li2016mks5andcep290 pages 9-11).</p>
+<h2 id="5-transition-zone-assembly-hierarchy-and-module-architecture">5. Transition Zone Assembly Hierarchy and Module Architecture</h2>
+<p>The ciliary TZ in <em>C. elegans</em> assembles through a well-characterized hierarchical pathway. MKSR-1 occupies a defined position within this hierarchy as a <strong>core MKS module protein</strong>:</p>
+<table>
+<thead>
+<tr>
+<th>Level in hierarchy</th>
+<th>Protein(s)</th>
+<th>Module assignment</th>
+<th>Dependence (what it requires for TZ localization)</th>
+<th>Role in TZ</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>1 (most upstream)</td>
+<td>MKS-5 / RPGRIP1L</td>
+<td>Master TZ assembly factor / scaffold linking MKS and NPHP branches</td>
+<td>Localizes independently of CEP-290; required for localization of essentially all tested TZ proteins, including CEP-290, MKS-module, and NPHP-module proteins (li2016mks5andcep290 pages 9-11, li2016mks5andcep290 pages 3-5, jensen2015formationofthe pages 1-2, jensen2015formationofthe pages 8-9)</td>
+<td>Foundational organizer of TZ formation; establishes TZ ultrastructure, supports Y-link formation, and helps create the ciliary zone of exclusion/barrier (li2016mks5andcep290 pages 3-5, jensen2015formationofthe pages 1-2, jensen2015formationofthe pages 7-8, jensen2015formationofthe pages 4-5)</td>
+</tr>
+<tr>
+<td>2A</td>
+<td>NPHP-1, NPHP-4</td>
+<td>NPHP module</td>
+<td>Assemble in the MKS-5-dependent branch; localization does not require CEP-290 (li2016mks5andcep290 pages 11-12, li2016mks5andcep290 pages 16-18, li2016mks5andcep290 pages 3-5)</td>
+<td>Parallel TZ branch that works redundantly with the MKS branch to seal the ciliary compartment, maintain membrane attachments, and support ciliogenesis/barrier function (li2016mks5andcep290 pages 16-18, jensen2015formationofthe pages 1-2, jensen2015formationofthe pages 7-8, jensen2015formationofthe pages 2-4)</td>
+</tr>
+<tr>
+<td>2B</td>
+<td>CEP-290</td>
+<td>CEP-290-dependent MKS assembly branch</td>
+<td>Requires MKS-5 for TZ localization; acts downstream of MKS-5 and upstream of MKS-module proteins (li2016mks5andcep290 pages 9-11, li2016mks5andcep290 pages 11-12, li2016mks5andcep290 pages 16-18, li2016mks5andcep290 pages 3-5)</td>
+<td>Core assembly factor for the MKS pathway; required for Y-links/apical ring integrity and ciliary gate function, and specifically recruits/organizes MKS-module proteins at the TZ (li2016mks5andcep290 pages 18-20, li2016mks5andcep290 pages 9-11, li2016mks5andcep290 pages 11-12)</td>
+</tr>
+<tr>
+<td>3 (core MKS layer)</td>
+<td>MKS-1, MKSR-1/B9D1, MKSR-2/B9D2, MKS-2/TMEM216, TMEM-231</td>
+<td>Core MKS module</td>
+<td>Require CEP-290 and MKS-5 for TZ localization; core members are interdependent with one another for proper localization (li2016mks5andcep290 pages 18-20, li2016mks5andcep290 pages 9-11, li2016mks5andcep290 pages 16-18, li2016mks5andcep290 pages 7-9)</td>
+<td>Principal MKS gate components; organize the membrane-proximal barrier, support TZ ultrastructure, and are necessary for proper ciliary compartmentalization/gate function (li2016mks5andcep290 pages 18-20, li2016mks5andcep290 pages 16-18, jensen2015formationofthe pages 14-15, jensen2015formationofthe pages 2-4)</td>
+</tr>
+<tr>
+<td>4 (peripheral MKS layer)</td>
+<td>TMEM-17, TMEM-67, TMEM-218, TMEM-237</td>
+<td>Peripheral MKS module</td>
+<td>Require CEP-290, MKS-5, and intact core MKS proteins for TZ localization; do not control localization of core MKS proteins (li2016mks5andcep290 pages 18-20, li2016mks5andcep290 pages 16-18, li2016mks5andcep290 pages 7-9)</td>
+<td>Downstream effectors/accessory MKS components that elaborate TZ composition and contribute to mature gate/barrier function rather than initiating core assembly (li2016mks5andcep290 pages 18-20, li2016mks5andcep290 pages 16-18, jensen2015formationofthe pages 2-4)</td>
+</tr>
+</tbody>
+</table>
+<p><em>Table: This table summarizes the hierarchical assembly of the C. elegans ciliary transition zone, placing MKSR-1/B9D1 within the CEP-290-dependent core MKS module. It is useful for understanding which proteins act upstream versus downstream in building the transition-zone barrier.</em></p>
+<p><strong>MKS-5/RPGRIP1L</strong> serves as the foundational scaffold, localizing independently of all other TZ proteins and being required for localization of essentially all known TZ components (li2016mks5andcep290 pages 3-5, jensen2015formationofthe pages 1-2, jensen2015formationofthe pages 7-8). Downstream of MKS-5, the pathway bifurcates into two genetically separable branches: the <strong>NPHP module</strong> (NPHP-1, NPHP-4) and the <strong>CEP-290-dependent MKS module</strong> (li2016mks5andcep290 pages 11-12, li2016mks5andcep290 pages 16-18). CEP-290 requires MKS-5 for its own TZ localization and is in turn required for proper localization of all MKS module components, including MKSR-1 (li2016mks5andcep290 pages 9-11, li2016mks5andcep290 pages 3-5).</p>
+<p>Within the MKS module, MKSR-1 is classified as a <strong>core component</strong>, along with MKS-1, MKSR-2, MKS-2/TMEM216, and TMEM-231. These core proteins show interdependent localization—removal of any one disrupts TZ localization of the others (li2016mks5andcep290 pages 18-20, li2016mks5andcep290 pages 16-18). Peripheral MKS module proteins (TMEM-17, TMEM-67, TMEM-218, TMEM-237) depend on the core proteins for their TZ localization but do not influence core protein assembly (li2016mks5andcep290 pages 18-20, li2016mks5andcep290 pages 16-18).</p>
+<h2 id="6-genetic-interactions-and-functional-redundancy">6. Genetic Interactions and Functional Redundancy</h2>
+<p>A hallmark of MKSR-1 function is its <strong>genetic redundancy with NPHP module proteins</strong>. Single <em>mksr-1</em> mutants (<em>ok2092</em>) are <strong>non-Dyf</strong> (no dye-filling defect) and display no overt defects in cilium formation, intraflagellar transport (IFT), or chemosensory behaviors (bialas2009functionalinteractionsbetween pages 1-2, bialas2009functionalinteractionsbetween pages 6-7, warburtonpitt2012ciliogenesisincaenorhabditis pages 3-4). However, when <em>mksr-1</em> mutations are combined with mutations in NPHP module genes (<em>nphp-1</em> or <em>nphp-4</em>), severe <strong>synthetic phenotypes</strong> emerge, including dye-filling defects, loss of basal body-TZ membrane anchoring, disruption of TZ ultrastructure and Y-links, and axoneme malformations (jensen2015formationofthe pages 1-2, bialas2009functionalinteractionsbetween pages 7-9, warburtonpitt2012ciliogenesisincaenorhabditis pages 4-6). These synthetic interactions define the genetic separability of the MKS and NPHP modules while demonstrating their functional redundancy in establishing the ciliary gate.</p>
+<p>Additionally, <em>nphp-2;mksr-1</em> double mutants exhibit sensillum-specific dye-filling defects and abnormal TZ spread in amphid neurons, as well as shortened phasmid dendritic length indicative of TZ displacement (warburtonpitt2012ciliogenesisincaenorhabditis pages 4-6, warburtonpitt2015theciliopathygene pages 95-99).</p>
+<h2 id="7-role-in-ciliary-signaling-and-the-ciliary-zone-of-exclusion-cize">7. Role in Ciliary Signaling and the Ciliary Zone of Exclusion (CIZE)</h2>
+<p>The TZ, to which MKSR-1 localizes, establishes a <strong>ciliary zone of exclusion (CIZE)</strong> that compartmentalizes signaling proteins and controls phosphoinositide abundance within the cilium (jensen2015formationofthe pages 14-15, jensen2015formationofthe pages 1-2, jensen2015formationofthe pages 12-14). The CIZE model, developed primarily from <em>C. elegans</em> studies, demonstrates that PIP2 is highly concentrated at the periciliary membrane but is excluded from the distal ciliary compartment in an MKS-5-dependent manner (jensen2015formationofthe pages 14-15, jensen2015formationofthe pages 12-14). The TZ barrier also prevents inappropriate entry of non-ciliary membrane proteins and retains ciliary residents like ARL-13 within the cilium (jensen2015formationofthe pages 12-14).</p>
+<p>While MKSR-1 single mutants do not show gross signaling defects, double mutant analysis with other B9 family members (<em>mksr-1;mksr-2</em>) revealed increased lifespan, suggesting MKSR-1 functions upstream of the <strong>DAF-2/DAF-16 insulin-IGF-I signaling pathway</strong> to regulate longevity specification, likely through its role in cilia-dependent sensory signaling (bialas2009functionalinteractionsbetween pages 9-10, bialas2009functionalinteractionsbetween pages 10-11).</p>
+<h2 id="8-evolutionary-conservation-and-disease-relevance">8. Evolutionary Conservation and Disease Relevance</h2>
+<p>The B9 protein family is highly conserved across ciliated eukaryotes. Phylogenetic analysis shows that all three B9 domain proteins (MKS1, B9D1/MKSR-1, B9D2/MKSR-2) strictly co-occur in organisms that possess cilia and are independently lost in non-ciliated lineages such as land plants, amoebozoans, and dikaryan fungi (zhang2010identificationofnovel pages 8-9, bialas2009functionalinteractionsbetween pages 5-6).</p>
+<p>The human ortholog <strong>B9D1</strong> is a causative gene for <strong>Meckel syndrome type 9</strong> (MKS9), a severe autosomal recessive lethal ciliopathy characterized by occipital encephalocele, cystic kidneys, and polydactyly (OpenTargets Search: -B9D1). B9D1 mutations have also been identified in patients with <strong>Joubert syndrome 27</strong> (JBTS27), a milder ciliopathy characterized by the "molar tooth sign" cerebellar malformation (OpenTargets Search: -B9D1). This spectrum of disease severity from the same gene—ranging from lethal MKS to mild JBTS—reflects the functional complexity of the B9 complex in maintaining ciliary gate function across different tissues and developmental contexts.</p>
+<h2 id="9-summary">9. Summary</h2>
+<p>MKSR-1 (B9D1) is a non-enzymatic, non-transporter structural/adapter protein that functions as a core component of the ciliary transition zone diffusion barrier in <em>C. elegans</em>. Its primary role is to form part of the B9 protein complex (MKS1–MKSR-2–MKSR-1), which is essential for maintaining selective ciliary membrane composition by preventing non-selective diffusion of proteins and lipids across the transition zone. MKSR-1 localizes specifically to the transition zone of sensory cilia, where it participates in the MKS module—a multiprotein assembly that works redundantly with the NPHP module to establish the ciliary gate. The protein assembles hierarchically downstream of MKS-5 and CEP-290, and its localization is interdependent with other core MKS components. Through its role in ciliary compartmentalization, MKSR-1 indirectly supports multiple signaling pathways that depend on proper ciliary function, including insulin-IGF signaling and sensory perception. Mutations in the human ortholog B9D1 cause the ciliopathies Meckel syndrome and Joubert syndrome, underscoring the critical importance of this protein in ciliary biology.</p>
+<p>References</p>
+<ol>
+<li>
+<p>(bialas2009functionalinteractionsbetween pages 5-6): Nathan J. Bialas, Peter N. Inglis, Chunmei Li, Jon F. Robinson, Jeremy D. K. Parker, Michael P. Healey, Erica E. Davis, Chrystal D. Inglis, Tiina Toivonen, David C. Cottell, Oliver E. Blacque, Lynne M. Quarmby, Nicholas Katsanis, and Michel R. Leroux. Functional interactions between the ciliopathy-associated meckel syndrome 1 (mks1) protein and two novel mks1-related (mksr) proteins. Journal of Cell Science, 122:611-624, Mar 2009. URL: https://doi.org/10.1242/jcs.028621, doi:10.1242/jcs.028621. This article has 98 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(okazaki2020formationofthe pages 5-7): Misato Okazaki, Takuya Kobayashi, Shuhei Chiba, Ryota Takei, Luxiaoxue Liang, Kazuhisa Nakayama, and Yohei Katoh. Formation of the b9-domain protein complex mks1–b9d2–b9d1 is essential as a diffusion barrier for ciliary membrane proteins. Molecular Biology of the Cell, 31:2259-2268, Sep 2020. URL: https://doi.org/10.1091/mbc.e20-03-0208, doi:10.1091/mbc.e20-03-0208. This article has 32 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(zhang2010identificationofnovel pages 8-9): Dapeng Zhang and L. Aravind. Identification of novel families and classification of the c2 domain superfamily elucidate the origin and evolution of membrane targeting activities in eukaryotes. Gene, 469 1-2:18-30, Dec 2010. URL: https://doi.org/10.1016/j.gene.2010.08.006, doi:10.1016/j.gene.2010.08.006. This article has 169 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(li2016mks5andcep290 pages 9-11): Chunmei Li, Victor L. Jensen, Kwangjin Park, Julie Kennedy, Francesc R. Garcia-Gonzalo, Marta Romani, Roberta De Mori, Ange-Line Bruel, Dominique Gaillard, Bérénice Doray, Estelle Lopez, Jean-Baptiste Rivière, Laurence Faivre, Christel Thauvin-Robinet, Jeremy F. Reiter, Oliver E. Blacque, Enza Maria Valente, and Michel R. Leroux. Mks5 and cep290 dependent assembly pathway of the ciliary transition zone. PLOS Biology, 14:e1002416, Mar 2016. URL: https://doi.org/10.1371/journal.pbio.1002416, doi:10.1371/journal.pbio.1002416. This article has 176 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(okazaki2020formationofthe pages 1-5): Misato Okazaki, Takuya Kobayashi, Shuhei Chiba, Ryota Takei, Luxiaoxue Liang, Kazuhisa Nakayama, and Yohei Katoh. Formation of the b9-domain protein complex mks1–b9d2–b9d1 is essential as a diffusion barrier for ciliary membrane proteins. Molecular Biology of the Cell, 31:2259-2268, Sep 2020. URL: https://doi.org/10.1091/mbc.e20-03-0208, doi:10.1091/mbc.e20-03-0208. This article has 32 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(zhang2010identificationofnovel pages 5-6): Dapeng Zhang and L. Aravind. Identification of novel families and classification of the c2 domain superfamily elucidate the origin and evolution of membrane targeting activities in eukaryotes. Gene, 469 1-2:18-30, Dec 2010. URL: https://doi.org/10.1016/j.gene.2010.08.006, doi:10.1016/j.gene.2010.08.006. This article has 169 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(bialas2009functionalinteractionsbetween pages 3-5): Nathan J. Bialas, Peter N. Inglis, Chunmei Li, Jon F. Robinson, Jeremy D. K. Parker, Michael P. Healey, Erica E. Davis, Chrystal D. Inglis, Tiina Toivonen, David C. Cottell, Oliver E. Blacque, Lynne M. Quarmby, Nicholas Katsanis, and Michel R. Leroux. Functional interactions between the ciliopathy-associated meckel syndrome 1 (mks1) protein and two novel mks1-related (mksr) proteins. Journal of Cell Science, 122:611-624, Mar 2009. URL: https://doi.org/10.1242/jcs.028621, doi:10.1242/jcs.028621. This article has 98 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(okazaki2020formationofthe pages 21-27): Misato Okazaki, Takuya Kobayashi, Shuhei Chiba, Ryota Takei, Luxiaoxue Liang, Kazuhisa Nakayama, and Yohei Katoh. Formation of the b9-domain protein complex mks1–b9d2–b9d1 is essential as a diffusion barrier for ciliary membrane proteins. Molecular Biology of the Cell, 31:2259-2268, Sep 2020. URL: https://doi.org/10.1091/mbc.e20-03-0208, doi:10.1091/mbc.e20-03-0208. This article has 32 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(jensen2015formationofthe pages 14-15): Victor L Jensen, Chunmei Li, Rachel V Bowie, Lara Clarke, Swetha Mohan, Oliver E Blacque, and Michel R Leroux. Formation of the transition zone by mks5/rpgrip1l establishes a ciliary zone of exclusion (cize) that compartmentalises ciliary signalling proteins and controls pip2 ciliary abundance. The EMBO Journal, 34:2537-2556, Oct 2015. URL: https://doi.org/10.15252/embj.201488044, doi:10.15252/embj.201488044. This article has 164 citations.</p>
+</li>
+<li>
+<p>(jensen2015formationofthe pages 12-14): Victor L Jensen, Chunmei Li, Rachel V Bowie, Lara Clarke, Swetha Mohan, Oliver E Blacque, and Michel R Leroux. Formation of the transition zone by mks5/rpgrip1l establishes a ciliary zone of exclusion (cize) that compartmentalises ciliary signalling proteins and controls pip2 ciliary abundance. The EMBO Journal, 34:2537-2556, Oct 2015. URL: https://doi.org/10.15252/embj.201488044, doi:10.15252/embj.201488044. This article has 164 citations.</p>
+</li>
+<li>
+<p>(li2016mks5andcep290 pages 18-20): Chunmei Li, Victor L. Jensen, Kwangjin Park, Julie Kennedy, Francesc R. Garcia-Gonzalo, Marta Romani, Roberta De Mori, Ange-Line Bruel, Dominique Gaillard, Bérénice Doray, Estelle Lopez, Jean-Baptiste Rivière, Laurence Faivre, Christel Thauvin-Robinet, Jeremy F. Reiter, Oliver E. Blacque, Enza Maria Valente, and Michel R. Leroux. Mks5 and cep290 dependent assembly pathway of the ciliary transition zone. PLOS Biology, 14:e1002416, Mar 2016. URL: https://doi.org/10.1371/journal.pbio.1002416, doi:10.1371/journal.pbio.1002416. This article has 176 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(li2016mks5andcep290 pages 16-18): Chunmei Li, Victor L. Jensen, Kwangjin Park, Julie Kennedy, Francesc R. Garcia-Gonzalo, Marta Romani, Roberta De Mori, Ange-Line Bruel, Dominique Gaillard, Bérénice Doray, Estelle Lopez, Jean-Baptiste Rivière, Laurence Faivre, Christel Thauvin-Robinet, Jeremy F. Reiter, Oliver E. Blacque, Enza Maria Valente, and Michel R. Leroux. Mks5 and cep290 dependent assembly pathway of the ciliary transition zone. PLOS Biology, 14:e1002416, Mar 2016. URL: https://doi.org/10.1371/journal.pbio.1002416, doi:10.1371/journal.pbio.1002416. This article has 176 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(li2016mks5andcep290 pages 3-5): Chunmei Li, Victor L. Jensen, Kwangjin Park, Julie Kennedy, Francesc R. Garcia-Gonzalo, Marta Romani, Roberta De Mori, Ange-Line Bruel, Dominique Gaillard, Bérénice Doray, Estelle Lopez, Jean-Baptiste Rivière, Laurence Faivre, Christel Thauvin-Robinet, Jeremy F. Reiter, Oliver E. Blacque, Enza Maria Valente, and Michel R. Leroux. Mks5 and cep290 dependent assembly pathway of the ciliary transition zone. PLOS Biology, 14:e1002416, Mar 2016. URL: https://doi.org/10.1371/journal.pbio.1002416, doi:10.1371/journal.pbio.1002416. This article has 176 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(bialas2009functionalinteractionsbetween pages 1-2): Nathan J. Bialas, Peter N. Inglis, Chunmei Li, Jon F. Robinson, Jeremy D. K. Parker, Michael P. Healey, Erica E. Davis, Chrystal D. Inglis, Tiina Toivonen, David C. Cottell, Oliver E. Blacque, Lynne M. Quarmby, Nicholas Katsanis, and Michel R. Leroux. Functional interactions between the ciliopathy-associated meckel syndrome 1 (mks1) protein and two novel mks1-related (mksr) proteins. Journal of Cell Science, 122:611-624, Mar 2009. URL: https://doi.org/10.1242/jcs.028621, doi:10.1242/jcs.028621. This article has 98 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(bialas2009functionalinteractionsbetween pages 6-7): Nathan J. Bialas, Peter N. Inglis, Chunmei Li, Jon F. Robinson, Jeremy D. K. Parker, Michael P. Healey, Erica E. Davis, Chrystal D. Inglis, Tiina Toivonen, David C. Cottell, Oliver E. Blacque, Lynne M. Quarmby, Nicholas Katsanis, and Michel R. Leroux. Functional interactions between the ciliopathy-associated meckel syndrome 1 (mks1) protein and two novel mks1-related (mksr) proteins. Journal of Cell Science, 122:611-624, Mar 2009. URL: https://doi.org/10.1242/jcs.028621, doi:10.1242/jcs.028621. This article has 98 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(bialas2009functionalinteractionsbetween pages 7-9): Nathan J. Bialas, Peter N. Inglis, Chunmei Li, Jon F. Robinson, Jeremy D. K. Parker, Michael P. Healey, Erica E. Davis, Chrystal D. Inglis, Tiina Toivonen, David C. Cottell, Oliver E. Blacque, Lynne M. Quarmby, Nicholas Katsanis, and Michel R. Leroux. Functional interactions between the ciliopathy-associated meckel syndrome 1 (mks1) protein and two novel mks1-related (mksr) proteins. Journal of Cell Science, 122:611-624, Mar 2009. URL: https://doi.org/10.1242/jcs.028621, doi:10.1242/jcs.028621. This article has 98 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(warburtonpitt2012ciliogenesisincaenorhabditis pages 3-4): Simon R. F. Warburton-Pitt, Andrew R. Jauregui, Chunmei Li, Juan Wang, M. Leroux, and M. Barr. Ciliogenesis in caenorhabditis elegans requires genetic interactions between ciliary middle segment localized nphp-2 (inversin) and transition zone-associated proteins. Journal of Cell Science, 125:2592-2603, Jun 2012. URL: https://doi.org/10.1242/jcs.095539, doi:10.1242/jcs.095539. This article has 57 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(jensen2015formationofthe pages 1-2): Victor L Jensen, Chunmei Li, Rachel V Bowie, Lara Clarke, Swetha Mohan, Oliver E Blacque, and Michel R Leroux. Formation of the transition zone by mks5/rpgrip1l establishes a ciliary zone of exclusion (cize) that compartmentalises ciliary signalling proteins and controls pip2 ciliary abundance. The EMBO Journal, 34:2537-2556, Oct 2015. URL: https://doi.org/10.15252/embj.201488044, doi:10.15252/embj.201488044. This article has 164 citations.</p>
+</li>
+<li>
+<p>(warburtonpitt2012ciliogenesisincaenorhabditis pages 4-6): Simon R. F. Warburton-Pitt, Andrew R. Jauregui, Chunmei Li, Juan Wang, M. Leroux, and M. Barr. Ciliogenesis in caenorhabditis elegans requires genetic interactions between ciliary middle segment localized nphp-2 (inversin) and transition zone-associated proteins. Journal of Cell Science, 125:2592-2603, Jun 2012. URL: https://doi.org/10.1242/jcs.095539, doi:10.1242/jcs.095539. This article has 57 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(warburtonpitt2015theciliopathygene pages 95-99): Simon R. F. Warburton-Pitt. The ciliopathy gene nphp 2 functions in multiple gene networks and regulates ciliogenesis in c. elegans. ArXiv, Jan 2015. URL: https://doi.org/10.7282/t3v40wx3, doi:10.7282/t3v40wx3. This article has 0 citations.</p>
+</li>
+<li>
+<p>(OpenTargets Search: -B9D1): Open Targets Query (-B9D1, 8 results). Buniello, A. et al. (2025). Open Targets Platform: facilitating therapeutic hypotheses building in drug discovery. Nucleic Acids Research.</p>
+</li>
+<li>
+<p>(caenenbraz2024newfunctionsof pages 8-10): Chloe Caenen-Braz, Latifa Bouzhir, and Pascale Dupuis-Williams. New functions of b9d2 in tight junctions and epithelial polarity. Scientific Reports, Oct 2024. URL: https://doi.org/10.1038/s41598-024-75577-w, doi:10.1038/s41598-024-75577-w. This article has 4 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(jensen2015formationofthe pages 2-4): Victor L Jensen, Chunmei Li, Rachel V Bowie, Lara Clarke, Swetha Mohan, Oliver E Blacque, and Michel R Leroux. Formation of the transition zone by mks5/rpgrip1l establishes a ciliary zone of exclusion (cize) that compartmentalises ciliary signalling proteins and controls pip2 ciliary abundance. The EMBO Journal, 34:2537-2556, Oct 2015. URL: https://doi.org/10.15252/embj.201488044, doi:10.15252/embj.201488044. This article has 164 citations.</p>
+</li>
+<li>
+<p>(he2026ciliopathyrelatedb9protein pages 1-2): Ruida He, Yan Li, Minjun Jin, Huike Jiao, Yue Shen, Qize Han, Xilang Pan, Suning Wang, Zaisheng Lin, Jingshi Li, Chao Lu, Dan Meng, Zongfu Cao, Qing Shang, Nan Lv, Kai Wan, Huafang Gao, Xu Ma, Haiyan Yin, Haishuang Chang, Liang Wang, Minna Luo, Junmin Pan, Chengtian Zhao, and Muqing Cao. Ciliopathy-related b9 protein complex regulates ciliary axonemal microtubule posttranslational modifications and initiation of ciliogenesis. Journal of Clinical Investigation, Oct 2026. URL: https://doi.org/10.1172/jci196365, doi:10.1172/jci196365. This article has 0 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(he2026ciliopathyrelatedb9protein pages 4-5): Ruida He, Yan Li, Minjun Jin, Huike Jiao, Yue Shen, Qize Han, Xilang Pan, Suning Wang, Zaisheng Lin, Jingshi Li, Chao Lu, Dan Meng, Zongfu Cao, Qing Shang, Nan Lv, Kai Wan, Huafang Gao, Xu Ma, Haiyan Yin, Haishuang Chang, Liang Wang, Minna Luo, Junmin Pan, Chengtian Zhao, and Muqing Cao. Ciliopathy-related b9 protein complex regulates ciliary axonemal microtubule posttranslational modifications and initiation of ciliogenesis. Journal of Clinical Investigation, Oct 2026. URL: https://doi.org/10.1172/jci196365, doi:10.1172/jci196365. This article has 0 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(he2026ciliopathyrelatedb9protein pages 2-4): Ruida He, Yan Li, Minjun Jin, Huike Jiao, Yue Shen, Qize Han, Xilang Pan, Suning Wang, Zaisheng Lin, Jingshi Li, Chao Lu, Dan Meng, Zongfu Cao, Qing Shang, Nan Lv, Kai Wan, Huafang Gao, Xu Ma, Haiyan Yin, Haishuang Chang, Liang Wang, Minna Luo, Junmin Pan, Chengtian Zhao, and Muqing Cao. Ciliopathy-related b9 protein complex regulates ciliary axonemal microtubule posttranslational modifications and initiation of ciliogenesis. Journal of Clinical Investigation, Oct 2026. URL: https://doi.org/10.1172/jci196365, doi:10.1172/jci196365. This article has 0 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(jensen2015formationofthe pages 8-9): Victor L Jensen, Chunmei Li, Rachel V Bowie, Lara Clarke, Swetha Mohan, Oliver E Blacque, and Michel R Leroux. Formation of the transition zone by mks5/rpgrip1l establishes a ciliary zone of exclusion (cize) that compartmentalises ciliary signalling proteins and controls pip2 ciliary abundance. The EMBO Journal, 34:2537-2556, Oct 2015. URL: https://doi.org/10.15252/embj.201488044, doi:10.15252/embj.201488044. This article has 164 citations.</p>
+</li>
+<li>
+<p>(jensen2015formationofthe pages 7-8): Victor L Jensen, Chunmei Li, Rachel V Bowie, Lara Clarke, Swetha Mohan, Oliver E Blacque, and Michel R Leroux. Formation of the transition zone by mks5/rpgrip1l establishes a ciliary zone of exclusion (cize) that compartmentalises ciliary signalling proteins and controls pip2 ciliary abundance. The EMBO Journal, 34:2537-2556, Oct 2015. URL: https://doi.org/10.15252/embj.201488044, doi:10.15252/embj.201488044. This article has 164 citations.</p>
+</li>
+<li>
+<p>(jensen2015formationofthe pages 4-5): Victor L Jensen, Chunmei Li, Rachel V Bowie, Lara Clarke, Swetha Mohan, Oliver E Blacque, and Michel R Leroux. Formation of the transition zone by mks5/rpgrip1l establishes a ciliary zone of exclusion (cize) that compartmentalises ciliary signalling proteins and controls pip2 ciliary abundance. The EMBO Journal, 34:2537-2556, Oct 2015. URL: https://doi.org/10.15252/embj.201488044, doi:10.15252/embj.201488044. This article has 164 citations.</p>
+</li>
+<li>
+<p>(li2016mks5andcep290 pages 11-12): Chunmei Li, Victor L. Jensen, Kwangjin Park, Julie Kennedy, Francesc R. Garcia-Gonzalo, Marta Romani, Roberta De Mori, Ange-Line Bruel, Dominique Gaillard, Bérénice Doray, Estelle Lopez, Jean-Baptiste Rivière, Laurence Faivre, Christel Thauvin-Robinet, Jeremy F. Reiter, Oliver E. Blacque, Enza Maria Valente, and Michel R. Leroux. Mks5 and cep290 dependent assembly pathway of the ciliary transition zone. PLOS Biology, 14:e1002416, Mar 2016. URL: https://doi.org/10.1371/journal.pbio.1002416, doi:10.1371/journal.pbio.1002416. This article has 176 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(li2016mks5andcep290 pages 7-9): Chunmei Li, Victor L. Jensen, Kwangjin Park, Julie Kennedy, Francesc R. Garcia-Gonzalo, Marta Romani, Roberta De Mori, Ange-Line Bruel, Dominique Gaillard, Bérénice Doray, Estelle Lopez, Jean-Baptiste Rivière, Laurence Faivre, Christel Thauvin-Robinet, Jeremy F. Reiter, Oliver E. Blacque, Enza Maria Valente, and Michel R. Leroux. Mks5 and cep290 dependent assembly pathway of the ciliary transition zone. PLOS Biology, 14:e1002416, Mar 2016. URL: https://doi.org/10.1371/journal.pbio.1002416, doi:10.1371/journal.pbio.1002416. This article has 176 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(bialas2009functionalinteractionsbetween pages 9-10): Nathan J. Bialas, Peter N. Inglis, Chunmei Li, Jon F. Robinson, Jeremy D. K. Parker, Michael P. Healey, Erica E. Davis, Chrystal D. Inglis, Tiina Toivonen, David C. Cottell, Oliver E. Blacque, Lynne M. Quarmby, Nicholas Katsanis, and Michel R. Leroux. Functional interactions between the ciliopathy-associated meckel syndrome 1 (mks1) protein and two novel mks1-related (mksr) proteins. Journal of Cell Science, 122:611-624, Mar 2009. URL: https://doi.org/10.1242/jcs.028621, doi:10.1242/jcs.028621. This article has 98 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(bialas2009functionalinteractionsbetween pages 10-11): Nathan J. Bialas, Peter N. Inglis, Chunmei Li, Jon F. Robinson, Jeremy D. K. Parker, Michael P. Healey, Erica E. Davis, Chrystal D. Inglis, Tiina Toivonen, David C. Cottell, Oliver E. Blacque, Lynne M. Quarmby, Nicholas Katsanis, and Michel R. Leroux. Functional interactions between the ciliopathy-associated meckel syndrome 1 (mks1) protein and two novel mks1-related (mksr) proteins. Journal of Cell Science, 122:611-624, Mar 2009. URL: https://doi.org/10.1242/jcs.028621, doi:10.1242/jcs.028621. This article has 98 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+</ol>
+<h2 id="artifacts">Artifacts</h2>
+<ul>
+<li><a href="mksr-1-deep-research-falcon_artifacts/artifact-00.md">Edison artifact artifact-00</a></li>
+<li><a href="mksr-1-deep-research-falcon_artifacts/artifact-01.md">Edison artifact artifact-01</a></li>
+</ul>
+<h2 id="citations">Citations</h2>
+<ol>
+<li>zhang2010identificationofnovel pages 8-9</li>
+<li>caenenbraz2024newfunctionsof pages 8-10</li>
+<li>okazaki2020formationofthe pages 5-7</li>
+<li>okazaki2020formationofthe pages 1-5</li>
+<li>jensen2015formationofthe pages 12-14</li>
+<li>bialas2009functionalinteractionsbetween pages 5-6</li>
+<li>zhang2010identificationofnovel pages 5-6</li>
+<li>bialas2009functionalinteractionsbetween pages 3-5</li>
+<li>okazaki2020formationofthe pages 21-27</li>
+<li>jensen2015formationofthe pages 14-15</li>
+<li>bialas2009functionalinteractionsbetween pages 1-2</li>
+<li>bialas2009functionalinteractionsbetween pages 6-7</li>
+<li>bialas2009functionalinteractionsbetween pages 7-9</li>
+<li>warburtonpitt2012ciliogenesisincaenorhabditis pages 3-4</li>
+<li>jensen2015formationofthe pages 1-2</li>
+<li>warburtonpitt2012ciliogenesisincaenorhabditis pages 4-6</li>
+<li>warburtonpitt2015theciliopathygene pages 95-99</li>
+<li>jensen2015formationofthe pages 2-4</li>
+<li>jensen2015formationofthe pages 8-9</li>
+<li>jensen2015formationofthe pages 7-8</li>
+<li>jensen2015formationofthe pages 4-5</li>
+<li>bialas2009functionalinteractionsbetween pages 9-10</li>
+<li>bialas2009functionalinteractionsbetween pages 10-11</li>
+<li>https://doi.org/10.1242/jcs.028621,</li>
+<li>https://doi.org/10.1091/mbc.e20-03-0208,</li>
+<li>https://doi.org/10.1016/j.gene.2010.08.006,</li>
+<li>https://doi.org/10.1371/journal.pbio.1002416,</li>
+<li>https://doi.org/10.15252/embj.201488044,</li>
+<li>https://doi.org/10.1242/jcs.095539,</li>
+<li>https://doi.org/10.7282/t3v40wx3,</li>
+<li>https://doi.org/10.1038/s41598-024-75577-w,</li>
+<li>https://doi.org/10.1172/jci196365,</li>
+</ol>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(mksr-1-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="Q21191" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="mksr-1-k03e64-wbgene00019364-q21191-research-notes">mksr-1 (K03E6.4 / WBGene00019364 / Q21191) — research notes</h1>
+<h2 id="identity">Identity</h2>
+<ul>
+<li>UniProt <strong>Q21191</strong> (Q21191_CAEEL), <em>Caenorhabditis elegans</em>, 229 aa.</li>
+<li>RecName: <strong>B9 domain-containing protein 1</strong> (i.e. <strong>B9D1</strong> ortholog) [UniProt Q21191, "RecName: Full=B9 domain-containing protein 1"].</li>
+<li>Gene: <strong>mksr-1</strong> ("MKS-1-related protein 1"); ORF <strong>K03E6.4</strong>; WormBase <strong>WBGene00019364</strong>; on Chromosome X.</li>
+<li>Domain content: a single <strong>B9 (C2-B9-type) domain</strong> (InterPro IPR010796 "C2_B9-type_dom"; Pfam PF07162 "B9-C2"; PROSITE PS51381 C2_B9). PANTHER PTHR12968:SF1 "B9 DOMAIN-CONTAINING PROTEIN 1".</li>
+<li>Belongs to the <strong>B9D family</strong> [UniProt Q21191, "Belongs to the B9D family."].</li>
+<li>NOT an integral membrane protein: no signal peptide, no transmembrane keyword. This distinguishes it from mks-2 (TMEM216, multi-pass membrane). mksr-1 is a peripheral B9/C2-domain component of the MKS module. (UniProt keywords: Cell projection, Cilium biogenesis/degradation, Cytoplasm, Cytoskeleton.)</li>
+<li>UniProt subcellular location: "Cytoplasm, cytoskeleton, cilium basal body" (ARBA electronic).</li>
+<li>UniProt binary interaction: <code>Q21191; Q9N423: mksr-2; NbExp=3; IntAct=EBI-330284, EBI-330279</code> — i.e. MKSR-1 binds <strong>MKSR-2 (B9D2, Q9N423)</strong>.</li>
+</ul>
+<h3 id="nomenclature-caution">Nomenclature caution</h3>
+<p>Older literature uses conflicting names for the three worm B9 proteins. Williams et al. 2008 (PMID:18337471) named them <strong>XBX-7 (MKS1), TZA-1 (B9D2), TZA-2 (B9D1)</strong>. Bialas et al. 2009 (PMID:19208769) and Williams et al. 2011 (PMID:21422230) use the now-standard <strong>MKS-1, MKSR-1/B9D1, MKSR-2/B9D2</strong>. UniProt, WormBase and the CAEEL_CILIOPATHY project all use <strong>mksr-1 = B9D1</strong>, <strong>mksr-2 = B9D2</strong>. I use the standard naming; where a paper uses other names I note the correspondence.</p>
+<h2 id="what-is-known">What is KNOWN</h2>
+<h3 id="family-domain-evolution">Family, domain, evolution</h3>
+<ul>
+<li>The B9 domain occurs "exclusively within a family of three proteins distributed widely in ciliated organisms" [PMID:19208769 abstract, "this domain occurs exclusively within a family of three proteins distributed widely in ciliated organisms"].</li>
+<li>Structure/fold predictions relate the B9 domain to a <strong>C2 domain</strong> (Ca2+/lipid-binding, synaptotagmin-like) [PMID:21422230, "B9 domains of MKS-1, MKSR-1, and MKSR-2 may be structurally related to C2 domains"; "This motif is predicted to bind Ca2+/lipids and participate—similar to synaptotagmin—in membrane/vesicle trafficking and fusion"]. This is a <em>predicted</em> biochemical property; no direct Ca2+/lipid-binding assay for MKSR-1 exists in these papers.</li>
+</ul>
+<h3 id="localization-experimental">Localization (experimental)</h3>
+<ul>
+<li>All three C. elegans B9 proteins (MKS-1, MKSR-1, MKSR-2) "localize to transition zones/basal bodies of sensory cilia" [PMID:19208769 abstract].</li>
+<li>Direct imaging: MKSR-1/B9D1 localizes to the <strong>ciliary transition zone</strong> in C. elegans sensory neurons [PMID:21422230, "This is evident for MKS-1, MKS-1 related-1 (MKSR-1)/B9D1, MKS-1 related-2 (MKSR-2)/B9D2, MKS-3/meckelin, NPHP-1, and NPHP-4"; GFP-MKSR-1 imaged at TZ, Fig 1–2, Fig 8G]. This is the basis of the WormBase IDA GO:0035869 (ciliary transition zone) annotation (PMID:21422230).</li>
+<li>Localization is <strong>co-dependent</strong> among the B9 proteins: "Their subcellular localization is largely co-dependent, pointing to a functional relationship between the proteins" [PMID:19208769 abstract].</li>
+<li>MKSR-1 TZ localization depends on upstream MKS-5: "mks-5 mutants failed to properly localize MKS-1, MKSR-1, and MKSR-2" <a href="https://pubmed.ncbi.nlm.nih.gov/21422230">PMID:21422230</a>.</li>
+<li>MKSR-1::tdTomato is used as a TZ comarker [mks-2 review cites PMID:26982032, "MKSR-1::tdTomato and MKS-2::GFP are TZ protein comarkers"].</li>
+</ul>
+<h3 id="the-mks-module-complex">The MKS module / complex</h3>
+<ul>
+<li>MKSR-1 is a member of the MKS/MKSR module together with MKS-1, MKSR-2, MKS-3, MKS-6: "MKS/MKSR module ... consisting of MKS-1/MKSR-1/MKSR-2/MKS-3/MKS-6" <a href="https://pubmed.ncbi.nlm.nih.gov/21422230">PMID:21422230</a>. Modeled in GO as the <strong>MKS complex (GO:0036038)</strong>.</li>
+<li>The MKS module and the NPHP module (NPHP-1/NPHP-4) are recruited/anchored by the central scaffold MKS-5/RPGRIP1L.</li>
+</ul>
+<h3 id="function-transition-zone-assembly-y-links-membrane-anchoring">Function: transition-zone assembly / Y-links / membrane anchoring</h3>
+<ul>
+<li>MKSR-1 acts, redundantly with the NPHP module, in building the TZ. The <strong>mksr-1;nphp-4</strong> double mutant has severe TZ ultrastructure defects — TZ not anchored to membrane, missing Y-links: "Phenotypes nearly identical to mks-6;nphp-4 mutants were observed in the mksr-1;nphp-4 strain" <a href="https://pubmed.ncbi.nlm.nih.gov/21422230">PMID:21422230</a>. (Table I: mksr-1;nphp-4 shows enlarged TZ membrane diameter and 0% of TZs with Y-links.)</li>
+<li>MKSR-1 is required for the TZ localization of other MKS-module proteins (MKS-6, MKS-3): "disrupting MKSR-1, MKSR-2, or MKS-5 results in TZ delocalization of MKS-6 ... and MKS-3" <a href="https://pubmed.ncbi.nlm.nih.gov/21422230">PMID:21422230</a>. This underlies the IMP GO:1904491 (protein localization to ciliary transition zone) and GO:0008104 (intracellular protein localization) annotations.</li>
+</ul>
+<h3 id="function-ciliary-gate-diffusion-barrier">Function: ciliary gate / diffusion barrier</h3>
+<ul>
+<li>MKSR-1 is required to restrict membrane-associated proteins from entering the cilium (ciliary gate). In the mksr-1 single mutant, three normally-excluded proteins accumulate inside cilia:</li>
+<li>MKS-3: "accumulates abnormally inside cilia (cil) and at dendritic tips (DT) in mks-5, mksr-1, and mksr-2 mutants" [PMID:21422230, Fig 9L].</li>
+<li>RPI-2 (RP2 ortholog): "accumulates within cilia of ... mksr-1, mksr-2, mks-5, mks-6, and nphp-4 single mutants" [PMID:21422230, Fig 9M].</li>
+<li>TRAM-1a: "accumulates within cilia of mksr-1, mksr-2, mks-5, mks-6, nphp-1, and nphp-4 mutants" [PMID:21422230, Fig 9N].</li>
+<li>General model: "TZ proteins normally function to maintain a boundary at the cilium base, establishing the TZ as a bona fide ciliary gate" <a href="https://pubmed.ncbi.nlm.nih.gov/21422230">PMID:21422230</a>. This supports a NEW GO:1903565 (negative regulation of protein localization to cilium) annotation, mirroring the mks-2 review.</li>
+<li>Notably, the mksr-1 <em>single</em> mutant already shows the gate defect (RPI-2, TRAM-1a, MKS-3 mislocalization) even though gross cilium structure is normal — the gate phenotype is more sensitive than the structural phenotype.</li>
+</ul>
+<h3 id="redundancy-single-mutant-subtlety">Redundancy / single-mutant subtlety</h3>
+<ul>
+<li>Single, double and triple mks/mksr mutants "do not display overt defects in ciliary structure, intraflagellar transport or chemosensation" [PMID:19208769 abstract].</li>
+<li>B9-gene mutations "do not overtly affect cilia formation unless they are in combination with a mutation in nph-1 or nph-4" [PMID:18337471 abstract]. → basis of the IGI GO:1905515 (non-motile cilium assembly) annotations (mksr-1 × nphp-1/nphp-4, WITH WBGene00011261=nphp-4, WBGene00007490=nphp-1).</li>
+</ul>
+<h3 id="lifespan-insulin-igf-phenotype">Lifespan / insulin-IGF phenotype</h3>
+<ul>
+<li>Double mks/mksr mutants have an increased lifespan phenotype due to abnormal insulin-IGF-I signaling: "we find genetic interactions between all double mks/mksr mutant combinations, manifesting as an increased lifespan phenotype, which is due to abnormal insulin-IGF-I signaling" [PMID:19208769 abstract]. → basis of the IGI GO:0008340 (determination of adult lifespan) annotations. This is an indirect, module-redundancy phenotype (a downstream consequence of impaired ciliary signaling), not a direct molecular function of MKSR-1.</li>
+</ul>
+<h3 id="larval-foraging-behavior">Larval foraging behavior</h3>
+<ul>
+<li>GO:0035177 (larval foraging behavior) IGI annotation from PMID:18337471 (WITH WBGene00011261 = nphp-4). Foraging/roaming behavior in worms depends on functional sensory cilia; a B9×nphp genetic interaction affecting cilia would plausibly affect foraging. The cached record is abstract-only (does not state "foraging" explicitly), so this is a curator judgment from full text — retained (KEEP_AS_NON_CORE), not overruled.</li>
+</ul>
+<h3 id="protein-interactions">Protein interactions</h3>
+<ul>
+<li>MKSR-1 binds MKSR-2 (B9D2). UniProt binary interaction Q21191–Q9N423 (NbExp=3); IntAct EBI-330284/EBI-330279; DIP-27480N. GOA has IPI GO:0005515 (protein binding) annotations with WITH/FROM UniProtKB:Q9N423 from PMID:14704431 (Li et al. 2004 worm interactome) and PMID:19123269 (Simonis et al. 2009 empirically-controlled interactome), plus one WB IPI from PMID:18337471 (WITH WBGene00021416 = mksr-2). The interaction is real, but <code>protein binding</code> is uninformative; the biologically meaningful fact is the B9D1–B9D2 (MKSR-1–MKSR-2) heterodimer within the MKS module.</li>
+</ul>
+<h2 id="what-is-not-known">What is NOT known</h2>
+<ul>
+<li><strong>No molecular-function GO term</strong> captures what MKSR-1 does. It is a structural/scaffold subunit of the TZ MKS module (diffusion-barrier / Y-link scaffold). GO has no "structural constituent of the ciliary transition zone" MF term; <code>structural molecule activity</code> (GO:0005198) is the closest placeholder. (Ontology gap — shared across MKS/NPHP-module genes; cf. the mks-2 review.)</li>
+<li>Whether the <strong>predicted C2/B9 Ca2+/lipid-binding</strong> activity is real for MKSR-1 (no direct biochemical assay).</li>
+<li>MKSR-1's <strong>direct binding partners</strong> beyond MKSR-2 in the worm TZ, and its precise position within the MKS-module architecture (super-resolution / proteomics not resolved for MKSR-1 specifically).</li>
+<li>Whether MKSR-1 has any <strong>non-redundant</strong> sub-function distinct from the other core MKS-module proteins (single mutants near-normal structurally; phenotypes emerge in nphp double mutants), though the single-mutant gate leak (RPI-2/TRAM-1a) indicates at least some non-fully-redundant barrier contribution.</li>
+</ul>
+<h2 id="annotation-review-plan-summary">Annotation review plan (summary)</h2>
+<table>
+<thead>
+<tr>
+<th>GO term</th>
+<th>Evid</th>
+<th>Ref</th>
+<th>Planned action</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>GO:0036038 MKS complex (part_of)</td>
+<td>IBA</td>
+<td>GO_REF:0000033</td>
+<td>ACCEPT (core; corroborated by direct imaging/genetics)</td>
+</tr>
+<tr>
+<td>GO:0060271 cilium assembly (involved_in)</td>
+<td>IBA</td>
+<td>GO_REF:0000033</td>
+<td>MODIFY → GO:1905515 non-motile cilium assembly (worm sensory cilia are non-motile; more specific)</td>
+</tr>
+<tr>
+<td>GO:0005929 cilium (located_in)</td>
+<td>IEA</td>
+<td>GO_REF:0000117</td>
+<td>MODIFY → GO:0035869 ciliary transition zone (specific; IDA-supported) / or KEEP_AS_NON_CORE</td>
+</tr>
+<tr>
+<td>GO:0005515 protein binding (enables) ×3</td>
+<td>IPI</td>
+<td>PMID:14704431 / 19123269 / 18337471</td>
+<td>KEEP_AS_NON_CORE (real MKSR-1–MKSR-2 interaction; uninformative term; do not remove experimental IPI)</td>
+</tr>
+<tr>
+<td>GO:1905515 non-motile cilium assembly (involved_in) ×2</td>
+<td>IGI</td>
+<td>PMID:18337471 / 21422230</td>
+<td>ACCEPT (core, redundant module function)</td>
+</tr>
+<tr>
+<td>GO:1904491 protein localization to ciliary transition zone (involved_in) ×2</td>
+<td>IMP</td>
+<td>PMID:26595381 / 21422230</td>
+<td>ACCEPT (PMID:21422230 shows MKSR-1 required for MKS-6/MKS-3 TZ localization; PMID:26595381 abstract-only, defer to curator)</td>
+</tr>
+<tr>
+<td>GO:0035869 ciliary transition zone (located_in)</td>
+<td>IDA</td>
+<td>PMID:21422230</td>
+<td>ACCEPT (core CC; direct imaging)</td>
+</tr>
+<tr>
+<td>GO:0008340 determination of adult lifespan (involved_in) ×4</td>
+<td>IGI</td>
+<td>PMID:19208769</td>
+<td>KEEP_AS_NON_CORE (indirect insulin-IGF phenotype in double mutants; not a core function)</td>
+</tr>
+<tr>
+<td>GO:0008104 intracellular protein localization (involved_in)</td>
+<td>IMP</td>
+<td>PMID:18337471</td>
+<td>MODIFY → GO:1904491 (the specific process is protein localization to the TZ)</td>
+</tr>
+<tr>
+<td>GO:0035177 larval foraging behavior (involved_in)</td>
+<td>IGI</td>
+<td>PMID:18337471</td>
+<td>KEEP_AS_NON_CORE (downstream sensory-cilium behavior; curator full-text judgment; abstract-only cache)</td>
+</tr>
+</tbody>
+</table>
+<p>Proposed NEW: GO:1903565 negative regulation of protein localization to cilium (ciliary gate; RPI-2/TRAM-1a/MKS-3 exclusion) — mirrors mks-2 review, directly supported in the mksr-1 single mutant.</p>
+<h2 id="deep-research">Deep research</h2>
+<ul>
+<li>Falcon deep research launched via <code>just deep-research-falcon worm mksr-1 --fallback perplexity-lite</code>. The wrapper reported a 600s timeout and the perplexity-lite fallback failed with a 401 quota error, but the underlying falcon (Edison) client actually completed at 1120s and wrote a genuine 50KB report (<code>mksr-1-deep-research-falcon.md</code>, 32 citations, artifacts folder). I read it: it independently confirms MKSR-1 = B9D1, a soluble single-B9-domain protein, obligate B9 complex with MKS-1/MKSR-2, TZ/basal-body localization and MKS-module/ciliopathy role — fully consistent with this review. It cites some additional non-cached sources (okazaki2020, zhang2010); I did NOT add those as citations since they are not in the publications cache and the review is anchored to verified cached PMIDs. This is a genuine late falcon file (kept per ground rules).</li>
+<li>Review grounded primarily on cached primary literature (PMID:21422230 full text; PMID:19208769, 18337471, 26595381 abstracts) and UniProt/GOA.</li>
+</ul>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: Q21191
+gene_symbol: mksr-1
+product_type: PROTEIN
+status: COMPLETE
+taxon:
+  id: NCBITaxon:6239
+  label: Caenorhabditis elegans
+description: &gt;-
+  MKSR-1 (MKS-1-related protein 1) is the Caenorhabditis elegans ortholog of human
+  B9D1, one of the three B9-domain proteins (with MKS-1/MKS1 and MKSR-2/B9D2). It is
+  a small, soluble B9/C2-domain protein and a core component of the MKS module, one
+  of the two protein modules (MKS and NPHP) that together assemble the ciliary
+  transition zone (TZ) at the base of sensory cilia. The TZ builds the Y-link
+  connectors that tether the axoneme doublet microtubules to the ciliary membrane
+  and forms the ciliary gate, a membrane diffusion barrier that restricts entry of
+  non-ciliary membrane proteins into the cilium. MKSR-1 localizes to the TZ of
+  ciliated sensory neurons; its localization is co-dependent with the other B9
+  proteins and requires the upstream scaffold MKS-5/RPGRIP1L. MKSR-1 in turn is
+  required for the TZ localization of other MKS-module proteins (e.g. MKS-6/CC2D2A
+  and MKS-3/meckelin) and forms a heterodimer with MKSR-2/B9D2. Consistent with the
+  strong redundancy among transition-zone genes, mksr-1 single mutants have no overt
+  defect in cilium structure or intraflagellar transport, whereas mksr-1;nphp-4
+  double mutants disrupt TZ membrane anchoring and Y-links; even in the single
+  mutant, however, the ciliary gate leaks, allowing membrane proteins such as
+  TRAM-1a and RPI-2 to enter the cilium. In humans, B9D1 is a Meckel-Gruber
+  syndrome/nephronophthisis-spectrum ciliopathy gene.
+existing_annotations:
+  - term:
+      id: GO:0036038
+      label: MKS complex
+    evidence_type: IBA
+    original_reference_id: GO_REF:0000033
+    qualifier: part_of
+    review:
+      summary: &gt;-
+        MKSR-1/B9D1 is a core B9-domain subunit of the MKS module (MKS complex) at
+        the ciliary transition zone. The phylogenetic (IBA) inference is directly
+        corroborated by experimental work in C. elegans placing MKSR-1 in the
+        MKS/MKSR module together with MKS-1, MKSR-2, MKS-3 and MKS-6.
+      action: ACCEPT
+      reason: &gt;-
+        Core cellular-component/complex annotation. The IBA inference from the B9D1
+        PANTHER family is consistent with direct C. elegans genetics and imaging, so
+        it is retained as a core annotation.
+      supported_by:
+        - reference_id: PMID:21422230
+          supporting_text: &gt;-
+            MKS/MKSR module ... consisting of MKS-1/MKSR-1/MKSR-2/MKS-3/MKS-6
+  - term:
+      id: GO:0060271
+      label: cilium assembly
+    evidence_type: IBA
+    original_reference_id: GO_REF:0000033
+    qualifier: involved_in
+    review:
+      summary: &gt;-
+        As a core MKS-module subunit, MKSR-1 participates (redundantly with the NPHP
+        module) in building the transition zone during assembly of the non-motile
+        sensory cilia of C. elegans. The generic &#39;cilium assembly&#39; term is correct
+        but less precise than &#39;non-motile cilium assembly&#39;, which is already
+        experimentally annotated for this gene and matches the fact that all worm
+        cilia are non-motile sensory cilia.
+      action: MODIFY
+      reason: &gt;-
+        The essence (a role in cilium assembly) is right, but a more specific term is
+        available and better supported. C. elegans sensory cilia are non-motile, and
+        the gene already carries experimental IGI annotations to non-motile cilium
+        assembly; generalize the IBA to the same specific process.
+      proposed_replacement_terms:
+        - id: GO:1905515
+          label: non-motile cilium assembly
+      propagation_review:
+        root_cause: TERM_SCOPING_PROBLEM
+        failure_modes:
+          - GRANULARITY_MISMATCH
+        source_entities:
+          - source_id: PANTHER:PTN000311628
+            source_label: PANTHER PTHR12968 B9 domain-containing family node
+            source_status: SUPPORTS_TRANSFER
+            comment: &gt;-
+              The B9D1 family node correctly propagates a cilium-assembly role, but
+              in C. elegans all cilia are non-motile sensory cilia, so the more
+              specific child term (non-motile cilium assembly) applies and is already
+              supported by experimental IGI annotations for mksr-1. This is a
+              granularity refinement, not an erroneous propagation.
+      supported_by:
+        - reference_id: PMID:18337471
+          supporting_text: &gt;-
+            regulate the formation and/or maintenance of cilia and dendrites in the
+            amphid and phasmid ciliated sensory neurons
+  - term:
+      id: GO:0005929
+      label: cilium
+    evidence_type: IEA
+    original_reference_id: GO_REF:0000117
+    qualifier: located_in
+    review:
+      summary: &gt;-
+        The ARBA electronic annotation places MKSR-1 in the cilium. This is correct
+        at a coarse level but far less informative than the experimentally
+        established ciliary transition-zone localization; MKSR-1 concentrates
+        specifically at the TZ at the ciliary base, not along the ciliary axoneme.
+      action: MODIFY
+      reason: &gt;-
+        The generic &#39;cilium&#39; location is subsumed by the specific, experimentally
+        supported &#39;ciliary transition zone&#39; localization (IDA, PMID:21422230).
+        Replace with the more informative and accurate compartment term.
+      proposed_replacement_terms:
+        - id: GO:0035869
+          label: ciliary transition zone
+      supported_by:
+        - reference_id: PMID:21422230
+          supporting_text: &gt;-
+            This is evident for MKS-1, MKS-1 related-1 (MKSR-1)/B9D1
+  - term:
+      id: GO:0005515
+      label: protein binding
+    evidence_type: IPI
+    original_reference_id: PMID:14704431
+    qualifier: enables
+    review:
+      summary: &gt;-
+        IntAct-curated binary interaction between MKSR-1 (Q21191) and MKSR-2/B9D2
+        (Q9N423) from the C. elegans interactome map. The interaction is real and
+        biologically meaningful (the B9D1-B9D2 heterodimer is a substructure of the
+        MKS module), but the generic &#39;protein binding&#39; term conveys no specific
+        molecular function.
+      action: KEEP_AS_NON_CORE
+      reason: &gt;-
+        Experimental (IPI) interaction data should not be removed. However, &#39;protein
+        binding&#39; is uninformative and is not the core function; the meaningful fact
+        (MKSR-1-MKSR-2/B9D1-B9D2 heterodimer within the MKS module) is captured by the
+        MKS-complex membership and the structural role in core_functions. Retained as
+        a non-core supporting annotation.
+      supported_by:
+        - reference_id: PMID:21422230
+          supporting_text: &gt;-
+            MKS/MKSR module ... consisting of MKS-1/MKSR-1/MKSR-2/MKS-3/MKS-6
+  - term:
+      id: GO:0005515
+      label: protein binding
+    evidence_type: IPI
+    original_reference_id: PMID:19123269
+    qualifier: enables
+    review:
+      summary: &gt;-
+        A second IntAct-curated MKSR-1-MKSR-2 binary interaction, from the
+        empirically-controlled C. elegans interactome. As above, the interaction is
+        genuine but &#39;protein binding&#39; is uninformative.
+      action: KEEP_AS_NON_CORE
+      reason: &gt;-
+        Do not remove experimental interaction evidence. &#39;Protein binding&#39; is a
+        low-information term; the MKSR-1-MKSR-2 heterodimer is represented by the
+        MKS-complex membership and structural role. Retained as non-core.
+      supported_by:
+        - reference_id: PMID:21422230
+          supporting_text: &gt;-
+            MKS/MKSR module ... consisting of MKS-1/MKSR-1/MKSR-2/MKS-3/MKS-6
+  - term:
+      id: GO:1905515
+      label: non-motile cilium assembly
+    evidence_type: IGI
+    original_reference_id: PMID:18337471
+    qualifier: involved_in
+    review:
+      summary: &gt;-
+        Williams et al. showed the C. elegans B9 proteins (including MKSR-1) function
+        redundantly with the nephrocystins: B9-gene mutations do not overtly affect
+        cilia unless combined with a mutation in nph-1 or nph-4, revealing a
+        (redundant) requirement of MKSR-1 for assembly of the non-motile sensory
+        cilia. Reflected by the genetic interaction with the NPHP module.
+      action: ACCEPT
+      reason: &gt;-
+        Well-supported IGI annotation capturing the canonical MKS/NPHP redundancy.
+        The synthetic ciliary phenotype with nphp genes is the standard genetic
+        signature placing MKSR-1 in the MKS module and demonstrating its redundant
+        role in cilium assembly. Core module-level function.
+      supported_by:
+        - reference_id: PMID:18337471
+          supporting_text: &gt;-
+            Mutations in the B9 genes do not overtly affect cilia formation unless
+            they are in combination with a mutation in nph-1 or nph-4
+  - term:
+      id: GO:1904491
+      label: protein localization to ciliary transition zone
+    evidence_type: IMP
+    original_reference_id: PMID:26595381
+    qualifier: involved_in
+    review:
+      summary: &gt;-
+        WormBase IMP annotation from the TMEM107 study, which dissected MKS-module
+        recruitment/organization at the TZ. The cached record is abstract-only; the
+        abstract establishes that TMEM-107 organizes recruitment of MKS-module
+        ciliopathy proteins to TZ subdomains, and the curator assigned the IMP for
+        MKSR-1&#39;s role in TZ protein localization from the full text.
+      action: ACCEPT
+      reason: &gt;-
+        Experimental (IMP) annotation by a WormBase curator; the full text (not in
+        cache) contains the direct evidence. Concordant with PMID:21422230, which
+        directly shows MKSR-1 is required for TZ localization of MKS-6 and MKS-3. Per
+        curation guidance the experimental annotation is retained rather than
+        second-guessed from an abstract-only cache.
+      supported_by:
+        - reference_id: PMID:26595381
+          supporting_text: &gt;-
+            TZ-localized MKS module by organizing recruitment of the ciliopathy
+            proteins
+  - term:
+      id: GO:1904491
+      label: protein localization to ciliary transition zone
+    evidence_type: IMP
+    original_reference_id: PMID:21422230
+    qualifier: involved_in
+    review:
+      summary: &gt;-
+        Williams et al. directly show that disrupting MKSR-1 causes TZ delocalization
+        of other MKS-module proteins: MKS-6 and MKS-3 fail to localize to the TZ in
+        mksr-1 mutants (MKS-3 additionally accumulates along the axoneme). This
+        defines MKSR-1 as required for correct protein localization to the transition
+        zone.
+      action: ACCEPT
+      reason: &gt;-
+        Directly supported experimental (IMP) annotation. Loss of mksr-1
+        mislocalizes downstream TZ proteins, demonstrating a role in establishing
+        protein localization to the transition zone. Core function.
+      supported_by:
+        - reference_id: PMID:21422230
+          supporting_text: &gt;-
+            disrupting MKSR-1, MKSR-2, or MKS-5 results in TZ delocalization of MKS-6
+        - reference_id: PMID:21422230
+          supporting_text: &gt;-
+            MKSR-1, MKSR-2, and MKS-5 restrict MKS-3 to the TZ membrane
+  - term:
+      id: GO:1905515
+      label: non-motile cilium assembly
+    evidence_type: IGI
+    original_reference_id: PMID:21422230
+    qualifier: involved_in
+    review:
+      summary: &gt;-
+        The genetic-interaction (IGI) evidence captures the MKS/NPHP redundancy in
+        cilium assembly: the mksr-1;nphp-4 double mutant produces severe TZ
+        ultrastructure defects (TZ not anchored to membrane, missing Y-links) nearly
+        identical to mks-6;nphp-4, whereas the mksr-1 single mutant is structurally
+        near-normal. WITH values reference the NPHP-module genes nphp-4/nphp-1.
+      action: ACCEPT
+      reason: &gt;-
+        Well-supported IGI annotation. The synthetic ultrastructural phenotype with
+        the NPHP module is the standard genetic signature placing mksr-1 in the MKS
+        module and demonstrating its (redundant) requirement for TZ/cilium assembly.
+      supported_by:
+        - reference_id: PMID:21422230
+          supporting_text: &gt;-
+            Phenotypes nearly identical to mks-6;nphp-4 mutants were observed in the
+            mksr-1;nphp-4 strain
+  - term:
+      id: GO:0035869
+      label: ciliary transition zone
+    evidence_type: IDA
+    original_reference_id: PMID:21422230
+    qualifier: located_in
+    review:
+      summary: &gt;-
+        Direct imaging of GFP/tdTomato-tagged MKSR-1 (B9D1) shows it concentrates at
+        the ciliary transition zone in C. elegans sensory neurons, adjacent to and
+        distinct from the basal body/transition-fibre region where IFT proteins
+        peak. This is the core experimentally-established localization.
+      action: ACCEPT
+      reason: &gt;-
+        Experimental (IDA) localization to the transition zone, concordant with the
+        IBA annotation and with the conserved TZ localization of B9D1 across
+        metazoans. Core cellular-component annotation.
+      supported_by:
+        - reference_id: PMID:21422230
+          supporting_text: &gt;-
+            This is evident for MKS-1, MKS-1 related-1 (MKSR-1)/B9D1
+  - term:
+      id: GO:0008340
+      label: determination of adult lifespan
+    evidence_type: IGI
+    original_reference_id: PMID:19208769
+    qualifier: involved_in
+    review:
+      summary: &gt;-
+        Bialas et al. found that all double mks/mksr mutant combinations (including
+        those involving mksr-1) show an increased-lifespan phenotype caused by
+        abnormal insulin-IGF-I signaling. This is an indirect, downstream consequence
+        of compromised ciliary signaling under module redundancy, not a direct
+        molecular function of MKSR-1.
+      action: KEEP_AS_NON_CORE
+      reason: &gt;-
+        Valid experimental (IGI) genetic-interaction annotation, but lifespan
+        determination is a pleiotropic downstream effect of impaired cilium/sensory
+        signaling rather than a core function of a transition-zone scaffold subunit.
+        Retained as a non-core annotation.
+      supported_by:
+        - reference_id: PMID:19208769
+          supporting_text: &gt;-
+            increased lifespan phenotype, which is due to abnormal insulin-IGF-I
+            signaling
+  - term:
+      id: GO:0005515
+      label: protein binding
+    evidence_type: IPI
+    original_reference_id: PMID:18337471
+    qualifier: enables
+    review:
+      summary: &gt;-
+        WormBase IPI annotation for a physical interaction of MKSR-1 with another B9
+        protein (WITH/FROM WBGene00021416 = mksr-2/B9D2), consistent with the
+        co-dependent B9-protein complex at the ciliary base. As with the IntAct IPIs,
+        the interaction is real but &#39;protein binding&#39; is uninformative.
+      action: KEEP_AS_NON_CORE
+      reason: &gt;-
+        Do not remove experimental interaction evidence. The MKSR-1-MKSR-2 heterodimer
+        it captures is represented by MKS-complex membership and the structural role
+        in core_functions; the generic term itself is non-core and low-information.
+      supported_by:
+        - reference_id: PMID:18337471
+          supporting_text: &gt;-
+            the C. elegans B9 proteins form a complex that localizes to the base of
+            cilia
+  - term:
+      id: GO:0008104
+      label: intracellular protein localization
+    evidence_type: IMP
+    original_reference_id: PMID:18337471
+    qualifier: involved_in
+    review:
+      summary: &gt;-
+        This generic &#39;intracellular protein localization&#39; IMP reflects MKSR-1&#39;s role
+        in localizing other ciliary/TZ proteins (the B9 proteins localize
+        co-dependently at the ciliary base, and MKSR-1 is required for TZ localization
+        of MKS-module proteins). A far more specific and better-supported term
+        exists: protein localization to the ciliary transition zone.
+      action: MODIFY
+      reason: &gt;-
+        The essence is right (MKSR-1 governs the localization of specific proteins),
+        but &#39;intracellular protein localization&#39; is over-general. Replace with the
+        specific process protein localization to ciliary transition zone, which is
+        directly documented and already annotated for this gene.
+      proposed_replacement_terms:
+        - id: GO:1904491
+          label: protein localization to ciliary transition zone
+      supported_by:
+        - reference_id: PMID:18337471
+          supporting_text: &gt;-
+            the C. elegans B9 proteins form a complex that localizes to the base of
+            cilia
+  - term:
+      id: GO:0035177
+      label: larval foraging behavior
+    evidence_type: IGI
+    original_reference_id: PMID:18337471
+    qualifier: involved_in
+    review:
+      summary: &gt;-
+        WormBase IGI annotation linking mksr-1 (redundantly with the NPHP module) to
+        larval foraging behavior. Foraging/roaming in C. elegans depends on
+        functional sensory cilia, so a B9-gene x nphp genetic interaction that
+        compromises cilia would be expected to affect foraging. The cached record is
+        abstract-only and does not itself state &#39;foraging&#39;, so this rests on the
+        curator&#39;s reading of the full text.
+      action: KEEP_AS_NON_CORE
+      reason: &gt;-
+        Downstream sensory-behavior phenotype rather than a core molecular/cellular
+        function of a TZ scaffold subunit. The experimental IGI annotation is
+        retained (not overruled from an abstract-only cache) but marked non-core.
+      supported_by:
+        - reference_id: PMID:18337471
+          supporting_text: &gt;-
+            regulate the formation and/or maintenance of cilia and dendrites in the
+            amphid and phasmid ciliated sensory neurons
+  - term:
+      id: GO:1903565
+      label: negative regulation of protein localization to cilium
+    evidence_type: IMP
+    original_reference_id: PMID:21422230
+    qualifier: involved_in
+    review:
+      summary: &gt;-
+        MKSR-1 is required for ciliary-gate (diffusion-barrier) function. In the
+        mksr-1 single mutant, membrane-associated proteins that are normally excluded
+        from cilia accumulate inside them: TRAM-1a and RPI-2 (RP2 ortholog) both
+        accumulate within cilia of mksr-1 mutants, and MKS-3 abnormally accumulates
+        inside cilia. This gate/barrier activity is the central function of the TZ and
+        is not otherwise captured in GOA for mksr-1.
+      action: NEW
+      reason: &gt;-
+        New annotation proposed to capture MKSR-1&#39;s ciliary-gate role, directly
+        demonstrated in the mksr-1 single mutant (leak of TRAM-1a, RPI-2 and MKS-3
+        into cilia). This mirrors the curated gate-function annotation modeled for the
+        sibling gene mks-2 and represents a core function currently missing from
+        mksr-1&#39;s GOA record.
+      supported_by:
+        - reference_id: PMID:21422230
+          supporting_text: &gt;-
+            accumulates within cilia of mksr-1, mksr-2, mks-5, mks-6, nphp-1, and
+            nphp-4 mutants
+        - reference_id: PMID:21422230
+          supporting_text: &gt;-
+            TZ proteins normally function to maintain a boundary at the cilium base,
+            establishing the TZ as a bona fide ciliary gate
+references:
+  - id: GO_REF:0000033
+    title: Annotation inferences using phylogenetic trees
+    findings: []
+  - id: GO_REF:0000117
+    title: Electronic Gene Ontology annotations created by ARBA machine learning models
+    findings: []
+  - id: PMID:14704431
+    title: A map of the interactome network of the metazoan C. elegans.
+    findings: []
+    reference_review:
+      relevance: MEDIUM
+      correctness: VERIFIED
+      review_notes: &gt;-
+        Li et al 2004 (Science), the large-scale C. elegans yeast two-hybrid
+        interactome map. Source (via IntAct) of an MKSR-1-MKSR-2 (Q21191-Q9N423)
+        binary interaction underlying an IPI &#39;protein binding&#39; annotation. Cached
+        record is abstract-only; the specific interaction is corroborated by the
+        UniProt binary-interaction record (NbExp=3) and by the independent
+        interactome study PMID:19123269. Interaction is real but the GO term it
+        supports is uninformative.
+  - id: PMID:18337471
+    title: Functional redundancy of the B9 proteins and nephrocystins in Caenorhabditis
+      elegans ciliogenesis.
+    findings:
+      - statement: &gt;-
+          The C. elegans B9 proteins (MKS-1/MKSR-1/MKSR-2) form a complex at the base
+          of cilia and function redundantly with the nephrocystins (nph-1/nph-4);
+          B9-gene mutations do not overtly affect cilia unless combined with a nph
+          mutation.
+        supporting_text: &gt;-
+          Mutations in the B9 genes do not overtly affect cilia formation unless they
+          are in combination with a mutation in nph-1 or nph-4
+    reference_review:
+      relevance: HIGH
+      correctness: VERIFIED
+      review_notes: &gt;-
+        Williams et al 2008 (Mol Biol Cell). Establishes B9-protein/nephrocystin
+        redundancy in worm ciliogenesis and the B9 complex at the ciliary base;
+        source of the IGI non-motile-cilium-assembly, larval-foraging, IMP protein
+        localization, and one IPI annotation. Cached record is abstract-only; uses the
+        older names XBX-7/TZA-1/TZA-2 for the B9 proteins (TZA-2 = B9D1 = mksr-1),
+        while the annotations use current WormBase naming.
+  - id: PMID:19123269
+    title: Empirically controlled mapping of the Caenorhabditis elegans protein-protein
+      interactome network.
+    findings: []
+    reference_review:
+      relevance: MEDIUM
+      correctness: VERIFIED
+      review_notes: &gt;-
+        Simonis et al 2009 (Nat Methods), the empirically-controlled C. elegans
+        interactome (Worm Interactome 2007). Independent source (via IntAct) of the
+        MKSR-1-MKSR-2 binary interaction supporting an IPI &#39;protein binding&#39;
+        annotation. Real interaction, uninformative GO term.
+  - id: PMID:19208769
+    title: Functional interactions between the ciliopathy-associated Meckel syndrome
+      1 (MKS1) protein and two novel MKS1-related (MKSR) proteins.
+    findings:
+      - statement: &gt;-
+          The B9 domain defines a family of three proteins (MKS-1, MKSR-1, MKSR-2) in
+          ciliated organisms; all three localize co-dependently to transition
+          zones/basal bodies of C. elegans sensory cilia. Double mks/mksr mutants show
+          an increased-lifespan phenotype due to abnormal insulin-IGF-I signaling.
+        supporting_text: &gt;-
+          increased lifespan phenotype, which is due to abnormal insulin-IGF-I
+          signaling
+    reference_review:
+      relevance: HIGH
+      correctness: VERIFIED
+      review_notes: &gt;-
+        Bialas et al 2009 (J Cell Sci); the paper that named MKSR-1/MKSR-2 and
+        established the B9 family, co-dependent TZ/basal-body localization, and the
+        insulin-IGF-I-dependent lifespan phenotype of double mutants. Source of the
+        determination-of-adult-lifespan IGI annotations. Cached record is
+        abstract-only.
+  - id: PMID:21422230
+    title: MKS and NPHP modules cooperate to establish basal body/transition zone membrane
+      associations and ciliary gate function during ciliogenesis.
+    findings:
+      - statement: &gt;-
+          MKSR-1/B9D1 localizes to the ciliary transition zone and is a member of the
+          MKS/MKSR module (with MKS-1, MKSR-2, MKS-3, MKS-6); the mksr-1;nphp-4 double
+          mutant disrupts TZ membrane anchoring and Y-links.
+        supporting_text: &gt;-
+          Phenotypes nearly identical to mks-6;nphp-4 mutants were observed in the
+          mksr-1;nphp-4 strain
+      - statement: &gt;-
+          MKSR-1 is required for the transition-zone localization of other MKS-module
+          proteins (MKS-6 and MKS-3), restricting MKS-3 to the TZ membrane.
+        supporting_text: &gt;-
+          MKSR-1, MKSR-2, and MKS-5 restrict MKS-3 to the TZ membrane
+      - statement: &gt;-
+          MKSR-1 contributes to ciliary-gate function; in mksr-1 mutants the
+          normally-excluded membrane proteins TRAM-1a and RPI-2 accumulate inside
+          cilia.
+        supporting_text: &gt;-
+          accumulates within cilia of mksr-1, mksr-2, mks-5, mks-6, nphp-1, and
+          nphp-4 mutants
+    reference_review:
+      relevance: HIGH
+      correctness: VERIFIED
+      review_notes: &gt;-
+        Williams et al 2011 (J Cell Biol); full text cached and MKSR-1 is extensively
+        assayed (TZ localization, mksr-1;nphp-4 TEM phenotype, requirement for MKS-6/
+        MKS-3 TZ localization, and ciliary-gate leak of TRAM-1a/RPI-2/MKS-3). Anchors
+        the IDA TZ localization, the IMP/IGI cilium-assembly and protein-localization
+        annotations, and the NEW ciliary-gate annotation.
+  - id: PMID:26595381
+    title: TMEM107 recruits ciliopathy proteins to subdomains of the ciliary transition
+      zone and causes Joubert syndrome.
+    findings:
+      - statement: &gt;-
+          TMEM-107 organizes recruitment of MKS-module ciliopathy proteins to
+          subdomains of the ciliary transition zone; MKS-module membrane proteins are
+          immobile and periodically arranged within the TZ.
+        supporting_text: &gt;-
+          TZ-localized MKS module by organizing recruitment of the ciliopathy
+          proteins
+    reference_review:
+      relevance: MEDIUM
+      correctness: VERIFIED
+      review_notes: &gt;-
+        Lambacher et al 2016 (Nat Cell Biol). Cached record is abstract-only; the
+        abstract supports the MKS-module TZ recruitment/architecture framing. The
+        WormBase IMP for MKSR-1 protein-localization-to-TZ draws on the full text;
+        deferring to the curator for that experimental evidence.
+core_functions:
+  - description: &gt;-
+      MKSR-1/B9D1 acts as a structural/scaffolding subunit of the MKS module of the
+      ciliary transition zone. As a soluble B9/C2-domain protein it localizes to the
+      TZ (dependent on MKS-5) and contributes to assembly and integrity of the TZ
+      (Y-link connectors and basal body/TZ membrane anchoring) and to the ciliary
+      gate - the membrane diffusion barrier that restricts non-ciliary membrane
+      proteins (e.g. TRAM-1a, RPI-2) from entering the cilium. It is required to
+      recruit/retain other MKS-module proteins (MKS-6, MKS-3) at the TZ and forms a
+      heterodimer with MKSR-2/B9D2. There is no GO molecular-function term that
+      precisely describes a transition-zone diffusion-barrier scaffold subunit;
+      &#39;structural molecule activity&#39; is used here as the closest available placeholder.
+    molecular_function:
+      id: GO:0005198
+      label: structural molecule activity
+    in_complex:
+      id: GO:0036038
+      label: MKS complex
+    locations:
+      - id: GO:0035869
+        label: ciliary transition zone
+    directly_involved_in:
+      - id: GO:1905515
+        label: non-motile cilium assembly
+      - id: GO:1904491
+        label: protein localization to ciliary transition zone
+      - id: GO:1903565
+        label: negative regulation of protein localization to cilium
+    supported_by:
+      - reference_id: PMID:21422230
+        supporting_text: &gt;-
+          MKSR-1, MKSR-2, and MKS-5 restrict MKS-3 to the TZ membrane
+      - reference_id: PMID:21422230
+        supporting_text: &gt;-
+          accumulates within cilia of mksr-1, mksr-2, mks-5, mks-6, nphp-1, and
+          nphp-4 mutants
+knowledge_gaps:
+  - gap_statement: &gt;-
+      MKSR-1 has no assigned molecular function and there is no GO term to express
+      one. Its role is to be a structural/diffusion-barrier scaffold subunit of the
+      ciliary transition-zone MKS module, but GO has no molecular-function term such
+      as &#34;structural constituent of the ciliary transition zone&#34; (or &#34;diffusion
+      barrier component&#34;), so the gene reads as MF-dark despite a well-understood
+      cellular-component and biological-process role.
+    boundary: &gt;-
+      It is firmly established that MKSR-1 = B9D1 is a B9/C2-domain protein of the TZ,
+      a core MKS-module component required (redundantly with the NPHP module) for
+      cilium/TZ assembly, for the ciliary gate, and for recruiting other MKS-module
+      proteins (MKS-6, MKS-3). What is missing is a molecular-function representation:
+      the worm GOA record carries only cellular-component and biological-process terms
+      plus an uninformative &#39;protein binding&#39;, and no informative molecular_function
+      annotation.
+    gap_kind:
+      - ONTOLOGY
+      - CURATION
+    dark_aspect: MF_DARK
+    status: OPEN
+    significance: &gt;-
+      This is the canonical &#34;structural subunit&#34; ontology gap shared across the
+      transition-zone/ciliopathy gene set (cf. the mks-2 review): a mechanistically
+      well-placed protein that cannot be given an informative MF term, contributing to
+      apparent molecular-function darkness across MKS/NPHP-module genes.
+    resolution: &gt;-
+      Develop/adopt a molecular-function term for a structural constituent of the
+      ciliary transition zone (analogous to &#34;structural constituent of ribosome&#34;),
+      then annotate MKSR-1 and the other core MKS/NPHP-module subunits to it.
+    provenance:
+      - reference_id: PMID:21422230
+        supporting_text: &gt;-
+          MKSR-1, MKSR-2, and MKS-5 restrict MKS-3 to the TZ membrane
+        reference_section_type: RESULTS
+    proposed_terms:
+      - proposed_name: structural constituent of ciliary transition zone
+        proposed_definition: &gt;-
+          The action of a protein that contributes to the structural integrity of the
+          ciliary transition zone, for example by acting as a scaffold or B9/C2-domain
+          subunit of the MKS or NPHP module that helps build the Y-link connectors and
+          the membrane diffusion barrier at the ciliary base, without itself
+          catalyzing a biochemical reaction.
+        proposed_parent:
+          id: GO:0005198
+          label: structural molecule activity
+  - gap_statement: &gt;-
+      The specific, non-redundant molecular contribution of MKSR-1/B9D1 within the MKS
+      module is undetermined: whether its predicted C2/B9 Ca2+/lipid-binding activity
+      is real, its direct binding partners in the worm TZ beyond MKSR-2/B9D2, and
+      whether MKSR-1 provides a discrete sub-function or is largely interchangeable
+      with the other core MKS-module proteins.
+    boundary: &gt;-
+      Genetics and imaging establish that MKSR-1 is a core MKS-module protein whose TZ
+      localization depends on MKS-5, that it is required to recruit MKS-6/MKS-3, that
+      it forms a heterodimer with MKSR-2, and that it contributes to the gate. The
+      predicted C2/B9 fold suggests Ca2+/lipid binding, but this has not been assayed
+      for MKSR-1. mksr-1 single mutants are structurally near-normal (defects emerge in
+      mksr-1;nphp-4 doubles), yet the single mutant already leaks TRAM-1a/RPI-2 into
+      cilia, indicating at least a partial non-redundant barrier contribution.
+    gap_kind:
+      - BIOLOGY
+    dark_aspect: RESIDUAL_SUBGAP
+    status: OPEN
+    significance: &gt;-
+      Distinguishing a genuine non-redundant role (and testing the predicted
+      C2/B9 membrane-binding activity) from full module redundancy is the load-bearing
+      question for interpreting B9D1 ciliopathy alleles and for understanding how
+      individual MKS-module subunits partition the barrier-building task.
+    resolution: &gt;-
+      Direct biochemistry of MKSR-1&#39;s B9/C2 domain (Ca2+/lipid binding), proximity
+      labelling/affinity purification of tagged MKSR-1 in ciliated neurons to map its
+      direct TZ partners, and separation-of-function alleles assayed for gate, Y-link,
+      and recruitment phenotypes.
+    provenance:
+      - reference_id: PMID:21422230
+        supporting_text: &gt;-
+          This motif is predicted to bind Ca2+/lipids and participate—similar to
+          synaptotagmin—in membrane/vesicle trafficking and fusion
+        reference_section_type: RESULTS
+proposed_new_terms:
+  - proposed_name: structural constituent of ciliary transition zone
+    proposed_definition: &gt;-
+      The action of a protein that contributes to the structural integrity of the
+      ciliary transition zone, for example by acting as a scaffold or B9/C2-domain
+      subunit of the MKS or NPHP module that helps build the Y-link connectors and the
+      membrane diffusion barrier at the ciliary base, without itself catalyzing a
+      biochemical reaction.
+    proposed_parent:
+      id: GO:0005198
+      label: structural molecule activity
+suggested_questions:
+  - question: &gt;-
+      Does the MKSR-1/B9D1 B9/C2 domain bind Ca2+ and/or membrane lipids in vitro, as
+      predicted from its synaptotagmin-like C2 fold, and is any such activity required
+      for its transition-zone function?
+    experts: []
+  - question: &gt;-
+      Beyond the MKSR-1-MKSR-2 (B9D1-B9D2) heterodimer, what are MKSR-1&#39;s direct
+      contacts within the MKS module, and does it occupy a discrete sub-position in the
+      transition-zone architecture?
+    experts: []
+suggested_experiments:
+  - description: &gt;-
+      In vitro biochemistry of the recombinant MKSR-1 B9/C2 domain (Ca2+ and
+      phospholipid binding assays), complemented by structure-guided mutagenesis of
+      candidate Ca2+/lipid-binding residues assayed in vivo for TZ localization and
+      gate function.
+    hypothesis: &gt;-
+      The MKSR-1 B9/C2 domain binds Ca2+/membrane lipids and this contributes to its
+      anchoring or barrier role at the transition zone.
+  - description: &gt;-
+      Proximity labelling (TurboID/BioID) or affinity purification of tagged MKSR-1 in
+      C. elegans ciliated neurons to map its direct transition-zone interaction
+      partners, and separation-of-function alleles tested for TRAM-1a exclusion (gate),
+      MKS-6/MKS-3 recruitment, and Y-link ultrastructure by TEM.
+    hypothesis: &gt;-
+      MKSR-1 occupies a specific position in the MKS-module interaction network with a
+      defined set of direct partners and separable recruitment vs barrier functions.
+tags:
+  - caeel-ciliopathy
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/genes/worm/nphp-2/nphp-2-ai-review.html
+++ b/genes/worm/nphp-2/nphp-2-ai-review.html
@@ -1,0 +1,2909 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>nphp-2 - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        .propagation-review {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f8fafc;
+            border-left: 3px solid #64748b;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .propagation-title {
+            font-weight: 600;
+            color: #334155;
+            margin-bottom: 0.25rem;
+        }
+
+        .propagation-row {
+            margin-top: 0.25rem;
+        }
+
+        .propagation-source {
+            margin-top: 0.5rem;
+            padding-top: 0.5rem;
+            border-top: 1px solid #e5e7eb;
+        }
+
+        .propagation-source-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #1d4ed8;
+        }
+
+        .propagation-comment {
+            color: #4b5563;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>nphp-2</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/Q9BPN3" target="_blank" class="term-link">
+                        Q9BPN3
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Caenorhabditis elegans</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-complete">
+                    COMPLETE
+                </span>
+            </div>
+
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "nphp-2";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="Q9BPN3" data-a="DESCRIPTION: NPHP-2 is the Caenorhabditis elegans ortholog of m..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>NPHP-2 is the Caenorhabditis elegans ortholog of mammalian inversin (INVS/nephrocystin-2, NPHP2), an ankyrin-repeat protein that acts as a non-catalytic structural organizer within ciliated sensory neurons. Rather than localizing to the ciliary transition zone like the nephrocystins NPHP-1 and NPHP-4, NPHP-2 marks the ciliary inversin compartment (InvC), a proximal subregion of the doublet-based ciliary shaft immediately distal to the transition zone in amphid channel and phasmid cilia. There it is required for anchoring the proximal-cilium pool of signaling components, including the cyclic-nucleotide-gated channel subunit TAX-2, and for proper ciliary microtubule ultrastructural patterning, cilium placement and anchoring, and ciliogenesis. NPHP-2 functions redundantly within genetic modules (with nphp-1/nphp-4, and with the doublet-region genes arl-13, klp-11 and unc-119) and interacts genetically with Meckel-syndrome (MKS) transition-zone genes in a sensillum-dependent manner; these activities are modulated upstream of tubulin glutamylation and are antagonized by the HDAC-6 deacetylase. Its calcium-binding EF-hand domain is required for InvC targeting and function. NPHP-2 is not a component of the intraflagellar transport machinery and is dispensable for transition-zone protein localization and IFT.</p>
+    </div>
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Proposed New Ontology Terms</h2>
+
+        <div class="proposed-term">
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>structural constituent of ciliary inversin compartment</h3>
+                <span class="vote-buttons" data-g="Q9BPN3" data-a="structural constituent of ciliary inversin compartment" data-r="" data-act="NEW">
+                    <button class="vote-btn" data-v="up" title="Agree this term should be created">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with creating this term">👎</button>
+                </span>
+            </div>
+
+
+            <p><strong>Definition:</strong> The action of a protein that contributes to the structural organization and integrity of the ciliary inversin compartment (InvC), a proximal subdomain of the doublet-based ciliary shaft distal to the transition zone, for example by scaffolding the retention of proximal-ciliary signaling components without itself catalyzing a biochemical reaction.</p>
+
+
+
+
+
+            <p><strong>Parent term:</strong>
+                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005198" target="_blank" class="term-link">
+                    structural molecule activity
+                </a>
+            </p>
+
+
+
+
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003674" target="_blank" class="term-link">
+                                    GO:0003674
+                                </a>
+                            </span>
+                            <span class="term-label">molecular_function</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ND</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000015
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9BPN3" data-a="GO:0003674" data-r="GO_REF:0000015" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Root molecular_function placeholder (ND = No biological Data). No specific molecular activity has been experimentally assigned to NPHP-2.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> NPHP-2 is a non-catalytic ankyrin-repeat protein and no specific molecular function has been experimentally determined. Its role is that of a structural organizer/genetic modifier acting through protein-protein interactions and a calcium-binding EF-hand, but no discrete MF term is supported by direct evidence. The ND placeholder is appropriate; the MF darkness is captured in knowledge_gaps.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0097543" target="_blank" class="term-link">
+                                    GO:0097543
+                                </a>
+                            </span>
+                            <span class="term-label">ciliary inversin compartment</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/25335890" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:25335890
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Ciliopathy proteins establish a bipartite signaling compartm...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9BPN3" data-a="GO:0097543" data-r="PMID:25335890" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct experimental localization of NPHP-2 to the ciliary inversin compartment (InvC), the proximal/middle segment of the doublet-based ciliary shaft just distal to the transition zone. This is the core, defining localization of NPHP-2 and distinguishes it from the transition-zone nephrocystins NPHP-1/NPHP-4.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Core localization, supported by multiple independent C. elegans studies. The InvC is conserved and distinct from the doublet region, and NPHP-2 marks it specifically. This is the most informative cellular-component annotation for the gene.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/25501555" target="_blank" class="term-link">
+                                        PMID:25501555
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">We conclude that NPHP-2 marks a region of the cilium distinct from the doublet region, and propose that this region is analogous to the InvC of mammalian cilia.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/22393243" target="_blank" class="term-link">
+                                        PMID:22393243
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">the C. elegans inversin ortholog, NPHP-2, localizes to the middle segment of sensory cilia</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1904108" target="_blank" class="term-link">
+                                    GO:1904108
+                                </a>
+                            </span>
+                            <span class="term-label">protein localization to ciliary inversin compartment</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/25335890" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:25335890
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Ciliopathy proteins establish a bipartite signaling compartm...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9BPN3" data-a="GO:1904108" data-r="PMID:25335890" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> NPHP-2 is required to anchor/localize signaling components to the proximal ciliary (InvC) region; in AFD thermosensory neurons it anchors the cGMP-gated channel within the proximal cilium. This is a core biological process for NPHP-2 and is directly grounded in the source paper.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Well-supported experimental (IMP) annotation. The source reference explicitly shows NPHP-2 is required to anchor a cGMP-gated ion channel in the proximal ciliary region, which is exactly the InvC subdomain NPHP-2 defines. Represents the best-characterized functional role of the protein.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/25335890" target="_blank" class="term-link">
+                                        PMID:25335890
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">requires NPHP-2 (known as inversin in mammals) to anchor a cGMP-gated ion channel within the proximal ciliary region</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>Structural organizer of the ciliary inversin compartment: NPHP-2 localizes to and marks the InvC (proximal/middle doublet region of sensory cilia, distal to the transition zone) and is required to anchor/localize proximal-ciliary signaling components there, including the cGMP-gated channel subunit TAX-2.</h3>
+                <span class="vote-buttons" data-g="Q9BPN3" data-a="FUNCTION: Structural organizer of the ciliary inversin compa..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1904108" target="_blank" class="term-link">
+                                protein localization to ciliary inversin compartment
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0097543" target="_blank" class="term-link">
+                                ciliary inversin compartment
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/25335890" target="_blank" class="term-link">
+                                PMID:25335890
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">requires NPHP-2 (known as inversin in mammals) to anchor a cGMP-gated ion channel within the proximal ciliary region</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/25501555" target="_blank" class="term-link">
+                                PMID:25501555
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">We conclude that NPHP-2 marks a region of the cilium distinct from the doublet region, and propose that this region is analogous to the InvC of mammalian cilia.</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>Contributes to sensory (non-motile) ciliogenesis, cilium placement/anchoring, and ciliary microtubule ultrastructural patterning, acting redundantly with nphp-1/nphp-4 and with the doublet-region module (arl-13, klp-11, unc-119) and as a sensillum-dependent modifier of the MKS transition-zone pathway.</h3>
+                <span class="vote-buttons" data-g="Q9BPN3" data-a="FUNCTION: Contributes to sensory (non-motile) ciliogenesis, ..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1905515" target="_blank" class="term-link">
+                                non-motile cilium assembly
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0097543" target="_blank" class="term-link">
+                                ciliary inversin compartment
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/25501555" target="_blank" class="term-link">
+                                PMID:25501555
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">These defects indicate that nphp-2 is required both for microtubule patterning and for cilia anchoring.</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/22393243" target="_blank" class="term-link">
+                                PMID:22393243
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">nphp-2 plays an important role in C. elegans cilia by acting as a modifier of the NPHP and MKS pathways to control cilia formation and development</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000015.md" target="_blank" class="term-link">
+                            GO_REF:0000015
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Use of the ND evidence code for Gene Ontology (GO) terms</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/25335890" target="_blank" class="term-link">
+                            PMID:25335890
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Ciliopathy proteins establish a bipartite signaling compartment in a C. elegans thermosensory neuron.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">NPHP-2 (mammalian inversin) anchors a cGMP-gated ion channel within the proximal ciliary region of the AFD thermosensory neuron.</div>
+
+                        <div class="finding-text">"requires NPHP-2 (known as inversin in mammals) to anchor a cGMP-gated ion channel within the proximal ciliary region"</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Nephronophthisis-associated proteins localize to the ciliary base of the AFD bipartite compartment.</div>
+
+                        <div class="finding-text">"One compartment, a bona fide cilium, is delineated by proteins associated with Bardet-Biedl syndrome (BBS), Meckel syndrome and nephronophthisis at its base"</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/22393243" target="_blank" class="term-link">
+                            PMID:22393243
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Ciliogenesis in Caenorhabditis elegans requires genetic interactions between ciliary middle segment localized NPHP-2 (inversin) and transition zone-associated proteins.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">NPHP-2, the C. elegans inversin ortholog, localizes to the ciliary middle segment (inversin compartment), not the transition zone.</div>
+
+                        <div class="finding-text">"the C. elegans inversin ortholog, NPHP-2, localizes to the middle segment of sensory cilia"</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <div class="finding-statement">nphp-2 is partially redundant with nphp-1 and nphp-4 for cilia placement.</div>
+
+                        <div class="finding-text">"nphp-2 is partially redundant with nphp-1 and nphp-4"</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <div class="finding-statement">nphp-2 genetically interacts with MKS orthologs in a sensilla-dependent manner to control cilia formation and placement.</div>
+
+                        <div class="finding-text">"nphp-2 also genetically interacts with MKS ciliopathy gene orthologs, including mks-1, mks-3, mks-6, mksr-1 and mksr-2, in a sensilla-dependent manner to control cilia formation and placement"</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <div class="finding-statement">nphp-2 is not required for transition-zone protein localization or for IFT.</div>
+
+                        <div class="finding-text">"nphp-2 is not required for correct localization of the NPHP- and MKS-encoded ciliary transition zone proteins or for intraflagellar transport (IFT)"</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <div class="finding-statement">NPHP-2 acts as a modifier of the NPHP and MKS pathways controlling cilia formation and development.</div>
+
+                        <div class="finding-text">"nphp-2 plays an important role in C. elegans cilia by acting as a modifier of the NPHP and MKS pathways to control cilia formation and development"</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/25501555" target="_blank" class="term-link">
+                            PMID:25501555
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">The nphp-2 and arl-13 genetic modules interact to regulate ciliogenesis and ciliary microtubule patterning in C. elegans.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">The C. elegans inversin compartment is conserved and distinct from the doublet region.</div>
+
+                        <div class="finding-text">"We show that the InvC is conserved and distinct from the doublet region."</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <div class="finding-statement">nphp-2 and doublet-region genes are redundantly required for ciliogenesis.</div>
+
+                        <div class="finding-text">"nphp-2 (the C. elegans Inversin homolog) and the doublet region genes arl-13, klp-11, and unc-119 are redundantly required for ciliogenesis."</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <div class="finding-statement">InvC and doublet-region genes form two modules antagonized by hdac-6.</div>
+
+                        <div class="finding-text">"InvC and doublet region genes can be sorted into two modules-nphp-2+klp-11 and arl-13+unc-119-which are both antagonized by the hdac-6 deacetylase."</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <div class="finding-statement">nphp-2 is required for ciliary microtubule patterning and cilia anchoring.</div>
+
+                        <div class="finding-text">"These defects indicate that nphp-2 is required both for microtubule patterning and for cilia anchoring."</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <div class="finding-statement">NPHP-2 requires its calcium-binding EF-hand domain for InvC targeting.</div>
+
+                        <div class="finding-text">"NPHP-2 does require its calcium binding EF hand domain for targeting to the InvC."</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <div class="finding-statement">NPHP-2 marks a ciliary region distinct from the doublet region, analogous to the mammalian InvC.</div>
+
+                        <div class="finding-text">"We conclude that NPHP-2 marks a region of the cilium distinct from the doublet region, and propose that this region is analogous to the InvC of mammalian cilia."</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/39110529" target="_blank" class="term-link">
+                            PMID:39110529
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Dimerization activates the Inversin complex in C. elegans.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">In C. elegans the canonical Inversin complex uses MLT-4 (INVS ortholog) and acts at epithelial junctions in molting, not in cilia.</div>
+
+                        <div class="finding-text">"the C. elegans homologues colocalize, albeit at epithelial junctions rather than cilia"</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <div class="finding-statement">How the Inversin-complex components assemble into a functionally active state is not fundamentally understood.</div>
+
+                        <div class="finding-text">"we lack fundamental knowledge about how the components might assemble into a functionally active state"</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        file:worm/nphp-2/nphp-2-deep-research-falcon.md
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Deep research report on nphp-2 (Edison Scientific Literature)</div>
+
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Questions for Experts</h2>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Does the NPHP-2 EF-hand bind calcium biochemically, and does calcium specify InvC localization, modulate NPHP-2 activity, or both?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q9BPN3" data-a="Q: Does the NPHP-2 EF-hand bind calcium biochemically..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> What are the direct binding partners of NPHP-2 in the ciliary inversin compartment, and do they include NEK8/ANKS6-type proteins?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q9BPN3" data-a="Q: What are the direct binding partners of NPHP-2 in ..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> What upstream cue initially patterns the inversin compartment independently of the transition zone, doublet-region and IFT machinery?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q9BPN3" data-a="Q: What upstream cue initially patterns the inversin ..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Experiments</h2>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Proximity-labeling (TurboID) or immunoprecipitation of endogenously tagged NPHP-2 in ciliated sensory neurons to identify the InvC interactome.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: NPHP-2 scaffolds a defined set of proximal-ciliary proteins that retain signaling components (e.g. TAX-2/TAX-4) in the InvC.</em></p>
+
+
+                </div>
+                <span class="vote-buttons" data-g="Q9BPN3" data-a="EXPERIMENT: Proximity-labeling (TurboID) or immunoprecipitatio..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> In vitro calcium-binding assays on the isolated EF-hand plus binding-dead point mutants assayed in vivo for InvC targeting and cGMP-gated channel anchoring.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: The EF-hand is a functional calcium sensor whose calcium binding is required for InvC targeting and/or NPHP-2 activity.</em></p>
+
+
+                </div>
+                <span class="vote-buttons" data-g="Q9BPN3" data-a="EXPERIMENT: In vitro calcium-binding assays on the isolated EF..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Candidate and forward genetic screens for factors required to establish the InvC, using an InvC marker (NPHP-2 GFP territory) and channel-anchoring readouts.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: A dedicated patterning cue, distinct from TZ/doublet-region/IFT genes, defines the proximal InvC subdomain.</em></p>
+
+
+                </div>
+                <span class="vote-buttons" data-g="Q9BPN3" data-a="EXPERIMENT: Candidate and forward genetic screens for factors ..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Knowledge Gaps</h2>
+        <p style="color: #555; font-size: 0.92rem; margin-top: -0.3rem;">
+            What is <em>not</em> known — curated, literature-grounded statements of the open
+            unknowns (the inverse of core functions).
+        </p>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> NPHP-2 has no assigned molecular function and no adequate GO molecular-function term to express one. It is a non-catalytic ankyrin-repeat protein whose role is to organize the ciliary inversin compartment and anchor proximal-ciliary signaling components, but GO has no structural-constituent-of-the-ciliary-inversin-compartment activity, so the gene reads as MF-dark despite a well-defined cellular and process-level role.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">ONTOLOGY</span><span class="badge">CURATION</span>
+                <span class="badge">MF_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> It is firmly established that NPHP-2 = inversin localizes to and marks the InvC, is required for microtubule patterning, cilia anchoring/placement and ciliogenesis, and anchors the proximal-cilium cGMP-gated channel. What is missing is a molecular-function representation: the worm GOA record carries only a cellular-component and a biological-process term plus the ND molecular_function root.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> This is the canonical structural/scaffold-subunit ontology gap shared across the ciliary inversin/nephrocystin gene set: a mechanistically well-understood organizer that cannot be annotated with an informative MF term, contributing to apparent molecular-function darkness.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Develop/adopt a molecular-function term for a structural constituent of the ciliary inversin compartment (analogous to structural constituent of ribosome) and annotate NPHP-2 to it; see proposed_new_terms.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"We conclude that NPHP-2 marks a region of the cilium distinct from the doublet region, and propose that this region is analogous to the InvC of mammalian cilia."</em> — PMID:25501555</li>
+
+            </ul>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Proposed term (ontology gap):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><strong>structural constituent of ciliary inversin compartment</strong></li>
+
+            </ul>
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> How the ciliary inversin compartment is initially established and maintained, and which direct molecular partners recruit and retain NPHP-2 there, is unknown. NPHP-2 reaches and is restricted to the InvC independently of transition-zone, doublet-region and other InvC genes, so the factor(s) that pattern the compartment and the NPHP-2 interactome that executes its scaffolding function have not been identified.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">RESIDUAL_SUBGAP</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> Established: NPHP-2 marks the InvC and is required for microtubule patterning and cilia anchoring; its ciliary targeting/restriction does not require the tested TZ, doublet-region or InvC genes; the InvC is set up early in development. Not established: the upstream cue that patterns the InvC and the direct binding partners through which NPHP-2 organizes it.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Identifying the InvC-patterning cue and the NPHP-2 interactome would convert a marks-a-region, required-for-patterning description into a mechanism, and would explain how nephronophthisis (inversin) mutations disrupt proximal-ciliary signaling.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Unbiased proximity-labeling/immunoprecipitation of tagged NPHP-2 in ciliated neurons, plus forward/candidate genetic screens for factors required for InvC establishment, with InvC-marker and channel-anchoring readouts.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"The mechanisms that establish and maintain the InvC are unknown."</em> — PMID:25501555</li>
+
+                <li><em>"The next challenge is to determine what initially patterns the doublet region and InvC, and to understand the function of these cilia regions."</em> — PMID:25501555</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> Whether the NPHP-2 EF-hand actually binds calcium and, if so, whether the calcium signal specifies NPHP-2 localization, modulates its activity, or both, is undetermined. The EF-hand is only a predicted calcium-binding motif; it is required for InvC targeting and function, but the biochemical calcium binding and the origin of any calcium cue are unproven.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">MF_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> Established: deletion of the EF-hand abolishes NPHP-2 localization to amphid/phasmid cilia and impairs rescue, so the domain is functionally essential in those cells. Not established: direct Ca2+ binding by the domain, and the source/nature of the calcium signal it would sense.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> If the EF-hand is a bona fide calcium sensor, NPHP-2 would gain a concrete molecular activity (calcium ion binding) linking ciliary calcium signaling to InvC organization; resolving this would also inform the conserved requirement for a calcium-binding domain in vertebrate inversin.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> In vitro calcium-binding assays on the isolated EF-hand, and separation-of-function EF-hand point mutants (binding-dead vs structural) tested for InvC targeting and channel anchoring in vivo.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"the origin and nature of the calcium signal these domains detect is unknown"</em> — PMID:25501555</li>
+
+                <li><em>"Two possibilities arise for the function of these domains: Ca2+ specifies the localization of NPHP-2, modulates the activity of the protein, or both."</em> — PMID:25501555</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The relationship between the ciliary NPHP-2/Y32G9A.6 and the canonical vertebrate-style Inversin complex is unresolved. In C. elegans the classical Inversin complex is built from MLT-4 (INVS), NEKL-2 (NEK8) and MLT-2 (ANKS6) and functions at epithelial junctions during molting rather than in cilia; whether ciliary NPHP-2 assembles an analogous NEK8/ANKS6-type module in the InvC, or acts independently, is not known.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">RESIDUAL_SUBGAP</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> Established: nphp-2/Y32G9A.6 is the ciliary inversin ortholog in the sensory-cilia literature, while the MLT-4/NEKL-2/MLT-2 complex acts at junctions in molting. Not established: whether the two systems share components or mechanism, and which worm protein is the true functional inversin ortholog in each context.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Clarifying the ortholog relationship determines how findings about the junctional Inversin complex (e.g. dimerization-dependent activation) transfer to ciliary NPHP-2 function and to human inversin/nephronophthisis biology.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Systematic tagging/interaction mapping of NPHP-2, MLT-4, NEKL-2 and MLT-2 across ciliated and epithelial tissues, with cross-rescue and complex-composition assays.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"the C. elegans homologues colocalize, albeit at epithelial junctions rather than cilia"</em> — PMID:39110529</li>
+
+                <li><em>"we lack fundamental knowledge about how the components might assemble into a functionally active state"</em> — PMID:39110529</li>
+
+            </ul>
+
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Tags</h2>
+        <div class="aliases">
+
+            <span class="badge">caeel-ciliopathy</span>
+
+        </div>
+    </div>
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Deep Research Sections -->
+
+    <div class="section">
+        <h2 class="section-title">Deep Research</h2>
+
+        <details class="deep-research-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; gap: 1rem;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Falcon</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(nphp-2-deep-research-falcon.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="Q9BPN3" data-a="DEEP_RESEARCH: Falcon" data-r="" data-act="DEEP_RESEARCH" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This deep research is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This deep research needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+
+                <div class="report-meta">
+
+                    <span class="report-meta-text">Comprehensive Research Report: *C. elegans* nphp-2 (Y32G9A.6) — The Inversin/NPHP2 Ortholog</span>
+
+
+                    <span class="report-badge">Falcon</span>
+
+
+                    <span class="report-badge">Edison Scientific Literature</span>
+
+
+                    <span class="report-badge">25 citations</span>
+
+
+                    <span class="report-badge">1 artifacts</span>
+
+
+                    <span class="report-meta-text">2026-07-04T21:08:12.929318</span>
+
+
+
+                </div>
+
+
+                <div class="artifact-list">
+
+
+
+                    <div class="artifact-link">
+                        <a href="nphp-2-deep-research-falcon_artifacts/artifact-00.md" class="term-link">Edison artifact artifact-00</a>
+                        <span>(text/markdown)</span>
+                    </div>
+
+
+                </div>
+
+                <p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h1 id="comprehensive-research-report-c-elegans-nphp-2-y32g9a6-the-inversinnphp2-ortholog">Comprehensive Research Report: <em>C. elegans</em> nphp-2 (Y32G9A.6) — The Inversin/NPHP2 Ortholog</h1>
+<h2 id="1-gene-identity-and-verification">1. Gene Identity and Verification</h2>
+<p>The gene <em>nphp-2</em> (UniProt Q9BPN3; ORF Y32G9A.6/CELE_Y32G9A.6) encodes the <em>Caenorhabditis elegans</em> ortholog of mammalian Inversin (INVS/NPHP2), a protein causally linked to nephronophthisis type 2 (infantile nephronophthisis) in humans (OpenTargets Search: nephronophthisis-INVS, warburtonpitt2012ciliogenesisincaenorhabditis pages 1-2). The assignment of Y32G9A.6 as the <em>C. elegans</em> inversin ortholog was confirmed through BLAST homology searches, the presence of an X-box promoter element (characteristic of ciliary genes regulated by the DAF-19 transcription factor), and conservation of key protein domains (warburtonpitt2015theciliopathygene pages 108-114, warburtonpitt2015theciliopathygene pages 104-108, warburtonpitt2012ciliogenesisincaenorhabditis pages 3-4). Importantly, <em>nphp-2</em> is distinct from <em>mlt-4</em>, another <em>C. elegans</em> ankyrin repeat-containing protein that was also identified in BLAST searches but lacks the X-box promoter and many inversin-specific domains (warburtonpitt2015theciliopathygene pages 108-114, warburtonpitt2015theciliopathygene pages 104-108).</p>
+<h2 id="2-protein-domain-architecture">2. Protein Domain Architecture</h2>
+<p>NPHP-2 is an ankyrin repeat domain-containing protein with a multi-domain architecture that mirrors its mammalian counterpart. Its key domains include:</p>
+<ul>
+<li><strong>Ankyrin repeat region</strong>: A defining feature conserved from mammalian inversin, required for ciliary targeting in specific neuron types (e.g., AWB neurons) (warburtonpitt2015theciliopathygene pages 29-33, warburtonpitt2014thenphp2and pages 4-5).</li>
+<li><strong>EF-hand calcium-binding domain</strong>: A predicted Ca²⁺-binding motif that is critically required for ciliary localization and function in amphid channel and phasmid cilia. Deletion of this domain results in faint or absent ciliary localization and failure to rescue mutant phenotypes (warburtonpitt2014thenphp2and pages 4-5, warburtonpitt2014thenphp2and pages 10-11). Notably, the EF-hand is dispensable in CEP and OLQ cilia, indicating cell-type-specific calcium-dependent regulation (warburtonpitt2014thenphp2and pages 4-5).</li>
+<li><strong>Nuclear localization signals (NLS)</strong>: Two bipartite NLS motifs are present, though individual deletion of either NLS1 or NLS2 does not perturb NPHP-2 localization (warburtonpitt2014thenphp2and pages 4-5, warburtonpitt2015theciliopathygene pages 108-114).</li>
+<li><strong>Destruction box (D-box)</strong>: A ubiquitination motif conserved with mammalian inversin (warburtonpitt2015theciliopathygene pages 108-114, warburtonpitt2012ciliogenesisincaenorhabditis pages 2-3).</li>
+<li><strong>Coil region</strong>: A novel structural feature not found in all inversin orthologs (warburtonpitt2015theciliopathygene pages 108-114, warburtonpitt2012ciliogenesisincaenorhabditis pages 2-3).</li>
+</ul>
+<p>The protein is not an enzyme, transporter, or signaling receptor; rather, it functions as a <strong>structural/adapter protein</strong> and <strong>genetic modifier</strong> that coordinates ciliary compartment organization through protein–protein interactions mediated by its ankyrin repeats and calcium-sensing EF-hand domain.</p>
+<h2 id="3-protein-isoforms-and-expression">3. Protein Isoforms and Expression</h2>
+<p>The <em>nphp-2</em> gene encodes two protein isoforms: NPHP-2L (full-length, longer isoform) and NPHP-2S (shorter isoform lacking a 22 amino acid region) (warburtonpitt2012ciliogenesisincaenorhabditis pages 2-3, warburtonpitt2015theciliopathygene pages 108-114). Both are expressed in ciliated sensory neurons of <em>C. elegans</em>, including amphid and phasmid neurons (warburtonpitt2012ciliogenesisincaenorhabditis pages 2-3, warburtonpitt2012ciliogenesisincaenorhabditis pages 3-4).</p>
+<h2 id="4-subcellular-localization">4. Subcellular Localization</h2>
+<p>The subcellular localization of NPHP-2 is central to understanding its function:</p>
+<ul>
+<li><strong>NPHP-2L</strong> localizes predominantly to the <strong>ciliary middle segment</strong>, a region equivalent to the <strong>Inversin compartment (InvC)</strong> of mammalian primary cilia. This is the proximal portion of the doublet microtubule-based ciliary shaft, situated distal to the transition zone (warburtonpitt2012ciliogenesisincaenorhabditis pages 2-3, warburtonpitt2012ciliogenesisincaenorhabditis pages 3-4, warburtonpitt2014thenphp2and pages 1-2). NPHP-2L also shows punctate localization in cell bodies (warburtonpitt2012ciliogenesisincaenorhabditis pages 3-4).</li>
+<li><strong>NPHP-2S</strong> localizes more broadly throughout the sensory neuron, including the cell body, axon, dendrite, and cilium, but is <strong>excluded from the nucleus and transition zone</strong> (warburtonpitt2012ciliogenesisincaenorhabditis pages 2-3, warburtonpitt2015theciliopathygene pages 108-114).</li>
+</ul>
+<p>This middle segment/InvC localization is distinct from most other ciliopathy-associated proteins (cystoproteins), which typically localize to the transition zone (warburtonpitt2012ciliogenesisincaenorhabditis pages 3-4). The confinement of NPHP-2 to proximal ciliary subdomains is maintained by the <strong>transition zone barrier/ciliary zone of exclusion (CIZE)</strong>, established by MKS-5/RPGRIP1L, which acts as a lipid gate restricting the diffusion of signaling proteins including NPHP-2 and GPCRs to distal ciliary domains (jensen2015formationofthe pages 1-2, jensen2015formationofthe pages 12-14).</p>
+<h2 id="5-primary-function-ciliary-structural-organizer-and-genetic-modifier">5. Primary Function: Ciliary Structural Organizer and Genetic Modifier</h2>
+<p>NPHP-2 is not a component of the intraflagellar transport (IFT) machinery, and IFT velocities are not significantly affected by <em>nphp-2</em> mutations (warburtonpitt2012ciliogenesisincaenorhabditis pages 1-2, warburtonpitt2012ciliogenesisincaenorhabditis pages 7-8). Instead, NPHP-2 functions as a <strong>structural organizer of the ciliary middle segment</strong> and as a <strong>genetic nexus</strong> connecting multiple ciliopathy-related protein modules:</p>
+<h3 id="51-ciliogenesis-and-cilia-placement">5.1 Ciliogenesis and Cilia Placement</h3>
+<p>NPHP-2 is required for proper cilia formation, placement, and orientation. Loss of <em>nphp-2</em> causes:<br />
+- <strong>Transition zone displacement and disorganization</strong>, with cilia dispersed over larger areas and anteriorly displaced phasmid cilia (warburtonpitt2012ciliogenesisincaenorhabditis pages 3-4, warburtonpitt2015theciliopathygene pages 95-99).<br />
+- <strong>Dye-filling (Dyf) defects</strong> in phasmid neurons, indicating that cilia fail to properly contact the sensory pore (warburtonpitt2012ciliogenesisincaenorhabditis pages 3-4, warburtonpitt2015theciliopathygene pages 95-99).<br />
+- <strong>Shortened phasmid dendrites</strong> (warburtonpitt2012ciliogenesisincaenorhabditis pages 8-9).<br />
+- In double mutants with <em>nphp-4</em>, severely compromised cilia with complete Dyf defects in both amphid and phasmid sensilla, demonstrating functional redundancy (warburtonpitt2012ciliogenesisincaenorhabditis pages 2-3, warburtonpitt2015theciliopathygene pages 95-99).</p>
+<h3 id="52-ciliary-microtubule-patterning">5.2 Ciliary Microtubule Patterning</h3>
+<p>NPHP-2 is required for proper microtubule ultrastructure within cilia. In <em>nphp-2</em> mutants, amphid channel cilia exhibit lengthwise shifts with asynchronous microtubule doublet B-tubules and disorganized Y-links at the transition zone (warburtonpitt2014thenphp2and pages 2-3, warburtonpitt2014thenphp2and pages 4-5). In <em>arl-13; nphp-2</em> double mutants, most amphid channel cilia are absent, and those present show only microtubule singlets with abnormal transition zone microtubules (warburtonpitt2014thenphp2and pages 4-5).</p>
+<h3 id="53-regulation-of-tubulin-post-translational-modifications">5.3 Regulation of Tubulin Post-Translational Modifications</h3>
+<p>NPHP-2 regulates tubulin glutamylation, a critical post-translational modification. Notably, glutamylation is not required for ciliary targeting of InvC or doublet region components; rather, glutamylation is modulated by <em>nphp-2</em>, <em>arl-13</em>, and <em>unc-119</em> (warburtonpitt2014thenphp2and pages 2-3, warburtonpitt2014thenphp2and pages 1-2).</p>
+<h3 id="54-ciliary-protein-compartmentalization">5.4 Ciliary Protein Compartmentalization</h3>
+<p>NPHP-2 is required for the correct localization of ciliary signaling proteins, including the cyclic nucleotide-gated channel subunits <strong>TAX-2</strong> and <strong>TAX-4</strong> to the proximal cilium/InvC (warburtonpitt2015theciliopathygene pages 29-33). NPHP-2 also regulates the ciliary localization of sensory signaling molecules in a cell-type-dependent manner (blacque2014compartmentswithina pages 7-8).</p>
+<h2 id="6-genetic-interaction-networks">6. Genetic Interaction Networks</h2>
+<p>NPHP-2 participates in multiple redundant genetic networks:</p>
+<h3 id="61-nphp-module">6.1 NPHP Module</h3>
+<p>NPHP-2 is partially redundant with <strong>NPHP-1</strong> and <strong>NPHP-4</strong> for cilia formation and transition zone placement in both amphid and phasmid neurons (warburtonpitt2012ciliogenesisincaenorhabditis pages 1-2, warburtonpitt2015theciliopathygene pages 104-108, warburtonpitt2015theciliopathygene pages 95-99). The <em>nphp-2; nphp-4</em> double mutant displays dramatically exacerbated ciliary defects compared to either single mutant (warburtonpitt2012ciliogenesisincaenorhabditis pages 2-3, warburtonpitt2015theciliopathygene pages 95-99). NPHP-2 physically interacts with NPHP-1 and NPHP-4, as well as with B9 domain proteins and MKS pathway components (warburtonpitt2015theciliopathygene pages 104-108, blacque2014compartmentswithina pages 7-8).</p>
+<h3 id="62-mkstransition-zone-module">6.2 MKS/Transition Zone Module</h3>
+<p>NPHP-2 genetically interacts with MKS pathway genes (<em>mks-1</em>, <em>mks-3</em>, <em>mks-6</em>, <em>mksr-1</em>, <em>mksr-2</em>) in a <strong>sensillum-specific manner</strong> to control cilia formation and placement (warburtonpitt2012ciliogenesisincaenorhabditis pages 1-2, warburtonpitt2015theciliopathygene pages 104-108). The NPHP and MKS modules work redundantly to seal the ciliary compartment and establish transition zone barriers (cevik2013activetransportand pages 5-6).</p>
+<h3 id="63-doublet-regioninvc-module">6.3 Doublet Region/InvC Module</h3>
+<p>NPHP-2 interacts with doublet region genes, forming two parallel redundant genetic modules: <strong>nphp-2 + klp-11</strong> and <strong>arl-13 + unc-119</strong>, both of which are antagonized by <strong>HDAC-6</strong> deacetylase and modulated by <strong>ARL-3</strong> (warburtonpitt2014thenphp2and pages 2-3, warburtonpitt2014thenphp2and pages 1-2). These modules regulate cilia placement, ciliary microtubule ultrastructure, tubulin glutamylation, and the sizes of the NPHP-2/InvC and ARL-13/doublet region territories (warburtonpitt2014thenphp2and pages 2-3, warburtonpitt2014thenphp2and pages 1-2, warburtonpitt2014thenphp2and pages 4-5).</p>
+<h2 id="7-relationship-to-the-mammalian-inversin-complex">7. Relationship to the Mammalian Inversin Complex</h2>
+<p>In mammals, inversin forms an Inversin complex (INV complex) with NEK8 and ANKS6 at the proximal ciliary shaft (beyrent2024dimerizationactivatesthe pages 1-2). In <em>C. elegans</em>, recent work by Beyrent et al. (2024) demonstrated that the <em>C. elegans</em> homologs <strong>MLT-4</strong> (INVS), <strong>NEKL-2</strong> (NEK8), and <strong>MLT-2</strong> (ANKS6) form a tripartite Inversin complex that is activated by <strong>dimerization</strong> — dynamic switching between an inactive monomer and an active dimer gates complex output (beyrent2024dimerizationactivatesthe pages 1-2). However, NPHP-2/Y32G9A.6 is distinct from MLT-4; the initial BLAST analysis identified both as potential inversin homologs, but NPHP-2 was selected as the closer ortholog based on domain conservation and X-box promoter usage, while MLT-4 functions primarily in epidermal molting (warburtonpitt2015theciliopathygene pages 108-114, warburtonpitt2015theciliopathygene pages 104-108). The relationship between the NPHP-2 ciliary functions and the MLT-4/NEKL-2/MLT-2 Inversin complex remains an area of ongoing investigation.</p>
+<h2 id="8-mammalian-inversin-and-wnt-signaling">8. Mammalian Inversin and Wnt Signaling</h2>
+<p>Mammalian inversin has been proposed to act as a <strong>molecular switch between canonical Wnt/β-catenin and non-canonical Wnt/planar cell polarity (PCP) pathways</strong> by targeting cytoplasmic Dishevelled (Dvl) for degradation, thereby downregulating canonical Wnt signaling and promoting PCP signaling (veland2013inversinnephrocystin2isrequired pages 4-4, goggolidou2014wntandplanar pages 2-4, veland2013inversinnephrocystin2isrequired pages 1-2). Studies in <em>inv</em>⁻/⁻ mouse embryonic fibroblasts showed elevated β-catenin signaling, upregulation of Wnt target genes, and defective ciliary localization of Dvl-3, leading to impaired cell polarity and migration (veland2013inversinnephrocystin2isrequired pages 4-4, veland2013inversinnephrocystin2isrequired pages 12-13). However, this model has been challenged by more recent in vivo studies showing no upregulation of canonical Wnt signaling and no nuclear β-catenin accumulation in <em>inv</em>⁻/⁻ mice, leading to the conclusion that the role of inversin in Wnt signaling is now unclear (warburtonpitt2015theciliopathygene pages 40-44). Whether NPHP-2 plays a similar role in Wnt signaling in <em>C. elegans</em> has not been directly demonstrated; the <em>C. elegans</em> studies have focused primarily on ciliary structural and IFT-related functions rather than Wnt pathway regulation.</p>
+<h2 id="9-summary-table-of-key-properties">9. Summary Table of Key Properties</h2>
+<table>
+<thead>
+<tr>
+<th>Property</th>
+<th>Summary</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Gene name</td>
+<td><strong>nphp-2</strong> (C. elegans); identified as the ciliary inversin/NPHP2 ortholog used in sensory-cilia studies, distinct from <strong>mlt-4</strong> (warburtonpitt2015theciliopathygene pages 108-114, warburtonpitt2015theciliopathygene pages 104-108, warburtonpitt2012ciliogenesisincaenorhabditis pages 7-8)</td>
+</tr>
+<tr>
+<td>ORF name</td>
+<td><strong>Y32G9A.6</strong> / CELE_Y32G9A.6 (matches the UniProt target context and literature assignment) (warburtonpitt2012ciliogenesisincaenorhabditis pages 2-3, warburtonpitt2012ciliogenesisincaenorhabditis pages 3-4)</td>
+</tr>
+<tr>
+<td>Mammalian ortholog</td>
+<td>Ortholog of mammalian <strong>INVS/NPHP2 (inversin)</strong> (warburtonpitt2012ciliogenesisincaenorhabditis pages 1-2, warburtonpitt2012ciliogenesisincaenorhabditis pages 7-8)</td>
+</tr>
+<tr>
+<td>Human disease association</td>
+<td>Human INVS/NPHP2 is associated with <strong>nephronophthisis type 2 / infantile nephronophthisis</strong> (OpenTargets Search: nephronophthisis-INVS)</td>
+</tr>
+<tr>
+<td>Protein isoforms</td>
+<td>Two isoforms are described: <strong>NPHP-2L</strong> (full-length) and <strong>NPHP-2S</strong> (shorter isoform lacking a 22 aa region) (warburtonpitt2012ciliogenesisincaenorhabditis pages 2-3, warburtonpitt2015theciliopathygene pages 108-114)</td>
+</tr>
+<tr>
+<td>Domain structure</td>
+<td>Conserved <strong>ankyrin repeat region</strong>, <strong>nuclear localization sequences (NLSs)</strong>, <strong>destruction box (D-box)</strong>, <strong>coil region</strong>, and predicted <strong>EF-hand Ca2+-binding domain</strong>; ankyrin repeats are a defining feature and EF-hand is functionally important in several cilia types (warburtonpitt2014thenphp2and pages 4-5, warburtonpitt2015theciliopathygene pages 108-114, warburtonpitt2012ciliogenesisincaenorhabditis pages 2-3, warburtonpitt2014thenphp2and pages 10-11)</td>
+</tr>
+<tr>
+<td>Role of ankyrin repeats</td>
+<td>Ankyrin-repeat region contributes to <strong>ciliary targeting</strong>, including evidence from AWB neurons (warburtonpitt2015theciliopathygene pages 29-33)</td>
+</tr>
+<tr>
+<td>Role of EF-hand</td>
+<td>EF-hand is required for robust <strong>ciliary localization and function</strong> in amphid channel and phasmid cilia; deletion causes faint/absent localization and poor rescue of mutant phenotypes, indicating Ca2+-dependent regulation (warburtonpitt2014thenphp2and pages 4-5, warburtonpitt2014thenphp2and pages 10-11)</td>
+</tr>
+<tr>
+<td>Localization: NPHP-2L</td>
+<td>Localizes mainly to the <strong>ciliary middle segment / Inversin compartment (InvC)</strong> of amphid and phasmid sensory cilia; this compartment is distinct from the transition zone (TZ) (warburtonpitt2012ciliogenesisincaenorhabditis pages 2-3, warburtonpitt2012ciliogenesisincaenorhabditis pages 3-4, warburtonpitt2014thenphp2and pages 1-2)</td>
+</tr>
+<tr>
+<td>Localization: NPHP-2S</td>
+<td>Broader localization throughout the <strong>cell body, axon, dendrite, and cilium</strong>, while being excluded from the <strong>nucleus</strong> and <strong>transition zone</strong> (warburtonpitt2012ciliogenesisincaenorhabditis pages 2-3, warburtonpitt2015theciliopathygene pages 108-114)</td>
+</tr>
+<tr>
+<td>Expression pattern</td>
+<td>Expressed in <strong>ciliated sensory neurons</strong> of C. elegans (including amphid and phasmid neurons) (warburtonpitt2012ciliogenesisincaenorhabditis pages 2-3, warburtonpitt2012ciliogenesisincaenorhabditis pages 3-4)</td>
+</tr>
+<tr>
+<td>Primary biological function</td>
+<td>Functions in <strong>ciliogenesis</strong>, <strong>cilia placement/orientation</strong>, <strong>transition zone placement</strong>, and organization of the proximal ciliary shaft/Inv compartment rather than as a core IFT factor (warburtonpitt2012ciliogenesisincaenorhabditis pages 1-2, warburtonpitt2012ciliogenesisincaenorhabditis pages 3-4, warburtonpitt2012ciliogenesisincaenorhabditis pages 7-8, warburtonpitt2014thenphp2and pages 2-3)</td>
+</tr>
+<tr>
+<td>Relationship to IFT</td>
+<td>NPHP-2 is <strong>not required for gross IFT function</strong>; IFT velocities were not significantly altered in nphp-2 mutants, arguing its primary role is structural/organizational rather than IFT cargo transport (warburtonpitt2012ciliogenesisincaenorhabditis pages 1-2, warburtonpitt2012ciliogenesisincaenorhabditis pages 7-8)</td>
+</tr>
+<tr>
+<td>Key genetic interactions: NPHP module</td>
+<td>Shows partially redundant interactions with <strong>nphp-1</strong> and <strong>nphp-4</strong> for cilia placement and ciliogenesis; <strong>nphp-2; nphp-4</strong> double mutants are strongly synthetic (warburtonpitt2012ciliogenesisincaenorhabditis pages 1-2, warburtonpitt2012ciliogenesisincaenorhabditis pages 2-3, warburtonpitt2015theciliopathygene pages 95-99)</td>
+</tr>
+<tr>
+<td>Key genetic interactions: MKS/TZ module</td>
+<td>Genetically interacts with <strong>mks-1, mks-3, mks-6, mksr-1, mksr-2</strong> and other TZ-associated components in a sensillum-dependent manner (warburtonpitt2012ciliogenesisincaenorhabditis pages 1-2, warburtonpitt2015theciliopathygene pages 104-108, warburtonpitt2015theciliopathygene pages 95-99)</td>
+</tr>
+<tr>
+<td>Key genetic interactions: ARL-13/doublet-region module</td>
+<td>Interacts with <strong>arl-13, klp-11, unc-119</strong>, with modules organized as <strong>nphp-2 + klp-11</strong> and <strong>arl-13 + unc-119</strong>, antagonized by <strong>hdac-6</strong>; these modules regulate ciliary microtubule patterning and compartment size (warburtonpitt2014thenphp2and pages 2-3, warburtonpitt2014thenphp2and pages 1-2)</td>
+</tr>
+<tr>
+<td>Ciliary signaling/protein localization roles</td>
+<td>Required for localization of <strong>TAX-2</strong> and partially for <strong>TAX-4</strong> to the proximal cilium/InvC; also linked to compartmentalization of signaling proteins in cilia (warburtonpitt2015theciliopathygene pages 29-33, blacque2014compartmentswithina pages 7-8)</td>
+</tr>
+<tr>
+<td>Mutant phenotypes</td>
+<td><strong>Dye-filling (Dyf) defects</strong>, <strong>transition zone/cilia displacement</strong>, <strong>mispositioned phasmid cilia</strong>, <strong>defective cilia orientation</strong>, and <strong>shorter phasmid dendrites</strong>; double mutants can show severe loss of cilia and major microtubule ultrastructural defects (warburtonpitt2012ciliogenesisincaenorhabditis pages 3-4, warburtonpitt2012ciliogenesisincaenorhabditis pages 8-9, warburtonpitt2015theciliopathygene pages 95-99, warburtonpitt2014thenphp2and pages 4-5)</td>
+</tr>
+<tr>
+<td>Microtubule/ultrastructure effects</td>
+<td>Required for proper <strong>microtubule patterning</strong>, including alignment of doublet/singlet regions, Y-link organization, and regulation of <strong>tubulin glutamylation</strong> together with the ARL-13 module (warburtonpitt2014thenphp2and pages 2-3, warburtonpitt2014thenphp2and pages 1-2, warburtonpitt2014thenphp2and pages 4-5)</td>
+</tr>
+<tr>
+<td>Subcompartment control</td>
+<td>The <strong>MKS-5/RPGRIP1L-dependent transition zone/CIZE</strong> helps confine NPHP-2 and other signaling proteins to appropriate ciliary subdomains, supporting stable ciliary compartmentalization (jensen2015formationofthe pages 1-2, jensen2015formationofthe pages 12-14)</td>
+</tr>
+</tbody>
+</table>
+<p><em>Table: This table summarizes the verified identity, domains, localization, genetic interactions, and mutant phenotypes of the C. elegans ciliary protein NPHP-2/Y32G9A.6. It is useful as a compact reference for functional annotation and for distinguishing nphp-2 from other ankyrin-repeat proteins such as mlt-4.</em></p>
+<h2 id="10-conclusions">10. Conclusions</h2>
+<p>NPHP-2 (Y32G9A.6) is the <em>C. elegans</em> ortholog of mammalian inversin/NPHP2, an ankyrin repeat and EF-hand domain-containing protein that functions as a ciliary structural organizer and genetic modifier rather than an enzyme or transporter. Its primary role is in the <strong>Inversin compartment (InvC) of sensory cilia</strong>, where it coordinates ciliogenesis, cilia placement and orientation, microtubule ultrastructural patterning, tubulin post-translational modifications, and ciliary protein compartmentalization. NPHP-2 acts as a physical and genetic nexus connecting the NPHP, MKS/transition zone, and doublet region protein modules. Its function requires calcium-sensing through its EF-hand domain and protein–protein interactions mediated by its ankyrin repeats. The protein serves as a valuable model for understanding ciliopathies, particularly nephronophthisis, and the molecular mechanisms underlying ciliary subcompartmentalization.</p>
+<p>References</p>
+<ol>
+<li>
+<p>(OpenTargets Search: nephronophthisis-INVS): Open Targets Query (nephronophthisis-INVS, 14 results). Buniello, A. et al. (2025). Open Targets Platform: facilitating therapeutic hypotheses building in drug discovery. Nucleic Acids Research.</p>
+</li>
+<li>
+<p>(warburtonpitt2012ciliogenesisincaenorhabditis pages 1-2): Simon R. F. Warburton-Pitt, Andrew R. Jauregui, Chunmei Li, Juan Wang, M. Leroux, and M. Barr. Ciliogenesis in caenorhabditis elegans requires genetic interactions between ciliary middle segment localized nphp-2 (inversin) and transition zone-associated proteins. Journal of Cell Science, 125:2592-2603, Jun 2012. URL: https://doi.org/10.1242/jcs.095539, doi:10.1242/jcs.095539. This article has 57 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(warburtonpitt2015theciliopathygene pages 108-114): Simon R. F. Warburton-Pitt. The ciliopathy gene nphp 2 functions in multiple gene networks and regulates ciliogenesis in c. elegans. ArXiv, Jan 2015. URL: https://doi.org/10.7282/t3v40wx3, doi:10.7282/t3v40wx3. This article has 0 citations.</p>
+</li>
+<li>
+<p>(warburtonpitt2015theciliopathygene pages 104-108): Simon R. F. Warburton-Pitt. The ciliopathy gene nphp 2 functions in multiple gene networks and regulates ciliogenesis in c. elegans. ArXiv, Jan 2015. URL: https://doi.org/10.7282/t3v40wx3, doi:10.7282/t3v40wx3. This article has 0 citations.</p>
+</li>
+<li>
+<p>(warburtonpitt2012ciliogenesisincaenorhabditis pages 3-4): Simon R. F. Warburton-Pitt, Andrew R. Jauregui, Chunmei Li, Juan Wang, M. Leroux, and M. Barr. Ciliogenesis in caenorhabditis elegans requires genetic interactions between ciliary middle segment localized nphp-2 (inversin) and transition zone-associated proteins. Journal of Cell Science, 125:2592-2603, Jun 2012. URL: https://doi.org/10.1242/jcs.095539, doi:10.1242/jcs.095539. This article has 57 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(warburtonpitt2015theciliopathygene pages 29-33): Simon R. F. Warburton-Pitt. The ciliopathy gene nphp 2 functions in multiple gene networks and regulates ciliogenesis in c. elegans. ArXiv, Jan 2015. URL: https://doi.org/10.7282/t3v40wx3, doi:10.7282/t3v40wx3. This article has 0 citations.</p>
+</li>
+<li>
+<p>(warburtonpitt2014thenphp2and pages 4-5): Simon R. F. Warburton-Pitt, Malan Silva, Ken C. Q. Nguyen, David H. Hall, and Maureen M. Barr. The nphp-2 and arl-13 genetic modules interact to regulate ciliogenesis and ciliary microtubule patterning in c. elegans. PLoS Genetics, 10:e1004866, Dec 2014. URL: https://doi.org/10.1371/journal.pgen.1004866, doi:10.1371/journal.pgen.1004866. This article has 44 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(warburtonpitt2014thenphp2and pages 10-11): Simon R. F. Warburton-Pitt, Malan Silva, Ken C. Q. Nguyen, David H. Hall, and Maureen M. Barr. The nphp-2 and arl-13 genetic modules interact to regulate ciliogenesis and ciliary microtubule patterning in c. elegans. PLoS Genetics, 10:e1004866, Dec 2014. URL: https://doi.org/10.1371/journal.pgen.1004866, doi:10.1371/journal.pgen.1004866. This article has 44 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(warburtonpitt2012ciliogenesisincaenorhabditis pages 2-3): Simon R. F. Warburton-Pitt, Andrew R. Jauregui, Chunmei Li, Juan Wang, M. Leroux, and M. Barr. Ciliogenesis in caenorhabditis elegans requires genetic interactions between ciliary middle segment localized nphp-2 (inversin) and transition zone-associated proteins. Journal of Cell Science, 125:2592-2603, Jun 2012. URL: https://doi.org/10.1242/jcs.095539, doi:10.1242/jcs.095539. This article has 57 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(warburtonpitt2014thenphp2and pages 1-2): Simon R. F. Warburton-Pitt, Malan Silva, Ken C. Q. Nguyen, David H. Hall, and Maureen M. Barr. The nphp-2 and arl-13 genetic modules interact to regulate ciliogenesis and ciliary microtubule patterning in c. elegans. PLoS Genetics, 10:e1004866, Dec 2014. URL: https://doi.org/10.1371/journal.pgen.1004866, doi:10.1371/journal.pgen.1004866. This article has 44 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(jensen2015formationofthe pages 1-2): Victor L Jensen, Chunmei Li, Rachel V Bowie, Lara Clarke, Swetha Mohan, Oliver E Blacque, and Michel R Leroux. Formation of the transition zone by mks5/rpgrip1l establishes a ciliary zone of exclusion (cize) that compartmentalises ciliary signalling proteins and controls pip2 ciliary abundance. The EMBO Journal, 34:2537-2556, Oct 2015. URL: https://doi.org/10.15252/embj.201488044, doi:10.15252/embj.201488044. This article has 164 citations.</p>
+</li>
+<li>
+<p>(jensen2015formationofthe pages 12-14): Victor L Jensen, Chunmei Li, Rachel V Bowie, Lara Clarke, Swetha Mohan, Oliver E Blacque, and Michel R Leroux. Formation of the transition zone by mks5/rpgrip1l establishes a ciliary zone of exclusion (cize) that compartmentalises ciliary signalling proteins and controls pip2 ciliary abundance. The EMBO Journal, 34:2537-2556, Oct 2015. URL: https://doi.org/10.15252/embj.201488044, doi:10.15252/embj.201488044. This article has 164 citations.</p>
+</li>
+<li>
+<p>(warburtonpitt2012ciliogenesisincaenorhabditis pages 7-8): Simon R. F. Warburton-Pitt, Andrew R. Jauregui, Chunmei Li, Juan Wang, M. Leroux, and M. Barr. Ciliogenesis in caenorhabditis elegans requires genetic interactions between ciliary middle segment localized nphp-2 (inversin) and transition zone-associated proteins. Journal of Cell Science, 125:2592-2603, Jun 2012. URL: https://doi.org/10.1242/jcs.095539, doi:10.1242/jcs.095539. This article has 57 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(warburtonpitt2015theciliopathygene pages 95-99): Simon R. F. Warburton-Pitt. The ciliopathy gene nphp 2 functions in multiple gene networks and regulates ciliogenesis in c. elegans. ArXiv, Jan 2015. URL: https://doi.org/10.7282/t3v40wx3, doi:10.7282/t3v40wx3. This article has 0 citations.</p>
+</li>
+<li>
+<p>(warburtonpitt2012ciliogenesisincaenorhabditis pages 8-9): Simon R. F. Warburton-Pitt, Andrew R. Jauregui, Chunmei Li, Juan Wang, M. Leroux, and M. Barr. Ciliogenesis in caenorhabditis elegans requires genetic interactions between ciliary middle segment localized nphp-2 (inversin) and transition zone-associated proteins. Journal of Cell Science, 125:2592-2603, Jun 2012. URL: https://doi.org/10.1242/jcs.095539, doi:10.1242/jcs.095539. This article has 57 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(warburtonpitt2014thenphp2and pages 2-3): Simon R. F. Warburton-Pitt, Malan Silva, Ken C. Q. Nguyen, David H. Hall, and Maureen M. Barr. The nphp-2 and arl-13 genetic modules interact to regulate ciliogenesis and ciliary microtubule patterning in c. elegans. PLoS Genetics, 10:e1004866, Dec 2014. URL: https://doi.org/10.1371/journal.pgen.1004866, doi:10.1371/journal.pgen.1004866. This article has 44 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(blacque2014compartmentswithina pages 7-8): Oliver E Blacque and Anna AWM Sanders. Compartments within a compartment. Organogenesis, 10:126-137, Jan 2014. URL: https://doi.org/10.4161/org.28830, doi:10.4161/org.28830. This article has 75 citations.</p>
+</li>
+<li>
+<p>(cevik2013activetransportand pages 5-6): Sebiha Cevik, Anna A. W. M. Sanders, Erwin Van Wijk, Karsten Boldt, Lara Clarke, Jeroen van Reeuwijk, Yuji Hori, Nicola Horn, Lisette Hetterschijt, Anita Wdowicz, Andrea Mullins, Katarzyna Kida, Oktay I. Kaplan, Sylvia E. C. van Beersum, Ka Man Wu, Stef J. F. Letteboer, Dorus A. Mans, Toshiaki Katada, Kenji Kontani, Marius Ueffing, Ronald Roepman, Hannie Kremer, and Oliver E. Blacque. Active transport and diffusion barriers restrict joubert syndrome-associated arl13b/arl-13 to an inv-like ciliary membrane subdomain. PLoS Genetics, 9:e1003977, Dec 2013. URL: https://doi.org/10.1371/journal.pgen.1003977, doi:10.1371/journal.pgen.1003977. This article has 115 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(beyrent2024dimerizationactivatesthe pages 1-2): Erika Beyrent, Derek T. Wei, Gwendolyn M. Beacham, Sangwoo Park, Jian Zheng, Matthew J. Paszek, and Gunther Hollopeter. Dimerization activates the inversin complex in <i>c. elegans</i>. Molecular Biology of the Cell, Oct 2024. URL: https://doi.org/10.1091/mbc.e24-05-0218, doi:10.1091/mbc.e24-05-0218. This article has 5 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(veland2013inversinnephrocystin2isrequired pages 4-4): Iben R. Veland, Rodrick Montjean, Lorraine Eley, Lotte B. Pedersen, Albrecht Schwab, Judith Goodship, Karsten Kristiansen, Stine F. Pedersen, Sophie Saunier, and Søren T. Christensen. Inversin/nephrocystin-2 is required for fibroblast polarity and directional cell migration. PLoS ONE, 8:e60193, Apr 2013. URL: https://doi.org/10.1371/journal.pone.0060193, doi:10.1371/journal.pone.0060193. This article has 86 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(goggolidou2014wntandplanar pages 2-4): Paraskevi Goggolidou. Wnt and planar cell polarity signaling in cystic renal disease. Organogenesis, 10:86-95, Oct 2014. URL: https://doi.org/10.4161/org.26766, doi:10.4161/org.26766. This article has 80 citations.</p>
+</li>
+<li>
+<p>(veland2013inversinnephrocystin2isrequired pages 1-2): Iben R. Veland, Rodrick Montjean, Lorraine Eley, Lotte B. Pedersen, Albrecht Schwab, Judith Goodship, Karsten Kristiansen, Stine F. Pedersen, Sophie Saunier, and Søren T. Christensen. Inversin/nephrocystin-2 is required for fibroblast polarity and directional cell migration. PLoS ONE, 8:e60193, Apr 2013. URL: https://doi.org/10.1371/journal.pone.0060193, doi:10.1371/journal.pone.0060193. This article has 86 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(veland2013inversinnephrocystin2isrequired pages 12-13): Iben R. Veland, Rodrick Montjean, Lorraine Eley, Lotte B. Pedersen, Albrecht Schwab, Judith Goodship, Karsten Kristiansen, Stine F. Pedersen, Sophie Saunier, and Søren T. Christensen. Inversin/nephrocystin-2 is required for fibroblast polarity and directional cell migration. PLoS ONE, 8:e60193, Apr 2013. URL: https://doi.org/10.1371/journal.pone.0060193, doi:10.1371/journal.pone.0060193. This article has 86 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(warburtonpitt2015theciliopathygene pages 40-44): Simon R. F. Warburton-Pitt. The ciliopathy gene nphp 2 functions in multiple gene networks and regulates ciliogenesis in c. elegans. ArXiv, Jan 2015. URL: https://doi.org/10.7282/t3v40wx3, doi:10.7282/t3v40wx3. This article has 0 citations.</p>
+</li>
+</ol>
+<h2 id="artifacts">Artifacts</h2>
+<ul>
+<li><a href="nphp-2-deep-research-falcon_artifacts/artifact-00.md">Edison artifact artifact-00</a></li>
+</ul>
+<h2 id="citations">Citations</h2>
+<ol>
+<li>warburtonpitt2012ciliogenesisincaenorhabditis pages 3-4</li>
+<li>warburtonpitt2012ciliogenesisincaenorhabditis pages 8-9</li>
+<li>warburtonpitt2015theciliopathygene pages 29-33</li>
+<li>blacque2014compartmentswithina pages 7-8</li>
+<li>cevik2013activetransportand pages 5-6</li>
+<li>beyrent2024dimerizationactivatesthe pages 1-2</li>
+<li>warburtonpitt2015theciliopathygene pages 40-44</li>
+<li>warburtonpitt2012ciliogenesisincaenorhabditis pages 1-2</li>
+<li>warburtonpitt2015theciliopathygene pages 108-114</li>
+<li>warburtonpitt2015theciliopathygene pages 104-108</li>
+<li>warburtonpitt2012ciliogenesisincaenorhabditis pages 2-3</li>
+<li>jensen2015formationofthe pages 1-2</li>
+<li>jensen2015formationofthe pages 12-14</li>
+<li>warburtonpitt2012ciliogenesisincaenorhabditis pages 7-8</li>
+<li>warburtonpitt2015theciliopathygene pages 95-99</li>
+<li>goggolidou2014wntandplanar pages 2-4</li>
+<li>https://doi.org/10.1242/jcs.095539,</li>
+<li>https://doi.org/10.7282/t3v40wx3,</li>
+<li>https://doi.org/10.1371/journal.pgen.1004866,</li>
+<li>https://doi.org/10.15252/embj.201488044,</li>
+<li>https://doi.org/10.4161/org.28830,</li>
+<li>https://doi.org/10.1371/journal.pgen.1003977,</li>
+<li>https://doi.org/10.1091/mbc.e24-05-0218,</li>
+<li>https://doi.org/10.1371/journal.pone.0060193,</li>
+<li>https://doi.org/10.4161/org.26766,</li>
+</ol>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(nphp-2-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="Q9BPN3" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="nphp-2-c-elegans-research-notes">nphp-2 (C. elegans) — research notes</h1>
+<p>Gene: nphp-2 / Y32G9A.6 / WBGene00021304<br />
+UniProt: Q9BPN3 (TrEMBL, unreviewed, PE=4 Predicted), 812 aa, ANK-repeat protein.<br />
+Human ortholog: INVS (inversin / nephrocystin-2, NPHP2). Ciliary "inversin compartment" protein.<br />
+Project: CAEEL_CILIOPATHY (flagship). Reviewed as a transition-zone-adjacent / inversin-compartment protein.</p>
+<h2 id="identity-verification-done">Identity verification (done)</h2>
+<ul>
+<li>UniProt Q9BPN3 GN=nphp-2, ORF Y32G9A.6a, WormBase WBGene00021304, taxon 6239. Confirmed.</li>
+<li>UniProt DR lines already carry two experimental GO annotations from WormBase:</li>
+<li>GO:0097543 ciliary inversin compartment (IDA)</li>
+<li>GO:1904108 protein localization to ciliary inversin compartment (IMP)</li>
+<li>Domain architecture (UniProt/InterPro): ankyrin-repeat region (11 ANK by SMART; PF00023/PF12796/PF13637),<br />
+  several disordered regions; no catalytic domain. PANTHER PTHR24198 (ankyrin repeat family).</li>
+<li>IMPORTANT ortholog nuance: there are TWO C. elegans ANK-repeat "inversin-like" proteins.</li>
+<li><strong>nphp-2 / Y32G9A.6</strong> = the <em>ciliary</em> inversin ortholog used in the Barr/Leroux sensory-cilia<br />
+    studies; selected as closest ortholog by X-box promoter usage + domain conservation<br />
+    [falcon report; warburtonpitt2012].</li>
+<li><strong>mlt-4</strong> = the INVS homolog that forms the canonical vertebrate-style "Inversin complex"<br />
+    (MLT-4/NEKL-2/MLT-2 = INVS/NEK8/ANKS6) but functions at <strong>epithelial junctions in molting,<br />
+    not cilia</strong> [PMID:39110529 Beyrent 2024, "loss-of-function mutations in the INVS homolog, MLT-4,<br />
+    result in a lethal-molting phenotype"; "the C. elegans homologues colocalize, albeit at<br />
+    epithelial junctions rather than cilia"].<br />
+  This is a genuine knowledge gap: which worm protein is the true functional inversin ortholog, and<br />
+  how the ciliary NPHP-2 relates to the junctional MLT-4/NEKL-2/MLT-2 complex, is unresolved.</li>
+</ul>
+<h2 id="existing-goa-annotations-3">Existing GOA annotations (3)</h2>
+<p>From nphp-2-goa.tsv (all WB-assigned):<br />
+1. GO:0003674 molecular_function — ND, GO_REF:0000015 (root placeholder; no MF assigned).<br />
+2. GO:0097543 ciliary inversin compartment — IDA, PMID:25335890, located_in.<br />
+3. GO:1904108 protein localization to ciliary inversin compartment — IMP, PMID:25335890, involved_in.</p>
+<p>Both experimental annotations trace to PMID:25335890 (Nguyen 2014, AFD thermosensory neuron paper).</p>
+<h2 id="key-literature-cached">Key literature (cached)</h2>
+<h3 id="pmid25335890-nguyen-liou-hall-leroux-2014-j-cell-sci-abstract-only-in-cache">PMID:25335890 (Nguyen, Liou, Hall, Leroux 2014, J Cell Sci) — abstract-only in cache</h3>
+<p>AFD thermosensory neuron bipartite signaling compartment.<br />
+- <a href="https://pubmed.ncbi.nlm.nih.gov/25335890" title="requires NPHP-2 (known as inversin in mammals) to anchor a cGMP-gated ion channel   within the proximal ciliary region">PMID:25335890</a> — NPHP-2 anchors the cGMP-gated channel (TAX-2/TAX-4) in the<br />
+  proximal cilium (the InvC region). This is the source of both GOA experimental annotations.<br />
+- <a href="https://pubmed.ncbi.nlm.nih.gov/25335890" title="One compartment, a bona fide cilium, is delineated by proteins associated with   Bardet-Biedl syndrome (BBS), Meckel syndrome and nephronophthisis at its base">PMID:25335890</a> — NPHP as base/TZ<br />
+  ciliopathy proteins.</p>
+<h3 id="pmid22393243-warburton-pitt-jauregui-li-wang-leroux-barr-2012-j-cell-sci-abstract-only">PMID:22393243 (Warburton-Pitt, Jauregui, Li, Wang, Leroux, Barr 2012, J Cell Sci) — abstract-only</h3>
+<p>"Ciliogenesis in C. elegans requires genetic interactions between ciliary middle segment localized<br />
+NPHP-2 (inversin) and transition zone-associated proteins."<br />
+- <a href="https://pubmed.ncbi.nlm.nih.gov/22393243" title="the C. elegans inversin ortholog, NPHP-2, localizes to the middle segment of   sensory cilia">PMID:22393243</a> — MIDDLE SEGMENT (InvC), NOT the transition zone. KEY distinction vs nphp-1/nphp-4.<br />
+- <a href="https://pubmed.ncbi.nlm.nih.gov/22393243" title="nphp-2 is partially redundant with nphp-1 and nphp-4 ... for cilia placement within   the head and tail sensilla">PMID:22393243</a>.<br />
+- <a href="https://pubmed.ncbi.nlm.nih.gov/22393243" title="nphp-2 also genetically interacts with MKS ciliopathy gene orthologs, including   mks-1, mks-3, mks-6, mksr-1 and mksr-2, in a sensilla-dependent manner to control cilia formation   and placement">PMID:22393243</a>.<br />
+- <a href="https://pubmed.ncbi.nlm.nih.gov/22393243" title="nphp-2 is not required for correct localization of the NPHP- and MKS-encoded ciliary   transition zone proteins or for intraflagellar transport (IFT)">PMID:22393243</a> — NOT a TZ-assembly or IFT gene.<br />
+- <a href="https://pubmed.ncbi.nlm.nih.gov/22393243" title="nphp-2 plays an important role in C. elegans cilia by acting as a modifier of the   NPHP and MKS pathways to control cilia formation and development">PMID:22393243</a>.</p>
+<h3 id="pmid25501555-warburton-pitt-silva-nguyen-hall-barr-2014-plos-genet-full-text-cached">PMID:25501555 (Warburton-Pitt, Silva, Nguyen, Hall, Barr 2014, PLoS Genet) — FULL TEXT cached</h3>
+<p>"The nphp-2 and arl-13 genetic modules interact to regulate ciliogenesis and ciliary microtubule<br />
+patterning in C. elegans." Most detailed nphp-2 paper.<br />
+- InvC conserved &amp; distinct from doublet region:<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/25501555" title="We show that the InvC is conserved and distinct from the doublet region.">PMID:25501555</a><br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/25501555" title="nphp-2 (the C. elegans Inversin homolog) and the doublet region genes arl-13,   klp-11, and unc-119 are redundantly required for ciliogenesis.">PMID:25501555</a><br />
+- Two modules antagonized by hdac-6:<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/25501555" title="InvC and doublet region genes can be sorted into two modules-nphp-2+klp-11 and   arl-13+unc-119-which are both antagonized by the hdac-6 deacetylase.">PMID:25501555</a><br />
+- Microtubule patterning + anchoring:<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/25501555" title="These defects indicate that nphp-2 is required both for microtubule patterning and   for cilia anchoring.">PMID:25501555</a><br />
+- Glutamylation is downstream:<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/25501555" title="glutamylation is modulated by nphp-2, arl-13, and unc-119">PMID:25501555</a><br />
+- EF-hand required for InvC targeting &amp; function:<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/25501555" title="NPHP-2 does require its calcium binding EF hand domain for targeting to the InvC.">PMID:25501555</a><br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/25501555" title="the calcium-binding EF-hand plays a significant role in both localization and   function of NPHP-2 in amphid channel and phasmid cilia">PMID:25501555</a><br />
+- Ciliary targeting independent of TZ/DR/InvC genes:<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/25501555" title="The ciliary targeting and restricted localization of NPHP-2, ARL-13, and UNC-119   does not require TZ-, doublet region, and InvC-associated genes.">PMID:25501555</a><br />
+- Marks a region distinct from the doublet region (= InvC):<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/25501555" title="We conclude that NPHP-2 marks a region of the cilium distinct from the doublet   region, and propose that this region is analogous to the InvC of mammalian cilia.">PMID:25501555</a><br />
+- GAP statements (field's own admissions):<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/25501555" title="The mechanisms that establish and maintain the InvC are unknown.">PMID:25501555</a><br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/25501555" title="how the InvC is initially established is not known.">PMID:25501555</a><br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/25501555" title="the origin and nature of the calcium signal these domains detect is unknown.">PMID:25501555</a><br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/25501555" title="The next challenge is to determine what initially patterns the doublet region and   InvC, and to understand the function of these cilia regions.">PMID:25501555</a><br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/25501555" title="Determining the mechanism by which HDAC-6 acts as a genetic modifier of InvC and   doublet region gene defects is an important future direction.">PMID:25501555</a><br />
+  EF-hand mechanism unresolved:<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/25501555" title="Two possibilities arise for the function of these domains: Ca2+ specifies the   localization of NPHP-2, modulates the activity of the protein, or both.">PMID:25501555</a></p>
+<h3 id="pmid39110529-beyrent-2024-mol-biol-cell-full-text-cached-backgroundortholog-nuance">PMID:39110529 (Beyrent 2024, Mol Biol Cell) — FULL TEXT cached — background/ortholog nuance</h3>
+<p>Inversin complex activated by dimerization; but the worm complex is MLT-4/NEKL-2/MLT-2, functioning<br />
+at epithelial junctions in molting, NOT the ciliary NPHP-2/Y32G9A.6.<br />
+- <a href="https://pubmed.ncbi.nlm.nih.gov/39110529" title="loss-of-function mutations in the INVS homolog, MLT-4, result in a lethal-molting   phenotype">PMID:39110529</a><br />
+- <a href="https://pubmed.ncbi.nlm.nih.gov/39110529" title="the C. elegans homologues colocalize, albeit at epithelial junctions rather than   cilia">PMID:39110529</a><br />
+- <a href="https://pubmed.ncbi.nlm.nih.gov/39110529" title="we lack fundamental knowledge about how the components might assemble into a   functionally active state">PMID:39110529</a><br />
+Use only for the ortholog-assignment knowledge gap; do NOT attribute MLT-4 findings to nphp-2.</p>
+<h3 id="deep-research-nphp-2-deep-research-falconmd-edison-scientific-literature-25-citations">Deep research: nphp-2-deep-research-falcon.md (Edison Scientific Literature, 25 citations)</h3>
+<p>Genuine, corroborates all of the above. Adds: two isoforms (NPHP-2L middle-segment/InvC; NPHP-2S<br />
+broader, TZ/nucleus-excluded); ankyrin repeats support ciliary targeting (AWB); required for TAX-2<br />
+(and partly TAX-4) proximal-cilium localization; NPHP-2 not an enzyme/transporter — a structural<br />
+organizer/genetic modifier. Falcon file:-quotes are NOT validator-checked, so I anchor claims to<br />
+PMID quotes above wherever used.</p>
+<h2 id="known-vs-not-known-explicit">KNOWN vs NOT-KNOWN (explicit)</h2>
+<p>KNOWN:<br />
+- NPHP-2 is the ciliary C. elegans inversin/INVS(NPHP2) ortholog; ANK-repeat protein, non-catalytic.<br />
+- Localizes to the ciliary inversin compartment (InvC) = middle/proximal doublet region of amphid &amp;<br />
+  phasmid sensory cilia, distal to the TZ (IDA, PMID:25335890; PMID:22393243; PMID:25501555).<br />
+- Required for microtubule ultrastructural patterning and cilia anchoring/placement; ciliogenesis<br />
+  (redundant with nphp-1/nphp-4 and with arl-13/klp-11/unc-119 modules).<br />
+- Required to anchor/localize the cGMP-gated channel TAX-2(/TAX-4) in the proximal cilium<br />
+  (PMID:25335890) → basis of GO:1904108 (protein localization to InvC, IMP).<br />
+- Regulates tubulin glutamylation (upstream), interacts genetically with MKS module and hdac-6.<br />
+- Its EF-hand (Ca-binding) domain is required for InvC targeting and function (PMID:25501555).</p>
+<p>NOT KNOWN / uncertain:<br />
+- No direct molecular function assigned (ND at MF root is currently accurate); whether the EF-hand<br />
+  actually binds Ca2+ biochemically (predicted, not shown) and whether Ca sensing specifies<br />
+  localization vs modulates activity.<br />
+- How the InvC is initially established/patterned (field states this is unknown).<br />
+- Direct binding partners of NPHP-2 in the worm InvC; whether it scaffolds a NEK8/ANKS6-like<br />
+  complex in cilia (the classical complex uses MLT-4 at junctions, PMID:39110529).<br />
+- Mechanism by which HDAC-6 antagonizes InvC/doublet-region gene function.<br />
+- Whether worm NPHP-2 has any Wnt/PCP role (mammalian inversin does; disputed; untested in worm).</p>
+<h2 id="curation-plan">Curation plan</h2>
+<ul>
+<li>GO:0003674 ND → ACCEPT (no MF experimentally defined; accurate placeholder). Note EF-hand<br />
+  Ca-binding as an ONTOLOGY/BIOLOGY knowledge-gap MF candidate, not a confident core MF.</li>
+<li>GO:0097543 ciliary inversin compartment (IDA) → ACCEPT, CORE localization.</li>
+<li>GO:1904108 protein localization to ciliary inversin compartment (IMP) → ACCEPT, CORE process<br />
+  (channel anchoring in the InvC).</li>
+<li>core_functions: InvC localization (CC) + protein localization to InvC / non-motile cilium assembly<br />
+  (BP). No confident MF (leave MF unpopulated / note gap).</li>
+<li>knowledge_gaps: (1) MF-dark — no molecular activity; EF-hand Ca-binding unverified (biology+ontology);<br />
+  (2) how the InvC is established/patterned &amp; NPHP-2's direct partners (biology, residual sub-gap);<br />
+  (3) ortholog-assignment: ciliary NPHP-2 vs junctional MLT-4/NEKL-2/MLT-2 Inversin complex (biology).</li>
+</ul>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: Q9BPN3
+gene_symbol: nphp-2
+product_type: PROTEIN
+status: COMPLETE
+taxon:
+  id: NCBITaxon:6239
+  label: Caenorhabditis elegans
+description: NPHP-2 is the Caenorhabditis elegans ortholog of mammalian inversin (INVS/nephrocystin-2,
+  NPHP2), an ankyrin-repeat protein that acts as a non-catalytic structural organizer within ciliated
+  sensory neurons. Rather than localizing to the ciliary transition zone like the nephrocystins NPHP-1
+  and NPHP-4, NPHP-2 marks the ciliary inversin compartment (InvC), a proximal subregion of the doublet-based
+  ciliary shaft immediately distal to the transition zone in amphid channel and phasmid cilia. There it
+  is required for anchoring the proximal-cilium pool of signaling components, including the cyclic-nucleotide-gated
+  channel subunit TAX-2, and for proper ciliary microtubule ultrastructural patterning, cilium placement
+  and anchoring, and ciliogenesis. NPHP-2 functions redundantly within genetic modules (with nphp-1/nphp-4,
+  and with the doublet-region genes arl-13, klp-11 and unc-119) and interacts genetically with Meckel-syndrome
+  (MKS) transition-zone genes in a sensillum-dependent manner; these activities are modulated upstream
+  of tubulin glutamylation and are antagonized by the HDAC-6 deacetylase. Its calcium-binding EF-hand
+  domain is required for InvC targeting and function. NPHP-2 is not a component of the intraflagellar
+  transport machinery and is dispensable for transition-zone protein localization and IFT.
+references:
+- id: GO_REF:0000015
+  title: Use of the ND evidence code for Gene Ontology (GO) terms
+  findings: []
+- id: PMID:25335890
+  title: Ciliopathy proteins establish a bipartite signaling compartment in a C. elegans thermosensory
+    neuron.
+  findings:
+  - statement: NPHP-2 (mammalian inversin) anchors a cGMP-gated ion channel within the proximal ciliary
+      region of the AFD thermosensory neuron.
+    supporting_text: requires NPHP-2 (known as inversin in mammals) to anchor a cGMP-gated ion channel
+      within the proximal ciliary region
+  - statement: Nephronophthisis-associated proteins localize to the ciliary base of the AFD bipartite
+      compartment.
+    supporting_text: One compartment, a bona fide cilium, is delineated by proteins associated with Bardet-Biedl
+      syndrome (BBS), Meckel syndrome and nephronophthisis at its base
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: PubMed-verified (Nguyen, Liou, Hall, Leroux 2014, J Cell Sci). Cached entry is abstract-only.
+      This is the WormBase source reference for both experimental GOA annotations (GO:0097543 IDA and
+      GO:1904108 IMP); the abstract explicitly states NPHP-2 anchors the cGMP-gated channel in the proximal
+      cilium, supporting the protein-localization-to-InvC annotation.
+- id: PMID:22393243
+  title: Ciliogenesis in Caenorhabditis elegans requires genetic interactions between ciliary middle segment
+    localized NPHP-2 (inversin) and transition zone-associated proteins.
+  findings:
+  - statement: NPHP-2, the C. elegans inversin ortholog, localizes to the ciliary middle segment (inversin
+      compartment), not the transition zone.
+    supporting_text: the C. elegans inversin ortholog, NPHP-2, localizes to the middle segment of sensory
+      cilia
+  - statement: nphp-2 is partially redundant with nphp-1 and nphp-4 for cilia placement.
+    supporting_text: nphp-2 is partially redundant with nphp-1 and nphp-4
+  - statement: nphp-2 genetically interacts with MKS orthologs in a sensilla-dependent manner to control
+      cilia formation and placement.
+    supporting_text: nphp-2 also genetically interacts with MKS ciliopathy gene orthologs, including mks-1,
+      mks-3, mks-6, mksr-1 and mksr-2, in a sensilla-dependent manner to control cilia formation and placement
+  - statement: nphp-2 is not required for transition-zone protein localization or for IFT.
+    supporting_text: nphp-2 is not required for correct localization of the NPHP- and MKS-encoded ciliary
+      transition zone proteins or for intraflagellar transport (IFT)
+  - statement: NPHP-2 acts as a modifier of the NPHP and MKS pathways controlling cilia formation and
+      development.
+    supporting_text: nphp-2 plays an important role in C. elegans cilia by acting as a modifier of the
+      NPHP and MKS pathways to control cilia formation and development
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &#39;PubMed-verified (Warburton-Pitt, Jauregui, Li, Wang, Leroux, Barr 2012, J Cell Sci).
+      Cached entry is abstract-only. Establishes the defining NPHP-2 features used in this review: middle-segment/InvC
+      (not TZ) localization, partial redundancy with nphp-1/nphp-4, sensillum-specific MKS genetic interactions,
+      and independence from TZ-protein localization and IFT.&#39;
+- id: PMID:25501555
+  title: The nphp-2 and arl-13 genetic modules interact to regulate ciliogenesis and ciliary microtubule
+    patterning in C. elegans.
+  findings:
+  - statement: The C. elegans inversin compartment is conserved and distinct from the doublet region.
+    supporting_text: We show that the InvC is conserved and distinct from the doublet region.
+  - statement: nphp-2 and doublet-region genes are redundantly required for ciliogenesis.
+    supporting_text: nphp-2 (the C. elegans Inversin homolog) and the doublet region genes arl-13, klp-11,
+      and unc-119 are redundantly required for ciliogenesis.
+  - statement: InvC and doublet-region genes form two modules antagonized by hdac-6.
+    supporting_text: InvC and doublet region genes can be sorted into two modules-nphp-2+klp-11 and arl-13+unc-119-which
+      are both antagonized by the hdac-6 deacetylase.
+  - statement: nphp-2 is required for ciliary microtubule patterning and cilia anchoring.
+    supporting_text: These defects indicate that nphp-2 is required both for microtubule patterning and
+      for cilia anchoring.
+  - statement: NPHP-2 requires its calcium-binding EF-hand domain for InvC targeting.
+    supporting_text: NPHP-2 does require its calcium binding EF hand domain for targeting to the InvC.
+  - statement: NPHP-2 marks a ciliary region distinct from the doublet region, analogous to the mammalian
+      InvC.
+    supporting_text: We conclude that NPHP-2 marks a region of the cilium distinct from the doublet region,
+      and propose that this region is analogous to the InvC of mammalian cilia.
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: PubMed-verified (Warburton-Pitt, Silva, Nguyen, Hall, Barr 2014, PLoS Genet); full text
+      cached. The most detailed nphp-2 study; provides the InvC-vs-doublet-region distinction, EF-hand
+      dependence, microtubule-patterning/anchoring role, and explicit field admissions of the open mechanistic
+      questions used in knowledge_gaps.
+- id: PMID:39110529
+  title: Dimerization activates the Inversin complex in C. elegans.
+  findings:
+  - statement: In C. elegans the canonical Inversin complex uses MLT-4 (INVS ortholog) and acts at epithelial
+      junctions in molting, not in cilia.
+    supporting_text: the C. elegans homologues colocalize, albeit at epithelial junctions rather than
+      cilia
+  - statement: How the Inversin-complex components assemble into a functionally active state is not fundamentally
+      understood.
+    supporting_text: we lack fundamental knowledge about how the components might assemble into a functionally
+      active state
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: PubMed-verified (Beyrent et al. 2024, Mol Biol Cell); full text cached. This paper is
+      about MLT-4/NEKL-2/MLT-2 (the junctional/molting Inversin complex), a DIFFERENT worm protein from
+      ciliary NPHP-2/Y32G9A.6. Cited only as background for the ortholog-assignment knowledge gap; its
+      MLT-4 findings are not attributed to nphp-2.
+- id: file:worm/nphp-2/nphp-2-deep-research-falcon.md
+  title: Deep research report on nphp-2 (Edison Scientific Literature)
+  findings: []
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: Genuine falcon/Edison deep-research report (25 citations, ~25 min run). Corroborates
+      the primary literature (middle-segment/InvC localization, EF-hand dependence, genetic-modifier role,
+      non-IFT). Used only for orientation; all load-bearing claims are anchored to PMID-verified verbatim
+      quotes.
+existing_annotations:
+- term:
+    id: GO:0003674
+    label: molecular_function
+  evidence_type: ND
+  original_reference_id: GO_REF:0000015
+  qualifier: enables
+  review:
+    summary: Root molecular_function placeholder (ND = No biological Data). No specific molecular activity
+      has been experimentally assigned to NPHP-2.
+    action: ACCEPT
+    reason: NPHP-2 is a non-catalytic ankyrin-repeat protein and no specific molecular function has been
+      experimentally determined. Its role is that of a structural organizer/genetic modifier acting through
+      protein-protein interactions and a calcium-binding EF-hand, but no discrete MF term is supported
+      by direct evidence. The ND placeholder is appropriate; the MF darkness is captured in knowledge_gaps.
+- term:
+    id: GO:0097543
+    label: ciliary inversin compartment
+  evidence_type: IDA
+  original_reference_id: PMID:25335890
+  qualifier: located_in
+  review:
+    summary: Direct experimental localization of NPHP-2 to the ciliary inversin compartment (InvC), the
+      proximal/middle segment of the doublet-based ciliary shaft just distal to the transition zone. This
+      is the core, defining localization of NPHP-2 and distinguishes it from the transition-zone nephrocystins
+      NPHP-1/NPHP-4.
+    action: ACCEPT
+    reason: Core localization, supported by multiple independent C. elegans studies. The InvC is conserved
+      and distinct from the doublet region, and NPHP-2 marks it specifically. This is the most informative
+      cellular-component annotation for the gene.
+    supported_by:
+    - reference_id: PMID:25501555
+      supporting_text: We conclude that NPHP-2 marks a region of the cilium distinct from the doublet
+        region, and propose that this region is analogous to the InvC of mammalian cilia.
+    - reference_id: PMID:22393243
+      supporting_text: the C. elegans inversin ortholog, NPHP-2, localizes to the middle segment of sensory
+        cilia
+- term:
+    id: GO:1904108
+    label: protein localization to ciliary inversin compartment
+  evidence_type: IMP
+  original_reference_id: PMID:25335890
+  qualifier: involved_in
+  review:
+    summary: NPHP-2 is required to anchor/localize signaling components to the proximal ciliary (InvC)
+      region; in AFD thermosensory neurons it anchors the cGMP-gated channel within the proximal cilium.
+      This is a core biological process for NPHP-2 and is directly grounded in the source paper.
+    action: ACCEPT
+    reason: Well-supported experimental (IMP) annotation. The source reference explicitly shows NPHP-2
+      is required to anchor a cGMP-gated ion channel in the proximal ciliary region, which is exactly
+      the InvC subdomain NPHP-2 defines. Represents the best-characterized functional role of the protein.
+    supported_by:
+    - reference_id: PMID:25335890
+      supporting_text: requires NPHP-2 (known as inversin in mammals) to anchor a cGMP-gated ion channel
+        within the proximal ciliary region
+core_functions:
+- description: &#39;Structural organizer of the ciliary inversin compartment: NPHP-2 localizes to and marks
+    the InvC (proximal/middle doublet region of sensory cilia, distal to the transition zone) and is required
+    to anchor/localize proximal-ciliary signaling components there, including the cGMP-gated channel subunit
+    TAX-2.&#39;
+  directly_involved_in:
+  - id: GO:1904108
+    label: protein localization to ciliary inversin compartment
+  locations:
+  - id: GO:0097543
+    label: ciliary inversin compartment
+  supported_by:
+  - reference_id: PMID:25335890
+    supporting_text: requires NPHP-2 (known as inversin in mammals) to anchor a cGMP-gated ion channel
+      within the proximal ciliary region
+  - reference_id: PMID:25501555
+    supporting_text: We conclude that NPHP-2 marks a region of the cilium distinct from the doublet region,
+      and propose that this region is analogous to the InvC of mammalian cilia.
+- description: Contributes to sensory (non-motile) ciliogenesis, cilium placement/anchoring, and ciliary
+    microtubule ultrastructural patterning, acting redundantly with nphp-1/nphp-4 and with the doublet-region
+    module (arl-13, klp-11, unc-119) and as a sensillum-dependent modifier of the MKS transition-zone
+    pathway.
+  directly_involved_in:
+  - id: GO:1905515
+    label: non-motile cilium assembly
+  locations:
+  - id: GO:0097543
+    label: ciliary inversin compartment
+  supported_by:
+  - reference_id: PMID:25501555
+    supporting_text: These defects indicate that nphp-2 is required both for microtubule patterning and
+      for cilia anchoring.
+  - reference_id: PMID:22393243
+    supporting_text: nphp-2 plays an important role in C. elegans cilia by acting as a modifier of the
+      NPHP and MKS pathways to control cilia formation and development
+proposed_new_terms:
+- proposed_name: structural constituent of ciliary inversin compartment
+  proposed_definition: The action of a protein that contributes to the structural organization and integrity
+    of the ciliary inversin compartment (InvC), a proximal subdomain of the doublet-based ciliary shaft
+    distal to the transition zone, for example by scaffolding the retention of proximal-ciliary signaling
+    components without itself catalyzing a biochemical reaction.
+  proposed_parent:
+    id: GO:0005198
+    label: structural molecule activity
+knowledge_gaps:
+- gap_statement: NPHP-2 has no assigned molecular function and no adequate GO molecular-function term
+    to express one. It is a non-catalytic ankyrin-repeat protein whose role is to organize the ciliary
+    inversin compartment and anchor proximal-ciliary signaling components, but GO has no structural-constituent-of-the-ciliary-inversin-compartment
+    activity, so the gene reads as MF-dark despite a well-defined cellular and process-level role.
+  boundary: &#39;It is firmly established that NPHP-2 = inversin localizes to and marks the InvC, is required
+    for microtubule patterning, cilia anchoring/placement and ciliogenesis, and anchors the proximal-cilium
+    cGMP-gated channel. What is missing is a molecular-function representation: the worm GOA record carries
+    only a cellular-component and a biological-process term plus the ND molecular_function root.&#39;
+  gap_kind:
+  - ONTOLOGY
+  - CURATION
+  dark_aspect: MF_DARK
+  status: OPEN
+  significance: &#39;This is the canonical structural/scaffold-subunit ontology gap shared across the ciliary
+    inversin/nephrocystin gene set: a mechanistically well-understood organizer that cannot be annotated
+    with an informative MF term, contributing to apparent molecular-function darkness.&#39;
+  resolution: Develop/adopt a molecular-function term for a structural constituent of the ciliary inversin
+    compartment (analogous to structural constituent of ribosome) and annotate NPHP-2 to it; see proposed_new_terms.
+  provenance:
+  - reference_id: PMID:25501555
+    supporting_text: We conclude that NPHP-2 marks a region of the cilium distinct from the doublet region,
+      and propose that this region is analogous to the InvC of mammalian cilia.
+  proposed_terms:
+  - proposed_name: structural constituent of ciliary inversin compartment
+    proposed_definition: The action of a protein that contributes to the structural organization and integrity
+      of the ciliary inversin compartment (InvC), for example by scaffolding the retention of proximal-ciliary
+      signaling components without itself catalyzing a biochemical reaction.
+    proposed_parent:
+      id: GO:0005198
+      label: structural molecule activity
+- gap_statement: How the ciliary inversin compartment is initially established and maintained, and which
+    direct molecular partners recruit and retain NPHP-2 there, is unknown. NPHP-2 reaches and is restricted
+    to the InvC independently of transition-zone, doublet-region and other InvC genes, so the factor(s)
+    that pattern the compartment and the NPHP-2 interactome that executes its scaffolding function have
+    not been identified.
+  boundary: &#39;Established: NPHP-2 marks the InvC and is required for microtubule patterning and cilia anchoring;
+    its ciliary targeting/restriction does not require the tested TZ, doublet-region or InvC genes; the
+    InvC is set up early in development. Not established: the upstream cue that patterns the InvC and
+    the direct binding partners through which NPHP-2 organizes it.&#39;
+  gap_kind:
+  - BIOLOGY
+  dark_aspect: RESIDUAL_SUBGAP
+  status: OPEN
+  significance: Identifying the InvC-patterning cue and the NPHP-2 interactome would convert a marks-a-region,
+    required-for-patterning description into a mechanism, and would explain how nephronophthisis (inversin)
+    mutations disrupt proximal-ciliary signaling.
+  resolution: Unbiased proximity-labeling/immunoprecipitation of tagged NPHP-2 in ciliated neurons, plus
+    forward/candidate genetic screens for factors required for InvC establishment, with InvC-marker and
+    channel-anchoring readouts.
+  provenance:
+  - reference_id: PMID:25501555
+    supporting_text: The mechanisms that establish and maintain the InvC are unknown.
+  - reference_id: PMID:25501555
+    supporting_text: The next challenge is to determine what initially patterns the doublet region and
+      InvC, and to understand the function of these cilia regions.
+- gap_statement: Whether the NPHP-2 EF-hand actually binds calcium and, if so, whether the calcium signal
+    specifies NPHP-2 localization, modulates its activity, or both, is undetermined. The EF-hand is only
+    a predicted calcium-binding motif; it is required for InvC targeting and function, but the biochemical
+    calcium binding and the origin of any calcium cue are unproven.
+  boundary: &#39;Established: deletion of the EF-hand abolishes NPHP-2 localization to amphid/phasmid cilia
+    and impairs rescue, so the domain is functionally essential in those cells. Not established: direct
+    Ca2+ binding by the domain, and the source/nature of the calcium signal it would sense.&#39;
+  gap_kind:
+  - BIOLOGY
+  dark_aspect: MF_DARK
+  status: OPEN
+  significance: If the EF-hand is a bona fide calcium sensor, NPHP-2 would gain a concrete molecular activity
+    (calcium ion binding) linking ciliary calcium signaling to InvC organization; resolving this would
+    also inform the conserved requirement for a calcium-binding domain in vertebrate inversin.
+  resolution: In vitro calcium-binding assays on the isolated EF-hand, and separation-of-function EF-hand
+    point mutants (binding-dead vs structural) tested for InvC targeting and channel anchoring in vivo.
+  provenance:
+  - reference_id: PMID:25501555
+    supporting_text: the origin and nature of the calcium signal these domains detect is unknown
+  - reference_id: PMID:25501555
+    supporting_text: &#39;Two possibilities arise for the function of these domains: Ca2+ specifies the localization
+      of NPHP-2, modulates the activity of the protein, or both.&#39;
+- gap_statement: The relationship between the ciliary NPHP-2/Y32G9A.6 and the canonical vertebrate-style
+    Inversin complex is unresolved. In C. elegans the classical Inversin complex is built from MLT-4 (INVS),
+    NEKL-2 (NEK8) and MLT-2 (ANKS6) and functions at epithelial junctions during molting rather than in
+    cilia; whether ciliary NPHP-2 assembles an analogous NEK8/ANKS6-type module in the InvC, or acts independently,
+    is not known.
+  boundary: &#39;Established: nphp-2/Y32G9A.6 is the ciliary inversin ortholog in the sensory-cilia literature,
+    while the MLT-4/NEKL-2/MLT-2 complex acts at junctions in molting. Not established: whether the two
+    systems share components or mechanism, and which worm protein is the true functional inversin ortholog
+    in each context.&#39;
+  gap_kind:
+  - BIOLOGY
+  dark_aspect: RESIDUAL_SUBGAP
+  status: OPEN
+  significance: Clarifying the ortholog relationship determines how findings about the junctional Inversin
+    complex (e.g. dimerization-dependent activation) transfer to ciliary NPHP-2 function and to human
+    inversin/nephronophthisis biology.
+  resolution: Systematic tagging/interaction mapping of NPHP-2, MLT-4, NEKL-2 and MLT-2 across ciliated
+    and epithelial tissues, with cross-rescue and complex-composition assays.
+  provenance:
+  - reference_id: PMID:39110529
+    supporting_text: the C. elegans homologues colocalize, albeit at epithelial junctions rather than
+      cilia
+  - reference_id: PMID:39110529
+    supporting_text: we lack fundamental knowledge about how the components might assemble into a functionally
+      active state
+suggested_questions:
+- question: Does the NPHP-2 EF-hand bind calcium biochemically, and does calcium specify InvC localization,
+    modulate NPHP-2 activity, or both?
+- question: What are the direct binding partners of NPHP-2 in the ciliary inversin compartment, and do
+    they include NEK8/ANKS6-type proteins?
+- question: What upstream cue initially patterns the inversin compartment independently of the transition
+    zone, doublet-region and IFT machinery?
+suggested_experiments:
+- description: Proximity-labeling (TurboID) or immunoprecipitation of endogenously tagged NPHP-2 in ciliated
+    sensory neurons to identify the InvC interactome.
+  hypothesis: NPHP-2 scaffolds a defined set of proximal-ciliary proteins that retain signaling components
+    (e.g. TAX-2/TAX-4) in the InvC.
+- description: In vitro calcium-binding assays on the isolated EF-hand plus binding-dead point mutants
+    assayed in vivo for InvC targeting and cGMP-gated channel anchoring.
+  hypothesis: The EF-hand is a functional calcium sensor whose calcium binding is required for InvC targeting
+    and/or NPHP-2 activity.
+- description: Candidate and forward genetic screens for factors required to establish the InvC, using
+    an InvC marker (NPHP-2 GFP territory) and channel-anchoring readouts.
+  hypothesis: A dedicated patterning cue, distinct from TZ/doublet-region/IFT genes, defines the proximal
+    InvC subdomain.
+tags:
+- caeel-ciliopathy
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/genes/worm/odr-1/odr-1-ai-review.html
+++ b/genes/worm/odr-1/odr-1-ai-review.html
@@ -1,0 +1,5403 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>odr-1 - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        .propagation-review {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f8fafc;
+            border-left: 3px solid #64748b;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .propagation-title {
+            font-weight: 600;
+            color: #334155;
+            margin-bottom: 0.25rem;
+        }
+
+        .propagation-row {
+            margin-top: 0.25rem;
+        }
+
+        .propagation-source {
+            margin-top: 0.5rem;
+            padding-top: 0.5rem;
+            border-top: 1px solid #e5e7eb;
+        }
+
+        .propagation-source-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #1d4ed8;
+        }
+
+        .propagation-comment {
+            color: #4b5563;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>odr-1</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/B1Q257" target="_blank" class="term-link">
+                        B1Q257
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Caenorhabditis elegans</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-complete">
+                    COMPLETE
+                </span>
+            </div>
+
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "odr-1";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="B1Q257" data-a="DESCRIPTION: odr-1 (gcy-10) encodes a receptor-type (single-pas..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>odr-1 (gcy-10) encodes a receptor-type (single-pass transmembrane) guanylyl cyclase of Caenorhabditis elegans. It has an extracellular periplasmic-binding- protein-like domain, a transmembrane helix, a cytoplasmic kinase-homology domain (predicted catalytically inactive), and a C-terminal guanylate cyclase catalytic domain that converts GTP to the second messenger cGMP (EC 4.6.1.2). ODR-1 is expressed in a defined set of ciliated sensory neurons (predominantly AWC, and also AWB, ASI, ASJ and ASK) and localizes to the sensory cilium and cell membrane. As a source of cGMP acting downstream of odorant receptors, ODR-1 is a shared signaling component required for AWC-mediated olfaction and odor discrimination and for AWB-mediated odor avoidance; the cGMP it produces gates the TAX-2/TAX-4 cyclic-nucleotide-gated channel. The same cGMP output is redeployed in other ciliated neurons, contributing to ASJ phototransduction, to bitter-tastant (quinine) sensitivity via non-cell-autonomous supply of cGMP to the EGL-4 PKG, and to maintenance of asymmetric olfactory-receptor (str-2) gene expression in AWC. No activating ligand for its extracellular domain has been identified.</p>
+    </div>
+
+
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004383" target="_blank" class="term-link">
+                                    GO:0004383
+                                </a>
+                            </span>
+                            <span class="term-label">guanylate cyclase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="B1Q257" data-a="GO:0004383" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Guanylate cyclase is the defining catalytic activity of ODR-1, supported by domain architecture (Pfam PF00211 cyclase domain 859-989), the E904A cyclase- domain mutant that abolishes activity and olfaction, and ISS transfer from orthologous receptor GCs. Correct and core.
+                        </div>
+
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/10774726" target="_blank" class="term-link">
+                                        PMID:10774726
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">the transmembrane guanylyl cyclase ODR-1</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005886" target="_blank" class="term-link">
+                                    GO:0005886
+                                </a>
+                            </span>
+                            <span class="term-label">plasma membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="B1Q257" data-a="GO:0005886" data-r="GO_REF:0000033" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> ODR-1 is a single-pass type I membrane protein. Its functionally relevant pool is in the sensory cilium (a specialized plasma-membrane compartment); plasma membrane is correct but less specific than the ciliary localization (see the IDA non-motile cilium annotation from PMID:10774726). Keep as a non-core supporting location.
+                        </div>
+
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006182" target="_blank" class="term-link">
+                                    GO:0006182
+                                </a>
+                            </span>
+                            <span class="term-label">cGMP biosynthetic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="B1Q257" data-a="GO:0006182" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Production of the cGMP second messenger is the direct biological process of ODR-1&#39;s cyclase activity and is central to all of its downstream roles. Core.
+                        </div>
+
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0007168" target="_blank" class="term-link">
+                                    GO:0007168
+                                </a>
+                            </span>
+                            <span class="term-label">receptor guanylyl cyclase signaling pathway</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="B1Q257" data-a="GO:0007168" data-r="GO_REF:0000033" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> ODR-1 is a receptor-type GC and its cGMP output drives sensory signal transduction, so this term is apt at the pathway level. Note the strict GO definition invokes an extracellular ligand binding the GC receptor; no ligand for ODR-1&#39;s ectodomain is known, and ODR-1 acts downstream of odorant receptors as a shared component. Retain as a non-core signaling-pathway term.
+                        </div>
+
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/10774726" target="_blank" class="term-link">
+                                        PMID:10774726
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">ODR-1 appears to be a shared signaling
+component downstream of odorant receptors</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0001653" target="_blank" class="term-link">
+                                    GO:0001653
+                                </a>
+                            </span>
+                            <span class="term-label">peptide receptor activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="B1Q257" data-a="GO:0001653" data-r="GO_REF:0000033" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetic (PANTHER) transfer from mammalian natriuretic-peptide-receptor guanylyl cyclases (NPR-A/NPR-B). C. elegans receptor GCs are orphan receptors with no demonstrated peptide ligand, and UniProt notes the ODR-1 extracellular domain may not be directly implicated in odorant detection. No experimental support for peptide-receptor activity in ODR-1; this is an over-annotation propagated from vertebrate paralogs.
+                        </div>
+
+
+
+
+                        <div class="propagation-review">
+                            <div class="propagation-title">Propagation Review</div>
+                            <div class="propagation-row">
+                                <strong>Root cause:</strong>
+                                <span class="badge">PROPAGATION BAD</span>
+                            </div>
+
+                            <div class="propagation-row">
+                                <strong>Failure modes:</strong>
+
+                                <span class="badge">FUNCTIONAL DIVERGENCE</span>
+
+                            </div>
+
+
+                            <div class="propagation-source">
+                                <strong>Sources checked:</strong>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">UniProtKB:P16066</span>
+
+                                    &middot; NPR1 (human natriuretic peptide receptor 1)
+
+
+                                    <span class="badge">SUPPORTS SOURCE BUT NOT TARGET</span>
+
+
+                                    <div class="propagation-comment">Bona fide peptide (natriuretic peptide) receptor GC; ODR-1 is an orphan receptor GC with no known peptide ligand, so peptide-receptor activity does not transfer.</div>
+
+                                </div>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">UniProtKB:P20594</span>
+
+                                    &middot; NPR2 (human natriuretic peptide receptor 2)
+
+
+                                    <span class="badge">SUPPORTS SOURCE BUT NOT TARGET</span>
+
+
+                                </div>
+
+                            </div>
+
+                        </div>
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004383" target="_blank" class="term-link">
+                                    GO:0004383
+                                </a>
+                            </span>
+                            <span class="term-label">guanylate cyclase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000120
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="B1Q257" data-a="GO:0004383" data-r="GO_REF:0000120" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Automated EC 4.6.1.2 / RHEA:13665 assignment of guanylate cyclase activity. Consistent with the catalytic domain and the manual ISS/IBA annotations. Core molecular function (duplicate of the manually supported term).
+                        </div>
+
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005524" target="_blank" class="term-link">
+                                    GO:0005524
+                                </a>
+                            </span>
+                            <span class="term-label">ATP binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="B1Q257" data-a="GO:0005524" data-r="GO_REF:0000002" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> InterPro (IPR000719) inference from the kinase-homology domain; UniProt lists candidate ATP-binding residues (515-523, 534). However UniProt predicts this kinase domain to be catalytically inactive (pseudokinase), so nucleotide binding is uncertain and, if it occurs, is regulatory/structural rather than a core function. Retain as a weak, non-core electronic annotation.
+                        </div>
+
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005886" target="_blank" class="term-link">
+                                    GO:0005886
+                                </a>
+                            </span>
+                            <span class="term-label">plasma membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000044
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="B1Q257" data-a="GO:0005886" data-r="GO_REF:0000044" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> UniProt Subcellular Location mapping (SL-0039). Correct but subsumed by the more specific ciliary localization. Non-core supporting location.
+                        </div>
+
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005929" target="_blank" class="term-link">
+                                    GO:0005929
+                                </a>
+                            </span>
+                            <span class="term-label">cilium</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000044
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="B1Q257" data-a="GO:0005929" data-r="GO_REF:0000044" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Ciliary localization is experimentally established (IDA to non-motile cilium, GO:0097730, from PMID:10774726). This SubCell-derived cilium annotation is correct and captures the core location; the sibling IDA non-motile cilium term is the more specific, core cellular component.
+                        </div>
+
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0007635" target="_blank" class="term-link">
+                                    GO:0007635
+                                </a>
+                            </span>
+                            <span class="term-label">chemosensory behavior</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000117
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="B1Q257" data-a="GO:0007635" data-r="GO_REF:0000117" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> ARBA electronic annotation. odr-1&#39;s chemosensory role is well established experimentally (olfaction, quinine avoidance). This generic term is correct but less informative than the specific olfactory/chemotaxis terms; keep as a non-core parent.
+                        </div>
+
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0009190" target="_blank" class="term-link">
+                                    GO:0009190
+                                </a>
+                            </span>
+                            <span class="term-label">cyclic nucleotide biosynthetic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="B1Q257" data-a="GO:0009190" data-r="GO_REF:0000002" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Generic parent of the specific, experimentally supported cGMP biosynthetic process (GO:0006182). Correct but redundant; keep as non-core.
+                        </div>
+
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0035556" target="_blank" class="term-link">
+                                    GO:0035556
+                                </a>
+                            </span>
+                            <span class="term-label">intracellular signal transduction</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="B1Q257" data-a="GO:0035556" data-r="GO_REF:0000002" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> High-level signal-transduction parent inferred from InterPro. Correct in spirit (cGMP second-messenger signaling) but uninformative relative to the specific receptor-GC-signaling / sensory-perception terms. Non-core.
+                        </div>
+
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0050913" target="_blank" class="term-link">
+                                    GO:0050913
+                                </a>
+                            </span>
+                            <span class="term-label">sensory perception of bitter taste</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000117
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="B1Q257" data-a="GO:0050913" data-r="GO_REF:0000117" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> ARBA electronic version of the experimentally supported quinine-sensitivity role (see IMP/IGI from PMID:23874221). odr-1 supplies cGMP non-cell- autonomously to EGL-4 in ASH; bitter-taste sensitivity is a peripheral, non-core role of odr-1.
+                        </div>
+
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004383" target="_blank" class="term-link">
+                                    GO:0004383
+                                </a>
+                            </span>
+                            <span class="term-label">guanylate cyclase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ISS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000024
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="B1Q257" data-a="GO:0004383" data-r="GO_REF:0000024" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Curator ISS transfer of guanylate cyclase activity from an orthologous receptor GC (UniProtKB:Q19187, gcy-12). Consistent with the catalytic domain and the E904A mutant phenotype. Core molecular function.
+                        </div>
+
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0050767" target="_blank" class="term-link">
+                                    GO:0050767
+                                </a>
+                            </span>
+                            <span class="term-label">regulation of neurogenesis</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/31259686" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:31259686
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The Caenorhabditis elegans Tubby homolog dynamically modulat...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="B1Q257" data-a="GO:0050767" data-r="PMID:31259686" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> From the Tubby (tub-1) study, in which odr-1 loss-of-function (&#34;receptor guanylyl cyclase signaling mutants&#34;) causes expanded AWB ciliary membrane fans and altered ciliary lipid/protein content. This is a downstream, sensory-signaling-dependent developmental readout of reduced cGMP signaling, not a distinct activity of ODR-1; retain but as a non-core developmental role.
+                        </div>
+
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/31259686" target="_blank" class="term-link">
+                                        PMID:31259686
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">AWB cilia width is significantly increased in odr-1 receptor guanylyl cyclase signaling mutants</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0097499" target="_blank" class="term-link">
+                                    GO:0097499
+                                </a>
+                            </span>
+                            <span class="term-label">protein localization to non-motile cilium</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/31259686" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:31259686
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The Caenorhabditis elegans Tubby homolog dynamically modulat...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="B1Q257" data-a="GO:0097499" data-r="PMID:31259686" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> odr-1 mutants show increased ciliary accumulation of TUB-1 and the PIP5-kinase PPK-1 in AWB cilia; loss of odr-1 sensory signaling thus alters ciliary protein localization. This is an indirect, non-cell-intrinsic consequence of reduced cGMP signaling rather than a direct trafficking function of ODR-1; keep as non-core.
+                        </div>
+
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/31259686" target="_blank" class="term-link">
+                                        PMID:31259686
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">we found that odr-1 mutants showed enrichment of a TUB-1 fusion protein in AWB cilia as compared to levels at the PCMC</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0010628" target="_blank" class="term-link">
+                                    GO:0010628
+                                </a>
+                            </span>
+                            <span class="term-label">positive regulation of gene expression</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/18832350" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:18832350
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The EGL-4 PKG acts with KIN-29 salt-inducible kinase and pro...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="B1Q257" data-a="GO:0010628" data-r="PMID:18832350" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> The cached abstract of PMID:18832350 describes EGL-4 PKG, KIN-29 and PKA regulating chemoreceptor gene expression and does not itself name odr-1; full text is unavailable. A role for odr-1 as an upstream cGMP source for EGL-4-dependent chemoreceptor-gene expression is plausible but cannot be verified from the abstract. Per curation policy the experimental annotation is not removed; treat as non-core and unverified from available text.
+                        </div>
+
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006182" target="_blank" class="term-link">
+                                    GO:0006182
+                                </a>
+                            </span>
+                            <span class="term-label">cGMP biosynthetic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ISS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/10774726" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:10774726
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Olfaction and odor discrimination are mediated by the C. ele...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="B1Q257" data-a="GO:0006182" data-r="PMID:10774726" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> cGMP biosynthesis is the direct process of ODR-1&#39;s cyclase activity, here transferred by similarity (WITH UniProtKB:P16066, a natriuretic-peptide- receptor GC) and anchored to the ODR-1 characterization paper. Core.
+                        </div>
+
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/10774726" target="_blank" class="term-link">
+                                        PMID:10774726
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">probably by overproduction of the shared second messenger cGMP</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0040015" target="_blank" class="term-link">
+                                    GO:0040015
+                                </a>
+                            </span>
+                            <span class="term-label">negative regulation of multicellular organism growth</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IGI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/26434723" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:26434723
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The Importance of cGMP Signaling in Sensory Cilia for Body S...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="B1Q257" data-a="GO:0040015" data-r="PMID:26434723" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Genetic-interaction annotation from the body-size study, whose abstract attributes cGMP-dependent body-size control specifically to gcy-12 (WITH UniProtKB:Q19187) and states EGL-4 partners with different GCs for different tasks. Body-size regulation is peripheral to odr-1&#39;s core sensory function. The experimental IGI is retained (full text not read) but marked non-core, and the reference is flagged as low relevance for odr-1.
+                        </div>
+
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0040014" target="_blank" class="term-link">
+                                    GO:0040014
+                                </a>
+                            </span>
+                            <span class="term-label">regulation of multicellular organism growth</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IGI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/26434723" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:26434723
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The Importance of cGMP Signaling in Sensory Cilia for Body S...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="B1Q257" data-a="GO:0040014" data-r="PMID:26434723" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Parent of the negative-regulation term above; same body-size study (WITH UniProtKB:G5EGF0). Peripheral to odr-1&#39;s core function; retain as non-core.
+                        </div>
+
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0007635" target="_blank" class="term-link">
+                                    GO:0007635
+                                </a>
+                            </span>
+                            <span class="term-label">chemosensory behavior</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/23874221" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:23874221
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The C. elegans cGMP-dependent protein kinase EGL-4 regulates...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="B1Q257" data-a="GO:0007635" data-r="PMID:23874221" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> odr-1 loss causes behavioral hypersensitivity to dilute quinine, a chemosensory (bitter-tastant avoidance) phenotype mediated by cGMP supply to EGL-4. Correct; a generic chemosensory-behavior term for a peripheral (bitter/ nociceptive) role. Keep as non-core.
+                        </div>
+
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/23874221" target="_blank" class="term-link">
+                                        PMID:23874221
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Loss-of-function mutations in the guanylyl cyclase genes odr-1, gcy-27, gcy-33 and gcy-34 resulted in behavioral hypersensitivity to dilute (1 mM) quinine</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0007635" target="_blank" class="term-link">
+                                    GO:0007635
+                                </a>
+                            </span>
+                            <span class="term-label">chemosensory behavior</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IGI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/23874221" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:23874221
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The C. elegans cGMP-dependent protein kinase EGL-4 regulates...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="B1Q257" data-a="GO:0007635" data-r="PMID:23874221" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Genetic-interaction version of the quinine-sensitivity chemosensory role (WITH UniProtKB:O76360). Same interpretation as the IMP above; non-core.
+                        </div>
+
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/23874221" target="_blank" class="term-link">
+                                        PMID:23874221
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">the cyclases may function in a non-cell-autonomous manner to provide cGMP to regulate EGL-4 function in ASH</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0050913" target="_blank" class="term-link">
+                                    GO:0050913
+                                </a>
+                            </span>
+                            <span class="term-label">sensory perception of bitter taste</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/23874221" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:23874221
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The C. elegans cGMP-dependent protein kinase EGL-4 regulates...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="B1Q257" data-a="GO:0050913" data-r="PMID:23874221" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Experimentally supported bitter-tastant (quinine) sensitivity role: odr-1(lof) animals are hypersensitive to dilute quinine and the defect is rescued by srb-6p::odr-1. A genuine but peripheral, non-cell-autonomous role of odr-1; non-core relative to olfaction.
+                        </div>
+
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/23874221" target="_blank" class="term-link">
+                                        PMID:23874221
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The quinine hypersensitivity of odr-1(lof) animals was rescued by srb-6p::odr-1 expression (p&lt;0.001), but not osm-10p::odr-1 expression (p&gt;0.5).</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0050913" target="_blank" class="term-link">
+                                    GO:0050913
+                                </a>
+                            </span>
+                            <span class="term-label">sensory perception of bitter taste</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IGI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/23874221" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:23874221
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The C. elegans cGMP-dependent protein kinase EGL-4 regulates...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="B1Q257" data-a="GO:0050913" data-r="PMID:23874221" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Genetic-interaction version of the quinine bitter-taste role (WITH UniProtKB:O76360). Same interpretation; non-core.
+                        </div>
+
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0007602" target="_blank" class="term-link">
+                                    GO:0007602
+                                </a>
+                            </span>
+                            <span class="term-label">phototransduction</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/20436480" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:20436480
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    C. elegans phototransduction requires a G protein-dependent ...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="B1Q257" data-a="GO:0007602" data-r="PMID:20436480" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> odr-1(n1936) mutants show a severe reduction in ASJ photocurrent density, demonstrating a requirement for membrane-associated GCs (odr-1, daf-11) in cGMP-dependent phototransduction. A genuine experimental role, but a redeployment of the same cGMP/CNG-channel machinery in a specialized context; peripheral to the core olfactory function, so non-core.
+                        </div>
+
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/20436480" target="_blank" class="term-link">
+                                        PMID:20436480
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">odr-1(n1936) mutant worms also showed a severe reduction in the density of photocurrents</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0010628" target="_blank" class="term-link">
+                                    GO:0010628
+                                </a>
+                            </span>
+                            <span class="term-label">positive regulation of gene expression</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/10571181" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:10571181
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Lateral signaling mediated by axon contact and calcium entry...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="B1Q257" data-a="GO:0010628" data-r="PMID:10571181" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> A cGMP signaling pathway used in olfaction (odr-1-dependent) maintains asymmetric expression of the olfactory receptor gene str-2 in adult AWC. This is a real, cGMP-mediated effect on gene expression, but a specialized developmental/maintenance role downstream of odr-1&#39;s cyclase activity; non-core.
+                        </div>
+
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/10571181" target="_blank" class="term-link">
+                                        PMID:10571181
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">A cGMP signaling
+pathway that is used in olfaction maintains str-2 expression after the initial
+decision has been made.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042048" target="_blank" class="term-link">
+                                    GO:0042048
+                                </a>
+                            </span>
+                            <span class="term-label">olfactory behavior</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/8348618" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:8348618
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Odorant-selective genes and neurons mediate olfaction in C. ...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="B1Q257" data-a="GO:0042048" data-r="PMID:8348618" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> odr-1 was isolated as an odr (odorant-response-abnormal) gene; the G647D mutant (n1930) causes loss of chemotaxis to volatile odorants. Olfactory behavior is the core organismal role of odr-1. Accept as core.
+                        </div>
+
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/8348618" target="_blank" class="term-link">
+                                        PMID:8348618
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Chemotaxis to subsets of volatile odorants is disrupted by
+mutations in the odr genes, which might be involved in odorant sensation or
+signal transduction.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1990834" target="_blank" class="term-link">
+                                    GO:1990834
+                                </a>
+                            </span>
+                            <span class="term-label">response to odorant</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/8348618" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:8348618
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Odorant-selective genes and neurons mediate olfaction in C. ...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="B1Q257" data-a="GO:1990834" data-r="PMID:8348618" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> odr-1 mutants are defective in chemotaxis responses to volatile odorants; the gene is required for the organism&#39;s response to odorants. Core sensory role.
+                        </div>
+
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/8348618" target="_blank" class="term-link">
+                                        PMID:8348618
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Chemotaxis to subsets of volatile odorants is disrupted by</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0097730" target="_blank" class="term-link">
+                                    GO:0097730
+                                </a>
+                            </span>
+                            <span class="term-label">non-motile cilium</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/10774726" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:10774726
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Olfaction and odor discrimination are mediated by the C. ele...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="B1Q257" data-a="GO:0097730" data-r="PMID:10774726" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct experimental localization (IDA, WormBase) of ODR-1 to the sensory (non-motile) cilium, reported in the ODR-1 characterization paper. This is the core cellular component where ODR-1 functions. The localization datum is in the full text (not the cached abstract), so no verbatim quote is attached; accept and defer to the curator&#39;s IDA.
+                        </div>
+
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004383" target="_blank" class="term-link">
+                                    GO:0004383
+                                </a>
+                            </span>
+                            <span class="term-label">guanylate cyclase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ISS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/10774726" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:10774726
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Olfaction and odor discrimination are mediated by the C. ele...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="B1Q257" data-a="GO:0004383" data-r="PMID:10774726" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> ISS assignment of guanylate cyclase activity anchored to the ODR-1 characterization paper (WITH UniProtKB:P16066). Core molecular function (duplicate of the other guanylate-cyclase annotations).
+                        </div>
+
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/10774726" target="_blank" class="term-link">
+                                        PMID:10774726
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">the transmembrane guanylyl cyclase ODR-1</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008355" target="_blank" class="term-link">
+                                    GO:0008355
+                                </a>
+                            </span>
+                            <span class="term-label">olfactory learning</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/10774726" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:10774726
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Olfaction and odor discrimination are mediated by the C. ele...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="B1Q257" data-a="GO:0008355" data-r="PMID:10774726" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> ODR-1 influences odor adaptation/discrimination (overexpression disrupts butanone adaptation and olfactory discrimination), consistent with an olfactory-plasticity (&#34;learning&#34;) role. A specialized aspect of odr-1&#39;s olfactory function; keep as non-core relative to the primary olfaction terms.
+                        </div>
+
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/10774726" target="_blank" class="term-link">
+                                        PMID:10774726
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Olfactory discrimination is also disrupted by ODR-1
+overexpression</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008355" target="_blank" class="term-link">
+                                    GO:0008355
+                                </a>
+                            </span>
+                            <span class="term-label">olfactory learning</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IGI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/10774726" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:10774726
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Olfaction and odor discrimination are mediated by the C. ele...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="B1Q257" data-a="GO:0008355" data-r="PMID:10774726" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Genetic-interaction version of the olfactory-adaptation/learning role (WITH WB:WBGene00001664). Same interpretation as the IMP; non-core.
+                        </div>
+
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/10774726" target="_blank" class="term-link">
+                                        PMID:10774726
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">ODR-1 can influence odor discrimination and adaptation as well as
+olfaction</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042048" target="_blank" class="term-link">
+                                    GO:0042048
+                                </a>
+                            </span>
+                            <span class="term-label">olfactory behavior</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/10774726" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:10774726
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Olfaction and odor discrimination are mediated by the C. ele...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="B1Q257" data-a="GO:0042048" data-r="PMID:10774726" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> ODR-1 is essential for responses to all AWC-sensed odorants; olfactory behavior is the core organismal function of odr-1. Accept as core.
+                        </div>
+
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/10774726" target="_blank" class="term-link">
+                                        PMID:10774726
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">ODR-1 is essential for
+responses to all AWC-sensed odorants</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0050918" target="_blank" class="term-link">
+                                    GO:0050918
+                                </a>
+                            </span>
+                            <span class="term-label">positive chemotaxis</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/10774726" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:10774726
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Olfaction and odor discrimination are mediated by the C. ele...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="B1Q257" data-a="GO:0050918" data-r="PMID:10774726" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> ODR-1 is required for AWC-mediated attraction (positive chemotaxis) to volatile odorants; ODR-1 is essential for responses to all AWC-sensed odorants. A specific, experimentally supported aspect of the core olfactory role. Accept.
+                        </div>
+
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/10774726" target="_blank" class="term-link">
+                                        PMID:10774726
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">ODR-1 is essential for
+responses to all AWC-sensed odorants</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0050919" target="_blank" class="term-link">
+                                    GO:0050919
+                                </a>
+                            </span>
+                            <span class="term-label">negative chemotaxis</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/10774726" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:10774726
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Olfaction and odor discrimination are mediated by the C. ele...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="B1Q257" data-a="GO:0050919" data-r="PMID:10774726" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> ODR-1 also acts in AWB, the sensory neuron pair that mediates avoidance (negative chemotaxis) of volatile odorants. Correct; a specific aspect of the core olfactory role. The AWB-avoidance datum is in the full text/UniProt FUNCTION rather than the cached abstract, so no verbatim quote is attached; accept and defer to the curator&#39;s IMP.
+                        </div>
+
+
+
+
+
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>Receptor-type guanylate cyclase: catalyzes the conversion of GTP to the second messenger cGMP (EC 4.6.1.2) via its C-terminal cyclase domain, acting at the ciliary/plasma membrane of sensory neurons. The catalytic identity is supported by domain architecture and by the cyclase-domain E904A mutant that causes probable loss of cyclase activity and loss of odorant chemotaxis.</h3>
+                <span class="vote-buttons" data-g="B1Q257" data-a="FUNCTION: Receptor-type guanylate cyclase: catalyzes the con..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004383" target="_blank" class="term-link">
+                            guanylate cyclase activity
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006182" target="_blank" class="term-link">
+                                cGMP biosynthetic process
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0060170" target="_blank" class="term-link">
+                                ciliary membrane
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0097730" target="_blank" class="term-link">
+                                non-motile cilium
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/10774726" target="_blank" class="term-link">
+                                PMID:10774726
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">the transmembrane guanylyl cyclase ODR-1</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>Shared cGMP-producing signaling component of AWC/AWB olfactory transduction: acting downstream of odorant receptors, ODR-1 generates the cGMP that gates the TAX-2/TAX-4 cyclic-nucleotide-gated channel, and is required for responses to all AWC-sensed odorants, for AWC attractive (positive) chemotaxis and AWB aversive (negative) chemotaxis, and for odor discrimination and adaptation.</h3>
+                <span class="vote-buttons" data-g="B1Q257" data-a="FUNCTION: Shared cGMP-producing signaling component of AWC/A..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004383" target="_blank" class="term-link">
+                            guanylate cyclase activity
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042048" target="_blank" class="term-link">
+                                olfactory behavior
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0007608" target="_blank" class="term-link">
+                                sensory perception of smell
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0097730" target="_blank" class="term-link">
+                                non-motile cilium
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/10774726" target="_blank" class="term-link">
+                                PMID:10774726
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">ODR-1 appears to be a shared signaling
+component downstream of odorant receptors</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/8348618" target="_blank" class="term-link">
+                                PMID:8348618
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">Chemotaxis to subsets of volatile odorants is disrupted by</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000002.md" target="_blank" class="term-link">
+                            GO_REF:0000002
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation through association of InterPro records with GO terms</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000024.md" target="_blank" class="term-link">
+                            GO_REF:0000024
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Manual transfer of experimentally-verified manual GO annotation data to orthologs by curator judgment of sequence similarity</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
+                            GO_REF:0000033
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Annotation inferences using phylogenetic trees</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
+                            GO_REF:0000044
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000117.md" target="_blank" class="term-link">
+                            GO_REF:0000117
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Electronic Gene Ontology annotations created by ARBA machine learning models</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000120.md" target="_blank" class="term-link">
+                            GO_REF:0000120
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Combined Automated Annotation using Multiple IEA Methods</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/10571181" target="_blank" class="term-link">
+                            PMID:10571181
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Lateral signaling mediated by axon contact and calcium entry regulates asymmetric odorant receptor expression in C. elegans.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/10774726" target="_blank" class="term-link">
+                            PMID:10774726
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Olfaction and odor discrimination are mediated by the C. elegans guanylyl cyclase ODR-1.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/18832350" target="_blank" class="term-link">
+                            PMID:18832350
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">The EGL-4 PKG acts with KIN-29 salt-inducible kinase and protein kinase A to regulate chemoreceptor gene expression and sensory behaviors in Caenorhabditis elegans.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/20436480" target="_blank" class="term-link">
+                            PMID:20436480
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">C. elegans phototransduction requires a G protein-dependent cGMP pathway and a taste receptor homolog.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/23874221" target="_blank" class="term-link">
+                            PMID:23874221
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">The C. elegans cGMP-dependent protein kinase EGL-4 regulates nociceptive behavioral sensitivity.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/26434723" target="_blank" class="term-link">
+                            PMID:26434723
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">The Importance of cGMP Signaling in Sensory Cilia for Body Size Regulation in Caenorhabditis elegans.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/31259686" target="_blank" class="term-link">
+                            PMID:31259686
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">The Caenorhabditis elegans Tubby homolog dynamically modulates olfactory cilia membrane morphogenesis and phospholipid composition.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/8348618" target="_blank" class="term-link">
+                            PMID:8348618
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Odorant-selective genes and neurons mediate olfaction in C. elegans.</div>
+
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Questions for Experts</h2>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> What activates ODR-1&#39;s guanylate cyclase in vivo — is there a ligand for its extracellular domain, or is its output regulated purely by intracellular inputs (G-protein/Ca2+/phosphorylation) downstream of odorant receptors?</p>
+
+                    <p style="margin-top: 0.5rem;"><em>Suggested experts: L&#39;Etoile ND, Bargmann CI</em></p>
+
+                </div>
+                <span class="vote-buttons" data-g="B1Q257" data-a="Q: What activates ODR-1&#39;s guanylate cyclase in vivo —..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Is ODR-1 a catalytically autonomous guanylyl cyclase, or does it act as a regulatory subunit / heterodimer with another GC (e.g. DAF-11) to produce cGMP in AWC/AWB and in ASJ photoreceptor neurons?</p>
+
+                    <p style="margin-top: 0.5rem;"><em>Suggested experts: Xu XZ</em></p>
+
+                </div>
+                <span class="vote-buttons" data-g="B1Q257" data-a="Q: Is ODR-1 a catalytically autonomous guanylyl cycla..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Experiments</h2>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Express and purify the ODR-1 cytoplasmic module (kinase-homology + cyclase domains) and assay GTP-to-cGMP conversion in vitro, comparing wild type with the E904A catalytic mutant and with co-expressed DAF-11 to test for heterodimeric activation.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: ODR-1 possesses guanylate cyclase activity that requires the cyclase domain (E904) and, like other receptor GCs, may need a partner GC (e.g. DAF-11) to form an active catalytic site.</em></p>
+
+
+                    <p style="margin-top: 0.5rem;">Type: in vitro enzymatic assay</p>
+
+                </div>
+                <span class="vote-buttons" data-g="B1Q257" data-a="EXPERIMENT: Express and purify the ODR-1 cytoplasmic module (k..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Use a genetically encoded cGMP sensor in AWC to measure odorant-evoked cGMP transients in wild type versus odr-1(lof) and odr-1(E904A), and test epistasis with tax-2/tax-4 for the downstream calcium response.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: ODR-1-produced cGMP gates the TAX-2/TAX-4 CNG channel in AWC to drive odorant responses.</em></p>
+
+
+                    <p style="margin-top: 0.5rem;">Type: in vivo cGMP/calcium imaging</p>
+
+                </div>
+                <span class="vote-buttons" data-g="B1Q257" data-a="EXPERIMENT: Use a genetically encoded cGMP sensor in AWC to me..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Knowledge Gaps</h2>
+        <p style="color: #555; font-size: 0.92rem; margin-top: -0.3rem;">
+            What is <em>not</em> known — curated, literature-grounded statements of the open
+            unknowns (the inverse of core functions).
+        </p>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The activating ligand and the in vivo mechanism that regulates ODR-1&#39;s cyclase output are unknown. No peptide or small-molecule ligand has been identified for its extracellular periplasmic-binding-protein-like domain, and it is undetermined how odorant-receptor/G-protein input, Ca2+, or phosphorylation modulate ODR-1 cGMP production during sensory transduction.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">RESIDUAL_SUBGAP</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> It is firmly established that ODR-1 is a transmembrane guanylyl cyclase producing cGMP that acts downstream of odorant receptors as a shared signaling component, that it is required for AWC/AWB olfaction, and that UniProt notes its extracellular domain &#34;may not be directly implicated in the detection of volatile odorants.&#34; What is missing is the upstream activator/regulator of its enzymatic activity.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> ODR-1 is the cGMP source for a canonical cGMP/CNG (TAX-2/TAX-4) sensory pathway; identifying what turns its cyclase on/off would define how olfactory-receptor signals are converted into second-messenger output in ciliated neurons.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Biochemical/electrophysiological identification of an ODR-1 activator (candidate ligand screens on the ectodomain; epistasis with odorant receptors and G proteins; cGMP measurement in defined neurons upon odorant stimulation).</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"ODR-1 appears to be a shared signaling
+component downstream of odorant receptors"</em> — PMID:10774726</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> Whether ODR-1&#39;s guanylate cyclase domain is catalytically active on its own (a functional cyclase) versus a regulatory subunit that must partner with another guanylyl cyclase (e.g. DAF-11) to form an active enzyme has not been directly tested; ODR-1 cyclase activity has never been measured on purified protein.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">RESIDUAL_SUBGAP</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> The E904A cyclase-domain mutant causes probable loss of cyclase activity and loss of chemotaxis, and ODR-1 and DAF-11 are co-expressed and jointly required in ASJ/ASK photoreceptor cells, indicating ODR-1 contributes to cGMP production; but no in vitro enzymology, dimerization state, or partner-dependence has been established. UniProt further predicts the adjacent kinase-homology domain to be catalytically inactive.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Several receptor guanylyl cyclases act as heterodimers or as regulatory (catalytically impaired) subunits; resolving ODR-1&#39;s catalytic autonomy would clarify whether the cGMP for AWC/AWB olfaction is made by ODR-1 itself or by an ODR-1-containing complex, and how much of odr-1 phenotypes reflect a non-catalytic/regulatory role.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> In vitro guanylate cyclase assays on purified/recombinant ODR-1 and defined catalytic-dead mutants; test ODR-1/DAF-11 heterodimerization and its contribution to neuronal cGMP.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"two membrane-associated GCs (daf-11 and odr-1) are expressed in C. elegans photoreceptor cells, including ASJ, ASK and AWB"</em> — PMID:20436480</li>
+
+            </ul>
+
+
+        </div>
+
+    </div>
+
+
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Deep Research Sections -->
+
+    <div class="section">
+        <h2 class="section-title">Deep Research</h2>
+
+        <details class="deep-research-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; gap: 1rem;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Falcon</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(odr-1-deep-research-falcon.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="B1Q257" data-a="DEEP_RESEARCH: Falcon" data-r="" data-act="DEEP_RESEARCH" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This deep research is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This deep research needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+
+                <div class="report-meta">
+
+                    <span class="report-meta-text">Comprehensive Research Report: ODR-1/GCY-10 Receptor-Type Guanylyl Cyclase in *Caenorhabditis elegans*</span>
+
+
+                    <span class="report-badge">Falcon</span>
+
+
+                    <span class="report-badge">Edison Scientific Literature</span>
+
+
+                    <span class="report-badge">25 citations</span>
+
+
+                    <span class="report-badge">2 artifacts</span>
+
+
+                    <span class="report-meta-text">2026-07-04T21:07:36.367454</span>
+
+
+
+                </div>
+
+
+                <div class="artifact-list">
+
+
+
+                    <div class="artifact-link">
+                        <a href="odr-1-deep-research-falcon_artifacts/artifact-00.md" class="term-link">Edison artifact artifact-00</a>
+                        <span>(text/markdown)</span>
+                    </div>
+
+
+
+
+                    <div class="artifact-link">
+                        <a href="odr-1-deep-research-falcon_artifacts/artifact-01.md" class="term-link">Edison artifact artifact-01</a>
+                        <span>(text/markdown)</span>
+                    </div>
+
+
+                </div>
+
+                <p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h1 id="comprehensive-research-report-odr-1gcy-10-receptor-type-guanylyl-cyclase-in-caenorhabditis-elegans">Comprehensive Research Report: ODR-1/GCY-10 Receptor-Type Guanylyl Cyclase in <em>Caenorhabditis elegans</em></h1>
+<h2 id="1-gene-and-protein-identity">1. Gene and Protein Identity</h2>
+<p>The gene <strong>odr-1</strong> (synonym <strong>gcy-10</strong>; locus R01E6.1; UniProt B1Q257) encodes a receptor-type guanylyl cyclase (rGC) in <em>Caenorhabditis elegans</em>. The protein is also known as "Odorant response abnormal protein 1," reflecting its original identification in behavioral screens for mutants with specific olfactory defects (bargmann2006chemosensationinc. pages 10-12). ODR-1 belongs to the adenylyl cyclase class-4/guanylyl cyclase protein family and possesses characteristic domains including a periplasmic-binding-protein-like extracellular domain (ECD), a transmembrane segment, a kinase homology domain (KHD), a hinge region, and a carboxy-terminal cyclase catalytic domain (ferkey2021chemosensorysignaltransduction pages 34-35).</p>
+<p>The following table summarizes the key molecular and functional properties of ODR-1:</p>
+<table>
+<thead>
+<tr>
+<th>Property</th>
+<th>Details</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Gene name/synonyms</td>
+<td><strong>odr-1</strong>; synonym <strong>gcy-10</strong>; protein described as receptor-type guanylate cyclase / Odorant response abnormal protein 1 in <em>Caenorhabditis elegans</em> (bargmann2006chemosensationinc. pages 10-12)</td>
+</tr>
+<tr>
+<td>UniProt accession</td>
+<td><strong>B1Q257</strong> (user-supplied target identity)</td>
+</tr>
+<tr>
+<td>Protein type</td>
+<td>Single-pass <strong>receptor-type guanylyl cyclase (rGC)</strong> in the adenylyl cyclase class-4/guanylyl cyclase family; function is mediated primarily by its intracellular cyclase domain rather than the extracellular domain in olfactory signaling (ferkey2021chemosensorysignaltransduction pages 35-35, bargmann2006chemosensationinc. pages 10-12)</td>
+</tr>
+<tr>
+<td>Enzymatic reaction</td>
+<td>Catalyzes <strong>GTP → cGMP</strong>; like other rGCs, catalytic activity requires dimerization of cyclase domains to form the active site for cGMP synthesis (ferkey2021chemosensorysignaltransduction pages 34-35, usuyama2012amodelof pages 2-3)</td>
+</tr>
+<tr>
+<td>Dimerization partner</td>
+<td>Strong evidence supports functional partnership with <strong>DAF-11</strong>; ODR-1 and DAF-11 likely form an <strong>obligate heterodimer</strong> because each individually lacks key catalytic residues, but together can form an active catalytic site (bargmann2006chemosensationinc. pages 10-12, ferkey2021chemosensorysignaltransduction pages 35-35)</td>
+</tr>
+<tr>
+<td>Neurons expressing ODR-1</td>
+<td>Reported in <strong>AWC, AWB, ASI, ASJ, and ASK</strong> sensory neurons; canonical olfactory roles are best established in AWC and AWB, with ASK/ASI/ASJ implicated in broader cGMP signaling and circuit modulation (bargmann2006chemosensationinc. pages 10-12, sojka2025anextensivegap pages 2-4, wu2022positiveinteractionbetween pages 2-4)</td>
+</tr>
+<tr>
+<td>Subcellular localization</td>
+<td>Functions at <strong>sensory cilia/ciliated sensory endings</strong> as a transmembrane rGC; recent work also links ODR-1 to regulation of <strong>AWC cilia and dendrite</strong> state, and odr-1 mutants show distorted AWC cilia morphology (sun2025multipleregulatorsconstrain pages 1-2, ferkey2021chemosensorysignaltransduction pages 18-19)</td>
+</tr>
+<tr>
+<td>Key pathway components (upstream and downstream)</td>
+<td><strong>Upstream:</strong> odor-responsive GPCR signaling and the Gα subunit <strong>ODR-3</strong>; ODR-1 is thought to be regulated mainly via intracellular/G-protein-linked mechanisms rather than classical extracellular ligand binding in AWC. <strong>Core transduction:</strong> <strong>ODR-1/DAF-11 → cGMP → TAX-2/TAX-4 CNG channels → Ca2+ influx/voltage-gated Ca2+ channels</strong>. <strong>Adaptation/plasticity:</strong> <strong>EGL-4/PKG</strong>, HPL-2, phosphodiesterases, and calcium-dependent feedback regulators. In another circuit context, ODR-1-generated cGMP can travel via gap junctions to <strong>ASH</strong> to modulate nociception (ferkey2021chemosensorysignaltransduction pages 35-35, usuyama2012amodelof pages 2-3, bargmann2006chemosensationinc. pages 10-12, ferkey2021chemosensorysignaltransduction pages 18-19, sojka2025anextensivegap pages 1-2)</td>
+</tr>
+<tr>
+<td>Primary biological functions</td>
+<td>Required for <strong>AWC- and AWB-mediated olfactory behaviors</strong>, especially chemotaxis to attractive volatile odorants and aspects of repellent sensing; contributes to <strong>olfactory adaptation/plasticity</strong> through cGMP-EGL-4 signaling; also has <strong>non-cell-autonomous modulatory roles</strong> in sensory circuits by supplying cGMP that dampens ASH aversive signaling (bargmann2006chemosensationinc. pages 10-12, ferkey2021chemosensorysignaltransduction pages 18-19, sojka2025anextensivegap pages 1-2)</td>
+</tr>
+<tr>
+<td>Known phenotypes of odr-1 mutants</td>
+<td>Mutants are defective in <strong>AWC/AWB olfactory responses</strong> and chemotaxis to AWC-sensed odors; can show altered olfactory adaptation/plasticity, hypersensitivity in <strong>ASH-mediated aversive responses</strong> when ODR-1-derived cGMP modulation is lost, and <strong>distorted AWC cilia morphology</strong> in recent studies; dauer formation is reported as largely normal compared with daf-11 mutants (bargmann2006chemosensationinc. pages 10-12, sojka2025anextensivegap pages 2-4, sojka2025anextensivegap pages 1-2, sun2025multipleregulatorsconstrain pages 1-2)</td>
+</tr>
+</tbody>
+</table>
+<p><em>Table: This table summarizes the main molecular, cellular, and functional properties of the C. elegans ODR-1/GCY-10 receptor guanylyl cyclase. It is useful as a compact reference for its enzymatic activity, expression pattern, pathway position, and mutant phenotypes.</em></p>
+<h2 id="2-enzymatic-function-and-catalytic-mechanism">2. Enzymatic Function and Catalytic Mechanism</h2>
+<p>ODR-1 catalyzes the conversion of GTP to the second messenger cyclic GMP (cGMP), a reaction classified under EC 4.6.1.2 (ferkey2021chemosensorysignaltransduction pages 34-35, usuyama2012amodelof pages 2-3). Like other receptor-type guanylyl cyclases, the cyclase domain of ODR-1 requires dimerization to form an active catalytic site that coordinates magnesium and binds GTP for cyclization into cGMP (ferkey2021chemosensorysignaltransduction pages 34-35).</p>
+<p>A distinguishing feature of ODR-1 is that it does not appear to function as a homodimer. Instead, ODR-1 forms an <strong>obligate heterodimer with DAF-11</strong>, another transmembrane guanylyl cyclase. Each protein individually lacks key catalytic residues necessary for full enzymatic activity, but when paired, the two subunits contribute complementary residues to reconstitute a functional active site (bargmann2006chemosensationinc. pages 10-12). This was demonstrated experimentally: fusion proteins of ODR-1 and DAF-11 intracellular domains, when co-expressed in ASEL neurons, were sufficient to restore cGMP production and calcium influx in response to pH stimuli, whereas neither alone could rescue function (ferkey2021chemosensorysignaltransduction pages 35-35). However, formal biochemical proof of heterodimerization in the native AWC cell context remains to be established (ferkey2021chemosensorysignaltransduction pages 35-35).</p>
+<p>Critically, the <strong>cyclase domain rather than the extracellular domain mediates the primary function</strong> of ODR-1 in olfactory signaling. ODR-1 proteins with deleted or mutated extracellular domains can still rescue olfactory defects in odr-1 mutants, indicating that ODR-1 does not act as a classical ligand-activated receptor in AWC (bargmann2006chemosensationinc. pages 10-12). Instead, ODR-1 is thought to be regulated intracellularly, downstream of G-protein-coupled receptor (GPCR) signaling, via the Gα subunit ODR-3 (ferkey2021chemosensorysignaltransduction pages 35-35, bargmann2006chemosensationinc. pages 10-12).</p>
+<h2 id="3-tissue-expression-and-subcellular-localization">3. Tissue Expression and Subcellular Localization</h2>
+<h3 id="neuronal-expression">Neuronal Expression</h3>
+<p>ODR-1 is expressed in a defined subset of amphid chemosensory neurons. The canonical expression pattern includes the <strong>AWC and AWB</strong> olfactory neuron pairs, where its role in olfaction has been most thoroughly studied (bargmann2006chemosensationinc. pages 10-12). Additional expression has been reported in <strong>ASI, ASJ, and ASK</strong> sensory neurons (sojka2025anextensivegap pages 2-4, stuhr2024c.elegansdisplay pages 1-5). The odr-1 promoter is commonly used as a marker for AWC and AWB neurons in experimental studies (sojka2025anextensivegap pages 2-4). The LIM homeodomain transcription factor LIM-4 has been shown to induce odr-1 expression as part of AWB neuronal fate specification (stuhr2024c.elegansdisplay pages 1-5).</p>
+<h3 id="subcellular-localization">Subcellular Localization</h3>
+<p>As a single-pass transmembrane rGC, ODR-1 is localized to the <strong>sensory cilia</strong> of chemosensory neurons. This is supported by functional evidence: ODR-1 function is required for maintaining proper AWC cilia morphology, and loss of odr-1 results in distorted AWC cilia (sun2025multipleregulatorsconstrain pages 1-2). Furthermore, ODR-1 function and cilia integrity are jointly required to maintain EGL-4/PKG in the cytoplasm prior to prolonged odor exposure, consistent with ODR-1 acting at the ciliary compartment where primary sensory transduction occurs (ferkey2021chemosensorysignaltransduction pages 18-19). The odr-1 promoter has been used to drive expression of GFP-tagged guanylyl cyclases to cilia and distal dendritic ends of AWC neurons (pandey2026alateralizedsensory pages 6-7).</p>
+<h2 id="4-signaling-pathways-and-biological-function">4. Signaling Pathways and Biological Function</h2>
+<h3 id="41-primary-function-awc-olfactory-signal-transduction">4.1 Primary Function: AWC Olfactory Signal Transduction</h3>
+<p>ODR-1 is a central component of the cGMP-based olfactory signal transduction pathway in AWC neurons. The pathway operates as follows:</p>
+<table>
+<thead>
+<tr>
+<th>Step Number</th>
+<th>Component/Molecule</th>
+<th>Gene Name</th>
+<th>Molecular Function</th>
+<th>Role in Pathway</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>1</td>
+<td>Attractive odorant detected in AWC</td>
+<td>not uniquely assigned</td>
+<td>External chemical cue sensed by olfactory receptor machinery</td>
+<td>Initiates AWC olfactory signaling that ultimately drives chemotaxis and adaptation; specific upstream receptors for many AWC odors remain incompletely defined (usuyama2012amodelof pages 2-3, bargmann2006chemosensationinc. pages 10-12)</td>
+</tr>
+<tr>
+<td>2</td>
+<td>Odor-responsive GPCR system</td>
+<td>multiple candidate GPCRs</td>
+<td>G protein-coupled receptor activity</td>
+<td>Couples odor detection to intracellular signaling in AWC and activates heterotrimeric G-protein signaling upstream of ODR-3 and guanylyl cyclase regulation (usuyama2012amodelof pages 2-3, bargmann2006chemosensationinc. pages 10-12)</td>
+</tr>
+<tr>
+<td>3</td>
+<td>G-protein alpha subunit</td>
+<td>odr-3</td>
+<td>Gα signaling transducer</td>
+<td>Acts downstream of odor-sensing GPCRs and upstream of guanylyl cyclase; in AWC models, odor input alters ODR-3 signaling, which suppresses cyclase activity during stimulation and relieves suppression after odor removal (usuyama2012amodelof pages 2-3, bargmann2006chemosensationinc. pages 10-12, usuyama2012amodelof pages 1-2)</td>
+</tr>
+<tr>
+<td>4</td>
+<td>Receptor guanylyl cyclase complex</td>
+<td>odr-1, daf-11</td>
+<td>Membrane guanylyl cyclase that converts GTP to cGMP</td>
+<td>Core cyclase step in AWC; ODR-1 and DAF-11 likely function as a heterodimer, with the intracellular cyclase domain providing the essential signaling output rather than the extracellular domain (ferkey2021chemosensorysignaltransduction pages 35-35, bargmann2006chemosensationinc. pages 10-12)</td>
+</tr>
+<tr>
+<td>5</td>
+<td>cGMP second messenger</td>
+<td>cGMP</td>
+<td>Diffusible cyclic nucleotide messenger</td>
+<td>Transduces cyclase activity into ion channel gating; cGMP levels are dynamically regulated during odor stimulation and recovery, helping encode ON/OFF response properties and adaptation state (usuyama2012amodelof pages 2-3, usuyama2012amodelof pages 1-2)</td>
+</tr>
+<tr>
+<td>6</td>
+<td>Cyclic nucleotide-gated channel</td>
+<td>tax-2, tax-4</td>
+<td>cGMP-gated cation channel</td>
+<td>Opens in response to cGMP and mediates the primary depolarizing sensory current in AWC, linking cyclase activity to electrical and calcium responses (bargmann2006chemosensationinc. pages 10-12, usuyama2012amodelof pages 2-3)</td>
+</tr>
+<tr>
+<td>7</td>
+<td>Calcium influx and amplification</td>
+<td>Ca2+ influx; channel complex includes CNG and downstream VGCCs</td>
+<td>Ionic signaling / second messenger</td>
+<td>CNG channel opening permits calcium entry and membrane depolarization; odor removal triggers a transient calcium rise in AWC, with feedback control shaping response duration and gain (usuyama2012amodelof pages 1-2, usuyama2012amodelof pages 2-3)</td>
+</tr>
+<tr>
+<td>8</td>
+<td>Voltage-gated calcium channel amplification</td>
+<td>unc-2 and other VGCC components</td>
+<td>Voltage-gated Ca2+ entry</td>
+<td>Acts downstream of the primary cGMP-gated event to amplify sensory depolarization and calcium signaling in olfactory neurons, contributing to full physiological output (ferkey2021chemosensorysignaltransduction pages 15-16, usuyama2012amodelof pages 2-3)</td>
+</tr>
+<tr>
+<td>9</td>
+<td>cGMP-dependent protein kinase adaptation arm</td>
+<td>egl-4</td>
+<td>PKG serine/threonine kinase activated by cGMP</td>
+<td>Mediates adaptation across timescales: rapidly tunes AWC response thresholds, later acts on cytoplasmic targets, and after prolonged odor exposure translocates to the nucleus; ODR-1 function is required to keep EGL-4 cytoplasmic before prolonged stimulation (ferkey2021chemosensorysignaltransduction pages 17-18, ferkey2021chemosensorysignaltransduction pages 18-19)</td>
+</tr>
+<tr>
+<td>10</td>
+<td>Nuclear feedback on gene expression</td>
+<td>hpl-2, odr-1</td>
+<td>Chromatin-mediated transcriptional repression</td>
+<td>After prolonged odor exposure, nuclear EGL-4 phosphorylates HPL-2, which represses transcription of odr-1, creating a negative-feedback loop that contributes to long-term olfactory adaptation/plasticity (ferkey2021chemosensorysignaltransduction pages 18-19)</td>
+</tr>
+</tbody>
+</table>
+<p><em>Table: This table summarizes the best-supported AWC olfactory signal transduction pathway centered on ODR-1, from odor detection through cGMP signaling and long-term adaptation. It is useful for mapping where ODR-1 acts enzymatically and how its output is integrated into calcium signaling and feedback regulation.</em></p>
+<p>The AWC olfactory neuron is an "OFF" neuron—it is tonically active in the absence of odor and is silenced by odor application. Upon odor removal, a transient increase in intracellular calcium occurs, the magnitude of which correlates with the duration of prior odor exposure (usuyama2012amodelof pages 1-2). Mathematical modeling of this pathway proposes that during odor stimulation, ODR-3 Gα suppresses guanylyl cyclase activity (reducing cGMP), and upon odor removal, the suppression ceases and cGMP synthesis is restored, opening CNG channels and triggering calcium influx (usuyama2012amodelof pages 2-3, usuyama2012amodelof pages 1-2). The model incorporates calcium-dependent negative feedback through guanylate cyclase-activating proteins (GCAPs/NCS-1) that regulate ODR-1 cyclase activity, ensuring transient calcium responses (usuyama2012amodelof pages 2-3).</p>
+<p>Loss of odr-1 function results in defective chemotaxis to AWC-sensed odorants including benzaldehyde, isoamyl alcohol, and butanone, as well as defective AWB-mediated avoidance of repellents such as 2-nonanone (bargmann2006chemosensationinc. pages 10-12, khan2022molecularandneuronal pages 35-41). Importantly, odr-1 mutants retain normal dauer formation, distinguishing ODR-1 from DAF-11, which is required for both olfaction and dauer signaling (bargmann2006chemosensationinc. pages 10-12).</p>
+<h3 id="42-role-in-olfactory-adaptation-and-plasticity">4.2 Role in Olfactory Adaptation and Plasticity</h3>
+<p>ODR-1 plays an essential role in olfactory adaptation through the cGMP-dependent protein kinase EGL-4. Adaptation in AWC occurs over multiple timescales: at short timescales (seconds), EGL-4 sets the threshold for calcium responsiveness needed for odor sensation in a gradient; at intermediate timescales (tens of minutes), EGL-4 phosphorylates cytoplasmic targets including the TAX-2 CNG channel subunit; after prolonged odor exposure (&gt;60–80 minutes), EGL-4 translocates to the AWC nucleus (ferkey2021chemosensorysignaltransduction pages 17-18, ferkey2021chemosensorysignaltransduction pages 18-19).</p>
+<p>ODR-1 function is specifically required to maintain EGL-4 in the cytoplasm until odor exposure triggers nuclear translocation. Furthermore, aberrantly high cGMP levels (due to loss of phosphodiesterases) block EGL-4 nuclear entry, indicating that precisely regulated cGMP dynamics—dependent on ODR-1—are critical for adaptation (ferkey2021chemosensorysignaltransduction pages 18-19). Once in the nucleus, EGL-4 phosphorylates the heterochromatin-binding factor HPL-2, which in turn <strong>downregulates transcription of the odr-1 gene itself</strong>, creating a negative feedback loop that contributes to long-term olfactory adaptation (ferkey2021chemosensorysignaltransduction pages 18-19). This mechanism may underlie heritable changes in AWC-mediated behaviors across generations.</p>
+<h3 id="43-non-cell-autonomous-modulation-of-nociception">4.3 Non-Cell-Autonomous Modulation of Nociception</h3>
+<p>A striking finding is that cGMP produced by ODR-1 in neurons such as AWB, AWC, and ASI can travel through gap junctions (innexin channels) to the ASH nociceptive neurons, where it acts non-cell-autonomously to dampen aversive signaling (sojka2025anextensivegap pages 1-2). Specifically, upon food deprivation, ODR-1-generated cGMP moves through an extensive gap junction neural network to reach ASH, where it binds to EGL-4 and stimulates phosphorylation and activation of RGS-2 and RGS-3, which in turn downregulate Gα (ODR-3/GPA-3) signaling and reduce behavioral sensitivity to nociceptive stimuli (sojka2025anextensivegap pages 1-2). Loss-of-function mutations in odr-1 result in hypersensitivity to ASH-detected chemical stimuli such as quinine, consistent with loss of this dampening mechanism (sojka2025anextensivegap pages 2-4, sojka2025anextensivegap pages 1-2). Similarly, cGMP produced by ODR-1 in ASK neurons has been shown to modulate the rising phase of ASH nociceptive calcium responses to copper ions through gap junction-mediated transport (wu2022positiveinteractionbetween pages 2-4).</p>
+<h3 id="44-role-in-awc-left-right-asymmetry">4.4 Role in AWC Left-Right Asymmetry</h3>
+<p>The AWC neuron pair exhibits stochastic left-right asymmetry, with one neuron adopting AWCON fate and the other AWCOFF fate, defined by differential chemoreceptor expression. ODR-1 is part of the cGMP signaling pathway (along with DAF-11, ODR-3, and EGL-4) that is essential for maintaining AWCON and AWCOFF identities throughout the animal's life (alqadah2016stochasticleft–rightneuronal pages 4-4). Recent work has further demonstrated that receptor guanylyl cyclases in AWC mediate lateralized context-dependent olfactory plasticity: while ODR-1 is necessary for hexanol attraction under baseline conditions, a related guanylyl cyclase GCY-12 mediates context-dependent plasticity specifically in AWCOFF neurons through asymmetric molecular mechanisms (pandey2026alateralizedsensory pages 1-3, pandey2026alateralizedsensory pages 3-4).</p>
+<h2 id="5-recent-developments">5. Recent Developments</h2>
+<h3 id="cilia-morphology-and-dlk-1-regulation-sun-et-al-2025">Cilia Morphology and DLK-1 Regulation (Sun et al., 2025)</h3>
+<p>A forward genetic screen identified ODR-1 as a regulator of DLK-1 (a conserved MAP3K) abundance in AWC sensory neurons. In odr-1 mutants, DLK-1 accumulates aberrantly throughout cilia and dendrites of AWC neurons, and AWC cilia display distorted morphology. These defects are ameliorated by loss of dlk-1 or its downstream transcription factor cebp-1, indicating a reciprocal antagonistic relationship between ODR-1 signaling and the DLK-1/CEBP-1 stress-signaling axis in maintaining ciliary structure (sun2025multipleregulatorsconstrain pages 1-2).</p>
+<h3 id="gap-junction-mediated-cgmp-signaling-network-sojka-et-al-2025">Gap Junction-Mediated cGMP Signaling Network (Sojka et al., 2025)</h3>
+<p>This study expanded the known network of innexin gap junctions that facilitate ODR-1-dependent cGMP transport to ASH neurons. Six additional innexins (INX-7, INX-15, INX-16, INX-17, UNC-7, and UNC-9) were identified as having overlapping and distinct roles within this regulatory network, underscoring the extensive non-cell-autonomous signaling circuit through which ODR-1-derived cGMP tunes sensory thresholds (sojka2025anextensivegap pages 2-4).</p>
+<h3 id="food-preference-behavior-stuhr-et-al-2024">Food Preference Behavior (Stuhr et al., 2024)</h3>
+<p>ODR-1 signaling in AWB and AWC sensory neurons was shown to mediate antipathy behavior toward certain diets, indicating that ODR-1's role extends beyond classical olfactory chemotaxis to food preference decisions that integrate nutritional needs with dietary lipid availability (stuhr2024c.elegansdisplay pages 1-5).</p>
+<h3 id="lateralized-olfactory-plasticity-pandey-et-al-2026">Lateralized Olfactory Plasticity (Pandey et al., 2026)</h3>
+<p>In a PNAS study, the authors demonstrated that symmetric behavioral plasticity in AWC neurons arises from asymmetric molecular mechanisms. While ODR-1 is required for baseline odorant attraction, GCY-12 drives context-dependent plasticity specifically in AWCOFF, revealing how multiple guanylyl cyclases partition signaling roles across lateralized neurons (pandey2026alateralizedsensory pages 1-3, pandey2026alateralizedsensory pages 3-4).</p>
+<h2 id="6-summary">6. Summary</h2>
+<p>ODR-1/GCY-10 is a receptor-type guanylyl cyclase that functions as the primary cGMP-generating enzyme in the AWC and AWB olfactory neurons of <em>C. elegans</em>. It catalyzes the conversion of GTP to cGMP as an obligate heterodimer with DAF-11, with each subunit contributing essential but incomplete catalytic residues to the active site. Unlike many mammalian rGCs, ODR-1 is not activated by extracellular ligand binding to its ECD; rather, it is regulated intracellularly downstream of G-protein signaling. ODR-1 functions at sensory cilia, where it participates in the core olfactory transduction cascade (GPCR → ODR-3 Gα → ODR-1/DAF-11 → cGMP → TAX-2/TAX-4 CNG channels → Ca²⁺ influx). Beyond primary sensory transduction, ODR-1 is integral to olfactory adaptation through EGL-4-mediated feedback and to non-cell-autonomous modulation of nociception via gap junction-mediated cGMP transport. Recent studies have additionally revealed roles for ODR-1 in maintaining cilia structural integrity, regulating DLK-1 signaling, mediating food preference behaviors, and supporting lateralized signaling within the AWC neuron pair.</p>
+<p>References</p>
+<ol>
+<li>
+<p>(bargmann2006chemosensationinc. pages 10-12): Cornelia Bargmann. Chemosensation in c. elegans. WormBook : the online review of C. elegans biology, pages 1-29, Oct 2006. URL: https://doi.org/10.1895/wormbook.1.123.1, doi:10.1895/wormbook.1.123.1. This article has 1160 citations.</p>
+</li>
+<li>
+<p>(ferkey2021chemosensorysignaltransduction pages 34-35): Denise M Ferkey, Piali Sengupta, and Noelle D L’Etoile. Chemosensory signal transduction in caenorhabditis elegans. Genetics, Mar 2021. URL: https://doi.org/10.1093/genetics/iyab004, doi:10.1093/genetics/iyab004. This article has 162 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(ferkey2021chemosensorysignaltransduction pages 35-35): Denise M Ferkey, Piali Sengupta, and Noelle D L’Etoile. Chemosensory signal transduction in caenorhabditis elegans. Genetics, Mar 2021. URL: https://doi.org/10.1093/genetics/iyab004, doi:10.1093/genetics/iyab004. This article has 162 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(usuyama2012amodelof pages 2-3): Mamoru Usuyama, Chisato Ushida, and Ryuzo Shingai. A model of the intracellular response of an olfactory neuron in caenorhabditis elegans to odor stimulation. PLoS ONE, 7:e42907, Aug 2012. URL: https://doi.org/10.1371/journal.pone.0042907, doi:10.1371/journal.pone.0042907. This article has 14 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(sojka2025anextensivegap pages 2-4): Savannah E. Sojka, Meredith J. Ezak, Emily A. Polk, Andrew P. Bischer, Katherine E. Neyland, Andrew P. Wojtovich, and Denise M. Ferkey. An extensive gap junction neural network modulates caenorhabditis elegans aversive behavior. Genes, 16:260, Feb 2025. URL: https://doi.org/10.3390/genes16030260, doi:10.3390/genes16030260. This article has 2 citations.</p>
+</li>
+<li>
+<p>(wu2022positiveinteractionbetween pages 2-4): Jing-Jing Wu, Sheng-Wu Yin, Hui Liu, Rong Li, Jia-Hao Huang, Ping-Zhou Wang, Yu Xu, Jia-Lu Zhao, Piao-Ping Wu, and Zheng-Xing Wu. Positive interaction between ash and ask sensory neurons accelerates nociception and inhibits behavioral adaptation. Nov 2022. URL: https://doi.org/10.1016/j.isci.2022.105287, doi:10.1016/j.isci.2022.105287. This article has 9 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(sun2025multipleregulatorsconstrain pages 1-2): Yue Sun, Junxiang Zhou, Arunima Debnath, Bokun Xie, Zhiping Wang, and Yishi Jin. Multiple regulators constrain the abundance of caenorhabditis elegans dlk-1 in ciliated sensory neurons. G3: Genes | Genomes | Genetics, Jan 2025. URL: https://doi.org/10.1093/g3journal/jkaf004, doi:10.1093/g3journal/jkaf004. This article has 1 citations.</p>
+</li>
+<li>
+<p>(ferkey2021chemosensorysignaltransduction pages 18-19): Denise M Ferkey, Piali Sengupta, and Noelle D L’Etoile. Chemosensory signal transduction in caenorhabditis elegans. Genetics, Mar 2021. URL: https://doi.org/10.1093/genetics/iyab004, doi:10.1093/genetics/iyab004. This article has 162 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(sojka2025anextensivegap pages 1-2): Savannah E. Sojka, Meredith J. Ezak, Emily A. Polk, Andrew P. Bischer, Katherine E. Neyland, Andrew P. Wojtovich, and Denise M. Ferkey. An extensive gap junction neural network modulates caenorhabditis elegans aversive behavior. Genes, 16:260, Feb 2025. URL: https://doi.org/10.3390/genes16030260, doi:10.3390/genes16030260. This article has 2 citations.</p>
+</li>
+<li>
+<p>(stuhr2024c.elegansdisplay pages 1-5): Nicole L. Stuhr, Carmen M. Ramos, Chris D. Turner, Alexander A. Soukas, and Sean P. Curran. C. elegans display antipathy behavior towards food after contemporaneous integration of nutritional needs and dietary lipid availability. bioRxiv, Feb 2024. URL: https://doi.org/10.1101/2024.02.23.581740, doi:10.1101/2024.02.23.581740. This article has 1 citations.</p>
+</li>
+<li>
+<p>(pandey2026alateralizedsensory pages 6-7): Anjali Pandey, Maya Katz, Stephen Nurrish, Alison Philbrook, and Piali Sengupta. A lateralized sensory signaling pathway mediates context-dependent olfactory plasticity in <i>caenorhabditis elegans</i>. Proceedings of the National Academy of Sciences, 123(8):e2519437123-e2519437123, Feb 2026. URL: https://doi.org/10.1073/pnas.2519437123, doi:10.1073/pnas.2519437123. This article has 2 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(usuyama2012amodelof pages 1-2): Mamoru Usuyama, Chisato Ushida, and Ryuzo Shingai. A model of the intracellular response of an olfactory neuron in caenorhabditis elegans to odor stimulation. PLoS ONE, 7:e42907, Aug 2012. URL: https://doi.org/10.1371/journal.pone.0042907, doi:10.1371/journal.pone.0042907. This article has 14 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(ferkey2021chemosensorysignaltransduction pages 15-16): Denise M Ferkey, Piali Sengupta, and Noelle D L’Etoile. Chemosensory signal transduction in caenorhabditis elegans. Genetics, Mar 2021. URL: https://doi.org/10.1093/genetics/iyab004, doi:10.1093/genetics/iyab004. This article has 162 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(ferkey2021chemosensorysignaltransduction pages 17-18): Denise M Ferkey, Piali Sengupta, and Noelle D L’Etoile. Chemosensory signal transduction in caenorhabditis elegans. Genetics, Mar 2021. URL: https://doi.org/10.1093/genetics/iyab004, doi:10.1093/genetics/iyab004. This article has 162 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(khan2022molecularandneuronal pages 35-41): Munzareen Khan. Molecular and neuronal mechanisms underlying context-dependent processing of odor valence in caenorhabditis elegans. Text, Jan 2022. URL: https://doi.org/10.48617/etd.190, doi:10.48617/etd.190. This article has 0 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(alqadah2016stochasticleft–rightneuronal pages 4-4): Amel Alqadah, Yi-Wen Hsieh, Rui Xiong, and Chiou-Fen Chuang. Stochastic left–right neuronal asymmetry in caenorhabditis elegans. Philosophical Transactions of the Royal Society B: Biological Sciences, 371:20150407, Dec 2016. URL: https://doi.org/10.1098/rstb.2015.0407, doi:10.1098/rstb.2015.0407. This article has 37 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(pandey2026alateralizedsensory pages 1-3): Anjali Pandey, Maya Katz, Stephen Nurrish, Alison Philbrook, and Piali Sengupta. A lateralized sensory signaling pathway mediates context-dependent olfactory plasticity in <i>caenorhabditis elegans</i>. Proceedings of the National Academy of Sciences, 123(8):e2519437123-e2519437123, Feb 2026. URL: https://doi.org/10.1073/pnas.2519437123, doi:10.1073/pnas.2519437123. This article has 2 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(pandey2026alateralizedsensory pages 3-4): Anjali Pandey, Maya Katz, Stephen Nurrish, Alison Philbrook, and Piali Sengupta. A lateralized sensory signaling pathway mediates context-dependent olfactory plasticity in <i>caenorhabditis elegans</i>. Proceedings of the National Academy of Sciences, 123(8):e2519437123-e2519437123, Feb 2026. URL: https://doi.org/10.1073/pnas.2519437123, doi:10.1073/pnas.2519437123. This article has 2 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+</ol>
+<h2 id="artifacts">Artifacts</h2>
+<ul>
+<li><a href="odr-1-deep-research-falcon_artifacts/artifact-00.md">Edison artifact artifact-00</a></li>
+<li><a href="odr-1-deep-research-falcon_artifacts/artifact-01.md">Edison artifact artifact-01</a></li>
+</ul>
+<h2 id="citations">Citations</h2>
+<ol>
+<li>ferkey2021chemosensorysignaltransduction pages 34-35</li>
+<li>ferkey2021chemosensorysignaltransduction pages 35-35</li>
+<li>sojka2025anextensivegap pages 2-4</li>
+<li>sun2025multipleregulatorsconstrain pages 1-2</li>
+<li>ferkey2021chemosensorysignaltransduction pages 18-19</li>
+<li>pandey2026alateralizedsensory pages 6-7</li>
+<li>usuyama2012amodelof pages 1-2</li>
+<li>usuyama2012amodelof pages 2-3</li>
+<li>sojka2025anextensivegap pages 1-2</li>
+<li>wu2022positiveinteractionbetween pages 2-4</li>
+<li>ferkey2021chemosensorysignaltransduction pages 15-16</li>
+<li>ferkey2021chemosensorysignaltransduction pages 17-18</li>
+<li>khan2022molecularandneuronal pages 35-41</li>
+<li>pandey2026alateralizedsensory pages 1-3</li>
+<li>pandey2026alateralizedsensory pages 3-4</li>
+<li>https://doi.org/10.1895/wormbook.1.123.1,</li>
+<li>https://doi.org/10.1093/genetics/iyab004,</li>
+<li>https://doi.org/10.1371/journal.pone.0042907,</li>
+<li>https://doi.org/10.3390/genes16030260,</li>
+<li>https://doi.org/10.1016/j.isci.2022.105287,</li>
+<li>https://doi.org/10.1093/g3journal/jkaf004,</li>
+<li>https://doi.org/10.1101/2024.02.23.581740,</li>
+<li>https://doi.org/10.1073/pnas.2519437123,</li>
+<li>https://doi.org/10.48617/etd.190,</li>
+<li>https://doi.org/10.1098/rstb.2015.0407,</li>
+</ol>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(odr-1-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="B1Q257" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="odr-1-gcy-10-research-notes-c-elegans">odr-1 (gcy-10) research notes — C. elegans</h1>
+<p>UniProt: <strong>B1Q257</strong> (GCY10_CAEEL). WormBase: WBGene00003848 / R01E6.1.<br />
+Gene symbol <strong>odr-1</strong> (Odorant response abnormal), synonym <strong>gcy-10</strong>.<br />
+EC 4.6.1.2 (guanylate cyclase). Reference proteome protein B1Q257.</p>
+<h2 id="identity-architecture-from-uniprot-b1q257">Identity / architecture (from UniProt B1Q257)</h2>
+<p>odr-1 encodes a <strong>receptor-type (transmembrane) guanylyl cyclase</strong>. Domain layout<br />
+(1067 aa, isoform b):<br />
+- Signal peptide 1–20; extracellular domain 21–438 (periplasmic-binding-protein-like<br />
+  ligand-binding fold, InterPro IPR028082 / SSF53822).<br />
+- Single-pass type I transmembrane helix 439–459.<br />
+- Cytoplasmic 460–1067, containing:<br />
+  - <strong>Protein-kinase-like (KHD) domain 509–791</strong> — annotated by UniProt as <em>predicted<br />
+    catalytically inactive</em>: "The protein kinase domain is predicted to be catalytically<br />
+    inactive." (ECO:0000255|PROSITE-ProRule:PRU00159). This is the canonical<br />
+    pseudokinase/kinase-homology domain of receptor guanylyl cyclases.<br />
+  - <strong>Guanylate cyclase (catalytic) domain 859–989</strong> (Pfam PF00211, PROSITE PS50125).<br />
+- N-glycosylation site (Asn411); glycoprotein.</p>
+<p>Family: adenylyl cyclase class-4 / guanylyl cyclase family; PANTHER PTHR11920<br />
+(GUANYLYL CYCLASE), subfamily PTHR11920:SF355 (RECEPTOR-TYPE GUANYLATE CYCLASE<br />
+GCY-10-RELATED). C. elegans has ~27 receptor-type + 7 soluble GCs<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/23874221" title="27 receptor-type GCYs and 7 soluble GCYs are encoded by the C. elegans genome">PMID:23874221</a>.</p>
+<p>Catalytic activity (UniProt, EC 4.6.1.2): GTP = 3',5'-cyclic GMP + diphosphate<br />
+(Rhea:RHEA:13665). The specific EC/cyclase activity for odr-1 is by-similarity<br />
+(ECO:0000250|UniProtKB:Q19187 = gcy-12); there is no direct in-vitro enzymology on<br />
+purified ODR-1.</p>
+<h2 id="subcellular-location-expression">Subcellular location / expression</h2>
+<ul>
+<li><strong>Cell membrane / cilium.</strong> UniProt: "Cell membrane ... Single-pass type I membrane<br />
+  protein. Cell projection, cilium ... Localizes in cilium of sensory neurons"<br />
+  (ECO:0000269|PMID:10774726). GOA: non-motile cilium (GO:0097730, IDA, PMID:10774726,<br />
+  WormBase).</li>
+<li><strong>Tissue specificity:</strong> "Expressed predominantly in AWC but also in AWB, ASI, ASJ and<br />
+  ASK sensory neurons and in I1 interneuron" (UniProt; PMID:10774726, PMID:9096403).<br />
+  PMID:20436480 corroborates AWB/ASJ/ASK expression: "two membrane-associated GCs<br />
+  (daf-11 and odr-1) are expressed in C. elegans photoreceptor cells, including ASJ, ASK<br />
+  and AWB".</li>
+</ul>
+<h2 id="known-functions-well-supported">KNOWN functions (well supported)</h2>
+<h3 id="molecular-function-guanylate-cyclase-cgmp-synthesis">Molecular function: guanylate cyclase (cGMP synthesis)</h3>
+<ul>
+<li>ODR-1 is a transmembrane guanylyl cyclase producing the second messenger cGMP. The<br />
+  cyclase identity is established by domain architecture and by the point mutant E904A<br />
+  in the cyclase domain: UniProt MUTAGEN 904 "E-&gt;A: Probable loss of cyclase activity.<br />
+  Loss of chemotaxis to some volatile odorants." (PMID:10774726). Note: activity is<br />
+  inferred (ISS/by-similarity), not measured on purified protein.</li>
+<li>Overexpression phenotype implicates cGMP overproduction:<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/10774726" title="Olfactory discrimination is also disrupted by ODR-1 overexpression,   probably by overproduction of the shared second messenger cGMP.">PMID:10774726</a></li>
+</ul>
+<h3 id="biological-process-olfaction-chemosensation-core">Biological process: olfaction / chemosensation (core)</h3>
+<ul>
+<li>ODR-1 is essential for AWC-mediated olfaction and required for responses to all<br />
+  AWC-sensed odorants:<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/10774726" title="We demonstrate that the transmembrane guanylyl cyclase ODR-1 is   essential for responses to all AWC-sensed odorants. ODR-1 appears to be a shared   signaling component downstream of odorant receptors.">PMID:10774726</a></li>
+<li>odr-1 was originally isolated as an <em>odr</em> (odorant-response-abnormal) gene in the<br />
+  founding olfaction screen: <a href="https://pubmed.ncbi.nlm.nih.gov/8348618" title="Chemotaxis to subsets of volatile odorants   is disrupted by mutations in the odr genes, which might be involved in odorant   sensation or signal transduction.">PMID:8348618</a>. Mutagenesis G647D (in n1930): "loss of chemotaxis<br />
+  to volatile odorants" (UniProt, PMID:8348618).</li>
+<li>Acts in both attractive (AWC) and repulsive (AWB) odor pathways (UniProt FUNCTION,<br />
+  PMID:10774726, PMID:8348618): "Regulates chemotaxis responses toward volatile odorants<br />
+  in AWC sensory neurons and their avoidance in AWB sensory neurons."</li>
+<li>Role in odor discrimination and adaptation (overexpression disrupts both;<br />
+  PMID:10774726).</li>
+</ul>
+<h3 id="phototransduction-asj-non-image-light-sensing">Phototransduction (ASJ) — non-image light sensing</h3>
+<ul>
+<li><a href="https://pubmed.ncbi.nlm.nih.gov/20436480" title="odr-1(n1936) mutant worms also showed a severe reduction in the   density of photocurrents ... These results demonstrate that membrane-associated GCs   are required for phototransduction in ASJ.">PMID:20436480</a> Model: LITE-1 → Gi/o (goa-1/gpa-3) →<br />
+  membrane GCs (daf-11, odr-1) → cGMP → CNG channel (tax-2/tax-4). This is the same<br />
+  cGMP→TAX-2/TAX-4 architecture as chemosensation, redeployed for light.</li>
+</ul>
+<h3 id="cgmp-supply-to-egl-4-pkg-for-bitterquinine-nociceptive-sensitivity">cGMP supply to EGL-4 (PKG) for bitter/quinine (nociceptive) sensitivity</h3>
+<ul>
+<li><a href="https://pubmed.ncbi.nlm.nih.gov/23874221" title="Loss-of-function mutations in the guanylyl cyclase genes odr-1,   gcy-27, gcy-33 and gcy-34 resulted in behavioral hypersensitivity to dilute (1 mM)   quinine">PMID:23874221</a> and the model that these GCs "function in a non-cell-autonomous manner to<br />
+  provide cGMP to regulate EGL-4 function in ASH" (odr-1 is not expressed in ASH).<br />
+  odr-1(lof) quinine hypersensitivity was rescued by srb-6p::odr-1 but not osm-10p::odr-1<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/23874221" title="The quinine hypersensitivity of odr-1(lof) animals was rescued by   srb-6p::odr-1 expression (p&lt;0.001), but not osm-10p::odr-1 expression (p&gt;0.5).">PMID:23874221</a>.<br />
+  → supports GO:0050913 (sensory perception of bitter taste) and GO:0007635<br />
+  (chemosensory behavior).</li>
+</ul>
+<h3 id="maintenance-of-asymmetric-str-2-olfactory-receptor-expression-in-awc">Maintenance of asymmetric str-2 (olfactory receptor) expression in AWC</h3>
+<ul>
+<li><a href="https://pubmed.ncbi.nlm.nih.gov/10571181" title="A cGMP signaling pathway that is used in olfaction maintains str-2   expression after the initial decision has been made.">PMID:10571181</a> odr-1 provides the cGMP;<br />
+  UniProt FUNCTION: "Required to maintain the expression of putative olfactory receptor<br />
+  str-2 in AWC neurons in adults (PubMed:10571181)." → supports GO:0010628 (positive<br />
+  regulation of gene expression), qualifier involved_in (WormBase, PMID:10571181).</li>
+</ul>
+<h3 id="awb-cilia-membrane-morphogenesis-developmental-non-cell-autonomous-readout">AWB cilia membrane morphogenesis (developmental / non-cell-autonomous readout)</h3>
+<ul>
+<li>In the Tubby paper, odr-1 is used as a "receptor guanylyl cyclase signaling mutant"<br />
+  whose reduced sensory signaling drives ciliary phenotypes:<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/31259686" title="AWB cilia width is significantly increased in odr-1 receptor guanylyl   cyclase signaling mutants">PMID:31259686</a>, <a href="https://pubmed.ncbi.nlm.nih.gov/31259686" title="we found that odr-1 mutants showed   enrichment of a TUB-1 fusion protein in AWB cilia as compared to levels at the PCMC">PMID:31259686</a>,<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/31259686" title="In odr-1 mutants, we observed significantly increased relative levels   of GFP::PPK-1 in AWB cilia">PMID:31259686</a>. This is the basis of the GOA IMP annotations<br />
+  GO:0097499 (protein localization to non-motile cilium) and GO:0050767 (regulation of<br />
+  neurogenesis) attributed to PMID:31259686. These are downstream/developmental<br />
+  consequences of loss of odr-1 sensory-signaling, not a distinct biochemical activity of<br />
+  ODR-1; they are best treated as non-core.</li>
+</ul>
+<h2 id="additional-peripheral-goa-annotations-reviewed">Additional / peripheral GOA annotations reviewed</h2>
+<ul>
+<li><strong>GO:0010628 positive regulation of gene expression, acts_upstream_of, IMP,<br />
+  PMID:18832350.</strong> The cached abstract of PMID:18832350 is about EGL-4/KIN-29/PKA<br />
+  regulating chemoreceptor (CR) gene expression and does not name odr-1; full text<br />
+  unavailable. Consistent with odr-1 supplying cGMP upstream of EGL-4, but odr-1's<br />
+  specific role here cannot be verified from the abstract → treat cautiously<br />
+  (non-core / UNDECIDED-leaning; keep, defer to curator, flag reference).</li>
+<li><strong>GO:0040015 / GO:0040014 regulation of multicellular organism growth (body size),<br />
+  IGI, PMID:26434723.</strong> The abstract of PMID:26434723 explicitly assigns body-size<br />
+  control to <strong>gcy-12</strong> ("gcy-12 ... provide cGMP to the EGL-4 ... only for limited tasks<br />
+  including body size regulation") and states EGL-4 partners with different GCs for<br />
+  different functions. odr-1 is not named in the abstract; the annotation is an IGI<br />
+  (WITH gcy-12 = Q19187 and G5EGF0). Body-size regulation is clearly peripheral to odr-1<br />
+  and, per the paper's own model, is a gcy-12 task → non-core; keep (do not REMOVE an<br />
+  experimental IGI on abstract-only grounds), mark non-core, flag reference relevance LOW.</li>
+<li><strong>GO:0001653 peptide receptor activity (IBA, GO_REF:0000033).</strong> This is a phylogenetic<br />
+  (PANTHER) inference from natriuretic-peptide-receptor GCs (mammalian NPR-A/NPR-B,<br />
+  UniProtKB:P16066/P20594). C. elegans receptor GCs are orphan receptors with no<br />
+  demonstrated peptide ligand; odr-1's extracellular domain is explicitly NOT implicated<br />
+  in odorant detection [UniProt DOMAIN "The extracellular domain may not be directly<br />
+  implicated in the detection of volatile odorants."]. "peptide receptor activity" is an<br />
+  over-annotation for odr-1 (no known peptide ligand) → MARK_AS_OVER_ANNOTATED / non-core.</li>
+<li><strong>GO:0004672 protein kinase activity (IEA, InterPro)</strong> — NOTE: present in the UniProt DR<br />
+  block but NOT in the GOA TSV/seeded review (so not in existing_annotations). UniProt<br />
+  explicitly states the kinase (KHD) domain is <em>predicted catalytically inactive</em>; a<br />
+  protein-kinase-activity annotation would be a pseudokinase over-annotation. Documented<br />
+  here for completeness / knowledge_gaps.</li>
+<li><strong>GO:0005524 ATP binding (IEA, InterPro:IPR000719).</strong> From the kinase-homology domain.<br />
+  UniProt lists ATP-binding residues (515–523, 534). Plausible structural nucleotide<br />
+  binding but the domain is a pseudokinase; keep as non-core (weak, IEA).</li>
+<li><strong>GO:0009190 cyclic nucleotide biosynthetic process / GO:0035556 intracellular signal<br />
+  transduction (IEA, InterPro).</strong> Generic parents of the specific, well-supported<br />
+  cGMP-biosynthesis / receptor-GC-signaling terms; keep as non-core (redundant with the<br />
+  specific experimental terms).</li>
+</ul>
+<h2 id="not-known-knowledge-gaps-explicit">NOT known / knowledge gaps (explicit)</h2>
+<ol>
+<li><strong>Activating ligand / stimulus for ODR-1 is unknown.</strong> No peptide or small-molecule<br />
+   ligand has been identified for the extracellular domain, and UniProt states the<br />
+   extracellular domain "may not be directly implicated in the detection of volatile<br />
+   odorants" <a href="https://pubmed.ncbi.nlm.nih.gov/10774726">PMID:10774726</a>. ODR-1 acts <em>downstream</em> of odorant receptors as a shared<br />
+   signaling component <a href="https://pubmed.ncbi.nlm.nih.gov/10774726" title="ODR-1 appears to be a shared signaling component    downstream of odorant receptors.">PMID:10774726</a>, so what activates/regulates its cyclase output in<br />
+   vivo (Ca2+, phosphorylation, GPCR/G-protein input, an orphan-receptor ligand) is<br />
+   undetermined.</li>
+<li><strong>Direct catalytic activity of ODR-1 has never been measured biochemically.</strong> The<br />
+   cyclase activity is inferred (ISS from gcy-12/Q19187 and mammalian NPRs) and from the<br />
+   E904A "probable loss of cyclase activity" phenotype <a href="https://pubmed.ncbi.nlm.nih.gov/10774726">PMID:10774726</a>; purified-protein<br />
+   enzymology is lacking. Whether ODR-1 homodimerizes or must heterodimerize with another<br />
+   GC (e.g. daf-11) to form an active catalytic unit is unresolved.</li>
+<li><strong>The kinase-homology domain: regulatory pseudokinase vs. active kinase.</strong> UniProt<br />
+   predicts it catalytically inactive (PRU00159). Whether it has any residual catalytic<br />
+   activity, and its regulatory role, are untested. (In this sense odr-1 is a candidate<br />
+   pseudokinase-containing, possibly regulatory-cyclase protein.)</li>
+<li>Cell-autonomous vs non-cell-autonomous scope: for quinine/EGL-4, ODR-1 acts<br />
+   non-cell-autonomously to supply cGMP to ASH <a href="https://pubmed.ncbi.nlm.nih.gov/23874221">PMID:23874221</a>; the diffusible-signal<br />
+   mechanism is not defined.</li>
+</ol>
+<h2 id="core-function-synthesis-for-core_functions">Core function synthesis (for core_functions)</h2>
+<ol>
+<li><strong>Molecular function:</strong> guanylate cyclase activity (GO:0004383) producing cGMP from<br />
+   GTP — the catalytic identity of the protein. Location: ciliary membrane / plasma<br />
+   membrane of sensory neurons.</li>
+<li><strong>cGMP biosynthetic process (GO:0006182) / receptor guanylyl cyclase signaling<br />
+   pathway (GO:0007168):</strong> generation of the cGMP second messenger that gates the<br />
+   TAX-2/TAX-4 CNG channel.</li>
+<li><strong>Sensory perception / olfaction (GO:0042048 olfactory behavior; sensory perception<br />
+   of smell):</strong> the organismal role — required for AWC/AWB olfaction and odor<br />
+   discrimination.</li>
+<li>Cellular location: <strong>non-motile cilium (GO:0097730) / ciliary membrane</strong> —<br />
+   experimentally localized (IDA, PMID:10774726).</li>
+</ol>
+<p>Non-core (pleiotropic / downstream / genetic-tool readouts): phototransduction, bitter<br />
+taste/quinine (via EGL-4), body-size regulation (gcy-12-attributed), AWB cilia membrane<br />
+morphogenesis, str-2 maintenance, chemoreceptor-gene expression.</p>
+<h2 id="deep-research">Deep research</h2>
+<p>Falcon deep-research launched (<code>just deep-research-falcon worm odr-1 --fallback
+perplexity-lite</code>). If it completes, its file is <code>odr-1-deep-research-*.md</code>. Review below<br />
+is grounded in primary cached literature (PMIDs above) and UniProt B1Q257, independent of<br />
+the deep-research summary.</p>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: B1Q257
+gene_symbol: odr-1
+product_type: PROTEIN
+status: COMPLETE
+taxon:
+  id: NCBITaxon:6239
+  label: Caenorhabditis elegans
+description: &gt;-
+  odr-1 (gcy-10) encodes a receptor-type (single-pass transmembrane) guanylyl
+  cyclase of Caenorhabditis elegans. It has an extracellular periplasmic-binding-
+  protein-like domain, a transmembrane helix, a cytoplasmic kinase-homology domain
+  (predicted catalytically inactive), and a C-terminal guanylate cyclase catalytic
+  domain that converts GTP to the second messenger cGMP (EC 4.6.1.2). ODR-1 is
+  expressed in a defined set of ciliated sensory neurons (predominantly AWC, and
+  also AWB, ASI, ASJ and ASK) and localizes to the sensory cilium and cell membrane.
+  As a source of cGMP acting downstream of odorant receptors, ODR-1 is a shared
+  signaling component required for AWC-mediated olfaction and odor discrimination
+  and for AWB-mediated odor avoidance; the cGMP it produces gates the TAX-2/TAX-4
+  cyclic-nucleotide-gated channel. The same cGMP output is redeployed in other
+  ciliated neurons, contributing to ASJ phototransduction, to bitter-tastant
+  (quinine) sensitivity via non-cell-autonomous supply of cGMP to the EGL-4 PKG,
+  and to maintenance of asymmetric olfactory-receptor (str-2) gene expression in
+  AWC. No activating ligand for its extracellular domain has been identified.
+alternative_products:
+- name: b {ECO:0000312|WormBase:R01E6.1b}
+  id: B1Q257-1
+- name: a {ECO:0000312|WormBase:R01E6.1a}
+  id: B1Q257-2
+  sequence_note: VSP_057702, VSP_057703, VSP_057704
+existing_annotations:
+- term:
+    id: GO:0004383
+    label: guanylate cyclase activity
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Guanylate cyclase is the defining catalytic activity of ODR-1, supported by
+      domain architecture (Pfam PF00211 cyclase domain 859-989), the E904A cyclase-
+      domain mutant that abolishes activity and olfaction, and ISS transfer from
+      orthologous receptor GCs. Correct and core.
+    action: ACCEPT
+    supported_by:
+    - reference_id: PMID:10774726
+      supporting_text: &#34;the transmembrane guanylyl cyclase ODR-1&#34;
+- term:
+    id: GO:0005886
+    label: plasma membrane
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: is_active_in
+  review:
+    summary: &gt;-
+      ODR-1 is a single-pass type I membrane protein. Its functionally relevant
+      pool is in the sensory cilium (a specialized plasma-membrane compartment);
+      plasma membrane is correct but less specific than the ciliary localization
+      (see the IDA non-motile cilium annotation from PMID:10774726). Keep as a
+      non-core supporting location.
+    action: KEEP_AS_NON_CORE
+- term:
+    id: GO:0006182
+    label: cGMP biosynthetic process
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Production of the cGMP second messenger is the direct biological process of
+      ODR-1&#39;s cyclase activity and is central to all of its downstream roles. Core.
+    action: ACCEPT
+- term:
+    id: GO:0007168
+    label: receptor guanylyl cyclase signaling pathway
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      ODR-1 is a receptor-type GC and its cGMP output drives sensory signal
+      transduction, so this term is apt at the pathway level. Note the strict GO
+      definition invokes an extracellular ligand binding the GC receptor; no ligand
+      for ODR-1&#39;s ectodomain is known, and ODR-1 acts downstream of odorant
+      receptors as a shared component. Retain as a non-core signaling-pathway term.
+    action: KEEP_AS_NON_CORE
+    supported_by:
+    - reference_id: PMID:10774726
+      supporting_text: &#34;ODR-1 appears to be a shared signaling \ncomponent downstream of odorant receptors&#34;
+- term:
+    id: GO:0001653
+    label: peptide receptor activity
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Phylogenetic (PANTHER) transfer from mammalian natriuretic-peptide-receptor
+      guanylyl cyclases (NPR-A/NPR-B). C. elegans receptor GCs are orphan receptors
+      with no demonstrated peptide ligand, and UniProt notes the ODR-1 extracellular
+      domain may not be directly implicated in odorant detection. No experimental
+      support for peptide-receptor activity in ODR-1; this is an over-annotation
+      propagated from vertebrate paralogs.
+    action: MARK_AS_OVER_ANNOTATED
+    propagation_review:
+      root_cause: PROPAGATION_BAD
+      failure_modes:
+      - FUNCTIONAL_DIVERGENCE
+      source_entities:
+      - source_id: UniProtKB:P16066
+        source_label: NPR1 (human natriuretic peptide receptor 1)
+        source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
+        comment: &gt;-
+          Bona fide peptide (natriuretic peptide) receptor GC; ODR-1 is an orphan
+          receptor GC with no known peptide ligand, so peptide-receptor activity
+          does not transfer.
+      - source_id: UniProtKB:P20594
+        source_label: NPR2 (human natriuretic peptide receptor 2)
+        source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
+- term:
+    id: GO:0004383
+    label: guanylate cyclase activity
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000120
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Automated EC 4.6.1.2 / RHEA:13665 assignment of guanylate cyclase activity.
+      Consistent with the catalytic domain and the manual ISS/IBA annotations. Core
+      molecular function (duplicate of the manually supported term).
+    action: ACCEPT
+- term:
+    id: GO:0005524
+    label: ATP binding
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: enables
+  review:
+    summary: &gt;-
+      InterPro (IPR000719) inference from the kinase-homology domain; UniProt lists
+      candidate ATP-binding residues (515-523, 534). However UniProt predicts this
+      kinase domain to be catalytically inactive (pseudokinase), so nucleotide
+      binding is uncertain and, if it occurs, is regulatory/structural rather than a
+      core function. Retain as a weak, non-core electronic annotation.
+    action: KEEP_AS_NON_CORE
+- term:
+    id: GO:0005886
+    label: plasma membrane
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000044
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      UniProt Subcellular Location mapping (SL-0039). Correct but subsumed by the
+      more specific ciliary localization. Non-core supporting location.
+    action: KEEP_AS_NON_CORE
+- term:
+    id: GO:0005929
+    label: cilium
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000044
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Ciliary localization is experimentally established (IDA to non-motile cilium,
+      GO:0097730, from PMID:10774726). This SubCell-derived cilium annotation is
+      correct and captures the core location; the sibling IDA non-motile cilium term
+      is the more specific, core cellular component.
+    action: ACCEPT
+- term:
+    id: GO:0007635
+    label: chemosensory behavior
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000117
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      ARBA electronic annotation. odr-1&#39;s chemosensory role is well established
+      experimentally (olfaction, quinine avoidance). This generic term is correct
+      but less informative than the specific olfactory/chemotaxis terms; keep as a
+      non-core parent.
+    action: KEEP_AS_NON_CORE
+- term:
+    id: GO:0009190
+    label: cyclic nucleotide biosynthetic process
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Generic parent of the specific, experimentally supported cGMP biosynthetic
+      process (GO:0006182). Correct but redundant; keep as non-core.
+    action: KEEP_AS_NON_CORE
+- term:
+    id: GO:0035556
+    label: intracellular signal transduction
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      High-level signal-transduction parent inferred from InterPro. Correct in
+      spirit (cGMP second-messenger signaling) but uninformative relative to the
+      specific receptor-GC-signaling / sensory-perception terms. Non-core.
+    action: KEEP_AS_NON_CORE
+- term:
+    id: GO:0050913
+    label: sensory perception of bitter taste
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000117
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      ARBA electronic version of the experimentally supported quinine-sensitivity
+      role (see IMP/IGI from PMID:23874221). odr-1 supplies cGMP non-cell-
+      autonomously to EGL-4 in ASH; bitter-taste sensitivity is a peripheral,
+      non-core role of odr-1.
+    action: KEEP_AS_NON_CORE
+- term:
+    id: GO:0004383
+    label: guanylate cyclase activity
+  evidence_type: ISS
+  original_reference_id: GO_REF:0000024
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Curator ISS transfer of guanylate cyclase activity from an orthologous
+      receptor GC (UniProtKB:Q19187, gcy-12). Consistent with the catalytic domain
+      and the E904A mutant phenotype. Core molecular function.
+    action: ACCEPT
+- term:
+    id: GO:0050767
+    label: regulation of neurogenesis
+  evidence_type: IMP
+  original_reference_id: PMID:31259686
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      From the Tubby (tub-1) study, in which odr-1 loss-of-function (&#34;receptor
+      guanylyl cyclase signaling mutants&#34;) causes expanded AWB ciliary membrane
+      fans and altered ciliary lipid/protein content. This is a downstream,
+      sensory-signaling-dependent developmental readout of reduced cGMP signaling,
+      not a distinct activity of ODR-1; retain but as a non-core developmental role.
+    action: KEEP_AS_NON_CORE
+    supported_by:
+    - reference_id: PMID:31259686
+      supporting_text: &#34;AWB cilia width is significantly increased in odr-1 receptor guanylyl cyclase signaling mutants&#34;
+- term:
+    id: GO:0097499
+    label: protein localization to non-motile cilium
+  evidence_type: IMP
+  original_reference_id: PMID:31259686
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      odr-1 mutants show increased ciliary accumulation of TUB-1 and the PIP5-kinase
+      PPK-1 in AWB cilia; loss of odr-1 sensory signaling thus alters ciliary
+      protein localization. This is an indirect, non-cell-intrinsic consequence of
+      reduced cGMP signaling rather than a direct trafficking function of ODR-1;
+      keep as non-core.
+    action: KEEP_AS_NON_CORE
+    supported_by:
+    - reference_id: PMID:31259686
+      supporting_text: &#34;we found that odr-1 mutants showed enrichment of a TUB-1 fusion protein in AWB cilia as compared to levels at the PCMC&#34;
+- term:
+    id: GO:0010628
+    label: positive regulation of gene expression
+  evidence_type: IMP
+  original_reference_id: PMID:18832350
+  qualifier: acts_upstream_of
+  review:
+    summary: &gt;-
+      The cached abstract of PMID:18832350 describes EGL-4 PKG, KIN-29 and PKA
+      regulating chemoreceptor gene expression and does not itself name odr-1;
+      full text is unavailable. A role for odr-1 as an upstream cGMP source for
+      EGL-4-dependent chemoreceptor-gene expression is plausible but cannot be
+      verified from the abstract. Per curation policy the experimental annotation is
+      not removed; treat as non-core and unverified from available text.
+    action: KEEP_AS_NON_CORE
+- term:
+    id: GO:0006182
+    label: cGMP biosynthetic process
+  evidence_type: ISS
+  original_reference_id: PMID:10774726
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      cGMP biosynthesis is the direct process of ODR-1&#39;s cyclase activity, here
+      transferred by similarity (WITH UniProtKB:P16066, a natriuretic-peptide-
+      receptor GC) and anchored to the ODR-1 characterization paper. Core.
+    action: ACCEPT
+    supported_by:
+    - reference_id: PMID:10774726
+      supporting_text: &#34;probably by overproduction of the shared second messenger cGMP&#34;
+- term:
+    id: GO:0040015
+    label: negative regulation of multicellular organism growth
+  evidence_type: IGI
+  original_reference_id: PMID:26434723
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Genetic-interaction annotation from the body-size study, whose abstract
+      attributes cGMP-dependent body-size control specifically to gcy-12 (WITH
+      UniProtKB:Q19187) and states EGL-4 partners with different GCs for different
+      tasks. Body-size regulation is peripheral to odr-1&#39;s core sensory function.
+      The experimental IGI is retained (full text not read) but marked non-core, and
+      the reference is flagged as low relevance for odr-1.
+    action: KEEP_AS_NON_CORE
+- term:
+    id: GO:0040014
+    label: regulation of multicellular organism growth
+  evidence_type: IGI
+  original_reference_id: PMID:26434723
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Parent of the negative-regulation term above; same body-size study
+      (WITH UniProtKB:G5EGF0). Peripheral to odr-1&#39;s core function; retain as
+      non-core.
+    action: KEEP_AS_NON_CORE
+- term:
+    id: GO:0007635
+    label: chemosensory behavior
+  evidence_type: IMP
+  original_reference_id: PMID:23874221
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      odr-1 loss causes behavioral hypersensitivity to dilute quinine, a
+      chemosensory (bitter-tastant avoidance) phenotype mediated by cGMP supply to
+      EGL-4. Correct; a generic chemosensory-behavior term for a peripheral (bitter/
+      nociceptive) role. Keep as non-core.
+    action: KEEP_AS_NON_CORE
+    supported_by:
+    - reference_id: PMID:23874221
+      supporting_text: &#34;Loss-of-function mutations in the guanylyl cyclase genes odr-1, gcy-27, gcy-33 and gcy-34 resulted in behavioral hypersensitivity to dilute (1 mM) quinine&#34;
+- term:
+    id: GO:0007635
+    label: chemosensory behavior
+  evidence_type: IGI
+  original_reference_id: PMID:23874221
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Genetic-interaction version of the quinine-sensitivity chemosensory role
+      (WITH UniProtKB:O76360). Same interpretation as the IMP above; non-core.
+    action: KEEP_AS_NON_CORE
+    supported_by:
+    - reference_id: PMID:23874221
+      supporting_text: &#34;the cyclases may function in a non-cell-autonomous manner to provide cGMP to regulate EGL-4 function in ASH&#34;
+- term:
+    id: GO:0050913
+    label: sensory perception of bitter taste
+  evidence_type: IMP
+  original_reference_id: PMID:23874221
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Experimentally supported bitter-tastant (quinine) sensitivity role: odr-1(lof)
+      animals are hypersensitive to dilute quinine and the defect is rescued by
+      srb-6p::odr-1. A genuine but peripheral, non-cell-autonomous role of odr-1;
+      non-core relative to olfaction.
+    action: KEEP_AS_NON_CORE
+    supported_by:
+    - reference_id: PMID:23874221
+      supporting_text: &#34;The quinine hypersensitivity of odr-1(lof) animals was rescued by srb-6p::odr-1 expression (p&lt;0.001), but not osm-10p::odr-1 expression (p&gt;0.5).&#34;
+- term:
+    id: GO:0050913
+    label: sensory perception of bitter taste
+  evidence_type: IGI
+  original_reference_id: PMID:23874221
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Genetic-interaction version of the quinine bitter-taste role (WITH
+      UniProtKB:O76360). Same interpretation; non-core.
+    action: KEEP_AS_NON_CORE
+- term:
+    id: GO:0007602
+    label: phototransduction
+  evidence_type: IMP
+  original_reference_id: PMID:20436480
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      odr-1(n1936) mutants show a severe reduction in ASJ photocurrent density,
+      demonstrating a requirement for membrane-associated GCs (odr-1, daf-11) in
+      cGMP-dependent phototransduction. A genuine experimental role, but a
+      redeployment of the same cGMP/CNG-channel machinery in a specialized context;
+      peripheral to the core olfactory function, so non-core.
+    action: KEEP_AS_NON_CORE
+    supported_by:
+    - reference_id: PMID:20436480
+      supporting_text: &#34;odr-1(n1936) mutant worms also showed a severe reduction in the density of photocurrents&#34;
+- term:
+    id: GO:0010628
+    label: positive regulation of gene expression
+  evidence_type: IMP
+  original_reference_id: PMID:10571181
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      A cGMP signaling pathway used in olfaction (odr-1-dependent) maintains
+      asymmetric expression of the olfactory receptor gene str-2 in adult AWC. This
+      is a real, cGMP-mediated effect on gene expression, but a specialized
+      developmental/maintenance role downstream of odr-1&#39;s cyclase activity; non-core.
+    action: KEEP_AS_NON_CORE
+    supported_by:
+    - reference_id: PMID:10571181
+      supporting_text: &#34;A cGMP signaling \npathway that is used in olfaction maintains str-2 expression after the initial \ndecision has been made.&#34;
+- term:
+    id: GO:0042048
+    label: olfactory behavior
+  evidence_type: IMP
+  original_reference_id: PMID:8348618
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      odr-1 was isolated as an odr (odorant-response-abnormal) gene; the G647D
+      mutant (n1930) causes loss of chemotaxis to volatile odorants. Olfactory
+      behavior is the core organismal role of odr-1. Accept as core.
+    action: ACCEPT
+    supported_by:
+    - reference_id: PMID:8348618
+      supporting_text: &#34;Chemotaxis to subsets of volatile odorants is disrupted by \nmutations in the odr genes, which might be involved in odorant sensation or \nsignal transduction.&#34;
+- term:
+    id: GO:1990834
+    label: response to odorant
+  evidence_type: IMP
+  original_reference_id: PMID:8348618
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      odr-1 mutants are defective in chemotaxis responses to volatile odorants; the
+      gene is required for the organism&#39;s response to odorants. Core sensory role.
+    action: ACCEPT
+    supported_by:
+    - reference_id: PMID:8348618
+      supporting_text: &#34;Chemotaxis to subsets of volatile odorants is disrupted by&#34;
+- term:
+    id: GO:0097730
+    label: non-motile cilium
+  evidence_type: IDA
+  original_reference_id: PMID:10774726
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Direct experimental localization (IDA, WormBase) of ODR-1 to the sensory
+      (non-motile) cilium, reported in the ODR-1 characterization paper. This is the
+      core cellular component where ODR-1 functions. The localization datum is in the
+      full text (not the cached abstract), so no verbatim quote is attached; accept
+      and defer to the curator&#39;s IDA.
+    action: ACCEPT
+- term:
+    id: GO:0004383
+    label: guanylate cyclase activity
+  evidence_type: ISS
+  original_reference_id: PMID:10774726
+  qualifier: enables
+  review:
+    summary: &gt;-
+      ISS assignment of guanylate cyclase activity anchored to the ODR-1
+      characterization paper (WITH UniProtKB:P16066). Core molecular function
+      (duplicate of the other guanylate-cyclase annotations).
+    action: ACCEPT
+    supported_by:
+    - reference_id: PMID:10774726
+      supporting_text: &#34;the transmembrane guanylyl cyclase ODR-1&#34;
+- term:
+    id: GO:0008355
+    label: olfactory learning
+  evidence_type: IMP
+  original_reference_id: PMID:10774726
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      ODR-1 influences odor adaptation/discrimination (overexpression disrupts
+      butanone adaptation and olfactory discrimination), consistent with an
+      olfactory-plasticity (&#34;learning&#34;) role. A specialized aspect of odr-1&#39;s
+      olfactory function; keep as non-core relative to the primary olfaction terms.
+    action: KEEP_AS_NON_CORE
+    supported_by:
+    - reference_id: PMID:10774726
+      supporting_text: &#34;Olfactory discrimination is also disrupted by ODR-1 \noverexpression&#34;
+- term:
+    id: GO:0008355
+    label: olfactory learning
+  evidence_type: IGI
+  original_reference_id: PMID:10774726
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Genetic-interaction version of the olfactory-adaptation/learning role
+      (WITH WB:WBGene00001664). Same interpretation as the IMP; non-core.
+    action: KEEP_AS_NON_CORE
+    supported_by:
+    - reference_id: PMID:10774726
+      supporting_text: &#34;ODR-1 can influence odor discrimination and adaptation as well as \nolfaction&#34;
+- term:
+    id: GO:0042048
+    label: olfactory behavior
+  evidence_type: IMP
+  original_reference_id: PMID:10774726
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      ODR-1 is essential for responses to all AWC-sensed odorants; olfactory
+      behavior is the core organismal function of odr-1. Accept as core.
+    action: ACCEPT
+    supported_by:
+    - reference_id: PMID:10774726
+      supporting_text: &#34;ODR-1 is essential for \nresponses to all AWC-sensed odorants&#34;
+- term:
+    id: GO:0050918
+    label: positive chemotaxis
+  evidence_type: IMP
+  original_reference_id: PMID:10774726
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      ODR-1 is required for AWC-mediated attraction (positive chemotaxis) to
+      volatile odorants; ODR-1 is essential for responses to all AWC-sensed
+      odorants. A specific, experimentally supported aspect of the core olfactory
+      role. Accept.
+    action: ACCEPT
+    supported_by:
+    - reference_id: PMID:10774726
+      supporting_text: &#34;ODR-1 is essential for \nresponses to all AWC-sensed odorants&#34;
+- term:
+    id: GO:0050919
+    label: negative chemotaxis
+  evidence_type: IMP
+  original_reference_id: PMID:10774726
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      ODR-1 also acts in AWB, the sensory neuron pair that mediates avoidance
+      (negative chemotaxis) of volatile odorants. Correct; a specific aspect of the
+      core olfactory role. The AWB-avoidance datum is in the full text/UniProt
+      FUNCTION rather than the cached abstract, so no verbatim quote is attached;
+      accept and defer to the curator&#39;s IMP.
+    action: ACCEPT
+core_functions:
+- description: &gt;-
+    Receptor-type guanylate cyclase: catalyzes the conversion of GTP to the second
+    messenger cGMP (EC 4.6.1.2) via its C-terminal cyclase domain, acting at the
+    ciliary/plasma membrane of sensory neurons. The catalytic identity is supported
+    by domain architecture and by the cyclase-domain E904A mutant that causes
+    probable loss of cyclase activity and loss of odorant chemotaxis.
+  molecular_function:
+    id: GO:0004383
+    label: guanylate cyclase activity
+  directly_involved_in:
+  - id: GO:0006182
+    label: cGMP biosynthetic process
+  locations:
+  - id: GO:0060170
+    label: ciliary membrane
+  - id: GO:0097730
+    label: non-motile cilium
+  supported_by:
+  - reference_id: PMID:10774726
+    supporting_text: &#34;the transmembrane guanylyl cyclase ODR-1&#34;
+- description: &gt;-
+    Shared cGMP-producing signaling component of AWC/AWB olfactory transduction:
+    acting downstream of odorant receptors, ODR-1 generates the cGMP that gates the
+    TAX-2/TAX-4 cyclic-nucleotide-gated channel, and is required for responses to
+    all AWC-sensed odorants, for AWC attractive (positive) chemotaxis and AWB
+    aversive (negative) chemotaxis, and for odor discrimination and adaptation.
+  molecular_function:
+    id: GO:0004383
+    label: guanylate cyclase activity
+  directly_involved_in:
+  - id: GO:0042048
+    label: olfactory behavior
+  - id: GO:0007608
+    label: sensory perception of smell
+  locations:
+  - id: GO:0097730
+    label: non-motile cilium
+  supported_by:
+  - reference_id: PMID:10774726
+    supporting_text: &#34;ODR-1 appears to be a shared signaling \ncomponent downstream of odorant receptors&#34;
+  - reference_id: PMID:8348618
+    supporting_text: &#34;Chemotaxis to subsets of volatile odorants is disrupted by&#34;
+knowledge_gaps:
+- gap_statement: &gt;-
+    The activating ligand and the in vivo mechanism that regulates ODR-1&#39;s cyclase
+    output are unknown. No peptide or small-molecule ligand has been identified for
+    its extracellular periplasmic-binding-protein-like domain, and it is undetermined
+    how odorant-receptor/G-protein input, Ca2+, or phosphorylation modulate ODR-1
+    cGMP production during sensory transduction.
+  boundary: &gt;-
+    It is firmly established that ODR-1 is a transmembrane guanylyl cyclase producing
+    cGMP that acts downstream of odorant receptors as a shared signaling component,
+    that it is required for AWC/AWB olfaction, and that UniProt notes its
+    extracellular domain &#34;may not be directly implicated in the detection of volatile
+    odorants.&#34; What is missing is the upstream activator/regulator of its enzymatic
+    activity.
+  gap_kind:
+  - BIOLOGY
+  dark_aspect: RESIDUAL_SUBGAP
+  status: OPEN
+  significance: &gt;-
+    ODR-1 is the cGMP source for a canonical cGMP/CNG (TAX-2/TAX-4) sensory pathway;
+    identifying what turns its cyclase on/off would define how olfactory-receptor
+    signals are converted into second-messenger output in ciliated neurons.
+  resolution: &gt;-
+    Biochemical/electrophysiological identification of an ODR-1 activator (candidate
+    ligand screens on the ectodomain; epistasis with odorant receptors and G
+    proteins; cGMP measurement in defined neurons upon odorant stimulation).
+  provenance:
+  - reference_id: PMID:10774726
+    supporting_text: &#34;ODR-1 appears to be a shared signaling \ncomponent downstream of odorant receptors&#34;
+- gap_statement: &gt;-
+    Whether ODR-1&#39;s guanylate cyclase domain is catalytically active on its own (a
+    functional cyclase) versus a regulatory subunit that must partner with another
+    guanylyl cyclase (e.g. DAF-11) to form an active enzyme has not been directly
+    tested; ODR-1 cyclase activity has never been measured on purified protein.
+  boundary: &gt;-
+    The E904A cyclase-domain mutant causes probable loss of cyclase activity and
+    loss of chemotaxis, and ODR-1 and DAF-11 are co-expressed and jointly required in
+    ASJ/ASK photoreceptor cells, indicating ODR-1 contributes to cGMP production;
+    but no in vitro enzymology, dimerization state, or partner-dependence has been
+    established. UniProt further predicts the adjacent kinase-homology domain to be
+    catalytically inactive.
+  gap_kind:
+  - BIOLOGY
+  dark_aspect: RESIDUAL_SUBGAP
+  status: OPEN
+  significance: &gt;-
+    Several receptor guanylyl cyclases act as heterodimers or as regulatory
+    (catalytically impaired) subunits; resolving ODR-1&#39;s catalytic autonomy would
+    clarify whether the cGMP for AWC/AWB olfaction is made by ODR-1 itself or by an
+    ODR-1-containing complex, and how much of odr-1 phenotypes reflect a
+    non-catalytic/regulatory role.
+  resolution: &gt;-
+    In vitro guanylate cyclase assays on purified/recombinant ODR-1 and defined
+    catalytic-dead mutants; test ODR-1/DAF-11 heterodimerization and its
+    contribution to neuronal cGMP.
+  provenance:
+  - reference_id: PMID:20436480
+    supporting_text: &#34;two membrane-associated GCs (daf-11 and odr-1) are expressed in C. elegans photoreceptor cells, including ASJ, ASK and AWB&#34;
+references:
+- id: GO_REF:0000002
+  title: Gene Ontology annotation through association of InterPro records with GO
+    terms
+  findings: []
+- id: GO_REF:0000024
+  title: Manual transfer of experimentally-verified manual GO annotation data to orthologs
+    by curator judgment of sequence similarity
+  findings: []
+- id: GO_REF:0000033
+  title: Annotation inferences using phylogenetic trees
+  findings: []
+- id: GO_REF:0000044
+  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location
+    vocabulary mapping, accompanied by conservative changes to GO terms applied by
+    UniProt
+  findings: []
+- id: GO_REF:0000117
+  title: Electronic Gene Ontology annotations created by ARBA machine learning models
+  findings: []
+- id: GO_REF:0000120
+  title: Combined Automated Annotation using Multiple IEA Methods
+  findings: []
+- id: PMID:10571181
+  title: Lateral signaling mediated by axon contact and calcium entry regulates asymmetric
+    odorant receptor expression in C. elegans.
+  findings: []
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PubMed-verified (Troemel, Sagasti, Bargmann, Cell 1999). Supports the odr-1
+      GO:0010628 (positive regulation of gene expression) annotation: a cGMP
+      signaling pathway used in olfaction maintains adult AWC str-2 expression.
+      Abstract-only in cache (full_text_available: false).
+- id: PMID:10774726
+  title: Olfaction and odor discrimination are mediated by the C. elegans guanylyl
+    cyclase ODR-1.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PubMed-verified (L&#39;Etoile &amp; Bargmann, Neuron 2000). The founding
+      characterization of ODR-1 as the transmembrane guanylyl cyclase required for
+      AWC olfaction; source of the ciliary localization (IDA) and the E904A
+      cyclase-domain mutant. Abstract-only in cache; multiple annotations trace here.
+- id: PMID:18832350
+  title: The EGL-4 PKG acts with KIN-29 salt-inducible kinase and protein kinase A
+    to regulate chemoreceptor gene expression and sensory behaviors in Caenorhabditis
+    elegans.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: UNVERIFIED
+    review_notes: &gt;-
+      PubMed-verified paper (van der Linden et al., Genetics 2008) about EGL-4/KIN-29/
+      PKA control of chemoreceptor gene expression. The cached abstract does not name
+      odr-1 and full text is unavailable, so odr-1&#39;s specific contribution to the
+      GO:0010628 acts_upstream_of annotation cannot be confirmed from available text.
+- id: PMID:20436480
+  title: C. elegans phototransduction requires a G protein-dependent cGMP pathway
+    and a taste receptor homolog.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PubMed-verified (Liu et al., Nat Neurosci 2010). Full text confirms odr-1(n1936)
+      reduces ASJ photocurrents and that membrane GCs (odr-1, daf-11) supply cGMP to
+      gate TAX-2/TAX-4 CNG channels downstream of LITE-1/Gi-o. Directly supports the
+      phototransduction annotation.
+- id: PMID:23874221
+  title: The C. elegans cGMP-dependent protein kinase EGL-4 regulates nociceptive
+    behavioral sensitivity.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PubMed-verified (Krzyzanowski et al., PLoS Genet 2013). Full text shows odr-1(lof)
+      quinine hypersensitivity, cell-selective rescue by srb-6p::odr-1, and a model in
+      which odr-1 supplies cGMP non-cell-autonomously to EGL-4 in ASH. Supports the
+      bitter-taste / chemosensory-behavior annotations.
+- id: PMID:26434723
+  title: The Importance of cGMP Signaling in Sensory Cilia for Body Size Regulation
+    in Caenorhabditis elegans.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PubMed-verified (Fujiwara et al., Genetics 2015). The abstract attributes cGMP-
+      dependent body-size control specifically to gcy-12 (not odr-1) and notes EGL-4
+      partners with different GCs for different tasks. odr-1&#39;s body-size IGI annotations
+      are peripheral/non-core; abstract-only, full text not read.
+- id: PMID:31259686
+  title: The Caenorhabditis elegans Tubby homolog dynamically modulates olfactory
+    cilia membrane morphogenesis and phospholipid composition.
+  findings: []
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PubMed-verified (DiTirro et al., eLife 2019). Full text uses odr-1 as a receptor-
+      guanylyl-cyclase signaling mutant: odr-1 loss expands AWB ciliary fans and
+      increases ciliary TUB-1, PPK-1 and PI(4,5)P2. Supports the (non-core) regulation
+      of neurogenesis / protein localization to non-motile cilium annotations.
+- id: PMID:8348618
+  title: Odorant-selective genes and neurons mediate olfaction in C. elegans.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PubMed-verified (Bargmann, Hartwieg, Horvitz, Cell 1993). The founding odr-screen
+      that isolated odr-1; source of the G647D (n1930) chemotaxis-loss mutant.
+      Abstract-only in cache. Supports the olfactory-behavior / response-to-odorant
+      annotations.
+suggested_questions:
+- question: &gt;-
+    What activates ODR-1&#39;s guanylate cyclase in vivo — is there a ligand for its
+    extracellular domain, or is its output regulated purely by intracellular inputs
+    (G-protein/Ca2+/phosphorylation) downstream of odorant receptors?
+  experts:
+  - L&#39;Etoile ND
+  - Bargmann CI
+- question: &gt;-
+    Is ODR-1 a catalytically autonomous guanylyl cyclase, or does it act as a
+    regulatory subunit / heterodimer with another GC (e.g. DAF-11) to produce cGMP in
+    AWC/AWB and in ASJ photoreceptor neurons?
+  experts:
+  - Xu XZ
+suggested_experiments:
+- hypothesis: &gt;-
+    ODR-1 possesses guanylate cyclase activity that requires the cyclase domain
+    (E904) and, like other receptor GCs, may need a partner GC (e.g. DAF-11) to form
+    an active catalytic site.
+  description: &gt;-
+    Express and purify the ODR-1 cytoplasmic module (kinase-homology + cyclase
+    domains) and assay GTP-to-cGMP conversion in vitro, comparing wild type with the
+    E904A catalytic mutant and with co-expressed DAF-11 to test for heterodimeric
+    activation.
+  experiment_type: in vitro enzymatic assay
+- hypothesis: &gt;-
+    ODR-1-produced cGMP gates the TAX-2/TAX-4 CNG channel in AWC to drive odorant
+    responses.
+  description: &gt;-
+    Use a genetically encoded cGMP sensor in AWC to measure odorant-evoked cGMP
+    transients in wild type versus odr-1(lof) and odr-1(E904A), and test epistasis
+    with tax-2/tax-4 for the downstream calcium response.
+  experiment_type: in vivo cGMP/calcium imaging
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/genes/worm/rde-2/rde-2-ai-review.html
+++ b/genes/worm/rde-2/rde-2-ai-review.html
@@ -1,0 +1,3364 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>rde-2 - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        .propagation-review {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f8fafc;
+            border-left: 3px solid #64748b;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .propagation-title {
+            font-weight: 600;
+            color: #334155;
+            margin-bottom: 0.25rem;
+        }
+
+        .propagation-row {
+            margin-top: 0.25rem;
+        }
+
+        .propagation-source {
+            margin-top: 0.5rem;
+            padding-top: 0.5rem;
+            border-top: 1px solid #e5e7eb;
+        }
+
+        .propagation-source-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #1d4ed8;
+        }
+
+        .propagation-comment {
+            color: #4b5563;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>rde-2</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/Q19672" target="_blank" class="term-link">
+                        Q19672
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Caenorhabditis elegans</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-draft">
+                    DRAFT
+                </span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Aliases:</span>
+                <div class="aliases">
+
+                    <span class="badge">mut-8</span>
+
+                    <span class="badge">F21C3.4</span>
+
+                </div>
+            </div>
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "rde-2";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="Q19672" data-a="DESCRIPTION: RDE-2 (also known as MUT-8) is an intrinsically di..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>RDE-2 (also known as MUT-8) is an intrinsically disordered bridging adaptor protein of the C. elegans Mutator complex, the germline machinery that amplifies secondary small interfering RNAs (22G-RNAs) for RNA-mediated silencing. RDE-2 has no catalytic activity and no canonical folded domain; its structured C-terminal domain binds the C-terminal domain of the 3&#39;-5&#39; exoribonuclease MUT-7, while its partially structured N-terminal region contacts the intrinsically disordered scaffold MUT-16. By physically linking MUT-7 to MUT-16, RDE-2 recruits the MUT-7 exoribonuclease into perinuclear Mutator foci, the phase-separated condensates (adjacent to but distinct from P granules) in which the RNA-dependent RNA polymerase RRF-1 synthesizes secondary siRNAs. This function is required for exogenous and endogenous RNAi, transposon silencing, and germline genome surveillance; loss of rde-2 abolishes secondary siRNA accumulation and causes RNAi resistance, transposon mobilization and an X-chromosome non-disjunction (high-incidence-of-males) phenotype. RDE-2 and its MUT-7 interaction are restricted to the Caenorhabditis lineage.</p>
+    </div>
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Proposed New Ontology Terms</h2>
+
+        <div class="proposed-term">
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>secondary siRNA amplification</h3>
+                <span class="vote-buttons" data-g="Q19672" data-a="secondary siRNA amplification" data-r="" data-act="NEW">
+                    <button class="vote-btn" data-v="up" title="Agree this term should be created">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with creating this term">👎</button>
+                </span>
+            </div>
+
+
+            <p><strong>Definition:</strong> The RNA-dependent RNA polymerase (RdRP)-mediated de novo synthesis of secondary small interfering RNAs (e.g. C. elegans 22G-RNAs) templated on target mRNAs recognized by primary small RNAs, occurring within a specialized RNA-processing compartment (Mutator focus). Distinguished from siRNA processing/Dicer-dependent primary siRNA generation.</p>
+
+
+
+            <p><strong>Justification:</strong> RDE-2 and the Mutator complex act specifically in RdRP-dependent secondary siRNA amplification, a step for which no dedicated GO term exists; siRNA processing (GO:0030422) conflates Dicer-dependent primary siRNA generation with amplification.</p>
+
+
+
+
+
+
+
+        </div>
+
+        <div class="proposed-term">
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>structural constituent of Mutator complex</h3>
+                <span class="vote-buttons" data-g="Q19672" data-a="structural constituent of Mutator complex" data-r="" data-act="NEW">
+                    <button class="vote-btn" data-v="up" title="Agree this term should be created">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with creating this term">👎</button>
+                </span>
+            </div>
+
+
+            <p><strong>Definition:</strong> A molecular function in which a protein provides a structural/organizational role as a subunit of the C. elegans Mutator complex, contributing to assembly of the siRNA-amplification compartment rather than catalysis.</p>
+
+
+
+            <p><strong>Justification:</strong> RDE-2 is an obligate structural adaptor subunit with no catalytic activity; molecular adaptor activity (GO:0060090) captures the bridging aspect, but a complex-specific structural-constituent term would more precisely express its &#39;be part of the machine&#39; role.</p>
+
+
+
+
+
+
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/15653635" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:15653635
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    RDE-2 interacts with MUT-7 to mediate RNA interference in Ca...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-modify">
+                            MODIFY
+                        </span>
+                        <span class="vote-buttons" data-g="Q19672" data-a="GO:0005515" data-r="PMID:15653635" data-act="MODIFY">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> The IPI interaction with MUT-7 (P34607) is real and central, but &#39;protein binding&#39; is uninformative. RDE-2&#39;s molecular function is to bridge the MUT-7 exoribonuclease to the MUT-16 scaffold, i.e. a molecular adaptor activity; this is the core molecular function of the protein.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Replace the uninformative &#39;protein binding&#39; with the more specific molecular adaptor activity. RDE-2 binds MUT-7 via its CTD and MUT-16 via its NTD, physically linking the two so that MUT-7 is recruited into Mutator foci (PMID:15653635, PMID:39188014).
+                        </div>
+
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0060090" target="_blank" class="term-link">
+                                    molecular adaptor activity
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/39188014" target="_blank" class="term-link">
+                                        PMID:39188014
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Caenorhabditis elegans MUT-7 contains a specific insertion within MUT7-C, which allows binding to MUT-8 and, consequently, MUT-7 recruitment to germ granules</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/19123269" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:19123269
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Empirically controlled mapping of the Caenorhabditis elegans...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q19672" data-a="GO:0005515" data-r="PMID:19123269" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> A second IPI &#39;protein binding&#39; annotation from a high-throughput interactome dataset recording the RDE-2/MUT-7 interaction. The interaction is genuine and corroborates the adaptor role, but the term itself is uninformative.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> &#39;protein binding&#39; conveys no functional specificity; the informative molecular function (molecular adaptor activity) is captured from the dedicated interaction studies. Retained as supporting evidence for the MUT-7 interaction but not as a core function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/30036386" target="_blank" class="term-link">
+                                        PMID:30036386
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">two proteins of unknown function, RDE-2 and MUT-15</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030422" target="_blank" class="term-link">
+                                    GO:0030422
+                                </a>
+                            </span>
+                            <span class="term-label">siRNA processing</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/15653635" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:15653635
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    RDE-2 interacts with MUT-7 to mediate RNA interference in Ca...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q19672" data-a="GO:0030422" data-r="PMID:15653635" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> RDE-2 is required for accumulation of siRNAs in vivo; the MUT-7/RDE-2 complex acts in the RdRP-dependent siRNA amplification step. GO:0030422 explicitly includes amplification of siRNA by RNA-directed RNA polymerase, so this is an appropriate core biological-process term.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> rde-2 mutants do not produce detectable siRNAs in vivo, and the complex functions downstream of primary siRNA production in amplification, consistent with the siRNA-processing term definition.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/15653635" target="_blank" class="term-link">
+                                        PMID:15653635
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Together these data hint at a role for the MUT-7/RDE-2 complex in the amplification step of the RNAi pathway in C.elegans.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1990633" target="_blank" class="term-link">
+                                    GO:1990633
+                                </a>
+                            </span>
+                            <span class="term-label">mutator focus</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/22713602" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:22713602
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    MUT-16 promotes formation of perinuclear mutator foci requir...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q19672" data-a="GO:1990633" data-r="PMID:22713602" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> RDE-2 is one of the six mutator proteins that localize to perinuclear Mutator foci in the germline, the siRNA-amplification compartment. This is the informative, species-appropriate cellular-component annotation and represents where RDE-2 carries out its function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Direct localization of the mutator proteins (including RDE-2) to perinuclear Mutator foci; RDE-2 localization to these foci depends on MUT-16 (PMID:30036386).
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/22713602" target="_blank" class="term-link">
+                                        PMID:22713602
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">each of the six mutator proteins localizes to punctate foci at the periphery of germline nuclei. The Mutator foci are adjacent to P granules</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016441" target="_blank" class="term-link">
+                                    GO:0016441
+                                </a>
+                            </span>
+                            <span class="term-label">post-transcriptional gene silencing</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/10535731" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:10535731
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The rde-1 gene, RNA interference, and transposon silencing i...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q19672" data-a="GO:0016441" data-r="PMID:10535731" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Loss of rde-2 causes RNAi resistance and transposon de-silencing, i.e. defective post-transcriptional gene silencing. This is a defining phenotype of the gene, though it is a parent of the more specific regulatory-ncRNA-mediated PTGS term.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct but general; the more specific GO:0035194 (regulatory ncRNA-mediated post-transcriptional gene silencing) better captures the mechanism and is retained as core. Kept as valid non-core context.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/15653635" target="_blank" class="term-link">
+                                        PMID:15653635
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">This allele, removing the last three-quarters of the gene, is viable and is RNAi resistant</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0045132" target="_blank" class="term-link">
+                                    GO:0045132
+                                </a>
+                            </span>
+                            <span class="term-label">meiotic chromosome segregation</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/10535731" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:10535731
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The rde-1 gene, RNA interference, and transposon silencing i...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q19672" data-a="GO:0045132" data-r="PMID:10535731" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> rde-2 mutants show a high-incidence-of-males (Him) phenotype caused by X-chromosome non-disjunction. This is a downstream, pleiotropic consequence of losing germline small-RNA silencing rather than evidence that RDE-2 acts directly in the meiotic chromosome-segregation machinery.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The segregation defect is an indirect consequence of the RNAi/silencing deficiency (shared with mut-7), not a direct molecular role of RDE-2 in meiosis. Retained as a non-core phenotype-based annotation.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/15653635" target="_blank" class="term-link">
+                                        PMID:15653635
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">both mut-7 and rde-2 mutants show a high incidence of males (him) phenotype</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0035194" target="_blank" class="term-link">
+                                    GO:0035194
+                                </a>
+                            </span>
+                            <span class="term-label">regulatory ncRNA-mediated post-transcriptional gene silencing</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/10535731" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:10535731
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The rde-1 gene, RNA interference, and transposon silencing i...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q19672" data-a="GO:0035194" data-r="PMID:10535731" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> RDE-2 is required for small-RNA (siRNA/22G-RNA)-guided silencing of endogenous and exogenous targets and of transposons; this term captures the specific mechanism of RDE-2&#39;s biological role and is a core process annotation.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Loss of rde-2 abolishes RdRP-dependent secondary siRNA accumulation and silencing, the defining regulatory-ncRNA-mediated PTGS function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/30036386" target="_blank" class="term-link">
+                                        PMID:30036386
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">mut-15, rde-2, rde-8, or rrf-1) result in a substantial loss of the RdRP-dependent secondary siRNAs</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
+                                    GO:0005829
+                                </a>
+                            </span>
+                            <span class="term-label">cytosol</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/15653635" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:15653635
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    RDE-2 interacts with MUT-7 to mediate RNA interference in Ca...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q19672" data-a="GO:0005829" data-r="PMID:15653635" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Biochemical fractionation placed the MUT-7/RDE-2 complex in the cytosolic (S100) fraction. This is correct but generic; the informative, function-relevant localization is the perinuclear Mutator focus (GO:1990633), which is a specialized cytoplasmic compartment.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Valid subcellular fraction data, but subsumed functionally by the Mutator-focus annotation. Kept as non-core supporting localization.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/15653635" target="_blank" class="term-link">
+                                        PMID:15653635
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">the MUT-7 and RDE-2 proteins are associated with each other in the cytosol, but not in the nucleus</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>Molecular adaptor that bridges the MUT-7 3&#39;-5&#39; exoribonuclease to the MUT-16 scaffold, recruiting MUT-7 into perinuclear Mutator foci for secondary siRNA amplification.</h3>
+                <span class="vote-buttons" data-g="Q19672" data-a="FUNCTION: Molecular adaptor that bridges the MUT-7 3&#39;-5&#39; exo..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0060090" target="_blank" class="term-link">
+                            molecular adaptor activity
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0035194" target="_blank" class="term-link">
+                                regulatory ncRNA-mediated post-transcriptional gene silencing
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1990633" target="_blank" class="term-link">
+                                mutator focus
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/39188014" target="_blank" class="term-link">
+                                PMID:39188014
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">Caenorhabditis elegans MUT-7 contains a specific insertion within MUT7-C, which allows binding to MUT-8 and, consequently, MUT-7 recruitment to germ granules</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/15653635" target="_blank" class="term-link">
+                                PMID:15653635
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">Together these data hint at a role for the MUT-7/RDE-2 complex in the amplification step of the RNAi pathway in C.elegans.</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:worm/rde-2/rde-2-deep-research-falcon.md
+
+                        </span>
+
+                        <div class="finding-text">RDE-2/MUT-8 is not an enzyme itself; rather, it serves a structural/adapter role</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>Required for RdRP (RRF-1)-dependent secondary siRNA (22G-RNA) amplification underlying RNA interference and transposon silencing in the germline.</h3>
+                <span class="vote-buttons" data-g="Q19672" data-a="FUNCTION: Required for RdRP (RRF-1)-dependent secondary siRN..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0060090" target="_blank" class="term-link">
+                            molecular adaptor activity
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030422" target="_blank" class="term-link">
+                                siRNA processing
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1990633" target="_blank" class="term-link">
+                                mutator focus
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/30036386" target="_blank" class="term-link">
+                                PMID:30036386
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">mut-15, rde-2, rde-8, or rrf-1) result in a substantial loss of the RdRP-dependent secondary siRNAs</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/10535731" target="_blank" class="term-link">
+                            PMID:10535731
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">The rde-1 gene, RNA interference, and transposon silencing in C. elegans.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Forward genetic screens for mutants resistant to double-stranded-RNA-mediated interference defined the RNAi-deficient (rde) complementation groups in C. elegans, the screen that isolated rde-2 alongside rde-1 and rde-4.</div>
+
+                        <div class="finding-text">"In order to study the interference process, we have selected C. elegans mutants resistant to dsRNA-mediated interference (RNAi)."</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/15653635" target="_blank" class="term-link">
+                            PMID:15653635
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">RDE-2 interacts with MUT-7 to mediate RNA interference in Caenorhabditis elegans.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">RDE-2 (F21C3.4 = rde-2/mut-8) was identified as a MUT-7-interacting protein by yeast two-hybrid, co-immunoprecipitation and re-localization; the MUT-7/RDE-2 complex acts downstream of primary siRNA production and upstream of target recognition, in the amplification step of RNAi.</div>
+
+                        <div class="finding-text">"Together these data hint at a role for the MUT-7/RDE-2 complex in the amplification step of the RNAi pathway in C.elegans."</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/19123269" target="_blank" class="term-link">
+                            PMID:19123269
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Empirically controlled mapping of the Caenorhabditis elegans protein-protein interactome network.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">High-throughput yeast two-hybrid interactome mapping reported an RDE-2 (Q19672) protein-protein interaction with MUT-7 (P34607).</div>
+
+                        <div class="finding-text">"Empirically controlled mapping of the Caenorhabditis elegans protein-protein interactome network."</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/22713602" target="_blank" class="term-link">
+                            PMID:22713602
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">MUT-16 promotes formation of perinuclear mutator foci required for RNA silencing in the C. elegans germline.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Each of the six mutator proteins (including RDE-2) localizes to perinuclear Mutator foci, punctate germline structures adjacent to but distinct from P granules that constitute an RNA-processing compartment for siRNA amplification with the RdRP RRF-1.</div>
+
+                        <div class="finding-text">"each of the six mutator proteins localizes to punctate foci at the periphery of germline nuclei. The Mutator foci are adjacent to P granules"</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/39188014" target="_blank" class="term-link">
+                            PMID:39188014
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">MUT-7 exoribonuclease activity and localization are mediated by an ancient domain.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Structural and biochemical study (crystal structure PDB 8Q66 of the MUT-7 CTD / MUT-8 CTD complex) showing RDE-2/MUT-8 binds the MUT-7 exoribonuclease via a worm-specific insertion in MUT7-C and thereby mediates MUT-7 recruitment to germ granules / Mutator foci.</div>
+
+                        <div class="finding-text">"Caenorhabditis elegans MUT-7 contains a specific insertion within MUT7-C, which allows binding to MUT-8 and, consequently, MUT-7 recruitment to germ granules"</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/30036386" target="_blank" class="term-link">
+                            PMID:30036386
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Distinct regions of the intrinsically disordered protein MUT-16 mediate assembly of a small RNA amplification complex and promote phase separation of mutator foci.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">MUT-16 is required for localization of RDE-2 (and other mutator proteins) to Mutator foci; RDE-2 in turn is required for MUT-7 localization, placing RDE-2 in a MUT-16 -&gt; RDE-2 -&gt; MUT-7 recruitment axis. Loss of any mutator complex protein abolishes RdRP-dependent secondary siRNAs.</div>
+
+                        <div class="finding-text">"MUT-16 is required for localization of MUT-2, MUT-7, RDE-2, MUT-14, and MUT-15, all of which localize independently of one another except for MUT-7, which requires RDE-2 for localization"</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Questions for Experts</h2>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Does RDE-2/MUT-8 possess any activity beyond bridging MUT-7 and MUT-16 - for example intrinsic RNA binding or a role in nucleating Mutator-focus condensation?</p>
+
+                    <p style="margin-top: 0.5rem;"><em>Suggested experts: René F. Ketting, Sebastian Falk, Carolyn M. Phillips</em></p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q19672" data-a="Q: Does RDE-2/MUT-8 possess any activity beyond bridg..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Experiments</h2>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Generate separation-of-function rde-2 alleles that retain MUT-16 binding but disrupt the MUT-7 CTD interface (guided by the PDB 8Q66 interface), assay MUT-7 focus localization, secondary 22G-RNA levels, and RNAi/transposon-silencing competence.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: RDE-2 acts purely as a structural adaptor whose sole essential role is to recruit and position MUT-7 within Mutator foci.</em></p>
+
+
+                    <p style="margin-top: 0.5rem;">Type: structure-guided mutagenesis with small-RNA sequencing and localization</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q19672" data-a="EXPERIMENT: Generate separation-of-function rde-2 alleles that..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Reconstitute recombinant RDE-2 with each mutator component and RRF-1 and test for direct binary interactions by pulldown/SEC and crosslinking mass spectrometry, and attempt cryo-EM of the assembled complex.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: RDE-2 directly contacts additional mutator components beyond MUT-7 and MUT-16.</em></p>
+
+
+                    <p style="margin-top: 0.5rem;">Type: in vitro interaction mapping / structural biology</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q19672" data-a="EXPERIMENT: Reconstitute recombinant RDE-2 with each mutator c..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Knowledge Gaps</h2>
+        <p style="color: #555; font-size: 0.92rem; margin-top: -0.3rem;">
+            What is <em>not</em> known — curated, literature-grounded statements of the open
+            unknowns (the inverse of core functions).
+        </p>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> Beyond acting as a passive structural bridge between MUT-7 and MUT-16, it is unknown whether the intrinsically disordered regions of RDE-2/MUT-8 have any additional molecular activity (e.g. RNA binding, condensate nucleation, or allosteric regulation of MUT-7 nuclease activity). RDE-2 has no catalytic activity and no canonical folded domain, so its full biochemical contribution to the complex is undefined.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">MF_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> It is firmly established that RDE-2&#39;s structured C-terminal domain binds the MUT-7 CTD (crystal structure PDB 8Q66) and that its partially structured N-terminal region contacts the MUT-16 scaffold, recruiting MUT-7 to Mutator foci. What is unknown is whether RDE-2 does anything mechanistically beyond this bridging.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Because RDE-2 is essential for secondary siRNA amplification but is not itself an enzyme, distinguishing &#39;pure scaffold/recruiter&#39; from &#39;active participant&#39; would determine whether the amplification defect in rde-2 mutants is purely a mislocalization/assembly failure or also a loss of a direct biochemical step.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> In vitro reconstitution of the MUT-16/RDE-2/MUT-7 module with siRNA-amplification assays, RNA-binding assays on isolated RDE-2 domains, and separation-of-function RDE-2 alleles that retain MUT-7/MUT-16 binding but disrupt any additional activity would resolve this.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"two proteins of unknown function, RDE-2 and MUT-15"</em> — PMID:30036386</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The complete set of RDE-2 direct binding partners within the Mutator complex is unresolved. Direct interactions are established only with MUT-7 (CTD-CTD) and MUT-16 (via the RDE-2 N-terminal region); whether RDE-2 directly contacts other mutator components (MUT-2/RDE-3, MUT-14, MUT-15, NYN-1/2, RDE-8) or the RdRP RRF-1, or merely co-resides with them in the focus, has not been tested biochemically.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">RESIDUAL_SUBGAP</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> RDE-2 localization to Mutator foci depends on MUT-16, and RDE-2 is in turn required for MUT-7 localization (a MUT-16 -&gt; RDE-2 -&gt; MUT-7 recruitment axis). Other mutator components localize via separate MUT-16 branches, but their direct/indirect relationship to RDE-2 is inferred from localization dependencies, not from binary interaction data.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Knowing which contacts are direct defines the true architecture of the amplification compartment and whether RDE-2 is a dedicated MUT-7 adaptor or a more central hub.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Systematic binary interaction mapping (e.g. reconstituted pulldowns, crosslinking mass spectrometry, or cryo-EM of the assembled complex) of RDE-2 against each mutator component.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"MUT-16 is required for localization of MUT-2, MUT-7, RDE-2, MUT-14, and MUT-15, all of which localize independently of one another except for MUT-7, which requires RDE-2 for localization"</em> — PMID:30036386</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> How RDE-2 mechanistically contributes to the secondary siRNA (22G-RNA) amplification reaction itself is unknown. It is established that rde-2 loss abolishes RdRP-dependent secondary siRNA accumulation, but whether RDE-2&#39;s only role is to recruit and position MUT-7, or whether it also participates in target-mRNA capture or templating for RRF-1, is undetermined.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span><span class="badge">ONTOLOGY</span>
+                <span class="badge">MF_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> The genetic requirement is clear (no detectable secondary siRNAs without rde-2) and the focus-assembly role is structurally defined, but the biochemical step at which RDE-2 acts within amplification is not.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Secondary siRNA amplification is the amplifying core of C. elegans RNA silencing and heritable epigenetic inheritance; resolving RDE-2&#39;s step would clarify a rate-limiting node. There is also no GO term for &#39;secondary siRNA amplification&#39; as a distinct process or for a &#39;structural constituent of the Mutator complex&#39;, so RDE-2&#39;s specific contribution cannot currently be expressed precisely.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Mechanistic in vitro amplification assays with defined mutator subcomplexes, plus ontology development for a secondary-siRNA-amplification process term and/or a Mutator-complex structural-constituent term.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"We propose that the mutator proteins and RRF-1 constitute an RNA processing compartment required for siRNA amplification and RNA silencing"</em> — PMID:22713602</li>
+
+            </ul>
+
+
+        </div>
+
+    </div>
+
+
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Deep Research Sections -->
+
+    <div class="section">
+        <h2 class="section-title">Deep Research</h2>
+
+        <details class="deep-research-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; gap: 1rem;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Falcon</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(rde-2-deep-research-falcon.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="Q19672" data-a="DEEP_RESEARCH: Falcon" data-r="" data-act="DEEP_RESEARCH" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This deep research is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This deep research needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+
+                <div class="report-meta">
+
+                    <span class="report-meta-text">Comprehensive Research Report: RDE-2/MUT-8 (UniProt Q19672, Gene F21C3.4) in *Caenorhabditis elegans*</span>
+
+
+                    <span class="report-badge">Falcon</span>
+
+
+                    <span class="report-badge">Edison Scientific Literature</span>
+
+
+                    <span class="report-badge">18 citations</span>
+
+
+                    <span class="report-badge">2 artifacts</span>
+
+
+                    <span class="report-meta-text">2026-07-04T21:03:45.416735</span>
+
+
+
+                </div>
+
+
+                <div class="artifact-list">
+
+
+
+                    <div class="artifact-link">
+                        <a href="rde-2-deep-research-falcon_artifacts/artifact-00.md" class="term-link">Edison artifact artifact-00</a>
+                        <span>(text/markdown)</span>
+                    </div>
+
+
+
+
+                    <div class="artifact-link">
+                        <a href="rde-2-deep-research-falcon_artifacts/artifact-01.md" class="term-link">Edison artifact artifact-01</a>
+                        <span>(text/markdown)</span>
+                    </div>
+
+
+                </div>
+
+                <p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h1 id="comprehensive-research-report-rde-2mut-8-uniprot-q19672-gene-f21c34-in-caenorhabditis-elegans">Comprehensive Research Report: RDE-2/MUT-8 (UniProt Q19672, Gene F21C3.4) in <em>Caenorhabditis elegans</em></h1>
+<h2 id="1-gene-identity-and-nomenclature">1. Gene Identity and Nomenclature</h2>
+<p>The gene <em>rde-2</em> (RNAi Deficient-2) in <em>Caenorhabditis elegans</em> encodes the protein RDE-2, which is also known as MUT-8 (Mutator-8). The gene is located at locus F21C3.4 on the <em>C. elegans</em> genome (UniProt accession Q19672). The dual nomenclature reflects its independent identification in two distinct genetic screens: <em>rde-2</em> was identified as a gene required for exogenous RNA interference (RNAi), while <em>mut-8</em> was identified in screens for mutator-class genes required for transposon silencing (phillips2012mut16promotesformation pages 2-4). The protein is annotated in UniProt as containing an SH2 domain, though the functional literature characterizes RDE-2/MUT-8 as a largely intrinsically disordered adaptor protein with a partially structured N-terminal domain (NTD) and a structured C-terminal domain (CTD) connected by a long flexible linker (busetto2024mut7exoribonucleaseactivity pages 4-5).</p>
+<h2 id="2-primary-molecular-function-bridging-adaptor-in-the-mutator-complex">2. Primary Molecular Function: Bridging Adaptor in the Mutator Complex</h2>
+<p>RDE-2/MUT-8 functions as a <strong>bridging adaptor protein</strong> within the Mutator complex, a multi-protein assembly essential for small RNA amplification in the <em>C. elegans</em> germline. Its primary role is to physically connect the 3′–5′ exoribonuclease MUT-7 to the scaffolding protein MUT-16, thereby recruiting MUT-7 to Mutator foci and enabling its participation in RNA silencing (busetto2024mut7exoribonucleaseactivity pages 7-9, busetto2024mut7exoribonucleaseactivity pages 5-7).</p>
+<p>The key structural finding from Busetto et al. (2024) is summarized below:</p>
+<blockquote>
+<p>RDE-2/MUT-8 functions as a bridging adaptor in the <em>C. elegans</em> Mutator complex: its N-terminal domain (aa 36-235) contacts the MUT-16 scaffold at residues 584-724, while its C-terminal domain binds the MUT-7 C-terminal domain through an extended ~2140 Å² interface. This architecture links the MUT-7 exoribonuclease to the MUT-16 scaffold, enabling MUT-7 recruitment to Mutator foci and supporting RNAi function; disrupting the MUT-7–MUT-8 interaction causes RNAi-resistant phenotypes. (busetto2024mut7exoribonucleaseactivity pages 5-7, busetto2024mut7exoribonucleaseactivity pages 9-11)</p>
+</blockquote>
+<p><em>Blockquote: This blockquote summarizes the central mechanistic finding from Busetto et al. 2024 on how RDE-2/MUT-8 physically connects MUT-7 to the MUT-16 scaffold. It is useful for clearly stating the current best-supported molecular role of RDE-2 in Mutator complex assembly.</em></p>
+<p>Specifically, the C-terminal domain (CTD) of MUT-8/RDE-2 directly binds the MUT-7 CTD, forming an extensive protein–protein interaction interface of approximately 2,140 Å² (busetto2024mut7exoribonucleaseactivity pages 5-7, busetto2024mut7exoribonucleaseactivity pages 4-5). Both the CTD-N and CTD-C subdomains of MUT-7 contribute to this complex formation, with MUT-7 residues Arg853 and Thr855 playing critical roles at the interface (busetto2024mut7exoribonucleaseactivity pages 4-5). The N-terminal domain (NTD) of MUT-8 (amino acids 36–235), which is partially structured, directly contacts MUT-16 at residues 584–724, a region that is intrinsically disordered but both necessary and sufficient for binding (busetto2024mut7exoribonucleaseactivity pages 5-7). Crucially, MUT-7 alone cannot bind MUT-16 without MUT-8, and MUT-8's CTD alone is insufficient for MUT-16 binding, demonstrating that both interaction interfaces of MUT-8 are essential for linking the catalytic exoribonuclease to the scaffolding platform (busetto2024mut7exoribonucleaseactivity pages 5-7).</p>
+<p>RDE-2/MUT-8 is not an enzyme itself; rather, it serves a structural/adapter role, enabling the assembly of a functional small RNA amplification complex. Disruption of the MUT-7/MUT-8 interaction (e.g., via point mutations R853E, T855E in MUT-7) prevents MUT-7 localization to Mutator foci and causes RNAi-resistant phenotypes (busetto2024mut7exoribonucleaseactivity pages 9-11).</p>
+<h2 id="3-subcellular-localization">3. Subcellular Localization</h2>
+<p>RDE-2/MUT-8 localizes to <strong>perinuclear punctate structures termed Mutator foci</strong> in the <em>C. elegans</em> germline (phillips2012mut16promotesformation pages 2-4, phillips2012mut16promotesformation pages 4-5). These foci are present in both hermaphrodite and male germlines during larval and adult stages, with brightest concentrations in the mitotic proliferation region and transition zone (leptotene/zygotene) of the germline, persisting through the pachytene stage (phillips2012mut16promotesformation pages 2-4). In embryos, Mutator foci remain diffuse in the cytoplasm until approximately the 100-cell stage, when they associate with nuclear structures (sundby2021connectingthedots pages 4-6, phillips2022germgranulesand pages 8-9).</p>
+<p>Mutator foci are positioned adjacent to P granules (nuclear pore-associated ribonucleoprotein structures) but are distinct from them; they rarely overlap completely with P-granule markers such as PGL-1 and DRH-3 (phillips2012mut16promotesformation pages 4-5, phillips2012mut16promotesformation pages 1-2). Mutator foci form independently of core P-granule components, although simultaneous depletion of multiple P-granule proteins can disrupt Mutator foci formation (phillips2012mut16promotesformation pages 1-2, phillips2022germgranulesand pages 8-9). Z granules appear to bridge the region between P granules and Mutator foci, suggesting a spatial organization of these perinuclear compartments (sundby2021connectingthedots pages 6-7).</p>
+<p>Mutator foci exhibit liquid-like properties consistent with <strong>phase-separated condensates</strong>, including spherical shape, internal flow, component diffusion, and sensitivity to aliphatic alcohols (sundby2021connectingthedots pages 6-7, uebel2018distinctregionsof pages 1-2). MUT-16 nucleates Mutator foci formation through its intrinsically disordered C-terminal region, and the ternary MUT-7/MUT-8/MUT-16 complex promotes condensate formation (busetto2024mut7exoribonucleaseactivity pages 7-9, uebel2018distinctregionsof pages 1-2).</p>
+<h2 id="4-role-in-small-rna-pathways-and-biochemical-pathways">4. Role in Small RNA Pathways and Biochemical Pathways</h2>
+<p>RDE-2/MUT-8 functions within the <strong>WAGO-class 22G-RNA biogenesis pathway</strong>, which is central to multiple RNA silencing processes in <em>C. elegans</em>. The Mutator complex, in which RDE-2 is a core component, serves as the platform for amplification of secondary small interfering RNAs (siRNAs) called 22G-RNAs. These 22G-RNAs are synthesized by the RNA-dependent RNA polymerase (RdRP) RRF-1, which also localizes to Mutator foci (sundby2021connectingthedots pages 6-7, phillips2012mut16promotesformation pages 1-2). The Mutator complex captures recently transcribed target mRNAs at Mutator foci for small RNA amplification (phillips2022germgranulesand pages 8-9).</p>
+<p>Within this pathway, RDE-2/MUT-8 contributes to multiple silencing processes:</p>
+<ul>
+<li>
+<p><strong>Exogenous RNAi (exo-RNAi):</strong> RDE-2 is required for effective responses to exogenously introduced double-stranded RNA. Loss of <em>rde-2</em> causes defects in both germline and somatic RNAi, which can be rescued by RDE-2::GFP fusion transgenes (phillips2012mut16promotesformation pages 2-4).</p>
+</li>
+<li>
+<p><strong>Transposon silencing:</strong> <em>rde-2/mut-8</em> mutants exhibit active transposons due to defective transposon silencing, including Tc1 DNA transposons (phillips2012mut16promotesformation pages 2-4). The mutator class genes, including <em>rde-2</em>, were originally identified through their role in preventing Tc1 transposition in the germline.</p>
+</li>
+<li>
+<p><strong>Endogenous siRNA production:</strong> RDE-2 is required for accumulation of WAGO-class 22G siRNAs, including the abundant X-cluster siRNA 22G siR-1. Loss of <em>rde-2</em> substantially reduces 22G siR-1 levels (phillips2012mut16promotesformation pages 2-4).</p>
+</li>
+<li>
+<p><strong>piRNA-initiated silencing:</strong> The Mutator complex amplifies 22G-RNAs downstream of piRNA (21U-RNA) triggers. piRNA targets are shuttled to Mutator foci where the Mutator complex, including RDE-2, mediates secondary siRNA amplification (sundby2021connectingthedots pages 6-7).</p>
+</li>
+<li>
+<p><strong>Transgene silencing:</strong> The endo-RNAi pathway involving mutator complex components mediates tissue-specific silencing of integrated transgenes, particularly in the intestine (chen2024tissuespecificsilencingof pages 4-5, chen2024tissuespecificsilencingof pages 1-2). MUT-16 recruits the complex including MUT-8/RDE-2, which further recruits MUT-7 to assemble the functional mutator focus (chen2024tissuespecificsilencingof pages 4-5).</p>
+</li>
+<li>
+<p><strong>Antiviral defense and heritable RNAi:</strong> RDE-2 is involved in heritable silencing of RNA and functions after initiation of the original RNAi response, working in concert with MUT-7 (sterken2014aheritableantiviral pages 4-5). In experiments with Orsay virus (OrV), <em>rde-2</em> mutants failed to mount a trans-generational antiviral response; pre-exposed <em>rde-2</em> mutants did not show decreased viral replication in their offspring, unlike wild-type N2 animals (sterken2014aheritableantiviral pages 4-5).</p>
+</li>
+</ul>
+<h2 id="5-assembly-hierarchy-within-the-mutator-complex">5. Assembly Hierarchy within the Mutator Complex</h2>
+<p>The Mutator complex assembles through hierarchical recruitment mediated by distinct regions of the MUT-16 scaffold protein. RDE-2/MUT-8 is recruited to Mutator foci by the H-I region of MUT-16; deletion of this region causes RDE-2 to fail to localize (uebel2018distinctregionsof pages 5-7, uebel2018distinctregionsof pages 4-5). Once recruited, RDE-2 in turn recruits MUT-7 through their CTD–CTD interaction (busetto2024mut7exoribonucleaseactivity pages 5-7, uebel2018distinctregionsof pages 11-13). This places RDE-2 as a critical intermediate in a MUT-16 → RDE-2 → MUT-7 recruitment axis, which operates in parallel to other recruitment branches: the B-C region of MUT-16 recruits MUT-2, MUT-14, and MUT-15, with MUT-15 subsequently recruiting NYN-1/2 and RDE-8 (uebel2018distinctregionsof pages 11-13, uebel2018distinctregionsof pages 5-7). The RdRP RRF-1 is recruited through the F region of MUT-16 (uebel2018distinctregionsof pages 11-13).</p>
+<p>The following table summarizes the major components of the Mutator complex and their relationships:</p>
+<table>
+<thead>
+<tr>
+<th>Protein Name</th>
+<th>Known Function/Activity</th>
+<th>Relationship to RDE-2/MUT-8</th>
+<th>MUT-16 Recruitment Region</th>
+<th>Key References</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>MUT-16</td>
+<td>Core scaffold of Mutator foci; Q/N-rich, intrinsically disordered protein that nucleates Mutator complex assembly and promotes phase-separated condensates required for small-RNA amplification</td>
+<td>RDE-2/MUT-8 is recruited to Mutator foci by MUT-16; RDE-2 then links MUT-16 to MUT-7. A defined MUT-16 segment (aa 584-724; within H-I region) binds the RDE-2/MUT-7 module (uebel2018distinctregionsof pages 1-2, busetto2024mut7exoribonucleaseactivity pages 5-7, uebel2018distinctregionsof pages 2-4)</td>
+<td>Not applicable; scaffold itself</td>
+<td>(uebel2018distinctregionsof pages 1-2, busetto2024mut7exoribonucleaseactivity pages 5-7, uebel2018distinctregionsof pages 11-13, uebel2018distinctregionsof pages 2-4)</td>
+</tr>
+<tr>
+<td>MUT-2 / RDE-3</td>
+<td>Nucleotidyltransferase; mutator component required for RNA silencing and transposon control; localizes to Mutator foci</td>
+<td>Co-localizes with RDE-2 in Mutator foci; recruited independently of RDE-2 via MUT-16 scaffold, in a branch distinct from the RDE-2→MUT-7 linkage (phillips2012mut16promotesformation pages 4-5, uebel2018distinctregionsof pages 11-13)</td>
+<td>B-C region of MUT-16 (uebel2018distinctregionsof pages 11-13, uebel2018distinctregionsof pages 5-7)</td>
+<td>(phillips2012mut16promotesformation pages 4-5, uebel2018distinctregionsof pages 11-13)</td>
+</tr>
+<tr>
+<td>MUT-7</td>
+<td>3′-5′ exoribonuclease with MUT7-C domain; essential for RNA silencing and small-RNA production</td>
+<td>Direct binding partner of RDE-2/MUT-8: MUT-7 CTD binds MUT-8 CTD, and this interaction recruits MUT-7 to Mutator foci; disrupting the interface causes RNAi resistance (busetto2024mut7exoribonucleaseactivity pages 7-9, busetto2024mut7exoribonucleaseactivity pages 5-7, busetto2024mut7exoribonucleaseactivity pages 9-11, busetto2024mut7exoribonucleaseactivity pages 4-5)</td>
+<td>H-I region, indirectly via RDE-2/MUT-8 bridge (uebel2018distinctregionsof pages 11-13, uebel2018distinctregionsof pages 4-5)</td>
+<td>(busetto2024mut7exoribonucleaseactivity pages 7-9, busetto2024mut7exoribonucleaseactivity pages 5-7, busetto2024mut7exoribonucleaseactivity pages 9-11, uebel2018distinctregionsof pages 11-13)</td>
+</tr>
+<tr>
+<td>MUT-8 / RDE-2</td>
+<td>Adaptor/bridging protein in Mutator complex; required for exogenous RNAi, endogenous silencing, transposon repression, fertility, and WAGO-class 22G-RNA accumulation</td>
+<td>Central reference protein: bridges MUT-7 to MUT-16 using distinct domains; NTD contacts MUT-16, CTD binds MUT-7 CTD (phillips2012mut16promotesformation pages 2-4, busetto2024mut7exoribonucleaseactivity pages 5-7)</td>
+<td>H-I region; RDE-2 fails to localize when H-I is deleted (uebel2018distinctregionsof pages 5-7, uebel2018distinctregionsof pages 4-5)</td>
+<td>(phillips2012mut16promotesformation pages 2-4, busetto2024mut7exoribonucleaseactivity pages 5-7, uebel2018distinctregionsof pages 5-7)</td>
+</tr>
+<tr>
+<td>MUT-14</td>
+<td>RNA helicase mutator component involved in RNA silencing; localizes to Mutator foci</td>
+<td>Co-localizes with RDE-2 in the same perinuclear compartment; recruited in a branch separate from the RDE-2→MUT-7 arm (phillips2012mut16promotesformation pages 4-5, uebel2018distinctregionsof pages 11-13)</td>
+<td>B-C region of MUT-16 (uebel2018distinctregionsof pages 11-13, uebel2018distinctregionsof pages 5-7)</td>
+<td>(phillips2012mut16promotesformation pages 4-5, uebel2018distinctregionsof pages 11-13)</td>
+</tr>
+<tr>
+<td>MUT-15</td>
+<td>Mutator component needed for RNA silencing; also recruits downstream effectors</td>
+<td>Co-localizes with RDE-2; recruited independently of RDE-2 by MUT-16 and then helps recruit NYN-1/2 and RDE-8, placing it in a parallel branch to the RDE-2→MUT-7 linkage (phillips2012mut16promotesformation pages 4-5, uebel2018distinctregionsof pages 11-13)</td>
+<td>B-C region of MUT-16 (uebel2018distinctregionsof pages 11-13)</td>
+<td>(phillips2012mut16promotesformation pages 4-5, uebel2018distinctregionsof pages 11-13)</td>
+</tr>
+<tr>
+<td>RRF-1</td>
+<td>RNA-dependent RNA polymerase (RdRP) that synthesizes secondary WAGO-class 22G-RNAs in Mutator foci</td>
+<td>Works in the same amplification compartment as RDE-2; RDE-2 helps organize the Mutator complex that supports RRF-1-dependent 22G-RNA biogenesis, but no direct RDE-2–RRF-1 interaction is established in the cited evidence (sundby2021connectingthedots pages 6-7, phillips2012mut16promotesformation pages 1-2, phillips2012mut16promotesformation pages 5-7)</td>
+<td>F region of MUT-16 (with partial effects from other regions) (uebel2018distinctregionsof pages 11-13, uebel2018distinctregionsof pages 5-7)</td>
+<td>(uebel2018distinctregionsof pages 11-13, sundby2021connectingthedots pages 6-7, phillips2012mut16promotesformation pages 1-2, phillips2012mut16promotesformation pages 5-7)</td>
+</tr>
+<tr>
+<td>RDE-8</td>
+<td>NYN-domain endoribonuclease implicated in small-RNA amplification/silencing</td>
+<td>In the same Mutator amplification system as RDE-2, but recruited through the MUT-15 branch rather than through the RDE-2→MUT-7 bridge (uebel2018distinctregionsof pages 11-13, sundby2021connectingthedots pages 4-6)</td>
+<td>Indirect via B-C → MUT-15 branch (uebel2018distinctregionsof pages 11-13, uebel2018distinctregionsof pages 5-7)</td>
+<td>(uebel2018distinctregionsof pages 11-13, sundby2021connectingthedots pages 4-6)</td>
+</tr>
+<tr>
+<td>NYN-1 / NYN-2</td>
+<td>NYN-domain proteins associated with Mutator foci and small-RNA pathway assembly</td>
+<td>Parallel to RDE-2 branch: recruited downstream of MUT-15 rather than through RDE-2, but part of the same amplification compartment (uebel2018distinctregionsof pages 11-13, sundby2021connectingthedots pages 4-6)</td>
+<td>Indirect via B-C → MUT-15 branch (uebel2018distinctregionsof pages 11-13)</td>
+<td>(uebel2018distinctregionsof pages 11-13, sundby2021connectingthedots pages 4-6)</td>
+</tr>
+<tr>
+<td>SMUT-1</td>
+<td>RNA helicase-like mutator component of Mutator foci</td>
+<td>Co-recruited to Mutator foci with RDE-2 as part of the broader MUT-16-dependent complex; specific direct interaction with RDE-2 not defined in cited evidence (uebel2018distinctregionsof pages 1-2, uebel2018distinctregionsof pages 2-4)</td>
+<td>Specific MUT-16 subregion not resolved in the cited excerpts</td>
+<td>(uebel2018distinctregionsof pages 1-2, uebel2018distinctregionsof pages 2-4)</td>
+</tr>
+</tbody>
+</table>
+<p><em>Table: This table summarizes major C. elegans Mutator complex components, emphasizing how RDE-2/MUT-8 fits into assembly of the small-RNA amplification machinery. It is useful for quickly mapping protein function, recruitment logic, and the specific MUT-16 scaffold regions implicated by current evidence.</em></p>
+<h2 id="6-mutant-phenotypes">6. Mutant Phenotypes</h2>
+<p>Loss-of-function mutations in <em>rde-2/mut-8</em> produce a constellation of phenotypes reflecting its broad role in RNA silencing:</p>
+<ol>
+<li><strong>Defective exogenous RNAi</strong> — resistance to RNAi by feeding or injection (phillips2012mut16promotesformation pages 2-4).</li>
+<li><strong>Active transposons</strong> — reactivation of Tc1 and other DNA transposons due to failure of transposon silencing (phillips2012mut16promotesformation pages 2-4).</li>
+<li><strong>Temperature-sensitive sterility</strong> — fertility defects, particularly at elevated temperatures (phillips2012mut16promotesformation pages 2-4).</li>
+<li><strong>Elevated male production (Him phenotype)</strong> — indicative of X chromosome segregation defects (phillips2012mut16promotesformation pages 2-4).</li>
+<li><strong>Reduced WAGO-class 22G-siRNA levels</strong> — substantially diminished accumulation of secondary siRNAs (phillips2012mut16promotesformation pages 2-4).</li>
+<li><strong>Loss of heritable antiviral RNAi</strong> — inability to transmit antiviral silencing signals to progeny (sterken2014aheritableantiviral pages 4-5).</li>
+</ol>
+<h2 id="7-evolutionary-conservation">7. Evolutionary Conservation</h2>
+<p>MUT-8/RDE-2 and its interaction with MUT-7 appear to be <strong>restricted to the genus <em>Caenorhabditis</em></strong>. The Mutator complex as a whole is not present in animals outside <em>Caenorhabditis</em> (busetto2024mut7exoribonucleaseactivity pages 11-12, busetto2024mut7exoribonucleaseactivity pages 9-11). While the MUT-7 exoribonuclease is evolutionarily conserved (with orthologs such as EXD3 in humans and zebrafish), the specific insertion in MUT-7's MUT7-C domain that serves as the MUT-8 binding platform is a <em>Caenorhabditis</em>-specific adaptation. Co-expression experiments demonstrate that the MUT-8 CTD does not interact with human EXD3 or <em>Danio rerio</em> EXD3, confirming that the MUT-8 interaction is not conserved outside nematodes (busetto2024mut7exoribonucleaseactivity pages 11-12). Within <em>Caenorhabditis</em>, both MUT-8 and MUT-16 homologs are conserved, and the MUT-7 CTD function in establishing localization via MUT-8 is likely extended to other species in the genus (busetto2024mut7exoribonucleaseactivity pages 9-11).</p>
+<h2 id="8-summary">8. Summary</h2>
+<p>RDE-2/MUT-8 is a <em>C. elegans</em> adaptor protein that plays an essential structural role in the Mutator complex, a perinuclear, phase-separated condensate in the germline dedicated to small RNA amplification. Its primary molecular function is to bridge the 3′–5′ exoribonuclease MUT-7 to the scaffolding protein MUT-16, using distinct N-terminal and C-terminal protein interaction domains. Through this bridging function, RDE-2 enables the assembly of a functional small RNA amplification compartment that is required for WAGO-class 22G-RNA biogenesis, transposon silencing, exogenous and endogenous RNAi, antiviral defense, and transgenerational epigenetic inheritance. The protein localizes to perinuclear Mutator foci in the germline, adjacent to but distinct from P granules. RDE-2/MUT-8 and its interaction with MUT-7 appear to be specific to the <em>Caenorhabditis</em> genus, representing a lineage-specific adaptation of the small RNA silencing machinery.</p>
+<p>References</p>
+<ol>
+<li>
+<p>(phillips2012mut16promotesformation pages 2-4): Carolyn M. Phillips, Taiowa A. Montgomery, Peter C. Breen, and Gary Ruvkun. Mut-16 promotes formation of perinuclear mutator foci required for rna silencing in the c. elegans germline. Genes &amp; development, 26 13:1433-44, Jul 2012. URL: https://doi.org/10.1101/gad.193904.112, doi:10.1101/gad.193904.112. This article has 242 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(busetto2024mut7exoribonucleaseactivity pages 4-5): Virginia Busetto, Lizaveta Pshanichnaya, Raffael Lichtenberger, Stephan Hann, René F Ketting, and Sebastian Falk. Mut-7 exoribonuclease activity and localization are mediated by an ancient domain. Nucleic Acids Research, 52:9076-9091, Jul 2024. URL: https://doi.org/10.1093/nar/gkae610, doi:10.1093/nar/gkae610. This article has 6 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(busetto2024mut7exoribonucleaseactivity pages 7-9): Virginia Busetto, Lizaveta Pshanichnaya, Raffael Lichtenberger, Stephan Hann, René F Ketting, and Sebastian Falk. Mut-7 exoribonuclease activity and localization are mediated by an ancient domain. Nucleic Acids Research, 52:9076-9091, Jul 2024. URL: https://doi.org/10.1093/nar/gkae610, doi:10.1093/nar/gkae610. This article has 6 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(busetto2024mut7exoribonucleaseactivity pages 5-7): Virginia Busetto, Lizaveta Pshanichnaya, Raffael Lichtenberger, Stephan Hann, René F Ketting, and Sebastian Falk. Mut-7 exoribonuclease activity and localization are mediated by an ancient domain. Nucleic Acids Research, 52:9076-9091, Jul 2024. URL: https://doi.org/10.1093/nar/gkae610, doi:10.1093/nar/gkae610. This article has 6 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(busetto2024mut7exoribonucleaseactivity pages 9-11): Virginia Busetto, Lizaveta Pshanichnaya, Raffael Lichtenberger, Stephan Hann, René F Ketting, and Sebastian Falk. Mut-7 exoribonuclease activity and localization are mediated by an ancient domain. Nucleic Acids Research, 52:9076-9091, Jul 2024. URL: https://doi.org/10.1093/nar/gkae610, doi:10.1093/nar/gkae610. This article has 6 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(phillips2012mut16promotesformation pages 4-5): Carolyn M. Phillips, Taiowa A. Montgomery, Peter C. Breen, and Gary Ruvkun. Mut-16 promotes formation of perinuclear mutator foci required for rna silencing in the c. elegans germline. Genes &amp; development, 26 13:1433-44, Jul 2012. URL: https://doi.org/10.1101/gad.193904.112, doi:10.1101/gad.193904.112. This article has 242 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(sundby2021connectingthedots pages 4-6): Adam E. Sundby, Ruxandra I. Molnar, and Julie M. Claycomb. Connecting the dots: linking caenorhabditis elegans small rna pathways and germ granules. May 2021. URL: https://doi.org/10.1016/j.tcb.2020.12.012, doi:10.1016/j.tcb.2020.12.012. This article has 74 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(phillips2022germgranulesand pages 8-9): Carolyn M Phillips and Dustin L Updike. Germ granules and gene regulation in the caenorhabditis elegans germline. Genetics, Mar 2022. URL: https://doi.org/10.1093/genetics/iyab195, doi:10.1093/genetics/iyab195. This article has 79 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(phillips2012mut16promotesformation pages 1-2): Carolyn M. Phillips, Taiowa A. Montgomery, Peter C. Breen, and Gary Ruvkun. Mut-16 promotes formation of perinuclear mutator foci required for rna silencing in the c. elegans germline. Genes &amp; development, 26 13:1433-44, Jul 2012. URL: https://doi.org/10.1101/gad.193904.112, doi:10.1101/gad.193904.112. This article has 242 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(sundby2021connectingthedots pages 6-7): Adam E. Sundby, Ruxandra I. Molnar, and Julie M. Claycomb. Connecting the dots: linking caenorhabditis elegans small rna pathways and germ granules. May 2021. URL: https://doi.org/10.1016/j.tcb.2020.12.012, doi:10.1016/j.tcb.2020.12.012. This article has 74 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(uebel2018distinctregionsof pages 1-2): Celja J. Uebel, Dorian C. Anderson, Lisa M. Mandarino, Kevin I. Manage, Stephan Aynaszyan, and Carolyn M. Phillips. Distinct regions of the intrinsically disordered protein mut-16 mediate assembly of a small rna amplification complex and promote phase separation of mutator foci. PLOS Genetics, 14:e1007542, Jul 2018. URL: https://doi.org/10.1371/journal.pgen.1007542, doi:10.1371/journal.pgen.1007542. This article has 67 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(chen2024tissuespecificsilencingof pages 4-5): Siyu Chen, Weihong Liu, Lei Xiong, Zhiju Tao, and Di Zhao. Tissue-specific silencing of integrated transgenes achieved through endogenous rna interference in <i>caenorhabditis elegans</i>. RNA Biology, 21:449-458, Mar 2024. URL: https://doi.org/10.1080/15476286.2024.2332856, doi:10.1080/15476286.2024.2332856. This article has 3 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(chen2024tissuespecificsilencingof pages 1-2): Siyu Chen, Weihong Liu, Lei Xiong, Zhiju Tao, and Di Zhao. Tissue-specific silencing of integrated transgenes achieved through endogenous rna interference in <i>caenorhabditis elegans</i>. RNA Biology, 21:449-458, Mar 2024. URL: https://doi.org/10.1080/15476286.2024.2332856, doi:10.1080/15476286.2024.2332856. This article has 3 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(sterken2014aheritableantiviral pages 4-5): Mark G. Sterken, L. Basten Snoek, Kobus J. Bosman, Jikke Daamen, Joost A. G. Riksen, Jaap Bakker, Gorben P. Pijlman, and Jan E. Kammenga. A heritable antiviral rnai response limits orsay virus infection in caenorhabditis elegans n2. PLoS ONE, 9:e89760, Feb 2014. URL: https://doi.org/10.1371/journal.pone.0089760, doi:10.1371/journal.pone.0089760. This article has 61 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(uebel2018distinctregionsof pages 5-7): Celja J. Uebel, Dorian C. Anderson, Lisa M. Mandarino, Kevin I. Manage, Stephan Aynaszyan, and Carolyn M. Phillips. Distinct regions of the intrinsically disordered protein mut-16 mediate assembly of a small rna amplification complex and promote phase separation of mutator foci. PLOS Genetics, 14:e1007542, Jul 2018. URL: https://doi.org/10.1371/journal.pgen.1007542, doi:10.1371/journal.pgen.1007542. This article has 67 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(uebel2018distinctregionsof pages 4-5): Celja J. Uebel, Dorian C. Anderson, Lisa M. Mandarino, Kevin I. Manage, Stephan Aynaszyan, and Carolyn M. Phillips. Distinct regions of the intrinsically disordered protein mut-16 mediate assembly of a small rna amplification complex and promote phase separation of mutator foci. PLOS Genetics, 14:e1007542, Jul 2018. URL: https://doi.org/10.1371/journal.pgen.1007542, doi:10.1371/journal.pgen.1007542. This article has 67 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(uebel2018distinctregionsof pages 11-13): Celja J. Uebel, Dorian C. Anderson, Lisa M. Mandarino, Kevin I. Manage, Stephan Aynaszyan, and Carolyn M. Phillips. Distinct regions of the intrinsically disordered protein mut-16 mediate assembly of a small rna amplification complex and promote phase separation of mutator foci. PLOS Genetics, 14:e1007542, Jul 2018. URL: https://doi.org/10.1371/journal.pgen.1007542, doi:10.1371/journal.pgen.1007542. This article has 67 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(uebel2018distinctregionsof pages 2-4): Celja J. Uebel, Dorian C. Anderson, Lisa M. Mandarino, Kevin I. Manage, Stephan Aynaszyan, and Carolyn M. Phillips. Distinct regions of the intrinsically disordered protein mut-16 mediate assembly of a small rna amplification complex and promote phase separation of mutator foci. PLOS Genetics, 14:e1007542, Jul 2018. URL: https://doi.org/10.1371/journal.pgen.1007542, doi:10.1371/journal.pgen.1007542. This article has 67 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(phillips2012mut16promotesformation pages 5-7): Carolyn M. Phillips, Taiowa A. Montgomery, Peter C. Breen, and Gary Ruvkun. Mut-16 promotes formation of perinuclear mutator foci required for rna silencing in the c. elegans germline. Genes &amp; development, 26 13:1433-44, Jul 2012. URL: https://doi.org/10.1101/gad.193904.112, doi:10.1101/gad.193904.112. This article has 242 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(busetto2024mut7exoribonucleaseactivity pages 11-12): Virginia Busetto, Lizaveta Pshanichnaya, Raffael Lichtenberger, Stephan Hann, René F Ketting, and Sebastian Falk. Mut-7 exoribonuclease activity and localization are mediated by an ancient domain. Nucleic Acids Research, 52:9076-9091, Jul 2024. URL: https://doi.org/10.1093/nar/gkae610, doi:10.1093/nar/gkae610. This article has 6 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+</ol>
+<h2 id="artifacts">Artifacts</h2>
+<ul>
+<li><a href="rde-2-deep-research-falcon_artifacts/artifact-00.md">Edison artifact artifact-00</a></li>
+<li><a href="rde-2-deep-research-falcon_artifacts/artifact-01.md">Edison artifact artifact-01</a></li>
+</ul>
+<h2 id="citations">Citations</h2>
+<ol>
+<li>sundby2021connectingthedots pages 6-7</li>
+<li>phillips2022germgranulesand pages 8-9</li>
+<li>chen2024tissuespecificsilencingof pages 4-5</li>
+<li>sterken2014aheritableantiviral pages 4-5</li>
+<li>uebel2018distinctregionsof pages 11-13</li>
+<li>sundby2021connectingthedots pages 4-6</li>
+<li>uebel2018distinctregionsof pages 1-2</li>
+<li>chen2024tissuespecificsilencingof pages 1-2</li>
+<li>uebel2018distinctregionsof pages 5-7</li>
+<li>uebel2018distinctregionsof pages 4-5</li>
+<li>uebel2018distinctregionsof pages 2-4</li>
+<li>https://doi.org/10.1101/gad.193904.112,</li>
+<li>https://doi.org/10.1093/nar/gkae610,</li>
+<li>https://doi.org/10.1016/j.tcb.2020.12.012,</li>
+<li>https://doi.org/10.1093/genetics/iyab195,</li>
+<li>https://doi.org/10.1371/journal.pgen.1007542,</li>
+<li>https://doi.org/10.1080/15476286.2024.2332856,</li>
+<li>https://doi.org/10.1371/journal.pone.0089760,</li>
+</ol>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(rde-2-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="Q19672" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="rde-2-rnai-deficient-2-mut-8-research-notes">rde-2 (RNAi-deficient-2 / MUT-8) — research notes</h1>
+<p>Gene: <strong>rde-2</strong> = <strong>mut-8</strong> ; ORF <strong>F21C3.4</strong> ; UniProt <strong>Q19672</strong> ; WormBase <strong>WBGene00004324</strong><br />
+Organism: <em>Caenorhabditis elegans</em> (NCBITaxon:6239). Chromosome I.</p>
+<h2 id="identity-verified-from-uniprot-record-literature">Identity (verified from UniProt record + literature)</h2>
+<ul>
+<li>UniProt Q19672 names the protein "SH2 domain-containing protein" — this is an <strong>automated<br />
+  (ECO:0000313, TrEMBL) name only</strong>, and is almost certainly <strong>spurious</strong>. The primary structural<br />
+  paper explicitly states MUT-8 "has no previously annotated domains"<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/39188014" title="MUT-8 has no previously annotated domains, and the mechanism by which it recruits MUT-7 to Mutator foci remains unclear">PMID:39188014</a><br />
+  and that it is largely intrinsically disordered<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/39188014" title="MUT-8 is predicted to be mostly unstructured, except for a partially structured NTD that is connected to a structured CTD by a long, flexible linker">PMID:39188014</a>.<br />
+  There is NO evidence RDE-2 is an SH2-domain signaling protein. Do NOT propagate the "SH2 domain"<br />
+  name into functional claims.</li>
+<li>rde-2 and mut-8 were shown to be the same gene (F21C3.4) by allele sequencing/mapping<br />
+  [PMID:15653635 "F21C3.4 corresponds to rde-2/mut-8"; "the alleles of rde-2 and mut-8 contained lesions within this gene"].</li>
+<li>PDB <strong>8Q66</strong> (2.03 Å) covers the MUT-8 CTD (residues 322–567) in complex with the MUT-7 CTD<br />
+  (from the Busetto 2024 structure).</li>
+<li>Interacts (IntAct, NbExp=8) with <strong>mut-7 / P34607</strong>.</li>
+</ul>
+<h2 id="known-well-supported">KNOWN (well supported)</h2>
+<h3 id="molecular-function-bridging-adaptor-in-the-mutator-complex-structural-not-enzymatic">Molecular function: bridging adaptor in the Mutator complex (structural, not enzymatic)</h3>
+<ul>
+<li>RDE-2/MUT-8 is a <strong>bridging adaptor</strong>: its C-terminal domain binds the MUT-7 exoribonuclease CTD,<br />
+  and its N-terminal domain contacts the MUT-16 scaffold, thereby recruiting MUT-7 to Mutator foci<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/39188014" title="MUT-7 carries a worm-specific insertion in MUT7-C, which acts as a binding platform for the nematode-specific factor MUT-8. MUT-8, in turn, directly contacts the Mutator scaffold MUT-16, recruiting MUT-7 to Mutator foci">PMID:39188014</a>.</li>
+<li>The MUT-7CTD/MUT-8CTD heterodimer was crystallized (PDB 8Q66); the interaction is direct and both<br />
+  full-length proteins co-migrate on SEC (Busetto 2024). MUT-8 CTD is insoluble without MUT-7<br />
+  ("MUT-8FL and MUT-8CTD are insoluble without MUT-7"), consistent with an obligate partner/adaptor.</li>
+<li>The direct MUT-7 &lt;-&gt; RDE-2 interaction was first shown by yeast two-hybrid + co-IP + relocalization<br />
+  [PMID:15653635 "we identified RDE-2 as another component of this complex"; the C-terminal part of MUT-7<br />
+  (aa 787-910) and most of F21C3.4 (aa 144-585) are required for the interaction; co-IP of MUT-7 with<br />
+  RDE-2 antibodies from wild-type but not rde-2(pk1657) cytosol]. NOTE: 2005 work localized the<br />
+  cytosolic MUT-7/RDE-2 complex to the cytosol; the 2012 germline work (below) localizes RDE-2 to<br />
+  perinuclear Mutator foci. Both are used — the informative, current CC is the Mutator focus.</li>
+<li>Genetically, mut-7 and rde-2 interact (dominant enhancement of mut-7(ne311) by rde-2(pk716))<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/15653635" title="showing that mut-7 and rde-2 interact genetically and suggests that interaction   between the two wild-type proteins is required for RNAi">PMID:15653635</a>.</li>
+</ul>
+<h3 id="biological-process-secondary-sirna-22g-rna-amplification-rnai-transposon-silencing">Biological process: secondary siRNA (22G-RNA) amplification / RNAi / transposon silencing</h3>
+<ul>
+<li>rde-2 was defined as one of four RNAi-deficient complementation groups in the original Fire/Mello<br />
+  screen [PMID:10535731 — the rde-1 paper; the abstract foregrounds rde-1 and rde-4, but the full<br />
+  screen defined the rde-1..rde-4 groups including rde-2; the IMP annotations to<br />
+  post-transcriptional gene silencing / regulatory ncRNA-mediated silencing / meiotic chromosome<br />
+  segregation are attributed to this paper with WormBase variant WB:WBVar00090964].</li>
+<li>The MUT-7/RDE-2 complex acts <strong>downstream of primary siRNA production and upstream of target RNA<br />
+  recognition</strong> — i.e. in the amplification step [PMID:15653635 "Together these data hint at a role<br />
+  for the MUT-7/RDE-2 complex in the amplification step of the RNAi pathway in C.elegans"; "rde-2<br />
+  mutant animals do not produce detectable levels of siRNAs in vivo"].</li>
+<li>rde-2 is one of the six "mutator" genes whose products form perinuclear Mutator foci; loss of any<br />
+  mutator gene (including rde-2) causes substantial loss of RdRP-dependent secondary siRNAs<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/30036386" title="mutations in any of the Mutator complex proteins (mut-2, mut-7, mut-14 smut-1,   mut-15, rde-2, rde-8, or rrf-1) result in a substantial loss of the RdRP-dependent secondary siRNAs">PMID:30036386</a>.</li>
+<li>The Mutator focus is a platform for 22G-RNA amplification by the RdRP RRF-1<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/22713602" title="We propose that the mutator proteins and RRF-1 constitute an RNA processing   compartment required for siRNA amplification and RNA silencing">PMID:22713602</a>.</li>
+</ul>
+<h3 id="cellular-component-perinuclear-mutator-foci-germline">Cellular component: perinuclear Mutator foci (germline)</h3>
+<ul>
+<li>Each of the six mutator proteins localizes to perinuclear Mutator foci, adjacent to but distinct<br />
+  from P granules <a href="https://pubmed.ncbi.nlm.nih.gov/22713602" title="each of the six mutator proteins localizes to punctate foci at the   periphery of germline nuclei. The Mutator foci are adjacent to P granules">PMID:22713602</a>.</li>
+<li>RDE-2 localization to Mutator foci depends on MUT-16 <a href="https://pubmed.ncbi.nlm.nih.gov/30036386" title="MUT-16 is required for   localization of MUT-2, MUT-7, RDE-2, MUT-14, and MUT-15, all of which localize independently of   one another except for MUT-7, which requires RDE-2 for localization">PMID:30036386</a>.</li>
+<li>Earlier biochemistry placed the MUT-7/RDE-2 complex in the cytosol (S100), not nucleus<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/15653635" title="the MUT-7 and RDE-2 proteins are associated with each other in the cytosol, but   not in the nucleus">PMID:15653635</a> — this is the basis of the GO:0005829 cytosol IDA.</li>
+</ul>
+<h3 id="meiotic-chromosome-segregation-him-phenotype">Meiotic chromosome segregation / Him phenotype</h3>
+<ul>
+<li>rde-2 (and mut-7) mutants show a high-incidence-of-males (Him) phenotype from X non-disjunction<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/15653635" title="both mut-7 and rde-2 mutants show a high incidence of males (him) phenotype ...   caused by non-disjunction of the X-chromosome">PMID:15653635</a>. This is the basis of the meiotic chromosome<br />
+  segregation IMP; it is a downstream/pleiotropic consequence of losing germline small-RNA silencing,<br />
+  not evidence that RDE-2 acts directly in the meiotic segregation machinery.</li>
+</ul>
+<h2 id="not-known-genuine-gaps">NOT known (genuine gaps)</h2>
+<ol>
+<li><strong>Molecular activity beyond adaptor bridging.</strong> RDE-2/MUT-8 has no catalytic activity and no<br />
+   canonical folded domain family; whether the intrinsically disordered N-terminal/linker regions do<br />
+   anything beyond MUT-16 binding (e.g. RNA binding, condensate nucleation, regulation of MUT-7<br />
+   nuclease activity) is undetermined <a href="https://pubmed.ncbi.nlm.nih.gov/39188014" title="MUT-8 has no previously annotated domains, and    the mechanism by which it recruits MUT-7 to Mutator foci remains unclear">PMID:39188014</a>.</li>
+<li><strong>Full partner set within the Mutator complex.</strong> Direct binary partners are established for MUT-7<br />
+   (CTD-CTD) and MUT-16 (via MUT-8 NTD). Whether RDE-2 directly contacts other mutator components<br />
+   (MUT-2/RDE-3, MUT-14, MUT-15, NYN-1/2, RDE-8, RRF-1) or only co-resides in the focus is not<br />
+   resolved; the deep-research/Uebel data place MUT-2/MUT-14/MUT-15 in a separate MUT-16 recruitment<br />
+   branch, implying no direct RDE-2 contact, but this has not been tested biochemically.</li>
+<li><strong>Mechanistic role in amplification.</strong> It is established that rde-2 loss abolishes secondary siRNA<br />
+   accumulation, but whether RDE-2's only contribution is to recruit/position MUT-7 (i.e. it is a pure<br />
+   structural bridge) or whether it also actively contributes to target-mRNA capture / RdRP templating<br />
+   is unknown.</li>
+<li><strong>The "SH2 domain" annotation.</strong> The UniProt protein name is an unverified automated assignment<br />
+   contradicted by the structural literature; there is no experimental support for SH2/phosphotyrosine<br />
+   signaling function.</li>
+</ol>
+<h2 id="reference-correctness-flags">Reference correctness flags</h2>
+<ul>
+<li>PMID:10535731 (rde-1 paper) is <strong>abstract-only</strong> in cache and the abstract does not name rde-2, but<br />
+  it is the paper WormBase cites for the rde-2 IMP silencing/segregation annotations (the screen that<br />
+  isolated all rde complementation groups). Per repo guidelines, do NOT REMOVE experimental IMP on the<br />
+  basis that the abstract foregrounds rde-1. Relevance MEDIUM (foundational screen), correctness<br />
+  VERIFIED for its role as the defining rde screen; supporting text for rde-2 specifics comes from the<br />
+  2005 paper.</li>
+<li>PMID:19123269 (interactome) is a high-throughput Y2H network paper; the rde-2 protein-binding IPI<br />
+  (with MUT-7 / P34607) is corroborated by the dedicated 2005 and 2024 studies.</li>
+<li>PMID:39188014 (Busetto 2024) is the key molecular-function reference (structure of MUT-8 CTD /<br />
+  MUT-7 CTD; PDB 8Q66). Full text cached. Relevance HIGH.</li>
+<li>Deep research: falcon report (rde-2-deep-research-falcon.md) completed (~19 min, 18 citations); its<br />
+  central claims (bridging adaptor; Mutator-foci localization; 22G-RNA amplification) are corroborated<br />
+  by the primary papers fetched here. perplexity-lite fallback failed (401 quota) — not used.</li>
+</ul>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: Q19672
+gene_symbol: rde-2
+aliases:
+- mut-8
+- F21C3.4
+product_type: PROTEIN
+status: DRAFT
+taxon:
+  id: NCBITaxon:6239
+  label: Caenorhabditis elegans
+description: &gt;-
+  RDE-2 (also known as MUT-8) is an intrinsically disordered bridging adaptor protein
+  of the C. elegans Mutator complex, the germline machinery that amplifies secondary
+  small interfering RNAs (22G-RNAs) for RNA-mediated silencing. RDE-2 has no catalytic
+  activity and no canonical folded domain; its structured C-terminal domain binds the
+  C-terminal domain of the 3&#39;-5&#39; exoribonuclease MUT-7, while its partially structured
+  N-terminal region contacts the intrinsically disordered scaffold MUT-16. By physically
+  linking MUT-7 to MUT-16, RDE-2 recruits the MUT-7 exoribonuclease into perinuclear
+  Mutator foci, the phase-separated condensates (adjacent to but distinct from P granules)
+  in which the RNA-dependent RNA polymerase RRF-1 synthesizes secondary siRNAs. This
+  function is required for exogenous and endogenous RNAi, transposon silencing, and
+  germline genome surveillance; loss of rde-2 abolishes secondary siRNA accumulation and
+  causes RNAi resistance, transposon mobilization and an X-chromosome non-disjunction
+  (high-incidence-of-males) phenotype. RDE-2 and its MUT-7 interaction are restricted to
+  the Caenorhabditis lineage.
+references:
+- id: PMID:10535731
+  title: The rde-1 gene, RNA interference, and transposon silencing in C. elegans.
+  findings:
+  - statement: &gt;-
+      Forward genetic screens for mutants resistant to double-stranded-RNA-mediated
+      interference defined the RNAi-deficient (rde) complementation groups in C. elegans,
+      the screen that isolated rde-2 alongside rde-1 and rde-4.
+    reference_section_type: ABSTRACT
+    supporting_text: &gt;-
+      In order to study the interference process, we have selected C. elegans mutants
+      resistant to dsRNA-mediated interference (RNAi).
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Abstract-only in cache and foregrounds rde-1/rde-4 (rde-2 is not named in the
+      abstract), but this is the foundational rde screen that defined the rde-2
+      complementation group and is the reference WormBase cites for the rde-2 IMP
+      silencing/segregation annotations (with WB:WBVar00090964). Not removed on the basis
+      of abstract framing per curation guidance; specific rde-2 phenotypes are documented
+      in PMID:15653635.
+- id: PMID:15653635
+  title: RDE-2 interacts with MUT-7 to mediate RNA interference in Caenorhabditis elegans.
+  findings:
+  - statement: &gt;-
+      RDE-2 (F21C3.4 = rde-2/mut-8) was identified as a MUT-7-interacting protein by yeast
+      two-hybrid, co-immunoprecipitation and re-localization; the MUT-7/RDE-2 complex acts
+      downstream of primary siRNA production and upstream of target recognition, in the
+      amplification step of RNAi.
+    reference_section_type: RESULTS
+    supporting_text: &gt;-
+      Together these data hint at a role for the MUT-7/RDE-2 complex in the amplification
+      step of the RNAi pathway in C.elegans.
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Full text (PMC546165) directly assays RDE-2/Q19672: establishes the direct MUT-7
+      interaction, cytosolic complex, RNAi requirement, gene identity (F21C3.4 =
+      rde-2/mut-8), and the Him phenotype. Primary reference for the molecular function,
+      cytosol localization and siRNA-amplification role.
+- id: PMID:19123269
+  title: Empirically controlled mapping of the Caenorhabditis elegans protein-protein interactome network.
+  findings:
+  - statement: &gt;-
+      High-throughput yeast two-hybrid interactome mapping reported an RDE-2 (Q19672)
+      protein-protein interaction with MUT-7 (P34607).
+    reference_section_type: ABSTRACT
+    supporting_text: &gt;-
+      Empirically controlled mapping of the Caenorhabditis elegans protein-protein
+      interactome network.
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Systematic Y2H network study; source of a second IPI &#39;protein binding&#39; annotation
+      for the RDE-2/MUT-7 interaction. Corroborates, but is less informative than, the
+      dedicated MUT-7/RDE-2 studies (PMID:15653635, PMID:39188014).
+- id: PMID:22713602
+  title: MUT-16 promotes formation of perinuclear mutator foci required for RNA silencing in the C. elegans germline.
+  findings:
+  - statement: &gt;-
+      Each of the six mutator proteins (including RDE-2) localizes to perinuclear Mutator
+      foci, punctate germline structures adjacent to but distinct from P granules that
+      constitute an RNA-processing compartment for siRNA amplification with the RdRP RRF-1.
+    reference_section_type: ABSTRACT
+    supporting_text: &gt;-
+      each of the six mutator proteins localizes to punctate foci at the periphery of
+      germline nuclei. The Mutator foci are adjacent to P granules
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Abstract-only in cache but is the origin reference for the GO:1990633 mutator focus
+      localization of RDE-2; defines Mutator foci as the siRNA-amplification compartment.
+- id: PMID:39188014
+  title: MUT-7 exoribonuclease activity and localization are mediated by an ancient domain.
+  findings:
+  - statement: &gt;-
+      Structural and biochemical study (crystal structure PDB 8Q66 of the MUT-7 CTD /
+      MUT-8 CTD complex) showing RDE-2/MUT-8 binds the MUT-7 exoribonuclease via a
+      worm-specific insertion in MUT7-C and thereby mediates MUT-7 recruitment to germ
+      granules / Mutator foci.
+    reference_section_type: ABSTRACT
+    supporting_text: &gt;-
+      Caenorhabditis elegans MUT-7 contains a specific insertion within MUT7-C, which
+      allows binding to MUT-8 and, consequently, MUT-7 recruitment to germ granules
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PubMed/PMC-verified (PMC11347159); full text directly characterizes CeMUT-8 (Q19672)
+      as a mostly disordered adaptor with no annotated domains that bridges MUT-7 to the
+      MUT-16 scaffold, contradicting the automated UniProt &#39;SH2 domain&#39; name. Referenced by
+      UniProt as the source of PDB 8Q66.
+- id: PMID:30036386
+  title: Distinct regions of the intrinsically disordered protein MUT-16 mediate assembly of a small RNA amplification complex and promote phase separation of mutator foci.
+  findings:
+  - statement: &gt;-
+      MUT-16 is required for localization of RDE-2 (and other mutator proteins) to Mutator
+      foci; RDE-2 in turn is required for MUT-7 localization, placing RDE-2 in a
+      MUT-16 -&gt; RDE-2 -&gt; MUT-7 recruitment axis. Loss of any mutator complex protein
+      abolishes RdRP-dependent secondary siRNAs.
+    reference_section_type: RESULTS
+    supporting_text: &gt;-
+      MUT-16 is required for localization of MUT-2, MUT-7, RDE-2, MUT-14, and MUT-15, all
+      of which localize independently of one another except for MUT-7, which requires RDE-2
+      for localization
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Full text (PMC6072111) directly assays RDE-2 localization dependence and calls RDE-2
+      a protein of previously unknown function; supports the adaptor/recruitment role and
+      the requirement of the whole complex for secondary siRNA accumulation.
+existing_annotations:
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:15653635
+  qualifier: enables
+  review:
+    summary: &gt;-
+      The IPI interaction with MUT-7 (P34607) is real and central, but &#39;protein binding&#39;
+      is uninformative. RDE-2&#39;s molecular function is to bridge the MUT-7 exoribonuclease
+      to the MUT-16 scaffold, i.e. a molecular adaptor activity; this is the core molecular
+      function of the protein.
+    action: MODIFY
+    reason: &gt;-
+      Replace the uninformative &#39;protein binding&#39; with the more specific molecular adaptor
+      activity. RDE-2 binds MUT-7 via its CTD and MUT-16 via its NTD, physically linking
+      the two so that MUT-7 is recruited into Mutator foci (PMID:15653635, PMID:39188014).
+    proposed_replacement_terms:
+    - id: GO:0060090
+      label: molecular adaptor activity
+    supported_by:
+    - reference_id: PMID:39188014
+      supporting_text: &gt;-
+        Caenorhabditis elegans MUT-7 contains a specific insertion within MUT7-C, which
+        allows binding to MUT-8 and, consequently, MUT-7 recruitment to germ granules
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:19123269
+  qualifier: enables
+  review:
+    summary: &gt;-
+      A second IPI &#39;protein binding&#39; annotation from a high-throughput interactome dataset
+      recording the RDE-2/MUT-7 interaction. The interaction is genuine and corroborates
+      the adaptor role, but the term itself is uninformative.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      &#39;protein binding&#39; conveys no functional specificity; the informative molecular
+      function (molecular adaptor activity) is captured from the dedicated interaction
+      studies. Retained as supporting evidence for the MUT-7 interaction but not as a core
+      function.
+    supported_by:
+    - reference_id: PMID:30036386
+      supporting_text: &gt;-
+        two proteins of unknown function, RDE-2 and MUT-15
+- term:
+    id: GO:0030422
+    label: siRNA processing
+  evidence_type: IDA
+  original_reference_id: PMID:15653635
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      RDE-2 is required for accumulation of siRNAs in vivo; the MUT-7/RDE-2 complex acts in
+      the RdRP-dependent siRNA amplification step. GO:0030422 explicitly includes
+      amplification of siRNA by RNA-directed RNA polymerase, so this is an appropriate core
+      biological-process term.
+    action: ACCEPT
+    reason: &gt;-
+      rde-2 mutants do not produce detectable siRNAs in vivo, and the complex functions
+      downstream of primary siRNA production in amplification, consistent with the
+      siRNA-processing term definition.
+    supported_by:
+    - reference_id: PMID:15653635
+      supporting_text: &gt;-
+        Together these data hint at a role for the MUT-7/RDE-2 complex in the amplification
+        step of the RNAi pathway in C.elegans.
+- term:
+    id: GO:1990633
+    label: mutator focus
+  evidence_type: IDA
+  original_reference_id: PMID:22713602
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      RDE-2 is one of the six mutator proteins that localize to perinuclear Mutator foci in
+      the germline, the siRNA-amplification compartment. This is the informative,
+      species-appropriate cellular-component annotation and represents where RDE-2 carries
+      out its function.
+    action: ACCEPT
+    reason: &gt;-
+      Direct localization of the mutator proteins (including RDE-2) to perinuclear Mutator
+      foci; RDE-2 localization to these foci depends on MUT-16 (PMID:30036386).
+    supported_by:
+    - reference_id: PMID:22713602
+      supporting_text: &gt;-
+        each of the six mutator proteins localizes to punctate foci at the periphery of
+        germline nuclei. The Mutator foci are adjacent to P granules
+- term:
+    id: GO:0016441
+    label: post-transcriptional gene silencing
+  evidence_type: IMP
+  original_reference_id: PMID:10535731
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Loss of rde-2 causes RNAi resistance and transposon de-silencing, i.e. defective
+      post-transcriptional gene silencing. This is a defining phenotype of the gene, though
+      it is a parent of the more specific regulatory-ncRNA-mediated PTGS term.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Correct but general; the more specific GO:0035194 (regulatory ncRNA-mediated
+      post-transcriptional gene silencing) better captures the mechanism and is retained as
+      core. Kept as valid non-core context.
+    supported_by:
+    - reference_id: PMID:15653635
+      supporting_text: &gt;-
+        This allele, removing the last three-quarters of the gene, is viable and is RNAi
+        resistant
+- term:
+    id: GO:0045132
+    label: meiotic chromosome segregation
+  evidence_type: IMP
+  original_reference_id: PMID:10535731
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      rde-2 mutants show a high-incidence-of-males (Him) phenotype caused by X-chromosome
+      non-disjunction. This is a downstream, pleiotropic consequence of losing germline
+      small-RNA silencing rather than evidence that RDE-2 acts directly in the meiotic
+      chromosome-segregation machinery.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      The segregation defect is an indirect consequence of the RNAi/silencing deficiency
+      (shared with mut-7), not a direct molecular role of RDE-2 in meiosis. Retained as a
+      non-core phenotype-based annotation.
+    supported_by:
+    - reference_id: PMID:15653635
+      supporting_text: &gt;-
+        both mut-7 and rde-2 mutants show a high incidence of males (him) phenotype
+- term:
+    id: GO:0035194
+    label: regulatory ncRNA-mediated post-transcriptional gene silencing
+  evidence_type: IMP
+  original_reference_id: PMID:10535731
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      RDE-2 is required for small-RNA (siRNA/22G-RNA)-guided silencing of endogenous and
+      exogenous targets and of transposons; this term captures the specific mechanism of
+      RDE-2&#39;s biological role and is a core process annotation.
+    action: ACCEPT
+    reason: &gt;-
+      Loss of rde-2 abolishes RdRP-dependent secondary siRNA accumulation and silencing,
+      the defining regulatory-ncRNA-mediated PTGS function.
+    supported_by:
+    - reference_id: PMID:30036386
+      supporting_text: &gt;-
+        mut-15, rde-2, rde-8, or rrf-1) result in a substantial loss of the RdRP-dependent
+        secondary siRNAs
+- term:
+    id: GO:0005829
+    label: cytosol
+  evidence_type: IDA
+  original_reference_id: PMID:15653635
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Biochemical fractionation placed the MUT-7/RDE-2 complex in the cytosolic (S100)
+      fraction. This is correct but generic; the informative, function-relevant localization
+      is the perinuclear Mutator focus (GO:1990633), which is a specialized cytoplasmic
+      compartment.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Valid subcellular fraction data, but subsumed functionally by the Mutator-focus
+      annotation. Kept as non-core supporting localization.
+    supported_by:
+    - reference_id: PMID:15653635
+      supporting_text: &gt;-
+        the MUT-7 and RDE-2 proteins are associated with each other in the cytosol, but not
+        in the nucleus
+core_functions:
+- description: &gt;-
+    Molecular adaptor that bridges the MUT-7 3&#39;-5&#39; exoribonuclease to the MUT-16 scaffold,
+    recruiting MUT-7 into perinuclear Mutator foci for secondary siRNA amplification.
+  molecular_function:
+    id: GO:0060090
+    label: molecular adaptor activity
+  directly_involved_in:
+  - id: GO:0035194
+    label: regulatory ncRNA-mediated post-transcriptional gene silencing
+  locations:
+  - id: GO:1990633
+    label: mutator focus
+  supported_by:
+  - reference_id: PMID:39188014
+    supporting_text: &gt;-
+      Caenorhabditis elegans MUT-7 contains a specific insertion within MUT7-C, which
+      allows binding to MUT-8 and, consequently, MUT-7 recruitment to germ granules
+  - reference_id: PMID:15653635
+    supporting_text: &gt;-
+      Together these data hint at a role for the MUT-7/RDE-2 complex in the amplification
+      step of the RNAi pathway in C.elegans.
+  - reference_id: file:worm/rde-2/rde-2-deep-research-falcon.md
+    supporting_text: &gt;-
+      RDE-2/MUT-8 is not an enzyme itself; rather, it serves a structural/adapter role
+- description: &gt;-
+    Required for RdRP (RRF-1)-dependent secondary siRNA (22G-RNA) amplification underlying
+    RNA interference and transposon silencing in the germline.
+  molecular_function:
+    id: GO:0060090
+    label: molecular adaptor activity
+  directly_involved_in:
+  - id: GO:0030422
+    label: siRNA processing
+  locations:
+  - id: GO:1990633
+    label: mutator focus
+  supported_by:
+  - reference_id: PMID:30036386
+    supporting_text: &gt;-
+      mut-15, rde-2, rde-8, or rrf-1) result in a substantial loss of the RdRP-dependent
+      secondary siRNAs
+knowledge_gaps:
+- gap_statement: &gt;-
+    Beyond acting as a passive structural bridge between MUT-7 and MUT-16, it is unknown
+    whether the intrinsically disordered regions of RDE-2/MUT-8 have any additional
+    molecular activity (e.g. RNA binding, condensate nucleation, or allosteric regulation
+    of MUT-7 nuclease activity). RDE-2 has no catalytic activity and no canonical folded
+    domain, so its full biochemical contribution to the complex is undefined.
+  boundary: &gt;-
+    It is firmly established that RDE-2&#39;s structured C-terminal domain binds the MUT-7 CTD
+    (crystal structure PDB 8Q66) and that its partially structured N-terminal region
+    contacts the MUT-16 scaffold, recruiting MUT-7 to Mutator foci. What is unknown is
+    whether RDE-2 does anything mechanistically beyond this bridging.
+  gap_kind:
+  - BIOLOGY
+  dark_aspect: MF_DARK
+  status: OPEN
+  significance: &gt;-
+    Because RDE-2 is essential for secondary siRNA amplification but is not itself an
+    enzyme, distinguishing &#39;pure scaffold/recruiter&#39; from &#39;active participant&#39; would
+    determine whether the amplification defect in rde-2 mutants is purely a
+    mislocalization/assembly failure or also a loss of a direct biochemical step.
+  resolution: &gt;-
+    In vitro reconstitution of the MUT-16/RDE-2/MUT-7 module with siRNA-amplification
+    assays, RNA-binding assays on isolated RDE-2 domains, and separation-of-function RDE-2
+    alleles that retain MUT-7/MUT-16 binding but disrupt any additional activity would
+    resolve this.
+  provenance:
+  - reference_id: PMID:30036386
+    supporting_text: &gt;-
+      two proteins of unknown function, RDE-2 and MUT-15
+- gap_statement: &gt;-
+    The complete set of RDE-2 direct binding partners within the Mutator complex is
+    unresolved. Direct interactions are established only with MUT-7 (CTD-CTD) and MUT-16
+    (via the RDE-2 N-terminal region); whether RDE-2 directly contacts other mutator
+    components (MUT-2/RDE-3, MUT-14, MUT-15, NYN-1/2, RDE-8) or the RdRP RRF-1, or merely
+    co-resides with them in the focus, has not been tested biochemically.
+  boundary: &gt;-
+    RDE-2 localization to Mutator foci depends on MUT-16, and RDE-2 is in turn required for
+    MUT-7 localization (a MUT-16 -&gt; RDE-2 -&gt; MUT-7 recruitment axis). Other mutator
+    components localize via separate MUT-16 branches, but their direct/indirect relationship
+    to RDE-2 is inferred from localization dependencies, not from binary interaction data.
+  gap_kind:
+  - BIOLOGY
+  dark_aspect: RESIDUAL_SUBGAP
+  status: OPEN
+  significance: &gt;-
+    Knowing which contacts are direct defines the true architecture of the amplification
+    compartment and whether RDE-2 is a dedicated MUT-7 adaptor or a more central hub.
+  resolution: &gt;-
+    Systematic binary interaction mapping (e.g. reconstituted pulldowns, crosslinking mass
+    spectrometry, or cryo-EM of the assembled complex) of RDE-2 against each mutator
+    component.
+  provenance:
+  - reference_id: PMID:30036386
+    supporting_text: &gt;-
+      MUT-16 is required for localization of MUT-2, MUT-7, RDE-2, MUT-14, and MUT-15, all
+      of which localize independently of one another except for MUT-7, which requires RDE-2
+      for localization
+- gap_statement: &gt;-
+    How RDE-2 mechanistically contributes to the secondary siRNA (22G-RNA) amplification
+    reaction itself is unknown. It is established that rde-2 loss abolishes RdRP-dependent
+    secondary siRNA accumulation, but whether RDE-2&#39;s only role is to recruit and position
+    MUT-7, or whether it also participates in target-mRNA capture or templating for RRF-1,
+    is undetermined.
+  boundary: &gt;-
+    The genetic requirement is clear (no detectable secondary siRNAs without rde-2) and the
+    focus-assembly role is structurally defined, but the biochemical step at which RDE-2 acts
+    within amplification is not.
+  gap_kind:
+  - BIOLOGY
+  - ONTOLOGY
+  dark_aspect: MF_DARK
+  status: OPEN
+  significance: &gt;-
+    Secondary siRNA amplification is the amplifying core of C. elegans RNA silencing and
+    heritable epigenetic inheritance; resolving RDE-2&#39;s step would clarify a rate-limiting
+    node. There is also no GO term for &#39;secondary siRNA amplification&#39; as a distinct process
+    or for a &#39;structural constituent of the Mutator complex&#39;, so RDE-2&#39;s specific
+    contribution cannot currently be expressed precisely.
+  resolution: &gt;-
+    Mechanistic in vitro amplification assays with defined mutator subcomplexes, plus
+    ontology development for a secondary-siRNA-amplification process term and/or a
+    Mutator-complex structural-constituent term.
+  provenance:
+  - reference_id: PMID:22713602
+    supporting_text: &gt;-
+      We propose that the mutator proteins and RRF-1 constitute an RNA processing
+      compartment required for siRNA amplification and RNA silencing
+proposed_new_terms:
+- proposed_name: secondary siRNA amplification
+  proposed_definition: &gt;-
+    The RNA-dependent RNA polymerase (RdRP)-mediated de novo synthesis of secondary small
+    interfering RNAs (e.g. C. elegans 22G-RNAs) templated on target mRNAs recognized by
+    primary small RNAs, occurring within a specialized RNA-processing compartment (Mutator
+    focus). Distinguished from siRNA processing/Dicer-dependent primary siRNA generation.
+  justification: &gt;-
+    RDE-2 and the Mutator complex act specifically in RdRP-dependent secondary siRNA
+    amplification, a step for which no dedicated GO term exists; siRNA processing (GO:0030422)
+    conflates Dicer-dependent primary siRNA generation with amplification.
+- proposed_name: structural constituent of Mutator complex
+  proposed_definition: &gt;-
+    A molecular function in which a protein provides a structural/organizational role as a
+    subunit of the C. elegans Mutator complex, contributing to assembly of the
+    siRNA-amplification compartment rather than catalysis.
+  justification: &gt;-
+    RDE-2 is an obligate structural adaptor subunit with no catalytic activity; molecular
+    adaptor activity (GO:0060090) captures the bridging aspect, but a complex-specific
+    structural-constituent term would more precisely express its &#39;be part of the machine&#39;
+    role.
+suggested_questions:
+- question: &gt;-
+    Does RDE-2/MUT-8 possess any activity beyond bridging MUT-7 and MUT-16 - for example
+    intrinsic RNA binding or a role in nucleating Mutator-focus condensation?
+  experts:
+  - René F. Ketting
+  - Sebastian Falk
+  - Carolyn M. Phillips
+suggested_experiments:
+- hypothesis: &gt;-
+    RDE-2 acts purely as a structural adaptor whose sole essential role is to recruit and
+    position MUT-7 within Mutator foci.
+  description: &gt;-
+    Generate separation-of-function rde-2 alleles that retain MUT-16 binding but disrupt
+    the MUT-7 CTD interface (guided by the PDB 8Q66 interface), assay MUT-7 focus
+    localization, secondary 22G-RNA levels, and RNAi/transposon-silencing competence.
+  experiment_type: structure-guided mutagenesis with small-RNA sequencing and localization
+- hypothesis: &gt;-
+    RDE-2 directly contacts additional mutator components beyond MUT-7 and MUT-16.
+  description: &gt;-
+    Reconstitute recombinant RDE-2 with each mutator component and RRF-1 and test for
+    direct binary interactions by pulldown/SEC and crosslinking mass spectrometry, and
+    attempt cryo-EM of the assembled complex.
+  experiment_type: in vitro interaction mapping / structural biology
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/pages/projects/CAEEL_CILIOPATHY.html
+++ b/pages/projects/CAEEL_CILIOPATHY.html
@@ -383,16 +383,16 @@
 <h3 id="2-intraflagellar-transport-ift-anterograde">2. Intraflagellar Transport (IFT) - Anterograde</h3>
 <p>Kinesin-2 motors and IFT-B complex:<br />
 - <strong><a href="../../genes/worm/osm-3/osm-3-ai-review.html">osm-3</a></strong> - Kinesin-2 motor (homodimeric)<br />
-- <strong>klp-11</strong> - Kinesin-2 motor (heterotrimeric with klp-20/kap-1)<br />
+- <strong><a href="../../genes/worm/klp-11/klp-11-ai-review.html">klp-11</a></strong> - Kinesin-2 motor (heterotrimeric with <a href="../../genes/worm/klp-20/klp-20-ai-review.html">klp-20</a>/kap-1)<br />
 - <strong><a href="../../genes/worm/osm-5/osm-5-ai-review.html">osm-5</a></strong> - IFT88 ortholog (IFT-B complex)<br />
 - <strong><a href="../../genes/worm/osm-6/osm-6-ai-review.html">osm-6</a></strong> - IFT52 ortholog<br />
 - <strong><a href="../../genes/worm/che-2/che-2-ai-review.html">che-2</a></strong> - IFT80 ortholog<br />
 - <strong><a href="../../genes/worm/che-13/che-13-ai-review.html">che-13</a></strong> - IFT57 ortholog<br />
 - <strong><a href="../../genes/worm/dyf-1/dyf-1-ai-review.html">dyf-1</a></strong> - Required for <a href="../../genes/worm/osm-3/osm-3-ai-review.html">osm-3</a> function<br />
 - <strong><a href="../../genes/worm/dyf-3/dyf-3-ai-review.html">dyf-3</a></strong> - IFT54 ortholog<br />
-- <strong>dyf-6</strong> - IFT46 ortholog<br />
+- <strong><a href="../../genes/worm/dyf-6/dyf-6-ai-review.html">dyf-6</a></strong> - IFT46 ortholog<br />
 - <strong><a href="../../genes/worm/dyf-11/dyf-11-ai-review.html">dyf-11</a></strong> - IFT54 ortholog<br />
-- <strong>dyf-13</strong> - TTC26 ortholog</p>
+- <strong><a href="../../genes/worm/dyf-13/dyf-13-ai-review.html">dyf-13</a></strong> - TTC26 ortholog</p>
 <h3 id="3-intraflagellar-transport-ift-retrograde">3. Intraflagellar Transport (IFT) - Retrograde</h3>
 <p>Dynein motor and IFT-A complex:<br />
 - <strong><a href="../../genes/worm/che-3/che-3-ai-review.html">che-3</a></strong> - Cytoplasmic dynein heavy chain<br />
@@ -407,10 +407,10 @@
 - <strong><a href="../../genes/worm/mks-3/mks-3-ai-review.html">mks-3</a></strong> - <a href="../../genes/human/TMEM67/TMEM67-ai-review.html">TMEM67</a> ortholog<br />
 - <strong><a href="../../genes/worm/mks-5/mks-5-ai-review.html">mks-5</a></strong> - RPGRIP1L ortholog<br />
 - <strong><a href="../../genes/worm/mks-6/mks-6-ai-review.html">mks-6</a></strong> - CC2D2A ortholog<br />
-- <strong>mksr-1</strong> - B9D1 ortholog<br />
+- <strong><a href="../../genes/worm/mksr-1/mksr-1-ai-review.html">mksr-1</a></strong> - B9D1 ortholog<br />
 - <strong><a href="../../genes/worm/mksr-2/mksr-2-ai-review.html">mksr-2</a></strong> - B9D2 ortholog<br />
 - <strong><a href="../../genes/worm/nphp-1/nphp-1-ai-review.html">nphp-1</a></strong> - NPHP1 ortholog<br />
-- <strong>nphp-2</strong> - Inversin ortholog<br />
+- <strong><a href="../../genes/worm/nphp-2/nphp-2-ai-review.html">nphp-2</a></strong> - Inversin ortholog<br />
 - <strong><a href="../../genes/worm/nphp-4/nphp-4-ai-review.html">nphp-4</a></strong> - NPHP4 ortholog</p>
 <h3 id="5-bbsome-complex">5. BBSome Complex</h3>
 <p>Bardet-Biedl syndrome proteins:<br />
@@ -420,7 +420,7 @@
 - <strong><a href="../../genes/worm/bbs-5/bbs-5-ai-review.html">bbs-5</a></strong> - <a href="../../genes/human/BBS5/BBS5-ai-review.html">BBS5</a> ortholog<br />
 - <strong><a href="../../genes/worm/bbs-7/bbs-7-ai-review.html">bbs-7</a></strong> - <a href="../../genes/human/BBS7/BBS7-ai-review.html">BBS7</a> ortholog<br />
 - <strong><a href="../../genes/worm/bbs-8/bbs-8-ai-review.html">bbs-8</a></strong> - BBS8/TTC8 ortholog<br />
-- <strong>bbs-9</strong> - <a href="../../genes/human/BBS9/BBS9-ai-review.html">BBS9</a>/PTHB1 ortholog</p>
+- <strong><a href="../../genes/worm/bbs-9/bbs-9-ai-review.html">bbs-9</a></strong> - <a href="../../genes/human/BBS9/BBS9-ai-review.html">BBS9</a>/PTHB1 ortholog</p>
 <h3 id="6-polycystic-kidney-disease-genes">6. Polycystic Kidney Disease Genes</h3>
 <ul>
 <li><strong><a href="../../genes/worm/lov-1/lov-1-ai-review.html">lov-1</a></strong> - PKD1 ortholog (male mating behavior)</li>
@@ -430,7 +430,7 @@
 <ul>
 <li><strong><a href="../../genes/worm/tax-2/tax-2-ai-review.html">tax-2</a></strong> - Cyclic nucleotide-gated channel alpha</li>
 <li><strong><a href="../../genes/worm/tax-4/tax-4-ai-review.html">tax-4</a></strong> - Cyclic nucleotide-gated channel beta</li>
-<li><strong>odr-1</strong> - Guanylyl cyclase</li>
+<li><strong><a href="../../genes/worm/odr-1/odr-1-ai-review.html">odr-1</a></strong> - Guanylyl cyclase</li>
 <li><strong><a href="../../genes/worm/pef-1/pef-1-ai-review.html">pef-1</a></strong> - PPEF phosphatase (2024 discovery)</li>
 </ul>
 <h2 id="genes-for-review-priority-order">Genes for Review (Priority Order)</h2>
@@ -606,7 +606,7 @@
 <li>Inglis PN et al. (2007) Curr Biol - X-box ciliary gene identification</li>
 <li>Williams CL et al. (2011) Nat Genet - MKS/NPHP transition zone</li>
 <li>Blacque OE et al. (2004) Curr Biol - BBS genes in IFT</li>
-<li>Wei Q et al. (2012) J Cell Biol - NPHP-2 genetic interactions</li>
+<li>Wei Q et al. (2012) J Cell Biol - <a href="../../genes/worm/nphp-2/nphp-2-ai-review.html">NPHP-2</a> genetic interactions</li>
 <li>Scheidel N &amp; Bharat T (2024) Sci Rep - <a href="../../genes/worm/pef-1/pef-1-ai-review.html">PEF-1</a> ciliary localization</li>
 </ul>
 <h2 id="project-status">Project Status</h2>

--- a/pages/projects/CAEEL_CILIOPATHY/CAEEL_CILIOPATHY_CURATION_RECOMMENDATIONS.html
+++ b/pages/projects/CAEEL_CILIOPATHY/CAEEL_CILIOPATHY_CURATION_RECOMMENDATIONS.html
@@ -1038,7 +1038,7 @@
 <h4 id="mark_as_over_annotated-go0005515-protein-binding">MARK_AS_OVER_ANNOTATED: <a href="http://amigo.geneontology.org/amigo/term/GO:0005515">GO:0005515</a> - protein binding</h4>
 <ul>
 <li><strong>Evidence:</strong> IPI</li>
-<li><strong>Issue:</strong> The term 'protein binding' (<a href="http://amigo.geneontology.org/amigo/term/GO:0005515">GO:0005515</a>) is too generic and uninformative per GO curation guidelines. The interaction with MKSR-1 is biologically relev</li>
+<li><strong>Issue:</strong> The term 'protein binding' (<a href="http://amigo.geneontology.org/amigo/term/GO:0005515">GO:0005515</a>) is too generic and uninformative per GO curation guidelines. The interaction with <a href="../../../genes/worm/mksr-1/mksr-1-ai-review.html">MKSR-1</a> is biologically relev</li>
 </ul>
 <h4 id="mark_as_over_annotated-go0005515-protein-binding_1">MARK_AS_OVER_ANNOTATED: <a href="http://amigo.geneontology.org/amigo/term/GO:0005515">GO:0005515</a> - protein binding</h4>
 <ul>

--- a/pages/projects/CAEEL_MITOPHAGY.html
+++ b/pages/projects/CAEEL_MITOPHAGY.html
@@ -402,7 +402,7 @@
 - <strong><a href="../../genes/worm/eat-3/eat-3-ai-review.html">eat-3</a></strong> - <a href="../../genes/DANRE/opa1/opa1-ai-review.html">OPA1</a> ortholog (inner membrane fusion)<br />
 - <strong><a href="../../genes/worm/fis-1/fis-1-ai-review.html">fis-1</a></strong> - FIS1 (fission factor)<br />
 - <strong><a href="../../genes/worm/fis-2/fis-2-ai-review.html">fis-2</a></strong> - MFF ortholog (fission)<br />
-- <strong>mff-1</strong> - MFF ortholog</p>
+- <strong><a href="../../genes/worm/mff-1/mff-1-ai-review.html">mff-1</a></strong> - MFF ortholog</p>
 <h3 id="4-core-autophagy-machinery">4. Core Autophagy Machinery</h3>
 <p>Shared with other autophagy pathways:<br />
 - <strong><a href="../../genes/worm/bec-1/bec-1-ai-review.html">bec-1</a></strong> - Beclin ortholog<br />

--- a/pages/projects/CAEEL_P_GRANULES.html
+++ b/pages/projects/CAEEL_P_GRANULES.html
@@ -415,7 +415,7 @@
 <h3 id="8-mutator-foci-components">8. Mutator Foci Components</h3>
 <p>Adjacent condensate for siRNA amplification:<br />
 - <strong><a href="../../genes/worm/mut-16/mut-16-ai-review.html">mut-16</a></strong> - Mutator 16 (Mutator focus scaffold)<br />
-- <strong>rde-2</strong> - RNAi defective 2</p>
+- <strong><a href="../../genes/worm/rde-2/rde-2-ai-review.html">rde-2</a></strong> - RNAi defective 2</p>
 <h3 id="9-rna-metabolism">9. RNA Metabolism</h3>
 <ul>
 <li><strong><a href="../../genes/worm/car-1/car-1-ai-review.html">car-1</a></strong> - Cytokinesis, apoptosis, RNA-associated (LSM14)</li>

--- a/pages/projects/CAEEL_SURVEILLANCE_IMMUNITY.html
+++ b/pages/projects/CAEEL_SURVEILLANCE_IMMUNITY.html
@@ -412,7 +412,7 @@
 <p>Induced defense genes:<br />
 - <strong><a href="../../genes/worm/irg-1/irg-1-ai-review.html">irg-1</a></strong> - Infection response gene 1 (key readout)<br />
 - <strong><a href="../../genes/worm/irg-2/irg-2-ai-review.html">irg-2</a></strong> - Infection response gene 2<br />
-- <strong>lys-1/2/7/8</strong> - Lysozymes<br />
+- <strong><a href="../../genes/worm/lys-1/lys-1-ai-review.html">lys-1</a>/2/7/8</strong> - Lysozymes<br />
 - <strong>clec-* family</strong> - C-type lectins<br />
 - <strong>abf-* family</strong> - Antibacterial factors<br />
 - <strong>cnc-* family</strong> - Caenacins (antifungal)<br />


### PR DESCRIPTION
## Summary

Automated regeneration of static assets after gene review or template changes.

## Generated Assets

| Asset | Count/Status |
|-------|--------------|
| Gene review YAML files | 2904 |
| Gene review HTML pages | 2904 |
| Project pages | 1098 |
| Module pages | 87 |
| Browser app (data.js) | Updated |
| Validation report | Updated |

## Trigger

This PR was triggered by changes to:
- genes/**/*.yaml - gene review data files
- src/ai_gene_review/schema/** - LinkML schema files
- src/ai_gene_review/templates/** - Jinja2 templates
- src/ai_gene_review/render.py - rendering code
- src/ai_gene_review/render_modules.py - module rendering code
- src/ai_gene_review/export/** - export code
- src/ai_gene_review/browser/** - browser app assets
- src/ai_gene_review/tools/minify_linkml_browser_data.py - browser data compaction
- projects/*.md - project definitions
- modules/**/*.yaml - module definitions
- project.justfile - just recipes used by CI
- .github/workflows/generate-pages.yaml - workflow definition

## Review

- [ ] Spot-check a few gene review HTML pages render correctly
- [ ] Spot-check module tree browser pages render correctly
- [ ] Verify browser app loads and filters work
- [ ] Check validation report for new issues
