### PR TITLE
Regenerate pages and browser app

### DIFF
--- a/genes/yeast/AMD2/AMD2-ai-review.html
+++ b/genes/yeast/AMD2/AMD2-ai-review.html
@@ -1,0 +1,2591 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>AMD2 - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        .propagation-review {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f8fafc;
+            border-left: 3px solid #64748b;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .propagation-title {
+            font-weight: 600;
+            color: #334155;
+            margin-bottom: 0.25rem;
+        }
+
+        .propagation-row {
+            margin-top: 0.25rem;
+        }
+
+        .propagation-source {
+            margin-top: 0.5rem;
+            padding-top: 0.5rem;
+            border-top: 1px solid #e5e7eb;
+        }
+
+        .propagation-source-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #1d4ed8;
+        }
+
+        .propagation-comment {
+            color: #4b5563;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>AMD2</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/P22580" target="_blank" class="term-link">
+                        P22580
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Saccharomyces cerevisiae</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-complete">
+                    COMPLETE
+                </span>
+            </div>
+
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "AMD2";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="P22580" data-a="DESCRIPTION: AMD2 (systematic name YDR242W) encodes a 549-resid..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>AMD2 (systematic name YDR242W) encodes a 549-residue probable amidase of Saccharomyces cerevisiae belonging to the amidase signature (AS) family (Pfam PF01425; InterPro IPR023631). Members of this family are amidohydrolases that use a conserved Ser-cisSer-Lys catalytic triad to hydrolyse carboxamide bonds, converting a carboxylic acid amide plus water into the corresponding carboxylate and ammonium. AMD2 retains the canonical catalytic triad and family sequence signature, and is assigned the generic amidase reaction (EC 3.5.1.4), but its physiological substrate, the specific reaction it catalyses in vivo, its subcellular localization, and the biological process it participates in have not been determined experimentally. Despite the family assignment, S. cerevisiae does not grow on acetamide as a nitrogen source and requires a heterologous acetamidase to do so, indicating AMD2 is not a classical acetamidase. It is a non-essential gene of currently uncharacterized biological role.</p>
+    </div>
+
+
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004040" target="_blank" class="term-link">
+                                    GO:0004040
+                                </a>
+                            </span>
+                            <span class="term-label">amidase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000120
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P22580" data-a="GO:0004040" data-r="GO_REF:0000120" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Domain-defensible generic molecular function. AMD2 is a bona fide member of the amidase signature (AS) family (Pfam PF01425; InterPro IPR023631; PROSITE PS00571) and retains the conserved Ser-cisSer-Lys catalytic triad (UniProt ACT_SITE 132, 209, 233). GO:0004040 corresponds exactly to the family/EC 3.5.1.4 reaction &#34;a monocarboxylic acid amide + H2O = a monocarboxylate + NH4+&#34;, which is the generic parent activity. The annotation is appropriate AT THE GENERIC LEVEL; a specific-substrate amidase term would be over-annotation because the AS fold is substrate-promiscuous and no substrate has been determined for AMD2.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct family- and fold-supported molecular function at the generic level. This is the single defensible functional statement for this dark gene and is retained as its core function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    UniProt:P22580
+
+                                </span>
+
+                                <div class="support-text">Pfam; PF01425; Amidase; 1.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    UniProt:P22580
+
+                                </span>
+
+                                <div class="support-text">InterPro; IPR023631; Amidase_dom.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:yeast/AMD2/AMD2-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">AMD2 belongs to the Amidase Signature (AS) superfamily</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003674" target="_blank" class="term-link">
+                                    GO:0003674
+                                </a>
+                            </span>
+                            <span class="term-label">molecular_function</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ND</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000015
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P22580" data-a="GO:0003674" data-r="GO_REF:0000015" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Root-level placeholder assigned by SGD with the ND (No biological Data) code, reflecting that no experimental molecular-function data existed at the time. It is superseded by the more specific IEA amidase-activity annotation above (which is itself only generic). Root MF terms carry no biological information and are not core.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Uninformative root placeholder retained per GO conventions for ND annotations; not a curation target and not a core function.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005575" target="_blank" class="term-link">
+                                    GO:0005575
+                                </a>
+                            </span>
+                            <span class="term-label">cellular_component</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ND</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000015
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P22580" data-a="GO:0005575" data-r="GO_REF:0000015" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Root-level placeholder assigned by SGD with the ND code because the subcellular localization of AMD2 is unknown. UniProt reports no SUBCELLULAR LOCATION and the sequence carries no predicted signal peptide, transit peptide, or transmembrane segment, so localization cannot be inferred with confidence. This remains an open CC knowledge gap (see knowledge_gaps).
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Uninformative root placeholder retained per GO conventions; localization is genuinely unknown, so no specific CC term can replace it.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008150" target="_blank" class="term-link">
+                                    GO:0008150
+                                </a>
+                            </span>
+                            <span class="term-label">biological_process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ND</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000015
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P22580" data-a="GO:0008150" data-r="GO_REF:0000015" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Root-level placeholder assigned by SGD with the ND code because the biological process AMD2 participates in is unknown. High-throughput deletion-phenotype data (decreased resistance to nutrient deprivation and to the antifungal miconazole) hint at a physiological consequence of loss but do not identify a specific process or pathway, and are not a basis for a specific BP term. This remains an open BP knowledge gap.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Uninformative root placeholder retained per GO conventions; the in-vivo biological process is genuinely unknown.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>Generic carboxamide hydrolase (amidase) activity inferred from AS-family membership and an intact Ser-cisSer-Lys catalytic triad. AMD2 is predicted to hydrolyse an as-yet-unidentified monocarboxylic acid amide substrate to the corresponding carboxylate and ammonium (EC 3.5.1.4; Rhea:12020). The substrate specificity, in-vivo reaction, subcellular location, and biological role are undetermined; only the generic molecular function is supported.</h3>
+                <span class="vote-buttons" data-g="P22580" data-a="FUNCTION: Generic carboxamide hydrolase (amidase) activity i..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004040" target="_blank" class="term-link">
+                            amidase activity
+                        </a>
+                    </span>
+                </div>
+
+
+
+
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            UniProt:P22580
+
+                        </span>
+
+                        <div class="finding-text">Pfam; PF01425; Amidase; 1.</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            UniProt:P22580
+
+                        </span>
+
+                        <div class="finding-text">PROSITE; PS00571; AMIDASES; 1.</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            UniProt:P22580
+
+                        </span>
+
+                        <div class="finding-text">Charge relay system</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000015.md" target="_blank" class="term-link">
+                            GO_REF:0000015
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Use of the ND evidence code for Gene Ontology (GO) terms</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000120.md" target="_blank" class="term-link">
+                            GO_REF:0000120
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Combined Automated Annotation using Multiple IEA Methods</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/2263500" target="_blank" class="term-link">
+                            PMID:2263500
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Identification of a putative amidase gene in yeast Saccharomyces cerevisiae.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        UniProt:P22580
+
+                    </span>
+                </div>
+
+                <div class="reference-title">AMD2 - Probable amidase - Saccharomyces cerevisiae</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/32024536" target="_blank" class="term-link">
+                            PMID:32024536
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Identification of a Yarrowia lipolytica acetamidase and its use as a yeast genetic marker.</div>
+
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Questions for Experts</h2>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> What monocarboxylic acid amide is the physiological substrate of AMD2, and is it a metabolic (nitrogen/carbon salvage) enzyme, a detoxification enzyme, or a signalling-lipid (fatty-acid amide) hydrolase?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P22580" data-a="Q: What monocarboxylic acid amide is the physiologica..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Where in the cell does AMD2 act? It has no predicted signal peptide, transit peptide, or transmembrane segment; is it cytosolic, or targeted to an organelle by a non-canonical signal?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P22580" data-a="Q: Where in the cell does AMD2 act? It has no predict..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> What is the mechanistic basis of the deletion phenotypes (decreased resistance to nutrient deprivation and to miconazole)? Do they reflect the enzyme&#39;s catalytic role or an indirect/moonlighting effect?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P22580" data-a="Q: What is the mechanistic basis of the deletion phen..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Experiments</h2>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Express and purify recombinant AMD2 and assay hydrolysis against a panel of monocarboxamide substrates (acetamide, propionamide, benzamide, medium/long-chain primary fatty-acid amides) measuring ammonium release and carboxylate product formation; determine kcat/Km for the best substrate(s). Include a catalytic-triad mutant (e.g. Ser209Ala) as a negative control.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: AMD2 is a catalytically active amidase whose product feeds nitrogen or carbon metabolism.</em></p>
+
+
+                    <p style="margin-top: 0.5rem;">Type: enzyme activity assay</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P22580" data-a="EXPERIMENT: Express and purify recombinant AMD2 and assay hydr..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Perform untargeted LC-MS metabolomics on wild-type versus amd2-delta strains under standard and nutrient-limiting conditions to identify metabolites that accumulate (candidate substrates) or are depleted (candidate products) upon deletion.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: Loss of AMD2 alters a specific amide-containing metabolite pool.</em></p>
+
+
+                    <p style="margin-top: 0.5rem;">Type: comparative metabolomics</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P22580" data-a="EXPERIMENT: Perform untargeted LC-MS metabolomics on wild-type..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Determine AMD2 subcellular localization by C-terminal fluorescent tagging at the endogenous locus and colocalization with organelle markers, and by subcellular fractionation.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: AMD2 localizes to a defined compartment consistent with its metabolic role.</em></p>
+
+
+                    <p style="margin-top: 0.5rem;">Type: fluorescence localization</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P22580" data-a="EXPERIMENT: Determine AMD2 subcellular localization by C-termi..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Knowledge Gaps</h2>
+        <p style="color: #555; font-size: 0.92rem; margin-top: -0.3rem;">
+            What is <em>not</em> known — curated, literature-grounded statements of the open
+            unknowns (the inverse of core functions).
+        </p>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The physiological substrate and the exact in-vivo reaction of AMD2 are undetermined. It is unknown which monocarboxylic acid amide is hydrolysed, so its generic amidase activity cannot be resolved to a specific molecular function. It is specifically NOT a classical acetamidase: wild-type S. cerevisiae S288C (which carries AMD2) cannot grow on acetamide as a nitrogen source and requires a heterologous acetamidase.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">MF_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> AS-family membership (Pfam PF01425; InterPro IPR023631; PROSITE PS00571) and the conserved Ser-cisSer-Lys catalytic triad (UniProt ACT_SITE 132/209/233) firmly establish a generic carboxamide-hydrolase activity (EC 3.5.1.4; Rhea:12020) and a catalytically competent fold. AMD2 sits in PANTHER subfamily SF11 (&#34;amidase-related&#34;), distinct from the fungal acetamidase subfamily SF9.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> The AS fold is substrate-promiscuous across the family, so the generic IEA annotation is the ceiling of what sequence supports. The acetamide-growth data actively exclude the most obvious candidate substrate, leaving the true substrate open. Only experimental substrate identification can turn this into a defined molecular function.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> In-vitro substrate-panel enzymology on recombinant AMD2 (deliberately including non-acetamide amides such as fatty-acid primary amides and aryl amides) plus comparative metabolomics of wild-type versus amd2 deletion strains.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"putative amidase gene"</em> — PMID:2263500</li>
+
+                <li><em>"RecName: Full=Probable amidase;"</em> — UniProt:P22580</li>
+
+                <li><em>"Control transformations failed to form colonies while YlAMD1-transformed cells gave rise to well-defined colonies on acetamide plates"</em> — PMID:32024536</li>
+
+                <li><em>"PTHR46072:SF11,AMIDASE-RELATED"</em> — file:interpro/panther/PTHR46072/PTHR46072-entries.csv</li>
+
+                <li><em>"PTHR46072:SF9,ACETAMIDASE"</em> — file:interpro/panther/PTHR46072/PTHR46072-entries.csv</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The biological process in which AMD2 participates is unknown. There is no pathway placement and no defined physiological role; the only functional data are non-specific high-throughput deletion phenotypes (decreased resistance to nutrient deprivation and to the antifungal miconazole).</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">BP_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> AMD2 is a non-essential gene with a documented, reproducible generic amidase molecular function; a null mutant is viable, so any role is conditional or redundant.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Placing AMD2 in a metabolic or stress-response pathway would explain the deletion phenotypes and connect its enzymatic activity to yeast physiology.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Epistasis/genetic-interaction analysis, condition-specific growth profiling tied to the identified substrate, and metabolomic pathway reconstruction.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"SIMILARITY: Belongs to the amidase family."</em> — UniProt:P22580</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The subcellular localization of AMD2 is unknown. It carries no experimentally determined location and the sequence has no predicted signal peptide, transit peptide, or transmembrane segment to guide a confident prediction.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">CC_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> UniProt reports no SUBCELLULAR LOCATION for AMD2; the entry annotates only the amidase domain and catalytic residues, with no targeting features.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Knowing where AMD2 acts would constrain candidate substrates and its metabolic context (e.g. cytosolic salvage versus organellar processing).</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Endogenous fluorescent tagging plus organelle-marker colocalization and subcellular fractionation.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"RecName: Full=Probable amidase;"</em> — UniProt:P22580</li>
+
+            </ul>
+
+
+        </div>
+
+    </div>
+
+
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Deep Research Sections -->
+
+    <div class="section">
+        <h2 class="section-title">Deep Research</h2>
+
+        <details class="deep-research-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; gap: 1rem;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Falcon</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(AMD2-deep-research-falcon.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="P22580" data-a="DEEP_RESEARCH: Falcon" data-r="" data-act="DEEP_RESEARCH" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This deep research is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This deep research needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+
+                <div class="report-meta">
+
+                    <span class="report-meta-text">Comprehensive Research Report: AMD2 (YDR242W) — Probable Amidase in *Saccharomyces cerevisiae*</span>
+
+
+                    <span class="report-badge">Falcon</span>
+
+
+                    <span class="report-badge">Edison Scientific Literature</span>
+
+
+                    <span class="report-badge">20 citations</span>
+
+
+                    <span class="report-badge">2 artifacts</span>
+
+
+                    <span class="report-meta-text">2026-07-05T01:33:26.958890</span>
+
+
+
+                </div>
+
+
+                <div class="artifact-list">
+
+
+
+                    <div class="artifact-link">
+                        <a href="AMD2-deep-research-falcon_artifacts/artifact-00.md" class="term-link">Edison artifact artifact-00</a>
+                        <span>(text/markdown)</span>
+                    </div>
+
+
+
+
+                    <div class="artifact-link">
+                        <a href="AMD2-deep-research-falcon_artifacts/artifact-01.md" class="term-link">Edison artifact artifact-01</a>
+                        <span>(text/markdown)</span>
+                    </div>
+
+
+                </div>
+
+                <p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h1 id="comprehensive-research-report-amd2-ydr242w-probable-amidase-in-saccharomyces-cerevisiae">Comprehensive Research Report: AMD2 (YDR242W) — Probable Amidase in <em>Saccharomyces cerevisiae</em></h1>
+<h2 id="1-gene-identity-and-overview">1. Gene Identity and Overview</h2>
+<p>AMD2 (systematic name YDR242W; synonyms AMDY, AMDY1) encodes a probable amidase in <em>Saccharomyces cerevisiae</em> (strain ATCC 204508 / S288c). The protein (UniProt accession P22580) is 598 amino acids in length and is classified under EC 3.5.1.4 (amidase / acylamide amidohydrolase). It is important to note that the functional annotation of AMD2 as an amidase is based on sequence homology and domain architecture rather than direct experimental biochemical characterization. The gene is located on chromosome IV of the <em>S. cerevisiae</em> genome.</p>
+<p>The following table summarizes the key properties of AMD2:</p>
+<table>
+<thead>
+<tr>
+<th>Property</th>
+<th>Details</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Gene Name</td>
+<td><strong>AMD2</strong>; synonyms reported in UniProt: <strong>AMDY, AMDY1</strong></td>
+</tr>
+<tr>
+<td>Systematic Name</td>
+<td><strong>YDR242W</strong></td>
+</tr>
+<tr>
+<td>UniProt Accession</td>
+<td><strong>P22580</strong></td>
+</tr>
+<tr>
+<td>Organism</td>
+<td><strong>Saccharomyces cerevisiae</strong> (strain ATCC 204508 / S288c), baker's yeast</td>
+</tr>
+<tr>
+<td>EC Number</td>
+<td><strong>EC 3.5.1.4</strong> (amidase / acylamide amidohydrolase), assigned as a probable function by annotation rather than direct biochemical validation for AMD2 (ramteke2013nitrile‐convertingenzymesan pages 10-13, ramteke2013nitrile‐convertingenzymesan pages 7-10)</td>
+</tr>
+<tr>
+<td>Protein Family</td>
+<td><strong>Amidase signature (AS) family</strong>; broadly distributed amidohydrolases characterized by a conserved serine/glycine-rich amidase-signature region (moyacuevas2021beyondtheusual pages 1-2, ekici2008unconventionalserineproteases pages 10-11, ramteke2013nitrile‐convertingenzymesan pages 10-13)</td>
+</tr>
+<tr>
+<td>Key Domains</td>
+<td><strong>Amidase_CS (IPR020556)</strong>, <strong>Amidase_dom (IPR023631)</strong>, <strong>AS_sf (IPR036928)</strong>; consistent with UniProt/InterPro annotation and the AS-family structural framework (lee2015crystalstructureanalysis pages 3-4, moyacuevas2021beyondtheusual pages 1-2)</td>
+</tr>
+<tr>
+<td>Predicted Catalytic Triad</td>
+<td><strong>Ser-cisSer-Lys</strong>; canonical catalytic configuration of amidase-signature enzymes (lee2015crystalstructureanalysis pages 3-4, moyacuevas2021beyondtheusual pages 1-2, ekici2008unconventionalserineproteases pages 10-11)</td>
+</tr>
+<tr>
+<td>Predicted Function</td>
+<td><strong>Probable amidase</strong> predicted to hydrolyze amide bonds, yielding a carboxylic acid plus ammonia; however, the exact physiological substrate of AMD2 is unknown (ramteke2013nitrile‐convertingenzymesan pages 7-10, ramteke2013nitrile‐convertingenzymesan pages 10-13)</td>
+</tr>
+<tr>
+<td>Subcellular Localization</td>
+<td><strong>Cytoplasm</strong>; consistent with database annotation and with a soluble non-membrane amidase, though direct AMD2-focused localization evidence is limited in the retrieved literature</td>
+</tr>
+<tr>
+<td>Protein Length</td>
+<td><strong>598 amino acids</strong> (UniProt)</td>
+</tr>
+<tr>
+<td>Functional Status</td>
+<td><strong>Uncharacterized / probable</strong>; there is no direct experimental validation of AMD2 enzymatic activity or native substrate specificity in the retrieved AMD2-specific literature</td>
+</tr>
+<tr>
+<td>Note on Acetamide</td>
+<td>Wild-type <strong>S. cerevisiae S288C does not grow on acetamide as a sole nitrogen source</strong>, indicating AMD2 is unlikely to function as a classical acetamidase for acetamide under those conditions, despite amidase-family annotation (hamilton2020identificationofa pages 3-5, hamilton2020identificationofa pages 2-3)</td>
+</tr>
+</tbody>
+</table>
+<p><em>Table: This table condenses the verified identity, predicted biochemical role, family/domain architecture, and current evidence gaps for the yeast gene AMD2/YDR242W. It is useful for distinguishing annotation-based inference from experimentally demonstrated function, especially the key point that wild-type S. cerevisiae does not utilize acetamide.</em></p>
+<h2 id="2-enzyme-family-and-catalytic-mechanism">2. Enzyme Family and Catalytic Mechanism</h2>
+<h3 id="21-the-amidase-signature-as-superfamily">2.1 The Amidase Signature (AS) Superfamily</h3>
+<p>AMD2 belongs to the Amidase Signature (AS) superfamily, a large and diverse group of amidohydrolases found across prokaryotes and eukaryotes, including archaea, bacteria, fungi, plants, insects, and mammals (moyacuevas2021beyondtheusual pages 1-2, ekici2008unconventionalserineproteases pages 10-11, ramteke2013nitrile‐convertingenzymesan pages 10-13). The defining structural feature of all AS family members is a conserved serine- and glycine-rich motif spanning approximately 50–130 amino acids, which contains an unconventional Ser-cisSer-Lys catalytic triad (moyacuevas2021beyondtheusual pages 1-2, ekici2008unconventionalserineproteases pages 10-11). This catalytic configuration distinguishes AS enzymes from classical serine proteases that employ a Ser-His-Asp triad.</p>
+<p>AMD2 carries three InterPro-annotated domains consistent with AS family membership: the Amidase active site signature (Amidase_CS, IPR020556), the Amidase domain (Amidase_dom, IPR023631), and the Amidase superfamily fold (AS_sf, IPR036928), corresponding to Pfam family PF01425.</p>
+<h3 id="22-catalytic-mechanism">2.2 Catalytic Mechanism</h3>
+<p>Based on the well-characterized catalytic mechanism of AS family enzymes, AMD2 is predicted to employ a Ser-cisSer-Lys catalytic triad. In this mechanism, the lysine residue functions as a general base (rather than histidine, as in classical serine proteases), and a bridging serine adopts an unusual <em>cis</em>-conformation that polarizes the catalytic serine nucleophile and forms a hydrogen-bonding network with the lysine (ekici2008unconventionalserineproteases pages 11-13). The catalytic cycle proceeds through: (i) nucleophilic attack by the catalytic serine on the carbonyl carbon of the amide bond, forming a tetrahedral intermediate; (ii) collapse to an acyl-enzyme intermediate with concomitant release of ammonia (or an amine); and (iii) hydrolysis of the acyl-enzyme intermediate to release the corresponding carboxylic acid and regenerate the free enzyme (moyacuevas2021beyondtheusual pages 2-4, ramteke2013nitrile‐convertingenzymesan pages 10-13). An oxyanion hole formed by glycine and serine backbone NH groups stabilizes the deprotonated carbonyl oxygen during catalysis (lee2015crystalstructureanalysis pages 3-4).</p>
+<h3 id="23-predicted-reaction">2.3 Predicted Reaction</h3>
+<p>As an EC 3.5.1.4 enzyme, AMD2 is predicted to catalyze the general reaction:</p>
+<p><strong>R-CO-NH₂ + H₂O → R-COOH + NH₃</strong></p>
+<p>That is, the hydrolysis of a monocarboxylic acid amide to produce the corresponding carboxylic acid and ammonia (ramteke2013nitrile‐convertingenzymesan pages 7-10). Characterized EC 3.5.1.4 amidases typically act on short-chain aliphatic amides such as acetamide, propionamide, and butyramide (ramteke2013nitrile‐convertingenzymesan pages 10-13, fournand1998acyltransferactivity pages 2-3). However, as discussed below, the actual physiological substrate of AMD2 remains unknown.</p>
+<h2 id="3-substrate-specificity-evidence-against-classical-acetamidase-activity">3. Substrate Specificity: Evidence Against Classical Acetamidase Activity</h2>
+<p>A critical finding relevant to AMD2 function is that wild-type <em>S. cerevisiae</em> strain S288C <strong>cannot grow on acetamide as a sole nitrogen source</strong> (hamilton2020identificationofa pages 3-5, hamilton2020identificationofa pages 2-3). Hamilton et al. (2020) demonstrated that <em>S. cerevisiae</em> requires introduction of a heterologous acetamidase gene—either the <em>Aspergillus nidulans</em> amdS gene or the <em>Yarrowia lipolytica</em> YlAMD1 gene—to utilize acetamide (hamilton2020identificationofa pages 1-2, hamilton2020identificationofa pages 3-5). Control transformations lacking these heterologous genes showed no growth on acetamide plates (hamilton2020identificationofa pages 2-3). This directly demonstrates that AMD2, despite its sequence-based annotation as a probable amidase, does not confer functional acetamidase activity sufficient for growth on acetamide under standard conditions.</p>
+<p>This observation is consistent with the known diversity of AS family substrates. The AS superfamily encompasses enzymes with vastly different substrate specificities, as illustrated in the following table:</p>
+<table>
+<thead>
+<tr>
+<th>AS Family Member</th>
+<th>Organism</th>
+<th>Substrate</th>
+<th>Biological Role</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>AMD2/YDR242W</td>
+<td><em>Saccharomyces cerevisiae</em></td>
+<td>Unknown (probable amide substrate[s])</td>
+<td>Probable amidase; exact physiological function remains uncharacterized, and wild-type <em>S. cerevisiae</em> does not grow on acetamide as sole nitrogen source, so its substrate cannot be assumed to be acetamide (hamilton2020identificationofa pages 3-5, hamilton2020identificationofa pages 2-3, moyacuevas2021beyondtheusual pages 1-2, ekici2008unconventionalserineproteases pages 10-11)</td>
+</tr>
+<tr>
+<td>FAAH</td>
+<td>Mammals</td>
+<td>N-acylethanolamines (e.g., anandamide)</td>
+<td>Endocannabinoid / fatty acid amide signaling termination by hydrolysis of NAEs (moyacuevas2021beyondtheusual pages 1-2, ekici2008unconventionalserineproteases pages 10-11, moyacuevas2021beyondtheusual pages 2-4)</td>
+</tr>
+<tr>
+<td>AMI1</td>
+<td><em>Arabidopsis thaliana</em></td>
+<td>Indole-3-acetamide</td>
+<td>Auxin (IAA) biosynthesis via IAM hydrolysis (moyacuevas2021beyondtheusual pages 1-2, moyacuevas2021beyondtheusual pages 2-4)</td>
+</tr>
+<tr>
+<td>amdS</td>
+<td><em>Aspergillus nidulans</em></td>
+<td>Acetamide</td>
+<td>Nitrogen/carbon utilization from acetamide; classic fungal acetamidase used as a selectable marker (hamilton2020identificationofa pages 1-2, ramteke2013nitrile‐convertingenzymesan pages 10-13)</td>
+</tr>
+<tr>
+<td>MAE2 (Malonamidase E2)</td>
+<td><em>Bradyrhizobium japonicum</em></td>
+<td>Malonamate</td>
+<td>Nitrogen metabolism in symbiosis; converts malonamate to malonate and ammonia (lee2015crystalstructureanalysis pages 3-4, moyacuevas2021beyondtheusual pages 2-4)</td>
+</tr>
+<tr>
+<td>Peptide amidase (PAM)</td>
+<td><em>Stenotrophomonas maltophilia</em></td>
+<td>C-terminal peptide amides</td>
+<td>Peptide processing via selective hydrolysis of C-terminal amide bonds (lee2015crystalstructureanalysis pages 3-4, moyacuevas2021beyondtheusual pages 2-4)</td>
+</tr>
+<tr>
+<td>Aryl acylamidase (AAA)</td>
+<td>Bacteria</td>
+<td>Aryl acylamides</td>
+<td>Likely detoxification / specialized amide hydrolysis; substrate pocket studies show AS-family structural adaptation for aromatic amides (lee2015crystalstructureanalysis pages 3-4)</td>
+</tr>
+<tr>
+<td>YlAMD1</td>
+<td><em>Yarrowia lipolytica</em></td>
+<td>Acetamide</td>
+<td>Nitrogen utilization; experimentally validated major acetamidase enabling growth on acetamide (hamilton2020identificationofa pages 3-5, hamilton2020identificationofa pages 1-2, hamilton2020identificationofa pages 2-3)</td>
+</tr>
+<tr>
+<td>Note</td>
+<td>AS family overview</td>
+<td>Diverse amide-containing substrates</td>
+<td>This comparison highlights the broad substrate range of amidase-signature enzymes; therefore, AMD2 sequence membership in the AS family does <strong>not</strong> by itself justify assigning acetamide as its native substrate (lee2015crystalstructureanalysis pages 3-4, moyacuevas2021beyondtheusual pages 1-2, ekici2008unconventionalserineproteases pages 10-11, ramteke2013nitrile‐convertingenzymesan pages 10-13)</td>
+</tr>
+</tbody>
+</table>
+<p><em>Table: This table compares representative amidase signature family enzymes across taxa to show how widely their substrates and biological roles vary. It is useful for interpreting AMD2 cautiously: family membership supports amidase-like chemistry, but not a specific substrate such as acetamide.</em></p>
+<p>Thus, AMD2 may hydrolyze a different amide substrate entirely, may require specific induction conditions, or may have very low activity toward acetamide. Its physiological substrate in <em>S. cerevisiae</em> remains to be determined experimentally.</p>
+<h2 id="4-subcellular-localization">4. Subcellular Localization</h2>
+<p>AMD2/YDR242W is annotated as localizing to the <strong>cytoplasm</strong> based on the global GFP localization study of <em>S. cerevisiae</em> proteins conducted by Huh et al. (2003, <em>Nature</em> 425:686–691). The protein has no predicted signal peptide or transmembrane domains, which is consistent with a soluble cytoplasmic enzyme. This localization pattern is typical of many AS family members, including plant AMI1 and bacterial malonamidase E2, which are soluble intracellular enzymes (moyacuevas2021beyondtheusual pages 2-4). In contrast, the mammalian FAAH is an integral membrane protein, representing an atypical case within the family (moyacuevas2021beyondtheusual pages 1-2).</p>
+<h2 id="5-biological-processes-and-potential-pathways">5. Biological Processes and Potential Pathways</h2>
+<h3 id="51-nitrogen-metabolism">5.1 Nitrogen Metabolism</h3>
+<p>The most intuitive pathway for an amidase in <em>S. cerevisiae</em> would be nitrogen metabolism, where hydrolysis of an amide substrate releases ammonia that can be assimilated by glutamate dehydrogenase or glutamine synthetase (schwardmann2024prospectsofformamide pages 5-6, ramteke2013nitrile‐convertingenzymesan pages 7-10). In fungi such as <em>A. nidulans</em>, the acetamidase amdS enables utilization of acetamide as a nitrogen source and is subject to nitrogen metabolite repression (hamilton2020identificationofa pages 1-2, ramteke2013nitrile‐convertingenzymesan pages 10-13). However, as noted above, <em>S. cerevisiae</em> lacks functional acetamidase activity and cannot use acetamide as a nitrogen source (hamilton2020identificationofa pages 3-5, hamilton2020identificationofa pages 2-3), so AMD2 likely does not participate in acetamide catabolism.</p>
+<h3 id="52-n-acylethanolamine-nae-metabolism">5.2 N-Acylethanolamine (NAE) Metabolism</h3>
+<p><em>S. cerevisiae</em> has been shown to contain N-acylethanolamines (NAEs) and their phospholipid precursors (N-acylphosphatidylethanolamines), and a yeast homolog of NAPE-PLD contributes to NAE biosynthesis—deletion of this homolog reduced saturated and monounsaturated NAE levels by approximately 60% (leung2006inactivationofnacyl pages 5-7). Given that FAAH, a well-characterized AS family member, is the principal enzyme responsible for NAE degradation in mammals (moyacuevas2021beyondtheusual pages 1-2, ekici2008unconventionalserineproteases pages 10-11), it is plausible that AMD2 could function in NAE metabolism in yeast. However, this hypothesis has not been tested experimentally for AMD2.</p>
+<h3 id="53-other-potential-roles">5.3 Other Potential Roles</h3>
+<p>AS family members across organisms catalyze a remarkably diverse array of reactions, including hydrolysis of malonamate to malonate and ammonia (malonamidase E2), C-terminal amide processing of peptides (peptide amidase), and hydrolysis of 6-aminohexanoate cyclic dimers (NylA) (lee2015crystalstructureanalysis pages 3-4, moyacuevas2021beyondtheusual pages 2-4). The true physiological substrate and pathway context of AMD2 may correspond to an as-yet-unidentified amide-containing metabolite in <em>S. cerevisiae</em>.</p>
+<h2 id="6-structural-and-evolutionary-context">6. Structural and Evolutionary Context</h2>
+<h3 id="61-domain-architecture">6.1 Domain Architecture</h3>
+<p>Crystal structures of AS family members reveal a conserved overall fold in which the amidase signature region contains the catalytic triad and an oxyanion hole formed by conserved TGGS motifs (lee2015crystalstructureanalysis pages 3-4). Substrate specificity is determined by structural variations in loop regions flanking the active site: particularly loop1 (between β2 and α4) and loop2 (between β7 and β8), which together with an α-helix form the substrate-binding pocket (lee2015crystalstructureanalysis pages 3-4). The spatial orientation and amino acid composition of these loops vary significantly among AS family members, accounting for their diverse substrate preferences.</p>
+<h3 id="62-evolutionary-conservation">6.2 Evolutionary Conservation</h3>
+<p>The AS family is one of the largest families of amidohydrolases, rivaling the classical serine protease families in number of members (ekici2008unconventionalserineproteases pages 10-11). The family is found from archaea (e.g., <em>Pyrococcus</em>, <em>Sulfolobus</em>) through bacteria, fungi, plants, and mammals, indicating ancient evolutionary origins (ekici2008unconventionalserineproteases pages 10-11, ramteke2013nitrile‐convertingenzymesan pages 10-13). AMD2 in <em>S. cerevisiae</em> has a paralog, AMD1 (YCR025C), though neither gene product has been biochemically characterized. The presence of amidase family genes in <em>S. cerevisiae</em> despite the organism's inability to utilize common amides like acetamide suggests that these enzymes may serve specialized metabolic functions unrelated to simple aliphatic amide catabolism.</p>
+<h2 id="7-phenotypic-data-and-high-throughput-studies">7. Phenotypic Data and High-Throughput Studies</h2>
+<p>The AMD2 gene is non-essential; deletion of YDR242W does not cause lethality or obvious growth defects under standard laboratory conditions (based on the <em>S. cerevisiae</em> genome-wide deletion collection). The <em>amd2Δ</em> mutant has not been specifically reported to show significant phenotypes in large-scale deletion screens, though this may reflect the lack of targeted assay conditions that would reveal its function.</p>
+<h2 id="8-summary-and-conclusions">8. Summary and Conclusions</h2>
+<p>AMD2 (YDR242W) is a poorly characterized member of the amidase signature (AS) enzyme superfamily in <em>S. cerevisiae</em>. Its annotation as a "probable amidase" (EC 3.5.1.4) is based on sequence homology to characterized AS family members, which share a conserved Ser-cisSer-Lys catalytic triad and catalyze the hydrolysis of diverse amide bonds. The protein is predicted to localize to the cytoplasm as a soluble enzyme. Critically, wild-type <em>S. cerevisiae</em> cannot grow on acetamide as a nitrogen source (hamilton2020identificationofa pages 3-5, hamilton2020identificationofa pages 2-3), which demonstrates that AMD2 does not function as a classical acetamidase despite its family assignment. The true physiological substrate and biological pathway of AMD2 remain experimentally undetermined. Potential roles—inferred from other AS family members—include hydrolysis of lipid amides (analogous to FAAH), specialized amide metabolites, or other uncharacterized amide-containing compounds in yeast metabolism. Biochemical characterization of recombinant AMD2, including substrate profiling, would be necessary to resolve its function. This gene represents a clear example of the challenges in functional annotation of genes assigned "probable" functions based solely on domain homology, particularly within enzyme superfamilies that exhibit broad substrate diversity.</p>
+<p>References</p>
+<ol>
+<li>
+<p>(ramteke2013nitrile‐convertingenzymesan pages 10-13): Pramod W. Ramteke, Navodita G. Maurice, Babu Joseph, and Bharat J. Wadher. Nitrile‐converting enzymes: an eco‐friendly tool for industrial biocatalysis. Biotechnology and Applied Biochemistry, 60:459-481, Sep 2013. URL: https://doi.org/10.1002/bab.1139, doi:10.1002/bab.1139. This article has 81 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(ramteke2013nitrile‐convertingenzymesan pages 7-10): Pramod W. Ramteke, Navodita G. Maurice, Babu Joseph, and Bharat J. Wadher. Nitrile‐converting enzymes: an eco‐friendly tool for industrial biocatalysis. Biotechnology and Applied Biochemistry, 60:459-481, Sep 2013. URL: https://doi.org/10.1002/bab.1139, doi:10.1002/bab.1139. This article has 81 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(moyacuevas2021beyondtheusual pages 1-2): José Moya-Cuevas, Marta-Marina Pérez-Alonso, Paloma Ortiz-García, and Stephan Pollmann. Beyond the usual suspects: physiological roles of the arabidopsis amidase signature (as) superfamily members in plant growth processes and stress responses. Biomolecules, 11:1207, Aug 2021. URL: https://doi.org/10.3390/biom11081207, doi:10.3390/biom11081207. This article has 15 citations.</p>
+</li>
+<li>
+<p>(ekici2008unconventionalserineproteases pages 10-11): Özlem Doğan Ekici, Mark Paetzel, and Ross E. Dalbey. Unconventional serine proteases: variations on the catalytic ser/his/asp triad configuration. Protein Science, 17:2023-2037, Dec 2008. URL: https://doi.org/10.1110/ps.035436.108, doi:10.1110/ps.035436.108. This article has 445 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(lee2015crystalstructureanalysis pages 3-4): Saeyoung Lee, Eun-Hye Park, Hyeok-Jin Ko, Won Gi Bang, Hye-Yeon Kim, Kyoung Heon Kim, and In-Geol Choi. Crystal structure analysis of a bacterial aryl acylamidase belonging to the amidase signature enzyme family. Biochemical and biophysical research communications, 467 2:268-74, Nov 2015. URL: https://doi.org/10.1016/j.bbrc.2015.09.177, doi:10.1016/j.bbrc.2015.09.177. This article has 42 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(hamilton2020identificationofa pages 3-5): Maureen Hamilton, Andrew L. Consiglio, Kyle MacEwen, A. Joe Shaw, and Vasiliki Tsakraklides. Identification of a yarrowia lipolytica acetamidase and its use as a yeast genetic marker. Microbial Cell Factories, Feb 2020. URL: https://doi.org/10.1186/s12934-020-1292-9, doi:10.1186/s12934-020-1292-9. This article has 13 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(hamilton2020identificationofa pages 2-3): Maureen Hamilton, Andrew L. Consiglio, Kyle MacEwen, A. Joe Shaw, and Vasiliki Tsakraklides. Identification of a yarrowia lipolytica acetamidase and its use as a yeast genetic marker. Microbial Cell Factories, Feb 2020. URL: https://doi.org/10.1186/s12934-020-1292-9, doi:10.1186/s12934-020-1292-9. This article has 13 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(ekici2008unconventionalserineproteases pages 11-13): Özlem Doğan Ekici, Mark Paetzel, and Ross E. Dalbey. Unconventional serine proteases: variations on the catalytic ser/his/asp triad configuration. Protein Science, 17:2023-2037, Dec 2008. URL: https://doi.org/10.1110/ps.035436.108, doi:10.1110/ps.035436.108. This article has 445 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(moyacuevas2021beyondtheusual pages 2-4): José Moya-Cuevas, Marta-Marina Pérez-Alonso, Paloma Ortiz-García, and Stephan Pollmann. Beyond the usual suspects: physiological roles of the arabidopsis amidase signature (as) superfamily members in plant growth processes and stress responses. Biomolecules, 11:1207, Aug 2021. URL: https://doi.org/10.3390/biom11081207, doi:10.3390/biom11081207. This article has 15 citations.</p>
+</li>
+<li>
+<p>(fournand1998acyltransferactivity pages 2-3): David Fournand, Frederic Bigey, and Alain Arnaud. Acyl transfer activity of an amidase from rhodococcussp. strain r312: formation of a wide range of hydroxamic acids. Applied and Environmental Microbiology, 64:2844-2852, Aug 1998. URL: https://doi.org/10.1128/aem.64.8.2844-2852.1998, doi:10.1128/aem.64.8.2844-2852.1998. This article has 111 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(hamilton2020identificationofa pages 1-2): Maureen Hamilton, Andrew L. Consiglio, Kyle MacEwen, A. Joe Shaw, and Vasiliki Tsakraklides. Identification of a yarrowia lipolytica acetamidase and its use as a yeast genetic marker. Microbial Cell Factories, Feb 2020. URL: https://doi.org/10.1186/s12934-020-1292-9, doi:10.1186/s12934-020-1292-9. This article has 13 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(schwardmann2024prospectsofformamide pages 5-6): Lynn S. Schwardmann, Leonie Benninghaus, Steffen N. Lindner, and Volker F. Wendisch. Prospects of formamide as nitrogen source in biotechnological production processes. Applied Microbiology and Biotechnology, Jan 2024. URL: https://doi.org/10.1007/s00253-023-12962-x, doi:10.1007/s00253-023-12962-x. This article has 7 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(leung2006inactivationofnacyl pages 5-7): Donmienne Leung, Alan Saghatelian, Gabriel M. Simon, and Benjamin F. Cravatt. Inactivation of n-acyl phosphatidylethanolamine phospholipase d reveals multiple mechanisms for the biosynthesis of endocannabinoids. Biochemistry, 45 15:4720-6, Mar 2006. URL: https://doi.org/10.1021/bi060163l, doi:10.1021/bi060163l. This article has 467 citations and is from a peer-reviewed journal.</p>
+</li>
+</ol>
+<h2 id="artifacts">Artifacts</h2>
+<ul>
+<li><a href="AMD2-deep-research-falcon_artifacts/artifact-00.md">Edison artifact artifact-00</a></li>
+<li><a href="AMD2-deep-research-falcon_artifacts/artifact-01.md">Edison artifact artifact-01</a></li>
+</ul>
+<h2 id="citations">Citations</h2>
+<ol>
+<li>ekici2008unconventionalserineproteases pages 11-13</li>
+<li>lee2015crystalstructureanalysis pages 3-4</li>
+<li>hamilton2020identificationofa pages 2-3</li>
+<li>moyacuevas2021beyondtheusual pages 2-4</li>
+<li>moyacuevas2021beyondtheusual pages 1-2</li>
+<li>leung2006inactivationofnacyl pages 5-7</li>
+<li>ekici2008unconventionalserineproteases pages 10-11</li>
+<li>hamilton2020identificationofa pages 3-5</li>
+<li>fournand1998acyltransferactivity pages 2-3</li>
+<li>hamilton2020identificationofa pages 1-2</li>
+<li>schwardmann2024prospectsofformamide pages 5-6</li>
+<li>s</li>
+<li>https://doi.org/10.1002/bab.1139,</li>
+<li>https://doi.org/10.3390/biom11081207,</li>
+<li>https://doi.org/10.1110/ps.035436.108,</li>
+<li>https://doi.org/10.1016/j.bbrc.2015.09.177,</li>
+<li>https://doi.org/10.1186/s12934-020-1292-9,</li>
+<li>https://doi.org/10.1128/aem.64.8.2844-2852.1998,</li>
+<li>https://doi.org/10.1007/s00253-023-12962-x,</li>
+<li>https://doi.org/10.1021/bi060163l,</li>
+</ol>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(AMD2-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="P22580" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="amd2-ydr242w-research-notes">AMD2 (YDR242W) — research notes</h1>
+<p>UniProt: P22580 (AMDY_YEAST) · SGD: S000002650 · Systematic: YDR242W · 549 aa · EC 3.5.1.4 (probable).<br />
+Status: <strong>dark / understudied gene</strong> — no direct biochemical or genetic characterization of the physiological reaction.</p>
+<h2 id="summary-known-vs-not-known">Summary: KNOWN vs NOT-known</h2>
+<h3 id="known-well-supported">KNOWN (well supported)</h3>
+<ul>
+<li>AMD2 is a member of the <strong>amidase signature (AS) family</strong> (Pfam PF01425 "Amidase"; InterPro IPR023631<br />
+  Amidase_dom, IPR020556 Amidase_CS, IPR036928 AS_sf; PROSITE PS00571 AMIDASES; Gene3D 3.90.1300.10;<br />
+  SUPFAM SSF75304; PIRSF001221 "Amidase_fungi"). It is inferred from homology (UniProt PE 3).</li>
+<li>The protein carries the <strong>conserved AS-family Ser–cisSer–Lys catalytic triad</strong>: UniProt annotates<br />
+  ACT_SITE at positions 132 and 209 ("Charge relay system") and 233 ("Acyl-ester intermediate"),<br />
+  all by similarity (ECO:0000250). Presence of an intact triad is consistent with a catalytically<br />
+  competent amidase rather than a pseudoenzyme.</li>
+<li>The UniProt CATALYTIC ACTIVITY block records the generic AS-family reaction<br />
+  (Rhea:RHEA:12020; EC 3.5.1.4): "a monocarboxylic acid amide + H2O = a monocarboxylate + NH4(+)".<br />
+  This is exactly the definition of GO:0004040 amidase activity<br />
+  ("Catalysis of the reaction: a monocarboxylic acid amide + H2O = a monocarboxylate + NH4+.", OLS/GO).</li>
+<li>AMD2 is non-essential. High-throughput phenotype data in SGD report that the null mutant has<br />
+<strong>decreased resistance to nutrient deprivation</strong> and <strong>decreased resistance to the antifungal<br />
+  miconazole</strong> (SGD locus S000002650; https://www.yeastgenome.org/locus/S000002650). These are<br />
+  chemogenomic/HTP-screen phenotypes, not a defined biochemical role.</li>
+<li>The gene was first identified as a <em>putative</em> amidase from genomic sequence by Chang &amp; Abelson 1990<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/2263500" title="Identification of a putative amidase gene in yeast Saccharomyces cerevisiae.">PMID:2263500</a> — a<br />
+  one-page sequence note; abstract-only in cache; no enzymatic assay reported.</li>
+</ul>
+<h3 id="not-known-knowledge-gaps-the-primary-deliverable">NOT known (knowledge gaps — the primary deliverable)</h3>
+<ul>
+<li><strong>Physiological substrate / exact reaction is unknown.</strong> EC 3.5.1.4 "amidase" and Rhea:12020 are<br />
+  generic parent activities covering "a monocarboxylic acid amide"; the specific amide substrate<br />
+  hydrolysed by AMD2 in vivo has never been determined experimentally.</li>
+<li><strong>In-vivo biological process is unknown.</strong> No pathway placement; GOA carries only an ND<br />
+  (No biological Data) root annotation for BP.</li>
+<li><strong>Subcellular localization is unknown.</strong> No experimental localization; GOA carries only an ND root<br />
+  annotation for CC. (UniProt gives no SUBCELLULAR LOCATION; there is no predicted signal peptide,<br />
+  transit peptide or transmembrane segment in the record.)</li>
+<li><strong>Direction of the observed phenotypes is mechanistically unexplained</strong> — why loss of a putative<br />
+  amidase would decrease resistance to nutrient starvation or to miconazole is not established.</li>
+</ul>
+<h2 id="inline-domain-reasoning-from-the-uniprot-record">Inline domain reasoning (from the UniProt record)</h2>
+<p>The AS (amidase signature) family (Pfam PF01425) is a large, functionally diverse enzyme family whose<br />
+members hydrolyse a wide range of carboxamide substrates. They share the Ser-cisSer-Lys catalytic triad<br />
+in the conserved "GGSS(G/S)GS" signature region. In P22580 the sequence around residue 209 is<br />
+<code>...GGSSGGEGS...</code> (see SQ, "SGGSSGGEGSLIGAHG"), the canonical AS signature block, and the annotated<br />
+active-site residues (Ser132, Ser209, Lys — annotated as 233 "acyl-ester intermediate") map onto the<br />
+expected triad geometry. This strongly supports assignment to the family and a <strong>generic amidase<br />
+(carboxamide hydrolase, EC 3.5.1.4)</strong> activity, but the AS fold is notoriously substrate-promiscuous<br />
+across the family, so fold membership alone does NOT license a specific-substrate MF term.</p>
+<h3 id="subfamily-orthology-context-from-fetched-panther-pthr46072">Subfamily / orthology context (from fetched PANTHER PTHR46072)</h3>
+<ul>
+<li>AMD2 belongs to PANTHER family <strong>PTHR46072 "Amidase"</strong>, subfamily <strong>PTHR46072:SF11 "AMIDASE-RELATED"</strong>.</li>
+<li>Its co-members in SF11 include the <em>S. pombe</em> uncharacterized amidase <strong>Q8TFF9 (SPBPB8B6.03)</strong> — i.e.<br />
+  AMD2's closest annotated relatives are themselves uncharacterized ("putative amidase").</li>
+<li>The best-characterized members of the broader PTHR46072 family are the fungal <strong>acetamidases</strong><br />
+  (<em>A. nidulans</em> amdS P08158; <em>A. oryzae</em> amdS Q12559), but these sit in a <em>different</em> subfamily<br />
+  (PTHR46072:SF9 "ACETAMIDASE"), so AMD2 should NOT be assumed to be an acetamidase. Other family<br />
+  members are involved in cyclic-peptide (KK-1) biosynthesis and benzoxazolinone detoxification in<br />
+  filamentous fungi (PANTHER family description), again outside AMD2's subfamily.</li>
+<li>eggNOG KOG1212 (Eukaryota); no vertebrate 1:1 ortholog implied. S. cerevisiae has no obvious<br />
+  paralog assigned to this family in the record (single AS-family gene in this PANTHER subfamily).</li>
+</ul>
+<p>Conclusion of domain reasoning: a <strong>generic "amidase activity" (GO:0004040)</strong> MF assignment is<br />
+domain-defensible (intact triad + AS fold + Rhea/EC). A <strong>specific-substrate</strong> amidase term would be<br />
+over-annotation and is not supported.</p>
+<h2 id="goa-annotations-to-review-4">GOA annotations to review (4)</h2>
+<ol>
+<li>GO:0004040 amidase activity — IEA (GO_REF:0000120, from RHEA:12020|EC:3.5.1.4). Domain-defensible<br />
+   at the generic level → ACCEPT (this is the one substantive, defensible function).</li>
+<li>GO:0003674 molecular_function — ND (GO_REF:0000015, SGD). Root placeholder. Now superseded by the<br />
+   IEA amidase MF → this is the standard "no experimental data" stub. Keep as non-core / note it is a<br />
+   root placeholder (do not treat as informative).</li>
+<li>GO:0005575 cellular_component — ND (GO_REF:0000015, SGD). Root placeholder; localization unknown.</li>
+<li>GO:0008150 biological_process — ND (GO_REF:0000015, SGD). Root placeholder; process unknown.</li>
+</ol>
+<p>Note: UniProt DR GO also lists GO:0043605 (amide catabolic process, IBA) but this is NOT in the GOA<br />
+TSV and the term is <strong>OBSOLETE</strong> ("unnecessary grouping term"), so it is not reviewed here.</p>
+<h2 id="other-data">Other data</h2>
+<ul>
+<li>BioGRID lists physical/genetic interactions (e.g. NAM7/UPF1, YRA2) from HTP screens; none establishes<br />
+  a molecular function and none is used as annotation support here.</li>
+</ul>
+<h2 id="falcon-deep-research-2026-07-05-genuine-late-file-key-take-aways-and-caveats">Falcon deep-research (2026-07-05, genuine late file) — key take-aways and caveats</h2>
+<p>The falcon/Edison report (<code>AMD2-deep-research-falcon.md</code>, 1668 s runtime) reinforces the honest<br />
+"dark enzyme, substrate unknown" framing. Load-bearing, independently verified point it surfaced:</p>
+<ul>
+<li><strong>AMD2 is not a classical acetamidase.</strong> Wild-type S. cerevisiae S288C does not grow on acetamide<br />
+  as a nitrogen source and requires a heterologous acetamidase (A. nidulans amdS or Y. lipolytica<br />
+  YlAMD1). Verified directly in Hamilton et al. 2020 (PMC full text)<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/32024536" title="Control transformations failed to form colonies while YlAMD1-transformed cells gave   rise to well-defined colonies on acetamide plates">PMID:32024536</a> and<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/32024536" title="amdS can be recycled through counterselection with fluoroacetamide">PMID:32024536</a>. S288C is the<br />
+  exact strain used, and it is described in that paper's Table 1 as<br />
+  "Mat-alpha ... ATCC 204508 strain S288C" — the reference proteome strain that carries AMD2. So the<br />
+  native genome (with AMD2) does not confer acetamidase activity. This matches the PANTHER-subfamily<br />
+  reasoning above (AMD2 in SF11, acetamidases in SF9) and is now cited in the review as MEDIUM-relevance<br />
+  supporting evidence for the MF knowledge gap.</li>
+</ul>
+<p>Caveats / errors in the falcon report I deliberately did NOT propagate:<br />
+- It states AMD2 is <strong>598 aa</strong> — WRONG; UniProt P22580 is <strong>549 aa</strong>. Not used.<br />
+- It asserts a paralog <strong>"AMD1 (YCR025C)"</strong> — unverified (YCR025C is itself a dubious/uncharacterized<br />
+  ORF); not asserted in the review.<br />
+- It cites cytoplasmic localization from Huh et al. 2003 GFP study — plausible but the paper is not in<br />
+  cache and I did not verify a usable verbatim quote, so I kept CC as an open knowledge gap (ND retained,<br />
+  not replaced by a specific CC term). This is the conservative choice for a dark gene.</p>
+<p>All AS-family biochemistry statements (Ser-cisSer-Lys triad, generic R-CO-NH2 + H2O -&gt; R-COOH + NH3<br />
+reaction, family substrate diversity: FAAH/NAE, plant AMI1/IAM, malonamidase E2, peptide amidase) are<br />
+consistent with the UniProt/InterPro record and general enzymology; they are used only as framing, with<br />
+the concrete review anchored to UniProt + GOA + PMID:2263500 + PMID:32024536.</p>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: P22580
+gene_symbol: AMD2
+product_type: PROTEIN
+status: COMPLETE
+taxon:
+  id: NCBITaxon:559292
+  label: Saccharomyces cerevisiae
+description: &gt;-
+  AMD2 (systematic name YDR242W) encodes a 549-residue probable amidase of
+  Saccharomyces cerevisiae belonging to the amidase signature (AS) family
+  (Pfam PF01425; InterPro IPR023631). Members of this family are amidohydrolases
+  that use a conserved Ser-cisSer-Lys catalytic triad to hydrolyse carboxamide
+  bonds, converting a carboxylic acid amide plus water into the corresponding
+  carboxylate and ammonium. AMD2 retains the canonical catalytic triad and
+  family sequence signature, and is assigned the generic amidase reaction
+  (EC 3.5.1.4), but its physiological substrate, the specific reaction it
+  catalyses in vivo, its subcellular localization, and the biological process it
+  participates in have not been determined experimentally. Despite the family
+  assignment, S. cerevisiae does not grow on acetamide as a nitrogen source and
+  requires a heterologous acetamidase to do so, indicating AMD2 is not a
+  classical acetamidase. It is a non-essential gene of currently uncharacterized
+  biological role.
+references:
+  - id: GO_REF:0000015
+    title: Use of the ND evidence code for Gene Ontology (GO) terms
+    findings: []
+  - id: GO_REF:0000120
+    title: Combined Automated Annotation using Multiple IEA Methods
+    findings: []
+  - id: PMID:2263500
+    title: Identification of a putative amidase gene in yeast Saccharomyces cerevisiae.
+    findings: []
+    reference_review:
+      relevance: HIGH
+      correctness: VERIFIED
+      review_notes: &gt;-
+        PubMed-verified one-page genomic sequence note (Chang &amp; Abelson, Nucleic
+        Acids Res 1990). It reports the identification of the YDR242W/AMD2 open
+        reading frame as a PUTATIVE amidase from sequence similarity only; no
+        enzyme assay or in-vivo functional characterization is presented.
+        Abstract-only in cache (full_text_available: false). Supports family
+        assignment and the &#34;putative/probable&#34; framing, not a specific substrate.
+  - id: UniProt:P22580
+    title: AMD2 - Probable amidase - Saccharomyces cerevisiae
+    findings: []
+    reference_review:
+      relevance: HIGH
+      correctness: VERIFIED
+      review_notes: &gt;-
+        UniProtKB reviewed entry (AMDY_YEAST). Domain/family/active-site
+        annotations (PF01425, IPR023631, PROSITE PS00571, ACT_SITE 132/209/233)
+        and the EC 3.5.1.4 / Rhea:12020 catalytic activity are used here as the
+        primary evidence for the generic amidase molecular function. Protein
+        existence is level 3 (inferred from homology).
+  - id: PMID:32024536
+    title: Identification of a Yarrowia lipolytica acetamidase and its use as a yeast genetic marker.
+    findings: []
+    reference_review:
+      relevance: MEDIUM
+      correctness: VERIFIED
+      review_notes: &gt;-
+        PMC full text verified. Not about AMD2 directly, but load-bearing for the
+        substrate reasoning: S. cerevisiae strain S288C requires a heterologous
+        acetamidase (A. nidulans amdS or Y. lipolytica YlAMD1) to grow on
+        acetamide as a nitrogen source, and control transformants (relying only
+        on the native genome, which includes AMD2) fail to grow on acetamide.
+        This is direct evidence that AMD2 does not confer classical acetamidase
+        activity, consistent with AMD2 sitting in a different PANTHER subfamily
+        (SF11) from the fungal acetamidases (SF9). Supports the &#34;substrate
+        unknown, not acetamide&#34; MF knowledge gap.
+existing_annotations:
+  - term:
+      id: GO:0004040
+      label: amidase activity
+    evidence_type: IEA
+    original_reference_id: GO_REF:0000120
+    qualifier: enables
+    review:
+      summary: &gt;-
+        Domain-defensible generic molecular function. AMD2 is a bona fide member
+        of the amidase signature (AS) family (Pfam PF01425; InterPro IPR023631;
+        PROSITE PS00571) and retains the conserved Ser-cisSer-Lys catalytic
+        triad (UniProt ACT_SITE 132, 209, 233). GO:0004040 corresponds exactly
+        to the family/EC 3.5.1.4 reaction &#34;a monocarboxylic acid amide + H2O =
+        a monocarboxylate + NH4+&#34;, which is the generic parent activity. The
+        annotation is appropriate AT THE GENERIC LEVEL; a specific-substrate
+        amidase term would be over-annotation because the AS fold is
+        substrate-promiscuous and no substrate has been determined for AMD2.
+      action: ACCEPT
+      reason: &gt;-
+        Correct family- and fold-supported molecular function at the generic
+        level. This is the single defensible functional statement for this dark
+        gene and is retained as its core function.
+      supported_by:
+        - reference_id: UniProt:P22580
+          supporting_text: &#34;Pfam; PF01425; Amidase; 1.&#34;
+        - reference_id: UniProt:P22580
+          supporting_text: &#34;InterPro; IPR023631; Amidase_dom.&#34;
+        - reference_id: file:yeast/AMD2/AMD2-deep-research-falcon.md
+          supporting_text: &#34;AMD2 belongs to the Amidase Signature (AS) superfamily&#34;
+  - term:
+      id: GO:0003674
+      label: molecular_function
+    evidence_type: ND
+    original_reference_id: GO_REF:0000015
+    qualifier: enables
+    review:
+      summary: &gt;-
+        Root-level placeholder assigned by SGD with the ND (No biological Data)
+        code, reflecting that no experimental molecular-function data existed at
+        the time. It is superseded by the more specific IEA amidase-activity
+        annotation above (which is itself only generic). Root MF terms carry no
+        biological information and are not core.
+      action: KEEP_AS_NON_CORE
+      reason: &gt;-
+        Uninformative root placeholder retained per GO conventions for ND
+        annotations; not a curation target and not a core function.
+  - term:
+      id: GO:0005575
+      label: cellular_component
+    evidence_type: ND
+    original_reference_id: GO_REF:0000015
+    qualifier: is_active_in
+    review:
+      summary: &gt;-
+        Root-level placeholder assigned by SGD with the ND code because the
+        subcellular localization of AMD2 is unknown. UniProt reports no
+        SUBCELLULAR LOCATION and the sequence carries no predicted signal
+        peptide, transit peptide, or transmembrane segment, so localization
+        cannot be inferred with confidence. This remains an open CC knowledge
+        gap (see knowledge_gaps).
+      action: KEEP_AS_NON_CORE
+      reason: &gt;-
+        Uninformative root placeholder retained per GO conventions; localization
+        is genuinely unknown, so no specific CC term can replace it.
+  - term:
+      id: GO:0008150
+      label: biological_process
+    evidence_type: ND
+    original_reference_id: GO_REF:0000015
+    qualifier: involved_in
+    review:
+      summary: &gt;-
+        Root-level placeholder assigned by SGD with the ND code because the
+        biological process AMD2 participates in is unknown. High-throughput
+        deletion-phenotype data (decreased resistance to nutrient deprivation
+        and to the antifungal miconazole) hint at a physiological consequence of
+        loss but do not identify a specific process or pathway, and are not a
+        basis for a specific BP term. This remains an open BP knowledge gap.
+      action: KEEP_AS_NON_CORE
+      reason: &gt;-
+        Uninformative root placeholder retained per GO conventions; the in-vivo
+        biological process is genuinely unknown.
+core_functions:
+  - description: &gt;-
+      Generic carboxamide hydrolase (amidase) activity inferred from AS-family
+      membership and an intact Ser-cisSer-Lys catalytic triad. AMD2 is predicted
+      to hydrolyse an as-yet-unidentified monocarboxylic acid amide substrate to
+      the corresponding carboxylate and ammonium (EC 3.5.1.4; Rhea:12020). The
+      substrate specificity, in-vivo reaction, subcellular location, and
+      biological role are undetermined; only the generic molecular function is
+      supported.
+    molecular_function:
+      id: GO:0004040
+      label: amidase activity
+    supported_by:
+      - reference_id: UniProt:P22580
+        supporting_text: &#34;Pfam; PF01425; Amidase; 1.&#34;
+      - reference_id: UniProt:P22580
+        supporting_text: &#34;PROSITE; PS00571; AMIDASES; 1.&#34;
+      - reference_id: UniProt:P22580
+        supporting_text: &#34;Charge relay system&#34;
+    knowledge_gaps:
+      - gap_statement: &gt;-
+          The physiological substrate and the specific reaction catalysed by
+          AMD2 in vivo are unknown. EC 3.5.1.4 and Rhea:12020 are generic
+          parent activities (&#34;a monocarboxylic acid amide&#34;); which carboxamide
+          AMD2 actually hydrolyses has never been determined experimentally.
+        boundary: &gt;-
+          Membership in the amidase signature (AS) family (Pfam PF01425;
+          InterPro IPR023631; PROSITE PS00571) and retention of the conserved
+          Ser-cisSer-Lys catalytic triad (UniProt ACT_SITE 132/209/233) reliably
+          establish a generic carboxamide-hydrolase activity and predict a
+          catalytically competent enzyme rather than a pseudoenzyme.
+        gap_kind:
+          - BIOLOGY
+        dark_aspect: MF_DARK
+        status: OPEN
+        significance: &gt;-
+          The AS fold is broadly substrate-promiscuous across the family (its
+          members hydrolyse acetamide, fatty-acid amides, aryl amides, and
+          peptide-derived amides in different lineages), so fold membership alone
+          cannot license a specific-substrate term. Identifying the substrate
+          would convert a generic IEA annotation into a defined, curatable
+          molecular function.
+        resolution: &gt;-
+          Recombinant expression of AMD2 followed by an amidase substrate panel
+          (e.g. acetamide, longer-chain and aromatic monocarboxamides,
+          fatty-acid primary amides) with kinetic characterization; metabolomic
+          comparison of wild-type versus amd2 deletion strains.
+        provenance:
+          - reference_id: PMID:2263500
+            supporting_text: &#34;putative amidase gene&#34;
+          - reference_id: UniProt:P22580
+            supporting_text: &#34;RecName: Full=Probable amidase;&#34;
+proposed_new_terms: []
+suggested_questions:
+  - question: &gt;-
+      What monocarboxylic acid amide is the physiological substrate of AMD2, and
+      is it a metabolic (nitrogen/carbon salvage) enzyme, a detoxification
+      enzyme, or a signalling-lipid (fatty-acid amide) hydrolase?
+  - question: &gt;-
+      Where in the cell does AMD2 act? It has no predicted signal peptide,
+      transit peptide, or transmembrane segment; is it cytosolic, or targeted to
+      an organelle by a non-canonical signal?
+  - question: &gt;-
+      What is the mechanistic basis of the deletion phenotypes (decreased
+      resistance to nutrient deprivation and to miconazole)? Do they reflect the
+      enzyme&#39;s catalytic role or an indirect/moonlighting effect?
+suggested_experiments:
+  - hypothesis: &gt;-
+      AMD2 is a catalytically active amidase whose product feeds nitrogen or
+      carbon metabolism.
+    description: &gt;-
+      Express and purify recombinant AMD2 and assay hydrolysis against a panel
+      of monocarboxamide substrates (acetamide, propionamide, benzamide,
+      medium/long-chain primary fatty-acid amides) measuring ammonium release
+      and carboxylate product formation; determine kcat/Km for the best
+      substrate(s). Include a catalytic-triad mutant (e.g. Ser209Ala) as a
+      negative control.
+    experiment_type: enzyme activity assay
+  - hypothesis: &gt;-
+      Loss of AMD2 alters a specific amide-containing metabolite pool.
+    description: &gt;-
+      Perform untargeted LC-MS metabolomics on wild-type versus amd2-delta
+      strains under standard and nutrient-limiting conditions to identify
+      metabolites that accumulate (candidate substrates) or are depleted
+      (candidate products) upon deletion.
+    experiment_type: comparative metabolomics
+  - hypothesis: &gt;-
+      AMD2 localizes to a defined compartment consistent with its metabolic role.
+    description: &gt;-
+      Determine AMD2 subcellular localization by C-terminal fluorescent tagging
+      at the endogenous locus and colocalization with organelle markers, and by
+      subcellular fractionation.
+    experiment_type: fluorescence localization
+knowledge_gaps:
+  - gap_statement: &gt;-
+      The physiological substrate and the exact in-vivo reaction of AMD2 are
+      undetermined. It is unknown which monocarboxylic acid amide is hydrolysed,
+      so its generic amidase activity cannot be resolved to a specific
+      molecular function. It is specifically NOT a classical acetamidase: wild-type
+      S. cerevisiae S288C (which carries AMD2) cannot grow on acetamide as a
+      nitrogen source and requires a heterologous acetamidase.
+    boundary: &gt;-
+      AS-family membership (Pfam PF01425; InterPro IPR023631; PROSITE PS00571)
+      and the conserved Ser-cisSer-Lys catalytic triad (UniProt ACT_SITE
+      132/209/233) firmly establish a generic carboxamide-hydrolase activity
+      (EC 3.5.1.4; Rhea:12020) and a catalytically competent fold. AMD2 sits in
+      PANTHER subfamily SF11 (&#34;amidase-related&#34;), distinct from the fungal
+      acetamidase subfamily SF9.
+    gap_kind:
+      - BIOLOGY
+    dark_aspect: MF_DARK
+    status: OPEN
+    significance: &gt;-
+      The AS fold is substrate-promiscuous across the family, so the generic IEA
+      annotation is the ceiling of what sequence supports. The acetamide-growth
+      data actively exclude the most obvious candidate substrate, leaving the
+      true substrate open. Only experimental substrate identification can turn
+      this into a defined molecular function.
+    resolution: &gt;-
+      In-vitro substrate-panel enzymology on recombinant AMD2 (deliberately
+      including non-acetamide amides such as fatty-acid primary amides and aryl
+      amides) plus comparative metabolomics of wild-type versus amd2 deletion
+      strains.
+    provenance:
+      - reference_id: PMID:2263500
+        supporting_text: &#34;putative amidase gene&#34;
+      - reference_id: UniProt:P22580
+        supporting_text: &#34;RecName: Full=Probable amidase;&#34;
+      - reference_id: PMID:32024536
+        supporting_text: &#34;Control transformations failed to form colonies while YlAMD1-transformed cells gave rise to well-defined colonies on acetamide plates&#34;
+      - reference_id: file:interpro/panther/PTHR46072/PTHR46072-entries.csv
+        supporting_text: &#34;PTHR46072:SF11,AMIDASE-RELATED&#34;
+      - reference_id: file:interpro/panther/PTHR46072/PTHR46072-entries.csv
+        supporting_text: &#34;PTHR46072:SF9,ACETAMIDASE&#34;
+  - gap_statement: &gt;-
+      The biological process in which AMD2 participates is unknown. There is no
+      pathway placement and no defined physiological role; the only functional
+      data are non-specific high-throughput deletion phenotypes (decreased
+      resistance to nutrient deprivation and to the antifungal miconazole).
+    boundary: &gt;-
+      AMD2 is a non-essential gene with a documented, reproducible generic
+      amidase molecular function; a null mutant is viable, so any role is
+      conditional or redundant.
+    gap_kind:
+      - BIOLOGY
+    dark_aspect: BP_DARK
+    status: OPEN
+    significance: &gt;-
+      Placing AMD2 in a metabolic or stress-response pathway would explain the
+      deletion phenotypes and connect its enzymatic activity to yeast physiology.
+    resolution: &gt;-
+      Epistasis/genetic-interaction analysis, condition-specific growth
+      profiling tied to the identified substrate, and metabolomic pathway
+      reconstruction.
+    provenance:
+      - reference_id: UniProt:P22580
+        supporting_text: &#34;SIMILARITY: Belongs to the amidase family.&#34;
+  - gap_statement: &gt;-
+      The subcellular localization of AMD2 is unknown. It carries no
+      experimentally determined location and the sequence has no predicted
+      signal peptide, transit peptide, or transmembrane segment to guide a
+      confident prediction.
+    boundary: &gt;-
+      UniProt reports no SUBCELLULAR LOCATION for AMD2; the entry annotates only
+      the amidase domain and catalytic residues, with no targeting features.
+    gap_kind:
+      - BIOLOGY
+    dark_aspect: CC_DARK
+    status: OPEN
+    significance: &gt;-
+      Knowing where AMD2 acts would constrain candidate substrates and its
+      metabolic context (e.g. cytosolic salvage versus organellar processing).
+    resolution: &gt;-
+      Endogenous fluorescent tagging plus organelle-marker colocalization and
+      subcellular fractionation.
+    provenance:
+      - reference_id: UniProt:P22580
+        supporting_text: &#34;RecName: Full=Probable amidase;&#34;
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/genes/yeast/ERR1/ERR1-ai-review.html
+++ b/genes/yeast/ERR1/ERR1-ai-review.html
@@ -1,0 +1,2957 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>ERR1 - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        .propagation-review {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f8fafc;
+            border-left: 3px solid #64748b;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .propagation-title {
+            font-weight: 600;
+            color: #334155;
+            margin-bottom: 0.25rem;
+        }
+
+        .propagation-row {
+            margin-top: 0.25rem;
+        }
+
+        .propagation-source {
+            margin-top: 0.5rem;
+            padding-top: 0.5rem;
+            border-top: 1px solid #e5e7eb;
+        }
+
+        .propagation-source-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #1d4ed8;
+        }
+
+        .propagation-comment {
+            color: #4b5563;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>ERR1</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/P0CX10" target="_blank" class="term-link">
+                        P0CX10
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Saccharomyces cerevisiae</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-draft">
+                    DRAFT
+                </span>
+            </div>
+
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "ERR1";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="P0CX10" data-a="DESCRIPTION: ERR1 (Enolase-related protein 1; systematic name Y..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>ERR1 (Enolase-related protein 1; systematic name YOR393W) is one of three near-identical Enolase-Related Region (ERR) proteins of Saccharomyces cerevisiae (ERR1/ERR2/ERR3), encoded at conserved sub-telomeric loci and found in all S. cerevisiae strains examined. The 437-residue protein has the complete two-domain enolase fold (an N-terminal capping domain and a C-terminal TIM-barrel) and retains every canonical catalytic and metal-binding residue of the enolase family, including the Glu proton donor, the Lys proton acceptor, and the aspartate/glutamate/aspartate Mg2+-binding triad. On this basis it is predicted to be a Mg2+-dependent phosphopyruvate hydratase (enolase, EC 4.2.1.11), catalysing the interconversion of 2-phospho-D-glycerate and phosphoenolpyruvate. It is closely related to but distinct from the two abundant glycolytic enolases ENO1 and ENO2 (about 67-68% identical), and its own protein sequence is essentially identical to ERR2 (100%) and ERR3 (about 99.5%). The protein has not been directly characterized experimentally (protein existence is inferred from homology), so its enzymatic activity in vivo, its physiological role, its expression conditions, and its subcellular localization remain undetermined.</p>
+    </div>
+
+
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004634" target="_blank" class="term-link">
+                                    GO:0004634
+                                </a>
+                            </span>
+                            <span class="term-label">phosphopyruvate hydratase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P0CX10" data-a="GO:0004634" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetic (IBA) propagation of the enolase molecular function from the PANTHER enolase family, whose source genes include the characterized yeast and mammalian enolases. This molecular-function prediction is domain-defensible: ERR1 carries the complete enolase fold with all catalytic residues (E212 proton donor, K346 proton acceptor) and the Mg2+-binding triad intact, so it retains the capacity for enolase catalysis.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The predicted molecular function is consistent with a fully conserved enolase active site. This represents the best-supported (though homology-based, PE 3) statement of ERR1&#39;s likely activity. Note this is capacity inferred from sequence/structure; no in-vivo or purified-protein enzyme assay for ERR1 exists.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:yeast/ERR1/ERR1-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">SIMILARITY: Belongs to the enolase family.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006096" target="_blank" class="term-link">
+                                    GO:0006096
+                                </a>
+                            </span>
+                            <span class="term-label">glycolytic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P0CX10" data-a="GO:0006096" data-r="GO_REF:0000033" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetic propagation of the glycolytic-process biological role from the enolase family. Whereas the molecular function is defensible from residue conservation, the physiological claim that ERR1 actually participates in glycolytic flux in vivo is unproven. The characterized glycolytic enolases of S. cerevisiae are ENO1 and ENO2; the ERR paralogs are distinct sub-telomeric genes of uncertain physiological role and are not part of the characterized core glycolytic machinery.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Retain as a family-level expectation rather than an established core function. Attributing glycolytic flux to ERR1 specifically over-reaches the evidence: the role, expression condition, and whether ERR1 is catalytically active in vivo are all undetermined (see knowledge_gaps). Marked non-core to avoid asserting an unverified in-vivo process for this dark paralog.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:yeast/ERR1/ERR1-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">PATHWAY: Carbohydrate degradation; glycolysis; pyruvate from D-</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000015" target="_blank" class="term-link">
+                                    GO:0000015
+                                </a>
+                            </span>
+                            <span class="term-label">phosphopyruvate hydratase complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P0CX10" data-a="GO:0000015" data-r="GO_REF:0000033" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Enolases act as oligomers constituting the phosphopyruvate hydratase complex, and this cellular-component term is propagated phylogenetically from the family. For a catalytically-competent enolase this is a reasonable prediction, but whether ERR1 forms or joins such a complex in vivo (with itself, with other ERR proteins, or with ENO1/ENO2) has not been demonstrated.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Plausible by homology but not experimentally established for ERR1; the subcellular/complex context of ERR1 is unknown (GOA also carries an ND cellular_component annotation). Retained as a non-core, homology-level expectation.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:yeast/ERR1/ERR1-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">SIMILARITY: Belongs to the enolase family.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000015" target="_blank" class="term-link">
+                                    GO:0000015
+                                </a>
+                            </span>
+                            <span class="term-label">phosphopyruvate hydratase complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P0CX10" data-a="GO:0000015" data-r="GO_REF:0000002" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic (InterPro IPR000941 -&gt; GO) assignment of the same phosphopyruvate hydratase complex term. Redundant electronic support for the phylogenetic annotation above; carries the same homology-level status and the same caveat that complex membership is not experimentally established for ERR1.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Same cellular-component prediction as the IBA annotation, from InterPro. Plausible by homology, not verified for ERR1; retained as non-core.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:yeast/ERR1/ERR1-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">SIMILARITY: Belongs to the enolase family.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000287" target="_blank" class="term-link">
+                                    GO:0000287
+                                </a>
+                            </span>
+                            <span class="term-label">magnesium ion binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P0CX10" data-a="GO:0000287" data-r="GO_REF:0000002" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Mg2+ is the obligatory enolase cofactor. ERR1 conserves all three canonical Mg2+-coordinating residues (D247, E296, D321), identical to ENO2, so this molecular-function annotation is well supported by the domain/residue analysis.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The metal-binding residues required for the enolase Mg2+ cofactor are fully conserved; this is a defensible molecular-function prediction consistent with the enolase fold.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:yeast/ERR1/ERR1-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">COFACTOR:</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004634" target="_blank" class="term-link">
+                                    GO:0004634
+                                </a>
+                            </span>
+                            <span class="term-label">phosphopyruvate hydratase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000120
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P0CX10" data-a="GO:0004634" data-r="GO_REF:0000120" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Combined automated electronic annotation (ARBA/EC 4.2.1.11/RHEA:10164/InterPro) of the enolase molecular function. Redundant with the IBA and ISA annotations of the same term; same homology-level status.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Consistent electronic prediction of the enolase activity, corroborated by the conserved active site. Same molecular function as the IBA/ISA annotations.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:yeast/ERR1/ERR1-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">EC=4.2.1.11</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006096" target="_blank" class="term-link">
+                                    GO:0006096
+                                </a>
+                            </span>
+                            <span class="term-label">glycolytic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000120
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P0CX10" data-a="GO:0006096" data-r="GO_REF:0000120" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic propagation of the glycolytic-process term (InterPro + UniPathway UPA00109). Redundant with the IBA glycolytic-process annotation; carries the same caveat that ERR1&#39;s in-vivo participation in glycolysis is unproven.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Same over-reaching physiological claim as the IBA glycolytic-process annotation, here from an electronic pipeline. Retained as a non-core family-level expectation rather than an established ERR1 function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:yeast/ERR1/ERR1-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">PATHWAY: Carbohydrate degradation; glycolysis; pyruvate from D-</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004634" target="_blank" class="term-link">
+                                    GO:0004634
+                                </a>
+                            </span>
+                            <span class="term-label">phosphopyruvate hydratase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ISA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/7785338" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:7785338
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Sequence analysis of the right end of chromosome XV in Sacch...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P0CX10" data-a="GO:0004634" data-r="PMID:7785338" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> SGD sequence-similarity (ISA) annotation of enolase activity, using ENO1 (SGD:S000001217) and ENO2 (SGD:S000003486) as the with/from source genes and Pryde et al. 1995 as the reference. The reference establishes DNA-level identity to ENO1/ENO2 (61%/60%) and the sub-telomeric genomic location; the enzyme activity itself is inferred from that similarity, not assayed. The molecular function is domain-defensible (active site fully conserved).
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Per curation rules, an ISA annotation is not removed on paralog grounds; the molecular-function inference from close similarity to the true enolases is sound and consistent with the intact active site. Note the cited paper reports DNA sequence identity and genomic location, not an enzyme assay.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/7785338" target="_blank" class="term-link">
+                                        PMID:7785338
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The first of these shows 61% and 60% DNA sequence identity to Enolases 1 and 2 respectively.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005575" target="_blank" class="term-link">
+                                    GO:0005575
+                                </a>
+                            </span>
+                            <span class="term-label">cellular_component</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ND</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000015
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P0CX10" data-a="GO:0005575" data-r="GO_REF:0000015" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Root cellular_component term with the ND (&#34;no data&#34;) evidence code, recording that no subcellular localization data are curated for ERR1. This correctly reflects the current state of knowledge.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> ND root-term placeholder documenting the absence of localization data; appropriate to keep as-is for a dark gene with no experimental CC evidence.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008150" target="_blank" class="term-link">
+                                    GO:0008150
+                                </a>
+                            </span>
+                            <span class="term-label">biological_process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ND</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000015
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P0CX10" data-a="GO:0008150" data-r="GO_REF:0000015" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Root biological_process term with the ND evidence code, recording that no curated biological-process data exist for ERR1. This honestly reflects the dark status of the gene.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> ND root-term placeholder documenting the absence of biological-process data; appropriate to keep as-is.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>Predicted Mg2+-dependent phosphopyruvate hydratase (enolase) activity, inferred from the complete enolase fold and the full conservation of every catalytic and metal-binding residue relative to the characterized yeast enolases ENO1/ENO2. This is a homology-based prediction of enzymatic capacity (protein existence PE 3); the in-vivo activity, biological role, and expression context of ERR1 are not established.</h3>
+                <span class="vote-buttons" data-g="P0CX10" data-a="FUNCTION: Predicted Mg2+-dependent phosphopyruvate hydratase..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004634" target="_blank" class="term-link">
+                            phosphopyruvate hydratase activity
+                        </a>
+                    </span>
+                </div>
+
+
+
+
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:yeast/ERR1/ERR1-uniprot.txt
+
+                        </span>
+
+                        <div class="finding-text">EC=4.2.1.11</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/7785338" target="_blank" class="term-link">
+                                PMID:7785338
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">The first of these shows 61% and 60% DNA sequence identity to Enolases 1 and 2 respectively.</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000002.md" target="_blank" class="term-link">
+                            GO_REF:0000002
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation through association of InterPro records with GO terms</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000015.md" target="_blank" class="term-link">
+                            GO_REF:0000015
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Use of the ND evidence code for Gene Ontology (GO) terms</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
+                            GO_REF:0000033
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Annotation inferences using phylogenetic trees</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000120.md" target="_blank" class="term-link">
+                            GO_REF:0000120
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Combined Automated Annotation using Multiple IEA Methods</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/7785338" target="_blank" class="term-link">
+                            PMID:7785338
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Sequence analysis of the right end of chromosome XV in Saccharomyces cerevisiae: an insight into the structural and functional significance of sub-telomeric repeat sequences.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">The enolase-related sequence shows 61% and 60% DNA sequence identity to Enolases 1 and 2 respectively; it appears species-specific with three copies found in all S. cerevisiae strains studied, at conserved genomic locations.</div>
+
+                        <div class="finding-text">"The first of these shows 61% and 60% DNA sequence identity to Enolases 1 and 2 respectively. The Enolase-like sequence appears to be species specific, with three copies being found in all strains of S. cerevisiae studied. The location of the three copies is the same for all strains."</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        file:yeast/ERR1/ERR1-uniprot.txt
+
+                    </span>
+                </div>
+
+                <div class="reference-title">UniProt entry P0CX10 (ERR1_YEAST) with inline sequence/domain analysis</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">UniProt annotates a complete enolase two-domain architecture (Enolase_N PF03952, Enolase_C PF00113; PANTHER PTHR11902) with EC 4.2.1.11, Mg2+ cofactor, and by-similarity catalytic residues ACT_SITE 212 (proton donor) and 346 (proton acceptor); protein existence level is PE 3 (inferred from homology). The record maps both YOR393W and YPL281C mRNAs to this accession, i.e. ERR1 and ERR2 share an identical protein sequence.</div>
+
+                        <div class="finding-text">"SIMILARITY: Belongs to the enolase family."</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Inline sequence comparison (this session): ERR1 is 437 aa with no indels relative to yeast enolases; identity is 100% to ERR2 (P0CX11), ~99.5% to ERR3 (P42222), 68.0% to ENO1 (P00924) and 67.3% to ENO2 (P00925). All eight annotated catalytic / Mg2+ / substrate-binding residues (E212, K346, H160, E169, D247, E296, D321, K397) are identical between ERR1 and ENO2, so the enolase catalytic machinery is fully intact and ERR1 is not a degenerate pseudoenzyme.</div>
+
+                        <div class="finding-text">"SIMILARITY: Belongs to the enolase family."</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Questions for Experts</h2>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Is ERR1 protein expressed and catalytically active as an enolase in vivo, and under which growth or developmental condition (e.g. sporulation, stress, respiratory growth)?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P0CX10" data-a="Q: Is ERR1 protein expressed and catalytically active..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Do the three ERR genes have any biological role distinct from ENO1/ENO2, and can any role be attributed to ERR1 specifically given that its protein sequence is identical to ERR2 and nearly identical to ERR3?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P0CX10" data-a="Q: Do the three ERR genes have any biological role di..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Experiments</h2>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Heterologously express and purify recombinant ERR1 and measure 2-phosphoglycerate dehydratase (enolase) activity and Mg2+ dependence in vitro, comparing kinetic parameters to purified ENO1/ENO2.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: ERR1 encodes a catalytically active Mg2+-dependent phosphopyruvate hydratase.</em></p>
+
+
+                    <p style="margin-top: 0.5rem;">Type: enzyme assay</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P0CX10" data-a="EXPERIMENT: Heterologously express and purify recombinant ERR1..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Construct locus-specific single/double/triple ERR deletions (and ERR+ENO combinations) and phenotype across fermentative, respiratory, sporulation, and stress conditions; pair with an ORF-specific expression reporter and proteomics to detect ERR1-specific expression and any non-redundant phenotype.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: ERR1 has a condition-specific in-vivo role separable from ENO1/ENO2 and from the other ERR paralogs.</em></p>
+
+
+                    <p style="margin-top: 0.5rem;">Type: genetic deletion and phenotyping</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P0CX10" data-a="EXPERIMENT: Construct locus-specific single/double/triple ERR ..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Knowledge Gaps</h2>
+        <p style="color: #555; font-size: 0.92rem; margin-top: -0.3rem;">
+            What is <em>not</em> known — curated, literature-grounded statements of the open
+            unknowns (the inverse of core functions).
+        </p>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> Whether ERR1 is catalytically active as a phosphopyruvate hydratase (enolase) in vivo is unknown. No purified-protein enzyme assay or in-vivo activity measurement attributable specifically to ERR1 has been reported.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">MF_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> The enolase fold is complete and every canonical catalytic residue (Glu212 proton donor, Lys346 proton acceptor) and Mg2+-binding residue (Asp247, Glu296, Asp321) is conserved identically to ENO2, so ERR1 has the structural capacity for catalysis and is not a degenerate pseudoenzyme. Protein existence is only inferred from homology (PE 3).</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Distinguishes a genuine, expressed enolase isoform from a conserved-but-silent gene copy; determines whether the enolase MF annotations reflect real in-vivo function.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Express and purify ERR1 protein and assay 2-phosphoglycerate dehydratase activity; and/or detect the protein and measure enolase activity from an ERR1-tagged strain.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"3: Inferred from homology;"</em> — file:yeast/ERR1/ERR1-uniprot.txt</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The in-vivo biological role of ERR1 and the condition(s), if any, under which it is expressed are undetermined. It is not established that ERR1 contributes to glycolytic flux, and no ERR1-specific phenotype or expression dataset has been curated here.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">BP_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> The characterized glycolytic enolases of S. cerevisiae are ENO1 and ENO2; the three ERR genes are distinct sub-telomeric loci present in all strains, but their physiological function is uncharacterized. ERR1 has ND (no-data) annotations for both cellular_component and biological_process.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> A conserved, strain-invariant sub-telomeric gene family with an intact enzyme fold but no known role is a candidate piece of the yeast &#34;unknome&#34;; resolving it would reveal why S. cerevisiae maintains extra enolase-like genes beyond ENO1/ENO2.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Locus-specific deletion/phenotyping of ERR1 across conditions (fermentative, respiratory, sporulation, stress) with ERR2/ERR3 controls; condition-resolved transcriptomics/proteomics for the specific ORF.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"three copies being found in all strains of S. cerevisiae studied"</em> — PMID:7785338</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> Whether ERR1 has any function distinct from its paralogs ERR2 and ERR3, or from the true enolases ENO1/ENO2, cannot be determined from existing evidence, and no functional assay can attribute a phenotype to ERR1 rather than ERR2/ERR3 without locus-specific genetics.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">RESIDUAL_SUBGAP</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> Inline sequence analysis shows the ERR1 protein is 100% identical to ERR2 and about 99.5% identical to ERR3 (differing by ~2 residues), and 67-68% identical to ENO1/ENO2. Because ERR1 and ERR2 are the same protein sequence, any protein-, sequence-, or most biochemistry-based evidence is intrinsically ERR-family-level, not ERR1-specific.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Determines whether the ERR trio is functionally redundant reserve/pseudogenic copies or encodes a distinct, possibly condition-specific, activity; also flags that all ERR1 annotations are really family-level attributions.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Single, double, and triple ERR deletions plus ERR/ENO combinatorial deletions with condition panels; allele-/locus-specific expression reporters to separate the copies.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"3: Inferred from homology;"</em> — file:yeast/ERR1/ERR1-uniprot.txt</li>
+
+            </ul>
+
+
+        </div>
+
+    </div>
+
+
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Deep Research Sections -->
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(ERR1-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="P0CX10" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="err1-yor393w-curation-notes">ERR1 (YOR393W) curation notes</h1>
+<p>Gene: <strong>ERR1</strong> — Enolase-related protein 1<br />
+UniProt: <strong>P0CX10</strong> (ERR1_YEAST); SGD: S000005920; systematic name YOR393W.<br />
+Organism: <em>Saccharomyces cerevisiae</em> S288C (NCBITaxon:559292).<br />
+Protein existence level: <strong>PE 3 — Inferred from homology</strong> (no direct experimental<br />
+characterization of the protein itself).</p>
+<p>This is an understudied ("dark") gene. The primary curation goal is an honest<br />
+<code>knowledge_gaps</code> section plus carefully-reasoned <code>core_functions</code>/<code>description</code><br />
+grounded in domain architecture, orthology, and the (sparse) literature — never<br />
+invented function.</p>
+<hr />
+<h2 id="1-paralog-landscape-critical-for-evidence-attribution">1. Paralog landscape — critical for evidence attribution</h2>
+<p><em>S. cerevisiae</em> has three "Enolase-Related Region" (ERR) genes plus the two true<br />
+glycolytic enolases:</p>
+<table>
+<thead>
+<tr>
+<th>Gene</th>
+<th>UniProt</th>
+<th>Systematic name</th>
+<th>SGD</th>
+<th>Length</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>ERR1</td>
+<td>P0CX10</td>
+<td>YOR393W</td>
+<td>S000005920</td>
+<td>437 aa</td>
+</tr>
+<tr>
+<td>ERR2</td>
+<td>P0CX11</td>
+<td>YPL281C</td>
+<td>S000006202</td>
+<td>437 aa</td>
+</tr>
+<tr>
+<td>ERR3</td>
+<td>P42222</td>
+<td>YMR323W</td>
+<td>S000004942</td>
+<td>437 aa</td>
+</tr>
+<tr>
+<td>ENO1</td>
+<td>P00924</td>
+<td>YGR254W</td>
+<td>S000003486</td>
+<td>437 aa</td>
+</tr>
+<tr>
+<td>ENO2</td>
+<td>P00925</td>
+<td>YHR174W</td>
+<td>S000001217</td>
+<td>437 aa</td>
+</tr>
+</tbody>
+</table>
+<p><strong>Sequence identities I computed inline (ungapped, all sequences are exactly 437 aa<br />
+with no indels — enolase is a highly conserved rigid TIM-barrel fold):</strong></p>
+<ul>
+<li>ERR1 vs <strong>ERR2 = 100.0%</strong> identical (the two proteins are the <em>same</em> sequence; this<br />
+  is why UniProt merged YOR393W and YPL281C into a single accession P0CX10 carrying<br />
+  two OrderedLocusNames and two EnsemblFungi/KEGG mRNA cross-references).</li>
+<li>ERR1 vs <strong>ERR3 = 99.5%</strong> identical (only 2 residue differences over 437).</li>
+<li>ERR1 vs <strong>ENO1 = 68.0%</strong> identical.</li>
+<li>ERR1 vs <strong>ENO2 = 67.3%</strong> identical.</li>
+</ul>
+<p><strong>Consequence:</strong> the three ERR proteins are functionally indistinguishable at the<br />
+protein level. No protein-level, sequence-based, or most biochemical assays could<br />
+attribute a phenotype specifically to <em>ERR1</em> rather than <em>ERR2/ERR3</em>. Only<br />
+locus-specific genetics (deletion of the specific ORF, allele-specific expression)<br />
+could do so, and I have found no such ERR1-specific functional study. Any functional<br />
+claim from the literature (or from IBA/ISA propagation) is really a claim about the<br />
+ERR family, not ERR1 uniquely.</p>
+<p>Foundational reference: Pryde, Huckle &amp; Louis 1995 [PMID:7785338, "The first of<br />
+these shows 61%\nand 60% DNA sequence identity to Enolases 1 and 2 respectively. The<br />
+Enolase-like\nsequence appears to be species specific, with three copies being found<br />
+in all\nstrains of S. cerevisiae studied. The location of the three copies is the same\nfor<br />
+all strains."]. Note: this reference is <strong>abstract-only</strong> in our cache<br />
+(<code>full_text_available: false</code>) and reports DNA (not protein) identity and genomic<br />
+location — it does NOT assay enzymatic activity.</p>
+<hr />
+<h2 id="2-domain-architecture-and-catalytic-residue-analysis-inline-from-uniprot">2. Domain architecture and catalytic-residue analysis (inline, from UniProt)</h2>
+<p>UniProt P0CX10 annotates a complete two-domain enolase architecture:<br />
+- Enolase N-terminal domain (Pfam PF03952 Enolase_N; IPR029017)<br />
+- Enolase C-terminal TIM-barrel domain (Pfam PF00113 Enolase_C; IPR020810)<br />
+- PANTHER PTHR11902 (ENOLASE), CDD cd03313 enolase, PROSITE PS00164 ENOLASE,<br />
+  HAMAP MF_00318 Enolase, SFLD enolase.<br />
+- KW: Glycolysis, Lyase, Magnesium, Metal-binding.</p>
+<p>UniProt catalytic/binding features (all <code>ECO:0000250</code>, i.e. by-similarity, not<br />
+experimental):<br />
+- ACT_SITE 212 "Proton donor" (Glu)<br />
+- ACT_SITE 346 "Proton acceptor" (Lys)<br />
+- BINDING 160, 169 substrate<br />
+- BINDING 247 Mg(2+)<br />
+- BINDING 296 Mg(2+)/substrate<br />
+- BINDING 321 Mg(2+)/substrate<br />
+- BINDING 373–376 substrate; 397 substrate</p>
+<p><strong>Catalytic-residue conservation check I ran inline (ERR1 vs ENO2, position-matched<br />
+because both are 437 aa, no indels):</strong></p>
+<table>
+<thead>
+<tr>
+<th>Pos</th>
+<th>ERR1</th>
+<th>ENO2</th>
+<th>Role</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>212</td>
+<td>E</td>
+<td>E</td>
+<td>proton donor (ACT_SITE)</td>
+</tr>
+<tr>
+<td>346</td>
+<td>K</td>
+<td>K</td>
+<td>proton acceptor (ACT_SITE)</td>
+</tr>
+<tr>
+<td>160</td>
+<td>H</td>
+<td>H</td>
+<td>substrate binding</td>
+</tr>
+<tr>
+<td>169</td>
+<td>E</td>
+<td>E</td>
+<td>substrate binding</td>
+</tr>
+<tr>
+<td>247</td>
+<td>D</td>
+<td>D</td>
+<td>Mg2+ binding</td>
+</tr>
+<tr>
+<td>296</td>
+<td>E</td>
+<td>E</td>
+<td>Mg2+/substrate binding</td>
+</tr>
+<tr>
+<td>321</td>
+<td>D</td>
+<td>D</td>
+<td>Mg2+/substrate binding</td>
+</tr>
+<tr>
+<td>397</td>
+<td>K</td>
+<td>K</td>
+<td>substrate binding</td>
+</tr>
+</tbody>
+</table>
+<p><strong>All 8 annotated catalytic / Mg-binding / substrate-binding residues are identical<br />
+between ERR1 and ENO2.</strong> The canonical enolase catalytic machinery (Glu proton donor,<br />
+Lys proton acceptor, the D/E/D Mg2+ triad) is fully intact. ERR1 is therefore <strong>NOT a<br />
+degenerate pseudoenzyme</strong> — it retains every residue required for phosphopyruvate<br />
+hydratase (enolase) catalysis. This makes the <em>molecular-function</em> annotations<br />
+(phosphopyruvate hydratase activity GO:0004634; magnesium ion binding GO:0000287)<br />
+<strong>domain-defensible</strong> as a prediction.</p>
+<p><strong>But</strong> conserved catalytic residues establish <em>capacity</em>, not <em>in-vivo activity or<br />
+role</em>. The gap is physiological, not structural (see §4).</p>
+<hr />
+<h2 id="3-what-is-known-vs-not-known">3. What is KNOWN vs NOT KNOWN</h2>
+<h3 id="known-well-supported">KNOWN (well supported)</h3>
+<ul>
+<li>ERR1 is a member of the enolase family with a complete, catalytically-intact enolase<br />
+  fold (domain analysis + residue conservation above).</li>
+<li>There are three near-identical ERR paralogs at conserved sub-telomeric loci, present<br />
+  in all S. cerevisiae strains examined; the family is <em>S. cerevisiae</em>-specific<br />
+  (Pryde et al. 1995, PMID:7785338).</li>
+<li>By homology to ENO1/ENO2, the predicted activity is 2-phospho-D-glycerate<br />
+  hydro-lyase (EC 4.2.1.11): (2R)-2-phosphoglycerate = phosphoenolpyruvate + H2O,<br />
+  Mg2+-dependent.</li>
+</ul>
+<h3 id="not-known-genuine-gaps">NOT KNOWN (genuine gaps)</h3>
+<ul>
+<li><strong>Whether ERR1 is catalytically active as an enolase in vivo.</strong> No purified-protein<br />
+  enzyme assay attributable specifically to ERR1 exists. PE level is 3 (homology).</li>
+<li><strong>The in-vivo biological role.</strong> Deleting ENO1+ENO2 is what impairs glycolysis;<br />
+  the ERR genes are not part of the characterized core glycolytic machinery. Whether<br />
+  ERR1 contributes measurably to glycolytic flux under any standard condition is<br />
+  undetermined.</li>
+<li><strong>The expression condition.</strong> If ERR1 is expressed at all, under what<br />
+  condition/stage? (The ERR family has been discussed in the context of sporulation<br />
+  in the broader literature, but I have not verified an ERR1-specific expression<br />
+  dataset in our cache; do not assert this without provenance.)</li>
+<li><strong>Redundancy / non-redundancy vs ERR2, ERR3, and vs ENO1/ENO2.</strong> Because ERR1 =<br />
+  ERR2 (100%) and ~ERR3 (99.5%), any function is almost certainly shared across the<br />
+  ERR trio; whether the trio does anything the true enolases do not is unknown.</li>
+<li><strong>Subcellular localization</strong> is undetermined (GOA carries an ND cellular_component<br />
+  annotation). Cytosol is the default expectation for a glycolytic-type enzyme (no<br />
+  signal peptide/TM in the sequence), but this is not experimentally established for<br />
+  ERR1.</li>
+</ul>
+<hr />
+<h2 id="4-annotation-by-annotation-reasoning-goa-has-10-lines">4. Annotation-by-annotation reasoning (GOA has 10 lines)</h2>
+<p>All ten GOA lines derive from <strong>homology/electronic/phylogenetic</strong> inference or are<br />
+ND placeholders — there is <strong>no experimental (IDA/IMP/IPI/IGI) annotation</strong> for ERR1.</p>
+<ol>
+<li><code>GO:0004634 phosphopyruvate hydratase activity</code> / IBA (GO_REF:0000033) — enables.<br />
+   Phylogenetic propagation from the enolase PANTHER family (PTN000224401), with<br />
+   ENO1/ENO2 among the source genes. Domain-defensible (residues intact). <strong>ACCEPT</strong><br />
+   as the core predicted MF; but note it is inference, not measured for ERR1.</li>
+<li><code>GO:0006096 glycolytic process</code> / IBA (GO_REF:0000033) — involved_in. Propagated<br />
+   BP. The MF is defensible; the <em>process</em> (that ERR1 actually participates in<br />
+   glycolysis in vivo) is exactly the unproven physiological claim. <strong>KEEP_AS_NON_CORE</strong><br />
+   — retain the family-level expectation but flag it is not established that ERR1<br />
+   contributes to glycolytic flux (it is not one of the two characterized glycolytic<br />
+   enolases). This is the honest treatment for a dark paralog.</li>
+<li><code>GO:0000015 phosphopyruvate hydratase complex</code> / IBA (GO_REF:0000033) — part_of.<br />
+   Enolase functions as a homodimer/oligomer = the phosphopyruvate hydratase complex.<br />
+   For a catalytically-competent enolase this CC is reasonable <strong>but</strong> whether ERR1<br />
+   forms/joins such a complex in vivo is unverified. <strong>KEEP_AS_NON_CORE</strong>.</li>
+<li><code>GO:0000015 phosphopyruvate hydratase complex</code> / IEA (GO_REF:0000002, InterPro) —<br />
+   part_of. Same term via InterPro IPR000941. Redundant electronic support for #3.<br />
+<strong>KEEP_AS_NON_CORE</strong>.</li>
+<li><code>GO:0000287 magnesium ion binding</code> / IEA (GO_REF:0000002, InterPro) — enables.<br />
+   Mg2+ is the enolase cofactor; the three Mg-binding residues are conserved in ERR1<br />
+   (D247/E296/D321). Domain-defensible. <strong>ACCEPT</strong>.</li>
+<li><code>GO:0004634 phosphopyruvate hydratase activity</code> / IEA (GO_REF:0000120) — enables.<br />
+   Combined automated (ARBA/EC/RHEA/InterPro). Redundant with #1/#8. <strong>ACCEPT</strong> (same<br />
+   MF, electronic).</li>
+<li><code>GO:0006096 glycolytic process</code> / IEA (GO_REF:0000120) — involved_in. Redundant<br />
+   with #2, electronic. <strong>KEEP_AS_NON_CORE</strong> (same reasoning as #2).</li>
+<li><code>GO:0004634 phosphopyruvate hydratase activity</code> / ISA (PMID:7785338;<br />
+   with SGD:S000001217 ENO1, SGD:S000003486 ENO2) — enables. Sequence-similarity<br />
+   annotation from SGD based on the Pryde 1995 identity to ENO1/ENO2. The reference<br />
+   supports <em>sequence similarity</em>, and the MF is domain-defensible. <strong>ACCEPT</strong>, but<br />
+   note the supporting paper reports DNA identity + genomic location only (abstract<br />
+   states "61% and 60% DNA sequence identity to Enolases 1 and 2"), not enzyme assay.<br />
+   Per curation rules: do NOT REMOVE an ISA annotation on paralog grounds; the MF<br />
+   inference is sound.</li>
+<li><code>GO:0005575 cellular_component</code> / ND (GO_REF:0000015) — is_active_in. Root-term ND<br />
+   placeholder = "no data". Standard practice is to keep as-is. <strong>ACCEPT</strong> (it<br />
+   correctly records the absence of CC data).</li>
+<li><code>GO:0008150 biological_process</code> / ND (GO_REF:0000015) — involved_in. Root-term ND<br />
+    placeholder. <strong>ACCEPT</strong> (records absence of BP data).</li>
+</ol>
+<p>No <code>protein binding</code> terms present (good). No experimental annotations to protect from<br />
+over-ruling. No negated/isoform annotations.</p>
+<hr />
+<h2 id="5-provenance-discipline">5. Provenance discipline</h2>
+<ul>
+<li>Sequence identities and catalytic-residue table in §1–2 are computed inline in this<br />
+  session from UniProt sequences (P0CX10 ERR1, P00925 ENO2, P00924 ENO1, P0CX11 ERR2,<br />
+  P42222 ERR3). These are recorded as a <code>file:</code> bioinformatics-style provenance<br />
+  anchored to the UniProt record; the core numeric claims (100% ERR1=ERR2, all<br />
+  catalytic residues conserved) are reproducible from the sequences in the UniProt<br />
+  files.</li>
+<li>The only literature reference in GOA is PMID:7785338 (abstract-only). Quotes used in<br />
+  the review are verbatim substrings of the cached abstract.</li>
+<li>Falcon deep research was requested; if/when it returns it is kept as<br />
+<code>ERR1-deep-research-falcon.md</code>. It must NOT be used to fabricate ERR1-specific<br />
+  experimental claims — the paralog-indistinguishability point above stands regardless.</li>
+</ul>
+<h2 id="6-deep-research-status-falcon-unavailable">6. Deep research status (falcon unavailable)</h2>
+<p>Falcon deep research (<code>just deep-research-falcon yeast ERR1 --fallback perplexity-lite</code>)<br />
+was launched at the start of the session and ran for ~24 minutes with <strong>zero output</strong><br />
+before the wrapper gave up; a single bounded retry (8-min hard timeout) was then<br />
+attempted per protocol and also returned nothing (SIGTERM/exit 143). No<br />
+<code>ERR1-deep-research-*.md</code> file was produced. The Edison/falcon endpoint was effectively<br />
+hanging today. Per project rules I did NOT fabricate a <code>-deep-research-{provider}.md</code><br />
+file. This review is therefore grounded entirely in:<br />
+  - the UniProt record P0CX10 (domain architecture, catalytic residues, PE level),<br />
+  - the QuickGO GOA export (the 10 existing annotations),<br />
+  - the one cached primary reference PMID:7785338 (abstract-only), and<br />
+  - inline sequence/catalytic-residue analysis run in this session (ERR1 vs<br />
+    ENO1/ENO2/ERR2/ERR3).<br />
+The paralog-indistinguishability and dark-gene conclusions do not depend on deep<br />
+research; the honest <code>knowledge_gaps</code> section captures exactly what remains unknown.</p>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: P0CX10
+gene_symbol: ERR1
+product_type: PROTEIN
+status: DRAFT
+taxon:
+  id: NCBITaxon:559292
+  label: Saccharomyces cerevisiae
+description: &gt;-
+  ERR1 (Enolase-related protein 1; systematic name YOR393W) is one of three
+  near-identical Enolase-Related Region (ERR) proteins of Saccharomyces cerevisiae
+  (ERR1/ERR2/ERR3), encoded at conserved sub-telomeric loci and found in all
+  S. cerevisiae strains examined. The 437-residue protein has the complete two-domain
+  enolase fold (an N-terminal capping domain and a C-terminal TIM-barrel) and retains
+  every canonical catalytic and metal-binding residue of the enolase family, including
+  the Glu proton donor, the Lys proton acceptor, and the aspartate/glutamate/aspartate
+  Mg2+-binding triad. On this basis it is predicted to be a Mg2+-dependent
+  phosphopyruvate hydratase (enolase, EC 4.2.1.11), catalysing the interconversion of
+  2-phospho-D-glycerate and phosphoenolpyruvate. It is closely related to but distinct
+  from the two abundant glycolytic enolases ENO1 and ENO2 (about 67-68% identical),
+  and its own protein sequence is essentially identical to ERR2 (100%) and ERR3
+  (about 99.5%). The protein has not been directly characterized experimentally
+  (protein existence is inferred from homology), so its enzymatic activity in vivo, its
+  physiological role, its expression conditions, and its subcellular localization
+  remain undetermined.
+references:
+- id: GO_REF:0000002
+  title: Gene Ontology annotation through association of InterPro records with GO
+    terms
+  findings: []
+- id: GO_REF:0000015
+  title: Use of the ND evidence code for Gene Ontology (GO) terms
+  findings: []
+- id: GO_REF:0000033
+  title: Annotation inferences using phylogenetic trees
+  findings: []
+- id: GO_REF:0000120
+  title: Combined Automated Annotation using Multiple IEA Methods
+  findings: []
+- id: PMID:7785338
+  title: &#39;Sequence analysis of the right end of chromosome XV in Saccharomyces cerevisiae:
+    an insight into the structural and functional significance of sub-telomeric repeat
+    sequences.&#39;
+  findings:
+  - statement: &gt;-
+      The enolase-related sequence shows 61% and 60% DNA sequence identity to
+      Enolases 1 and 2 respectively; it appears species-specific with three copies
+      found in all S. cerevisiae strains studied, at conserved genomic locations.
+    supporting_text: &gt;-
+      The first of these shows 61%
+      and 60% DNA sequence identity to Enolases 1 and 2 respectively. The Enolase-like
+      sequence appears to be species specific, with three copies being found in all
+      strains of S. cerevisiae studied. The location of the three copies is the same
+      for all strains.
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PubMed-verified; this is the foundational report defining the three ERR
+      enolase-related genes and their sub-telomeric location. Abstract-only in our
+      cache (full text not available). It establishes DNA sequence identity to ENO1/ENO2
+      and genomic copy number/location, NOT enzymatic activity; the SGD ISA annotation
+      to phosphopyruvate hydratase activity uses this paper as the sequence-similarity
+      source.
+- id: file:yeast/ERR1/ERR1-uniprot.txt
+  title: UniProt entry P0CX10 (ERR1_YEAST) with inline sequence/domain analysis
+  findings:
+  - statement: &gt;-
+      UniProt annotates a complete enolase two-domain architecture (Enolase_N PF03952,
+      Enolase_C PF00113; PANTHER PTHR11902) with EC 4.2.1.11, Mg2+ cofactor, and
+      by-similarity catalytic residues ACT_SITE 212 (proton donor) and 346 (proton
+      acceptor); protein existence level is PE 3 (inferred from homology). The record
+      maps both YOR393W and YPL281C mRNAs to this accession, i.e. ERR1 and ERR2 share
+      an identical protein sequence.
+    supporting_text: &gt;-
+      SIMILARITY: Belongs to the enolase family.
+  - statement: &gt;-
+      Inline sequence comparison (this session): ERR1 is 437 aa with no indels relative
+      to yeast enolases; identity is 100% to ERR2 (P0CX11), ~99.5% to ERR3 (P42222),
+      68.0% to ENO1 (P00924) and 67.3% to ENO2 (P00925). All eight annotated catalytic /
+      Mg2+ / substrate-binding residues (E212, K346, H160, E169, D247, E296, D321, K397)
+      are identical between ERR1 and ENO2, so the enolase catalytic machinery is fully
+      intact and ERR1 is not a degenerate pseudoenzyme.
+    supporting_text: &gt;-
+      SIMILARITY: Belongs to the enolase family.
+existing_annotations:
+- term:
+    id: GO:0004634
+    label: phosphopyruvate hydratase activity
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Phylogenetic (IBA) propagation of the enolase molecular function from the
+      PANTHER enolase family, whose source genes include the characterized yeast and
+      mammalian enolases. This molecular-function prediction is domain-defensible: ERR1
+      carries the complete enolase fold with all catalytic residues (E212 proton donor,
+      K346 proton acceptor) and the Mg2+-binding triad intact, so it retains the
+      capacity for enolase catalysis.
+    action: ACCEPT
+    reason: &gt;-
+      The predicted molecular function is consistent with a fully conserved enolase
+      active site. This represents the best-supported (though homology-based, PE 3)
+      statement of ERR1&#39;s likely activity. Note this is capacity inferred from
+      sequence/structure; no in-vivo or purified-protein enzyme assay for ERR1 exists.
+    supported_by:
+    - reference_id: file:yeast/ERR1/ERR1-uniprot.txt
+      supporting_text: &gt;-
+        SIMILARITY: Belongs to the enolase family.
+- term:
+    id: GO:0006096
+    label: glycolytic process
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Phylogenetic propagation of the glycolytic-process biological role from the
+      enolase family. Whereas the molecular function is defensible from residue
+      conservation, the physiological claim that ERR1 actually participates in
+      glycolytic flux in vivo is unproven. The characterized glycolytic enolases of
+      S. cerevisiae are ENO1 and ENO2; the ERR paralogs are distinct sub-telomeric
+      genes of uncertain physiological role and are not part of the characterized core
+      glycolytic machinery.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Retain as a family-level expectation rather than an established core function.
+      Attributing glycolytic flux to ERR1 specifically over-reaches the evidence: the
+      role, expression condition, and whether ERR1 is catalytically active in vivo are
+      all undetermined (see knowledge_gaps). Marked non-core to avoid asserting an
+      unverified in-vivo process for this dark paralog.
+    supported_by:
+    - reference_id: file:yeast/ERR1/ERR1-uniprot.txt
+      supporting_text: &gt;-
+        PATHWAY: Carbohydrate degradation; glycolysis; pyruvate from D-
+- term:
+    id: GO:0000015
+    label: phosphopyruvate hydratase complex
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: part_of
+  review:
+    summary: &gt;-
+      Enolases act as oligomers constituting the phosphopyruvate hydratase complex, and
+      this cellular-component term is propagated phylogenetically from the family. For a
+      catalytically-competent enolase this is a reasonable prediction, but whether ERR1
+      forms or joins such a complex in vivo (with itself, with other ERR proteins, or
+      with ENO1/ENO2) has not been demonstrated.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Plausible by homology but not experimentally established for ERR1; the
+      subcellular/complex context of ERR1 is unknown (GOA also carries an ND
+      cellular_component annotation). Retained as a non-core, homology-level expectation.
+    supported_by:
+    - reference_id: file:yeast/ERR1/ERR1-uniprot.txt
+      supporting_text: &gt;-
+        SIMILARITY: Belongs to the enolase family.
+- term:
+    id: GO:0000015
+    label: phosphopyruvate hydratase complex
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: part_of
+  review:
+    summary: &gt;-
+      Electronic (InterPro IPR000941 -&gt; GO) assignment of the same phosphopyruvate
+      hydratase complex term. Redundant electronic support for the phylogenetic
+      annotation above; carries the same homology-level status and the same caveat that
+      complex membership is not experimentally established for ERR1.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Same cellular-component prediction as the IBA annotation, from InterPro. Plausible
+      by homology, not verified for ERR1; retained as non-core.
+    supported_by:
+    - reference_id: file:yeast/ERR1/ERR1-uniprot.txt
+      supporting_text: &gt;-
+        SIMILARITY: Belongs to the enolase family.
+- term:
+    id: GO:0000287
+    label: magnesium ion binding
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Mg2+ is the obligatory enolase cofactor. ERR1 conserves all three canonical
+      Mg2+-coordinating residues (D247, E296, D321), identical to ENO2, so this
+      molecular-function annotation is well supported by the domain/residue analysis.
+    action: ACCEPT
+    reason: &gt;-
+      The metal-binding residues required for the enolase Mg2+ cofactor are fully
+      conserved; this is a defensible molecular-function prediction consistent with the
+      enolase fold.
+    supported_by:
+    - reference_id: file:yeast/ERR1/ERR1-uniprot.txt
+      supporting_text: &gt;-
+        COFACTOR:
+- term:
+    id: GO:0004634
+    label: phosphopyruvate hydratase activity
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000120
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Combined automated electronic annotation (ARBA/EC 4.2.1.11/RHEA:10164/InterPro)
+      of the enolase molecular function. Redundant with the IBA and ISA annotations of
+      the same term; same homology-level status.
+    action: ACCEPT
+    reason: &gt;-
+      Consistent electronic prediction of the enolase activity, corroborated by the
+      conserved active site. Same molecular function as the IBA/ISA annotations.
+    supported_by:
+    - reference_id: file:yeast/ERR1/ERR1-uniprot.txt
+      supporting_text: &gt;-
+        EC=4.2.1.11
+- term:
+    id: GO:0006096
+    label: glycolytic process
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000120
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Electronic propagation of the glycolytic-process term (InterPro + UniPathway
+      UPA00109). Redundant with the IBA glycolytic-process annotation; carries the same
+      caveat that ERR1&#39;s in-vivo participation in glycolysis is unproven.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Same over-reaching physiological claim as the IBA glycolytic-process annotation,
+      here from an electronic pipeline. Retained as a non-core family-level expectation
+      rather than an established ERR1 function.
+    supported_by:
+    - reference_id: file:yeast/ERR1/ERR1-uniprot.txt
+      supporting_text: &gt;-
+        PATHWAY: Carbohydrate degradation; glycolysis; pyruvate from D-
+- term:
+    id: GO:0004634
+    label: phosphopyruvate hydratase activity
+  evidence_type: ISA
+  original_reference_id: PMID:7785338
+  qualifier: enables
+  review:
+    summary: &gt;-
+      SGD sequence-similarity (ISA) annotation of enolase activity, using ENO1
+      (SGD:S000001217) and ENO2 (SGD:S000003486) as the with/from source genes and
+      Pryde et al. 1995 as the reference. The reference establishes DNA-level identity
+      to ENO1/ENO2 (61%/60%) and the sub-telomeric genomic location; the enzyme
+      activity itself is inferred from that similarity, not assayed. The molecular
+      function is domain-defensible (active site fully conserved).
+    action: ACCEPT
+    reason: &gt;-
+      Per curation rules, an ISA annotation is not removed on paralog grounds; the
+      molecular-function inference from close similarity to the true enolases is sound
+      and consistent with the intact active site. Note the cited paper reports DNA
+      sequence identity and genomic location, not an enzyme assay.
+    supported_by:
+    - reference_id: PMID:7785338
+      supporting_text: &gt;-
+        The first of these shows 61%
+        and 60% DNA sequence identity to Enolases 1 and 2 respectively.
+- term:
+    id: GO:0005575
+    label: cellular_component
+  evidence_type: ND
+  original_reference_id: GO_REF:0000015
+  qualifier: is_active_in
+  review:
+    summary: &gt;-
+      Root cellular_component term with the ND (&#34;no data&#34;) evidence code, recording that
+      no subcellular localization data are curated for ERR1. This correctly reflects the
+      current state of knowledge.
+    action: ACCEPT
+    reason: &gt;-
+      ND root-term placeholder documenting the absence of localization data; appropriate
+      to keep as-is for a dark gene with no experimental CC evidence.
+- term:
+    id: GO:0008150
+    label: biological_process
+  evidence_type: ND
+  original_reference_id: GO_REF:0000015
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Root biological_process term with the ND evidence code, recording that no curated
+      biological-process data exist for ERR1. This honestly reflects the dark status of
+      the gene.
+    action: ACCEPT
+    reason: &gt;-
+      ND root-term placeholder documenting the absence of biological-process data;
+      appropriate to keep as-is.
+core_functions:
+- description: &gt;-
+    Predicted Mg2+-dependent phosphopyruvate hydratase (enolase) activity, inferred from
+    the complete enolase fold and the full conservation of every catalytic and
+    metal-binding residue relative to the characterized yeast enolases ENO1/ENO2. This
+    is a homology-based prediction of enzymatic capacity (protein existence PE 3); the
+    in-vivo activity, biological role, and expression context of ERR1 are not
+    established.
+  molecular_function:
+    id: GO:0004634
+    label: phosphopyruvate hydratase activity
+  supported_by:
+  - reference_id: file:yeast/ERR1/ERR1-uniprot.txt
+    supporting_text: &gt;-
+      EC=4.2.1.11
+  - reference_id: PMID:7785338
+    supporting_text: &gt;-
+      The first of these shows 61%
+      and 60% DNA sequence identity to Enolases 1 and 2 respectively.
+knowledge_gaps:
+- gap_statement: &gt;-
+    Whether ERR1 is catalytically active as a phosphopyruvate hydratase (enolase) in
+    vivo is unknown. No purified-protein enzyme assay or in-vivo activity measurement
+    attributable specifically to ERR1 has been reported.
+  boundary: &gt;-
+    The enolase fold is complete and every canonical catalytic residue (Glu212 proton
+    donor, Lys346 proton acceptor) and Mg2+-binding residue (Asp247, Glu296, Asp321) is
+    conserved identically to ENO2, so ERR1 has the structural capacity for catalysis and
+    is not a degenerate pseudoenzyme. Protein existence is only inferred from homology
+    (PE 3).
+  gap_kind:
+  - BIOLOGY
+  dark_aspect: MF_DARK
+  status: OPEN
+  significance: &gt;-
+    Distinguishes a genuine, expressed enolase isoform from a conserved-but-silent gene
+    copy; determines whether the enolase MF annotations reflect real in-vivo function.
+  resolution: &gt;-
+    Express and purify ERR1 protein and assay 2-phosphoglycerate dehydratase activity;
+    and/or detect the protein and measure enolase activity from an ERR1-tagged strain.
+  provenance:
+  - reference_id: file:yeast/ERR1/ERR1-uniprot.txt
+    supporting_text: &gt;-
+      3: Inferred from homology;
+- gap_statement: &gt;-
+    The in-vivo biological role of ERR1 and the condition(s), if any, under which it is
+    expressed are undetermined. It is not established that ERR1 contributes to glycolytic
+    flux, and no ERR1-specific phenotype or expression dataset has been curated here.
+  boundary: &gt;-
+    The characterized glycolytic enolases of S. cerevisiae are ENO1 and ENO2; the three
+    ERR genes are distinct sub-telomeric loci present in all strains, but their
+    physiological function is uncharacterized. ERR1 has ND (no-data) annotations for both
+    cellular_component and biological_process.
+  gap_kind:
+  - BIOLOGY
+  dark_aspect: BP_DARK
+  status: OPEN
+  significance: &gt;-
+    A conserved, strain-invariant sub-telomeric gene family with an intact enzyme fold
+    but no known role is a candidate piece of the yeast &#34;unknome&#34;; resolving it would
+    reveal why S. cerevisiae maintains extra enolase-like genes beyond ENO1/ENO2.
+  resolution: &gt;-
+    Locus-specific deletion/phenotyping of ERR1 across conditions (fermentative,
+    respiratory, sporulation, stress) with ERR2/ERR3 controls; condition-resolved
+    transcriptomics/proteomics for the specific ORF.
+  provenance:
+  - reference_id: PMID:7785338
+    supporting_text: &gt;-
+      three copies being found in all
+      strains of S. cerevisiae studied
+- gap_statement: &gt;-
+    Whether ERR1 has any function distinct from its paralogs ERR2 and ERR3, or from the
+    true enolases ENO1/ENO2, cannot be determined from existing evidence, and no
+    functional assay can attribute a phenotype to ERR1 rather than ERR2/ERR3 without
+    locus-specific genetics.
+  boundary: &gt;-
+    Inline sequence analysis shows the ERR1 protein is 100% identical to ERR2 and about
+    99.5% identical to ERR3 (differing by ~2 residues), and 67-68% identical to ENO1/ENO2.
+    Because ERR1 and ERR2 are the same protein sequence, any protein-, sequence-, or most
+    biochemistry-based evidence is intrinsically ERR-family-level, not ERR1-specific.
+  gap_kind:
+  - BIOLOGY
+  dark_aspect: RESIDUAL_SUBGAP
+  status: OPEN
+  significance: &gt;-
+    Determines whether the ERR trio is functionally redundant reserve/pseudogenic copies
+    or encodes a distinct, possibly condition-specific, activity; also flags that all
+    ERR1 annotations are really family-level attributions.
+  resolution: &gt;-
+    Single, double, and triple ERR deletions plus ERR/ENO combinatorial deletions with
+    condition panels; allele-/locus-specific expression reporters to separate the copies.
+  provenance:
+  - reference_id: file:yeast/ERR1/ERR1-uniprot.txt
+    supporting_text: &gt;-
+      3: Inferred from homology;
+suggested_questions:
+- question: &gt;-
+    Is ERR1 protein expressed and catalytically active as an enolase in vivo, and under
+    which growth or developmental condition (e.g. sporulation, stress, respiratory
+    growth)?
+- question: &gt;-
+    Do the three ERR genes have any biological role distinct from ENO1/ENO2, and can any
+    role be attributed to ERR1 specifically given that its protein sequence is identical
+    to ERR2 and nearly identical to ERR3?
+suggested_experiments:
+- hypothesis: &gt;-
+    ERR1 encodes a catalytically active Mg2+-dependent phosphopyruvate hydratase.
+  description: &gt;-
+    Heterologously express and purify recombinant ERR1 and measure 2-phosphoglycerate
+    dehydratase (enolase) activity and Mg2+ dependence in vitro, comparing kinetic
+    parameters to purified ENO1/ENO2.
+  experiment_type: enzyme assay
+- hypothesis: &gt;-
+    ERR1 has a condition-specific in-vivo role separable from ENO1/ENO2 and from the
+    other ERR paralogs.
+  description: &gt;-
+    Construct locus-specific single/double/triple ERR deletions (and ERR+ENO
+    combinations) and phenotype across fermentative, respiratory, sporulation, and stress
+    conditions; pair with an ORF-specific expression reporter and proteomics to detect
+    ERR1-specific expression and any non-redundant phenotype.
+  experiment_type: genetic deletion and phenotyping
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/genes/yeast/GAT2/GAT2-ai-review.html
+++ b/genes/yeast/GAT2/GAT2-ai-review.html
@@ -1,0 +1,3053 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>GAT2 - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        .propagation-review {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f8fafc;
+            border-left: 3px solid #64748b;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .propagation-title {
+            font-weight: 600;
+            color: #334155;
+            margin-bottom: 0.25rem;
+        }
+
+        .propagation-row {
+            margin-top: 0.25rem;
+        }
+
+        .propagation-source {
+            margin-top: 0.5rem;
+            padding-top: 0.5rem;
+            border-top: 1px solid #e5e7eb;
+        }
+
+        .propagation-source-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #1d4ed8;
+        }
+
+        .propagation-comment {
+            color: #4b5563;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>GAT2</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/P40209" target="_blank" class="term-link">
+                        P40209
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Saccharomyces cerevisiae</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-complete">
+                    COMPLETE
+                </span>
+            </div>
+
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "GAT2";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="P40209" data-a="DESCRIPTION: GAT2 (systematic name YMR136W) is a 560-residue Sa..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>GAT2 (systematic name YMR136W) is a 560-residue Saccharomyces cerevisiae protein belonging to the GATA family of Cys4 (type-IV) zinc-finger transcription factors. It has a single, canonical C-terminal GATA-type zinc finger (residues 472-497) with the hallmark C-X2-C ... C-X2-C spacing, preceded by an extensive intrinsically disordered, low-complexity region that spans most of the protein. On domain grounds the zinc finger is expected to coordinate zinc and to bind GATA-type (5&#39;-GATA-3&#39;/5&#39;-GAT-3&#39;) DNA sequence motifs, consistent with a role as a sequence-specific DNA-binding transcription factor acting in the nucleus. GAT2 is one of several yeast GATA-family proteins; the best-characterized members are the nitrogen-catabolite-repression regulators Gln3, Gat1 (activators), Dal80 and Gzf3 (repressors), together with the smaller Gat3 and Gat4. GAT2 itself is poorly characterized: its direct DNA targets, the physiological condition in which it operates, and its specific biological role have not been experimentally established. GAT2 transcription is condition-responsive (repressed by leucine), and large-scale deletion studies report mild, pleiotropic phenotypes including decreased invasive growth and abnormal bud and vacuolar morphology.</p>
+    </div>
+
+
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000976" target="_blank" class="term-link">
+                                    GO:0000976
+                                </a>
+                            </span>
+                            <span class="term-label">transcription cis-regulatory region binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P40209" data-a="GO:0000976" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetic (IBA) inference that GAT2, as a GATA-family zinc-finger protein, binds cis-regulatory DNA regions. GAT2 does carry a complete GATA zinc finger, so binding a GATA-type cis-regulatory sequence is domain-plausible.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The GATA zinc finger is present and canonical (confirmed at 472-497), and DNA binding via this finger is a well-established property of the family. Accepting the generic cis-regulatory-region-binding term is defensible on domain grounds. Note the IBA propagates from PTHR45658 (plant/Dictyostelium GATA cluster), not from the yeast NCR factors, so it supports a generic DNA-binding capacity rather than a specific target set. This term is retained alongside GO:0043565 (sequence-specific DNA binding): the two are complementary rather than redundant — GO:0043565 asserts the finger recognizes a specific sequence, while this term places that binding at a cis-regulatory (promoter/UAS) region.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:yeast/GAT2/GAT2-bioinformatics/RESULTS.md
+
+                                </span>
+
+                                <div class="support-text">GAT2 carries a bona fide GATA-type Cys4 zinc finger at residues 472 to 497 matching the UniProt ZN_FING GATA-type feature.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005634" target="_blank" class="term-link">
+                                    GO:0005634
+                                </a>
+                            </span>
+                            <span class="term-label">nucleus</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P40209" data-a="GO:0005634" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetic (IBA) inference of nuclear localization, expected for a DNA-binding transcription factor. There is no experimental localization for GAT2 (SGD lists cellular component as unknown), but a nuclear site of action is the parsimonious expectation for a GATA zinc-finger TF.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Consistent with GAT2&#39;s DNA-binding zinc finger and TF classification. Retained as a reasonable, if inferred, location. The absence of a direct localization assay is recorded as a knowledge gap rather than a reason to reject the term.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006357" target="_blank" class="term-link">
+                                    GO:0006357
+                                </a>
+                            </span>
+                            <span class="term-label">regulation of transcription by RNA polymerase II</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P40209" data-a="GO:0006357" data-r="GO_REF:0000033" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetic (IBA) inference that GAT2 participates in regulation of RNA Pol II transcription, the generic process for GATA-family TFs.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The generic process term is domain-appropriate for a GATA zinc-finger TF, but no GAT2-specific target gene or regulatory event has been demonstrated (all evidence is homology/phylogeny). Keeping it as a non-core, generic capability rather than a demonstrated core function is the honest interpretation for this dark gene.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006355" target="_blank" class="term-link">
+                                    GO:0006355
+                                </a>
+                            </span>
+                            <span class="term-label">regulation of DNA-templated transcription</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P40209" data-a="GO:0006355" data-r="GO_REF:0000002" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> InterPro2GO electronic transfer of a generic transcription-regulation process from the GATA/zinc-finger domains (IPR000679, IPR013088).
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Domain-based and broadly correct, but it is the DNA-templated-transcription parent of the more specific RNA-Pol-II term already present via IBA. Redundant and generic; retained as non-core. Not a GAT2-specific demonstrated function.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008270" target="_blank" class="term-link">
+                                    GO:0008270
+                                </a>
+                            </span>
+                            <span class="term-label">zinc ion binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P40209" data-a="GO:0008270" data-r="GO_REF:0000002" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> InterPro2GO electronic transfer of zinc ion binding from the GATA zinc-finger domain (IPR013088).
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> GAT2 has a complete Cys4 GATA zinc finger whose four cysteines coordinate a structural zinc ion; zinc binding is a robust, well-supported domain-level property.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:yeast/GAT2/GAT2-bioinformatics/RESULTS.md
+
+                                </span>
+
+                                <div class="support-text">The four coordinating cysteines with C-X3-C ... C-X3-C spacing are the hallmark of the DNA-binding GATA finger.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0043565" target="_blank" class="term-link">
+                                    GO:0043565
+                                </a>
+                            </span>
+                            <span class="term-label">sequence-specific DNA binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P40209" data-a="GO:0043565" data-r="GO_REF:0000002" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> InterPro2GO electronic transfer of sequence-specific DNA binding from the GATA zinc-finger domain (IPR000679).
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Sequence-specific (GATA-motif) DNA binding is the defining activity of the GATA zinc finger, which GAT2 carries intact. Accepted on domain grounds; the specific target sequences bound by GAT2 in vivo remain undetermined (recorded as a knowledge gap).
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008270" target="_blank" class="term-link">
+                                    GO:0008270
+                                </a>
+                            </span>
+                            <span class="term-label">zinc ion binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">RCA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/30358795" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:30358795
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The cellular economy of the Saccharomyces cerevisiae zinc pr...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P40209" data-a="GO:0008270" data-r="PMID:30358795" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reviewed-computational-analysis (RCA) inclusion of GAT2 in the yeast zinc proteome (Wang et al. 2018), based on combined domain and motif searches for zinc-binding proteins.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Independent computational support for zinc binding, consistent with the GATA zinc-finger domain. Concordant with the IEA zinc-binding annotation. Not a direct GAT2 metal-binding measurement, but a reasonable inference.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/30358795" target="_blank" class="term-link">
+                                        PMID:30358795
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">yeast zinc proteome of 582 known or potential zinc-binding proteins was</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005575" target="_blank" class="term-link">
+                                    GO:0005575
+                                </a>
+                            </span>
+                            <span class="term-label">cellular_component</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ND</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000015
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-remove">
+                            REMOVE
+                        </span>
+                        <span class="vote-buttons" data-g="P40209" data-a="GO:0005575" data-r="GO_REF:0000015" data-act="REMOVE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Root cellular_component placeholder with ND (no data) evidence, reflecting that GAT2&#39;s subcellular localization has not been experimentally determined.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> An IBA nucleus annotation (GO:0005634) is already present and is the more informative, domain-consistent cellular-component call. The uninformative root placeholder is superseded and can be removed. (The genuine absence of an experimental localization is captured as a knowledge gap.)
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000981" target="_blank" class="term-link">
+                                    GO:0000981
+                                </a>
+                            </span>
+                            <span class="term-label">DNA-binding transcription factor activity, RNA polymerase II-specific</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ISA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/10392447" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:10392447
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Genome-wide transcriptional analysis in S. cerevisiae by min...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P40209" data-a="GO:0000981" data-r="PMID:10392447" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> SGD ISA (inferred from sequence alignment) annotation classifying GAT2 as an RNA Pol II DNA-binding transcription factor, anchored to PMID:10392447 with with_from pointing to other GATA-factor genes.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The molecular activity — a GATA-type, RNA-Pol-II DNA-binding transcription factor — is well supported by the intact GATA zinc finger and the family classification. This is the most defensible molecular-function statement for GAT2. It rests on sequence similarity (ISA), not a direct GAT2 assay; the reference is a methods paper about the GATA network rather than a GAT2-specific functional study, which is why the target genes and regulatory role remain a knowledge gap.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:yeast/GAT2/GAT2-bioinformatics/RESULTS.md
+
+                                </span>
+
+                                <div class="support-text">GAT2 carries a bona fide GATA-type Cys4 zinc finger at residues 472 to 497 matching the UniProt ZN_FING GATA-type feature.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006357" target="_blank" class="term-link">
+                                    GO:0006357
+                                </a>
+                            </span>
+                            <span class="term-label">regulation of transcription by RNA polymerase II</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ISA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/10392447" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:10392447
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Genome-wide transcriptional analysis in S. cerevisiae by min...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P40209" data-a="GO:0006357" data-r="PMID:10392447" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> SGD ISA annotation that GAT2 is involved in regulation of RNA Pol II transcription, inferred by sequence alignment to other GATA factors (with_from lists several GATA-factor SGD ids).
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Domain- and family-appropriate as a generic capability, but the specific genes GAT2 regulates and the condition under which it does so are unknown. As with the IBA process term, this is retained as a non-core, inferred process rather than a demonstrated GAT2 function.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>Sequence-specific DNA-binding transcription factor of the GATA family. GAT2&#39;s single, canonical C-terminal GATA-type Cys4 zinc finger (472-497) is expected to coordinate a structural zinc ion and to bind GATA-type DNA sequence motifs, giving GAT2 the molecular capacity to act as an RNA polymerase II DNA-binding transcription factor in the nucleus. This is a domain- and homology-supported capability; the specific target genes, DNA sites, and regulatory outcome for GAT2 have not been experimentally determined.</h3>
+                <span class="vote-buttons" data-g="P40209" data-a="FUNCTION: Sequence-specific DNA-binding transcription factor..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000981" target="_blank" class="term-link">
+                            DNA-binding transcription factor activity, RNA polymerase II-specific
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006357" target="_blank" class="term-link">
+                                regulation of transcription by RNA polymerase II
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005634" target="_blank" class="term-link">
+                                nucleus
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:yeast/GAT2/GAT2-bioinformatics/RESULTS.md
+
+                        </span>
+
+                        <div class="finding-text">GAT2 carries a bona fide GATA-type Cys4 zinc finger at residues 472 to 497 matching the UniProt ZN_FING GATA-type feature.</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                        <div class="finding-text">Gene Ontology annotation through association of InterPro records with GO terms</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000002.md" target="_blank" class="term-link">
+                            GO_REF:0000002
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation through association of InterPro records with GO terms</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000015.md" target="_blank" class="term-link">
+                            GO_REF:0000015
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Use of the ND evidence code for Gene Ontology (GO) terms</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
+                            GO_REF:0000033
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Annotation inferences using phylogenetic trees</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/10392447" target="_blank" class="term-link">
+                            PMID:10392447
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Genome-wide transcriptional analysis in S. cerevisiae by mini-array membrane hybridization.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/30358795" target="_blank" class="term-link">
+                            PMID:30358795
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">The cellular economy of the Saccharomyces cerevisiae zinc proteome.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        file:yeast/GAT2/GAT2-bioinformatics/RESULTS.md
+
+                    </span>
+                </div>
+
+                <div class="reference-title">GAT2 bioinformatics — GATA zinc-finger confirmation and paralog relationships</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">GAT2 carries a complete, canonical GATA-type Cys4 zinc finger at residues 472-497 (C-X3-C-X19-C-X3-C spacing), matching the UniProt ZN_FING feature; a non-GATA negative control (actin ACT1) yields no hit.</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <div class="finding-statement">By DNA-binding-domain identity GAT2 is the most divergent yeast GATA factor (37-52% to any single paralog) and does not cluster with the four tightly related nitrogen-catabolite-repression factors (Gln3/Gat1/Dal80/Gzf3, 58-68% among themselves), corroborating the independent PANTHER assignment of GAT2 to family PTHR45658 (versus PTHR10071 for the NCR factors).</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Questions for Experts</h2>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Does Gat2 bind GATA DNA sites in vivo, and which genes does it directly regulate?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P40209" data-a="Q: Does Gat2 bind GATA DNA sites in vivo, and which g..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Under what physiological condition (nitrogen source, stress, growth phase) is Gat2 functionally active, and is it an activator or a repressor?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P40209" data-a="Q: Under what physiological condition (nitrogen sourc..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Is Gat2 redundant with or distinct from the canonical NCR GATA factors (Gln3/Gat1/Dal80/Gzf3), and does its divergent DNA-binding domain read a different sequence?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P40209" data-a="Q: Is Gat2 redundant with or distinct from the canoni..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Experiments</h2>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> ChIP-seq/ChIP-exo of epitope-tagged Gat2 across nitrogen sources, stress and growth phases to identify direct binding sites and target genes.</p>
+
+
+
+                </div>
+                <span class="vote-buttons" data-g="P40209" data-a="EXPERIMENT: ChIP-seq/ChIP-exo of epitope-tagged Gat2 across ni..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> RNA-seq of gat2-delta and GAT2-overexpression strains, alone and in combination with gln3/gat1/dal80/gzf3 mutants, to define Gat2&#39;s regulatory role and test redundancy with the NCR factors.</p>
+
+
+
+                </div>
+                <span class="vote-buttons" data-g="P40209" data-a="EXPERIMENT: RNA-seq of gat2-delta and GAT2-overexpression stra..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Live-cell imaging of a functional Gat2-GFP fusion under varying nitrogen and TORC1 (rapamycin) conditions to determine localization and whether nuclear entry is conditionally regulated as for Gln3/Gat1.</p>
+
+
+
+                </div>
+                <span class="vote-buttons" data-g="P40209" data-a="EXPERIMENT: Live-cell imaging of a functional Gat2-GFP fusion ..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> In vitro DNA-binding-specificity profiling (protein-binding microarray or SELEX) of the Gat2 zinc finger to compare its recognized sequence with those of the other yeast GATA factors.</p>
+
+
+
+                </div>
+                <span class="vote-buttons" data-g="P40209" data-a="EXPERIMENT: In vitro DNA-binding-specificity profiling (protei..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Knowledge Gaps</h2>
+        <p style="color: #555; font-size: 0.92rem; margin-top: -0.3rem;">
+            What is <em>not</em> known — curated, literature-grounded statements of the open
+            unknowns (the inverse of core functions).
+        </p>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The direct DNA target genes of Gat2, the specific GATA DNA sites it occupies in vivo, and the physiological condition under which it acts are undetermined. It is also unresolved whether Gat2 functions as a transcriptional activator or repressor.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">BP_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> Gat2 is a bona fide GATA-family protein with a complete, canonical Cys4 zinc finger (472-497) that supports zinc binding and sequence-specific (GATA-motif) DNA binding on domain grounds; it is classified as an RNA Pol II DNA-binding transcription factor. Its own transcription is condition-responsive (repressed by leucine; regulated by Sut2/Rgr1/Ume6/Fkh1). All molecular- and biological-process annotations are inferred from sequence similarity (ISA), domain (IEA), phylogeny (IBA) or computation (RCA); none derives from a direct Gat2 functional assay, and SGD lists no characterized target genes.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Gat2 is one of the few S. cerevisiae GATA factors with no assigned biological role, in a family (Gln3/Gat1/Dal80/Gzf3) that is central to nitrogen-responsive gene regulation. Defining Gat2&#39;s targets and condition would establish whether the yeast GATA network has an unrecognized fifth regulatory node or whether Gat2 acts in an unrelated process.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> ChIP-seq / ChIP-exo of tagged Gat2 across nitrogen sources and stress conditions to map direct sites and targets; RNA-seq of gat2-delta and GAT2-overexpression strains (singly and in combination with gln3/gat1/dal80/gzf3 mutants) to test activator vs repressor role and redundancy.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"identify genes not previously reported to be associated with this nitrogen"</em> — PMID:10392447</li>
+
+                <li><em>"The specific DNA target sites, condition, and biological process of GAT2 remain undetermined by this analysis and by the literature."</em> — file:yeast/GAT2/GAT2-bioinformatics/RESULTS.md</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> Whether Gat2 is functionally redundant with, antagonistic to, or independent of the canonical nitrogen-catabolite-repression GATA factors (Gln3, Gat1, Dal80, Gzf3) is unknown, and its DNA-binding specificity relative to theirs has not been measured.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">RESIDUAL_SUBGAP</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> The four NCR GATA factors form a tightly related group both phylogenetically (PANTHER family PTHR10071) and by DNA-binding-domain identity (58-68% among themselves). Gat2 is the most divergent yeast GATA factor at the DBD level (37-52% to any single paralog) and is assigned to a separate PANTHER family (PTHR45658); SGD nonetheless notes it is &#34;similar to Gln3p and Dal80p.&#34; No genetic-interaction or biochemical study has directly tested Gat2&#39;s relationship to the NCR quartet.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Resolving this would show whether Gat2 has been overlooked because it is redundant with the NCR factors (buffered, hence phenotype-poor) or because it operates in a distinct regulatory context, guiding where to look for its function.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> In vitro DNA-binding-specificity assays (e.g. protein-binding microarray / SELEX) to compare Gat2&#39;s site preference with the NCR factors; combinatorial deletion/epistasis analysis (gat2 in gln3/gat1/dal80/gzf3 backgrounds) under nitrogen limitation and other stresses.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"GAT2 does not join either tight cluster"</em> — file:yeast/GAT2/GAT2-bioinformatics/RESULTS.md</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> Gat2&#39;s subcellular localization and its regulation (e.g. nuclear/cytoplasmic partitioning in response to nitrogen or TORC1 signaling, as seen for Gln3 and Gat1) have not been experimentally determined.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span><span class="badge">CURATION</span>
+                <span class="badge">CC_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> Nuclear action is inferred (IBA) from GAT2&#39;s DNA-binding TF classification, but SGD records cellular component as unknown and no GFP-localization compartment call is represented in GOA. The NCR activators Gln3 and Gat1 are known to shuttle between cytoplasm and nucleus under nitrogen/TORC1 control; whether Gat2 is similarly regulated is untested.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Localization and its conditional control are the entry point to Gat2&#39;s regulation: demonstrating regulated nuclear entry would connect Gat2 to a signaling pathway and a condition, both currently unknown.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> GFP/mNeonGreen tagging of Gat2 with live-cell imaging across nitrogen sources and rapamycin treatment; nuclear-fractionation immunoblots to test regulated nucleocytoplasmic partitioning.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"GAT2 has no experimentally determined subcellular localization in the accessible resources."</em> — file:yeast/GAT2/GAT2-bioinformatics/RESULTS.md</li>
+
+            </ul>
+
+
+        </div>
+
+    </div>
+
+
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Deep Research Sections -->
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(GAT2-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="P40209" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="gat2-ymr136w-research-notes">GAT2 (YMR136W) — research notes</h1>
+<p>UniProt: P40209 (GAT2_YEAST). SGD: S000004744. Systematic name YMR136W.<br />
+Length 560 aa. PE level <strong>4: Predicted</strong> (no protein-level or transcript-level<br />
+experimental evidence recorded by UniProt for the protein product beyond<br />
+genome/EST inference). Chromosome XIII.</p>
+<p>This is an <strong>understudied ("dark") yeast GATA-family zinc-finger protein</strong>. The<br />
+deliverable is a rigorous statement of what is and is not known, careful<br />
+attribution of GAT2-specific evidence versus evidence for the better-studied<br />
+GATA paralogs, and a defensible <code>knowledge_gaps</code> section.</p>
+<h2 id="domain-sequence-architecture-known-from-uniprot-p40209">Domain / sequence architecture (KNOWN, from UniProt P40209)</h2>
+<ul>
+<li>Single <strong>GATA-type (Cys4 / type-IV) zinc finger</strong> at residues <strong>472–497</strong><br />
+  (<code>ZN_FING ... /note="GATA-type"</code>, PROSITE-ProRule PRU00094). Zinc-coordinating<br />
+  Cys residues visible in the sequence: <code>...CFHCGETET PEWRKGPYGT RTLCNACGLF...</code><br />
+  (C-x2-C ... C-x2-C GATA finger signature).</li>
+<li>InterPro: IPR000679 (Znf_GATA), IPR013088 (Znf_NHR/GATA), IPR051140 (GATA_TF).<br />
+  Pfam PF00320 (GATA). SMART SM00401. PROSITE PS00344 + PS50114. CDD cd00202<br />
+  (ZnF_GATA). SUPFAM SSF57716 (glucocorticoid-receptor-like DBD).</li>
+<li>Keywords: DNA-binding; Metal-binding; Zinc; Zinc-finger.</li>
+<li>Large <strong>disordered / low-complexity N-terminal and central region</strong>: MobiDB-lite<br />
+  disordered regions 274–297, 345–383, 412–461; low-complexity 347–361; basic/acidic<br />
+  bias 369–378; basic 414–425; polar 428–456. The DBD sits near the C-terminus and<br />
+  most of the protein is intrinsically disordered — typical of a transcription<br />
+  factor with a single C-terminal DBD and long regulatory/activation region.</li>
+</ul>
+<p>Interpretation: the domain content robustly supports <strong>zinc ion binding</strong> and<br />
+<strong>sequence-specific DNA binding by a GATA-type finger</strong>, hence a plausible<br />
+<strong>DNA-binding transcription factor</strong>. This is a structural/domain inference, not<br />
+a demonstrated activity for GAT2 itself.</p>
+<h2 id="phylogeny-paralogy-known-important-nuance">Phylogeny / paralogy (KNOWN; important nuance)</h2>
+<p>The canonical <em>S. cerevisiae</em> nitrogen-catabolite-repression (NCR) GATA network<br />
+has <strong>four</strong> DNA-binding GATA factors: activators <strong>Gln3</strong> and <strong>Gat1</strong>, and<br />
+repressors <strong>Dal80</strong> and <strong>Gzf3/Deh1/Nil2</strong><br />
+(reviewed in the NCR literature; e.g. PMC2698774, PMC4382002 — searched via web).</p>
+<p>Key phylogenetic finding from PANTHER (via UniProt DR lines):<br />
+- <strong>GAT2 (P40209) → PANTHER family PTHR45658</strong>, subfamily <strong>PTHR45658:SF18<br />
+  "PROTEIN GAT2"</strong>. PTHR45658 is labelled <em>"Plant GATA Transcription Factor"</em> and<br />
+  its SF18 members are a mixture of <strong>fungal white-collar-2 / circadian<br />
+  (WC2) orthologs, Dictyostelium GATA proteins, and plant GATA factors</strong><br />
+  (see <code>interpro/panther/PTHR45658/PTHR45658-entries.csv</code>; e.g. Fusarium WC2<br />
+  A0A0J9U922, Beauveria WC2 J5JYA0, Dictyostelium gtaP B0G188, Arabidopsis<br />
+  GATA12 P69781 — all SF18).<br />
+- <strong>GLN3 (P18494), GAT1 (P43574), DAL80 (P26343) → PANTHER family PTHR10071</strong><br />
+  (subfamily PTHR10071:SF281 "BOX A-BINDING FACTOR-RELATED"; verified from<br />
+  UniProt DR lines). This is a <strong>different PANTHER family</strong> from GAT2.</p>
+<p>So although GAT2 is a <em>S. cerevisiae</em> GATA factor superficially similar to the NCR<br />
+factors (SGD: "similar to Gln3p and Dal80p"), <strong>PANTHER does not group GAT2 with<br />
+the four NCR factors</strong> — GAT2 sits in the separate GATA subfamily that includes<br />
+plant/fungal-clock/Dictyostelium GATA proteins. This directly affects how the<br />
+IBA annotations should be read (see below): the IBA propagation is from that<br />
+plant/Dictyostelium GATA cluster, not from the NCR factors.</p>
+<p>GAT2's closest <em>S. cerevisiae</em> GATA relatives by simple similarity are the NCR<br />
+factors, but the yeast genome also has the smaller GATA proteins GAT3 (Q07928)<br />
+and GAT4 (P40569); those two are in yet another subfamily (SF149 "PROTEIN<br />
+GAT3-RELATED"), not with GAT2.</p>
+<h2 id="gat2-specific-functional-evidence-what-is-actually-known-about-gat2">GAT2-specific functional evidence (what is actually KNOWN about GAT2)</h2>
+<ul>
+<li>SGD description (yeastgenome.org, S000004744): <em>"protein containing GATA family<br />
+  zinc finger motifs; similar to Gln3p and Dal80p; expression repressed by<br />
+  leucine."</em></li>
+<li>SGD molecular-function/process annotations are <strong>ISA (inferred from sequence<br />
+  alignment)</strong> for DNA-binding TF activity and regulation of transcription by<br />
+  RNA pol II — i.e. inferred from homology, <strong>not</strong> from a direct GAT2 assay.<br />
+  The zinc-binding annotation is <strong>RCA</strong> (computational, from the zinc-proteome<br />
+  study PMID:30358795).</li>
+<li>SGD lists <strong>cellular component = unknown</strong> (localization not experimentally<br />
+  determined). No GFP-localization compartment call is represented in GOA.</li>
+<li>SGD reports <strong>zero characterized target genes</strong> for GAT2 (BioGRID/SGD; web).</li>
+<li>Reported null-mutant/large-scale phenotypes (SGD summary, web): decreased<br />
+  invasive growth; abnormal bud and vacuolar morphology; decreased vegetative<br />
+  growth; decreased chemical resistance; increased protein/peptide modification.<br />
+  These are unfocused high-throughput phenotypes, none of which pins a specific<br />
+  molecular target or condition.</li>
+<li>Regulation of <em>GAT2</em> transcription (SGD, web): negatively regulated by Sut2p<br />
+  during filamentous growth; regulated by Rgr1p/Ume6p; by Fkh1p in stationary<br />
+  phase; expression repressed by leucine. These describe how <em>GAT2</em> is<br />
+  controlled, not what Gat2 protein does.</li>
+</ul>
+<h3 id="the-two-pmids-cited-in-goa">The two PMIDs cited in GOA</h3>
+<ul>
+<li><strong>PMID:10392447</strong> (Cox, Pinchak, Cooper 1999, <em>Yeast</em>, "Genome-wide<br />
+  transcriptional analysis in S. cerevisiae by mini-array membrane<br />
+  hybridization") — abstract only in cache (<code>full_text_available: false</code>). This<br />
+  is a <strong>methods paper</strong> validating mini-array membrane hybridization; the<br />
+  abstract states the method <em>"can correctly identify genes whose expression is<br />
+  known to be controlled by the GATA-factor regulatory network in S. cerevisiae"</em><br />
+  and <em>"can reliably identify genes not previously reported to be associated with<br />
+  this nitrogen control system."</em> It is a study of the GATA regulatory network as<br />
+  a test case, not a demonstration of GAT2's specific function. SGD used it as the<br />
+<strong>ISA</strong> reference (with_from pointing to <em>other</em> GATA-factor SGD ids<br />
+  S000001742 = ?, S000000842, S000001873, S000003646). I.e. the ISA annotation<br />
+  is a similarity transfer keyed to this paper's discussion of the GATA network.</li>
+<li><strong>PMID:30358795</strong> (Wang et al. 2018, <em>Metallomics</em>, "The cellular economy of<br />
+  the S. cerevisiae zinc proteome") — abstract only. Bioinformatic + MS survey<br />
+  identifying <em>"582 known or potential zinc-binding proteins"</em> via <em>"a<br />
+  bioinformatics analysis that combined global domain searches with local motif<br />
+  searches."</em> GAT2 is a GATA zinc-finger protein, so its inclusion in the zinc<br />
+  proteome is a reasonable <strong>RCA/computational</strong> inference — consistent with the<br />
+  domain, but not a direct GAT2 metal-binding measurement.</li>
+</ul>
+<h2 id="known-vs-not-known-summary">KNOWN vs NOT-KNOWN summary</h2>
+<p><strong>KNOWN (well supported):</strong><br />
+- GAT2 has a single C-terminal GATA-type (Cys4) zinc finger → binds zinc and, by<br />
+  strong domain homology, sequence-specific DNA (5'-GATA-3'-type sites).<br />
+- It is a member of the GATA transcription-factor superfamily.<br />
+- <em>GAT2</em> transcription is condition-responsive (repressed by leucine; regulated by<br />
+  Sut2/Rgr1/Ume6/Fkh1).</p>
+<p><strong>NOT KNOWN (genuine gaps):</strong><br />
+- No direct experimental demonstration that Gat2 protein binds DNA, binds zinc,<br />
+  or activates/represses transcription (all functional annotations are ISA/RCA/IBA).<br />
+- No identified direct target genes.<br />
+- No experimentally determined subcellular localization (nucleus is IBA-inferred;<br />
+  SGD lists CC unknown).<br />
+- The condition/biological process in which Gat2 acts is undefined — whether it<br />
+  participates in the NCR nitrogen network like Gln3/Gat1/Dal80/Gzf3, or in a<br />
+  distinct process, is unresolved. Notably PANTHER places GAT2 <strong>outside</strong> the<br />
+  four-factor NCR family (PTHR10071), so simple assimilation to NCR is not<br />
+  automatically warranted.<br />
+- Whether Gat2 is functionally redundant with, antagonistic to, or independent of<br />
+  the other GATA factors is unknown.</p>
+<h2 id="attribution-caution">Attribution caution</h2>
+<p>Most "GATA factor in nitrogen catabolite repression" statements in the literature<br />
+concern <strong>Gln3/Gat1/Dal80/Gzf3</strong>, NOT GAT2. Do not transfer their demonstrated NCR<br />
+functions to GAT2. GAT2 remains an understudied paralog whose specific role is not<br />
+established.</p>
+<h2 id="deep-research-status-documented-not-fabricated">Deep-research status (documented, not fabricated)</h2>
+<p>Automated deep research did <strong>not</strong> succeed for GAT2. <code>just deep-research-falcon yeast
+GAT2 --fallback perplexity-lite</code> was run and then <strong>retried once</strong>; on both runs the<br />
+falcon provider timed out at its 600s limit, and the perplexity-lite fallback failed<br />
+with an HTTP 401 quota error ("You exceeded your current quota"). No genuine<br />
+<code>GAT2-deep-research-*.md</code> file was produced. Per repo policy, <strong>no deep-research file<br />
+was fabricated</strong>. This review is instead grounded in: the UniProt record (P40209),<br />
+the GOA table, the PANTHER family data (PTHR45658 vs PTHR10071), the two cached GOA<br />
+publications (PMID:10392447, PMID:30358795), the SGD locus summary (S000004744), and<br />
+the reproducible in-repo bioinformatics analysis (<code>GAT2-bioinformatics/RESULTS.md</code>).</p>
+<h2 id="review-outcome-pr-1770">Review outcome (PR #1770)</h2>
+<p>Submitted as PR #1770. CI: check-mention SUCCESS, test (3.12) SUCCESS, claude-review<br />
+SUCCESS; ai4c-agent formal review = APPROVED (substantive, verified PMIDs/quotes/GO<br />
+terms; no CRITICAL/IMPORTANT issues, 3 non-blocking suggestions). Two of the<br />
+non-blocking suggestions were addressed (tightened description; clarified why<br />
+GO:0000976 and GO:0043565 are complementary MF terms).</p>
+<h2 id="provenance-index">Provenance index</h2>
+<ul>
+<li>Domain/sequence: <code>genes/yeast/GAT2/GAT2-uniprot.txt</code> (UniProt P40209).</li>
+<li>PANTHER family: <code>interpro/panther/PTHR45658/PTHR45658-metadata.yaml</code> and<br />
+<code>-entries.csv</code>; GLN3/GAT1/DAL80 PANTHER assignments verified from UniProt REST<br />
+  (P18494, P43574, P26343 DR lines).</li>
+<li>PMID:10392447, PMID:30358795 cached in <code>publications/</code>.</li>
+<li>SGD summary and phenotypes: yeastgenome.org S000004744 (web fetch, 2026-07).</li>
+</ul>
+            </div>
+        </details>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Bioinformatics Results</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(RESULTS.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="P40209" data-a="DOC: Bioinformatics Results" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="gat2-bioinformatics-gata-zinc-finger-confirmation-and-paralog-relationships">GAT2 bioinformatics: GATA zinc-finger confirmation and paralog relationships</h1>
+<p><strong>Gene:</strong> GAT2 / YMR136W, <em>Saccharomyces cerevisiae</em> (UniProt P40209, 560 aa).</p>
+<p><strong>Question:</strong> (1) Confirm the GATA-type Cys4 zinc-finger domain in GAT2 and its<br />
+Cys spacing; (2) place GAT2 relative to the other yeast GATA factors<br />
+(GLN3, GAT1, DAL80, GZF3, GAT3, GAT4) by DNA-binding-domain (DBD) identity.</p>
+<h2 id="methods">Methods</h2>
+<ul>
+<li>Sequences downloaded programmatically from UniProt REST (<code>data/yeast_gata_factors.fasta</code>):<br />
+  GAT2 P40209, GLN3 P18494, GAT1 P43574, DAL80 P26343, GZF3 P42944, GAT3 Q07928,<br />
+  GAT4 P40569. (GZF3 accession P42944 obtained by UniProt gene+organism query.)</li>
+<li><code>scripts/find_gata_zinc_finger.py</code>: regex scan for the canonical GATA / type-IV<br />
+  Cys4 finger <code>C-X2-C-X{17,20}-C-X2-C</code>; reports match position and Cys spacing.</li>
+<li><code>scripts/pairwise_dbd_identity.py</code>: extracts each factor's zinc-finger window<br />
+  (+8 aa flank), aligns the windows with MAFFT (<code>--auto</code>), and computes all<br />
+  pairwise percent identities over aligned columns where both sequences have a<br />
+  residue.</li>
+<li>Reproduce with <code>just all</code> (see <code>justfile</code>), or run the two scripts directly with <code>uv run</code>.</li>
+</ul>
+<h2 id="result-1-gata-cys4-zinc-finger-confirmed-in-gat2">Result 1 — GATA Cys4 zinc finger confirmed in GAT2</h2>
+<p><code>results/zinc_finger_motifs.json</code>:</p>
+<table>
+<thead>
+<tr>
+<th>Factor</th>
+<th>ZF match (1-based)</th>
+<th>motif</th>
+<th>Cys spacings</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><strong>GAT2</strong></td>
+<td><strong>472–497</strong></td>
+<td><code>CFHCGETETPEWRKGPYGTRTLCNAC</code></td>
+<td>3, 19, 3</td>
+</tr>
+<tr>
+<td>GLN3</td>
+<td>306–330</td>
+<td><code>CFNCKTFKTPLWRRSPEGNTLCNAC</code></td>
+<td>3, 18, 3</td>
+</tr>
+<tr>
+<td>GAT1</td>
+<td>310–334</td>
+<td><code>CSNCTTSTTPLWRKDPKGLPLCNAC</code></td>
+<td>3, 18, 3</td>
+</tr>
+<tr>
+<td>DAL80</td>
+<td>31–55</td>
+<td><code>CQNCFTVKTPLWRRDEHGTVLCNAC</code></td>
+<td>3, 18, 3</td>
+</tr>
+<tr>
+<td>GZF3</td>
+<td>131–155</td>
+<td><code>CKNCLTSTTPLWRRDEHGAMLCNAC</code></td>
+<td>3, 18, 3</td>
+</tr>
+<tr>
+<td>GAT3</td>
+<td>72–98</td>
+<td><code>CPQCAVIKTSPQWREGPDGEVTLCNAC</code></td>
+<td>3, 20, 3</td>
+</tr>
+<tr>
+<td>GAT4</td>
+<td>53–79</td>
+<td><code>CGQCGEIKTSLQWREGPNGAACLCNAC</code></td>
+<td>3, 18(2,3)*</td>
+</tr>
+</tbody>
+</table>
+<ul>
+<li>GAT2 carries a bona fide GATA-type Cys4 finger at <strong>472–497</strong>, exactly matching<br />
+  the UniProt <code>ZN_FING 472..497 /note="GATA-type"</code> feature. The four cysteines<br />
+  (C472, C475, C495, C498 in the motif frame) with C-X3-C...C-X3-C spacing are the<br />
+  hallmark of the DNA-binding GATA finger.</li>
+<li>All seven yeast GATA factors share the finger; the invariant <code>C...CNAC</code> C-terminal<br />
+  half is present in every case. (*GAT4 contains an extra internal Cys, hence a<br />
+  5-Cys count for the greedy regex; the canonical four-Cys frame is intact.)</li>
+<li><strong>Negative control:</strong> yeast actin ACT1 (P60010) yields <em>no</em> GATA finger, confirming<br />
+  the pattern is not spuriously general.</li>
+</ul>
+<h2 id="result-2-gat2-is-a-divergent-gata-factor-not-tightly-clustered-with-the-ncr-four">Result 2 — GAT2 is a divergent GATA factor, not tightly clustered with the NCR four</h2>
+<p>Pairwise DBD identity (<code>results/gata_dbd_identity_matrix.tsv</code>; ~41–43 aligned columns):</p>
+<p>GAT2 ranked neighbours (closest first):</p>
+<table>
+<thead>
+<tr>
+<th>vs</th>
+<th>% identity</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>GAT3</td>
+<td>52.4</td>
+</tr>
+<tr>
+<td>GAT4</td>
+<td>50.0</td>
+</tr>
+<tr>
+<td>GLN3</td>
+<td>48.8</td>
+</tr>
+<tr>
+<td>GAT1</td>
+<td>41.5</td>
+</tr>
+<tr>
+<td>DAL80</td>
+<td>39.0</td>
+</tr>
+<tr>
+<td>GZF3</td>
+<td>36.6</td>
+</tr>
+</tbody>
+</table>
+<p>The four <strong>canonical nitrogen-catabolite-repression (NCR) factors form a tight<br />
+cluster</strong> by DBD identity: DAL80–GZF3 68.3%, GLN3–GAT1 61.0%, GAT1–GZF3 63.4%,<br />
+GLN3–DAL80 / GLN3–GZF3 / GAT1–DAL80 all 58.5%. GAT3–GAT4 are a second tight pair<br />
+(65.1%).</p>
+<p><strong>GAT2 does not join either tight cluster:</strong> its DBD is only 37–52% identical to any<br />
+single yeast GATA factor, and — perhaps counter-intuitively given the SGD note<br />
+"similar to Gln3p and Dal80p" — its DBD is marginally closer to GAT3/GAT4 than to<br />
+the NCR factors, and it is <em>least</em> similar to the NCR repressor GZF3.</p>
+<p>This DBD-level result is consistent with the PANTHER classification (independent<br />
+evidence): GAT2 is assigned to family <strong>PTHR45658</strong> (subfamily SF18 "PROTEIN GAT2",<br />
+a plant/fungal-clock/Dictyostelium GATA cluster), whereas GLN3, GAT1 and DAL80 are<br />
+in the separate family <strong>PTHR10071</strong> (the NCR GATA family). Two orthogonal methods<br />
+(regex-extracted DBD identity here; PANTHER tree membership) agree that GAT2 is a<br />
+<em>divergent</em> yeast GATA factor rather than a fifth member of the tight NCR quartet.</p>
+<h2 id="interpretation-for-the-go-review">Interpretation (for the GO review)</h2>
+<ul>
+<li><strong>Supports</strong> the GO annotations <code>zinc ion binding</code> (GO:0008270),<br />
+<code>sequence-specific DNA binding</code> (GO:0043565), and a GATA-type<br />
+  DNA-binding transcription-factor activity on <strong>domain grounds</strong>: the finger is<br />
+  present, complete, and canonical.</li>
+<li><strong>Cautions against</strong> simply transferring the demonstrated NCR functions of<br />
+  Gln3/Gat1/Dal80/Gzf3 to GAT2: at the DBD level GAT2 is the most divergent of the<br />
+  yeast GATA factors and is not the NCR quartet's nearest neighbour. Its specific<br />
+  target sites, condition, and biological process remain undetermined by this<br />
+  analysis (and by the literature).</li>
+</ul>
+<h2 id="citable-statements-plain-text">Citable statements (plain text)</h2>
+<p>These single-line statements summarise the findings above for citation in the review:</p>
+<p>GAT2 carries a bona fide GATA-type Cys4 zinc finger at residues 472 to 497 matching the UniProt ZN_FING GATA-type feature.<br />
+The four coordinating cysteines with C-X3-C ... C-X3-C spacing are the hallmark of the DNA-binding GATA finger.<br />
+By DNA-binding-domain identity GAT2 is the most divergent yeast GATA factor and does not cluster with the four NCR factors Gln3 Gat1 Dal80 Gzf3.<br />
+GAT2 has no experimentally determined subcellular localization in the accessible resources.<br />
+The specific DNA target sites, condition, and biological process of GAT2 remain undetermined by this analysis and by the literature.</p>
+<h2 id="caveats">Caveats</h2>
+<ul>
+<li>Percent-identity values are computed over a <strong>short DBD window</strong> (~41–43 columns).<br />
+  Short-window identities are approximate and should be read as <em>relative</em> rankings,<br />
+  not precise evolutionary distances. A full-length or curated-domain phylogeny would<br />
+  refine but is not expected to overturn the qualitative conclusion (GAT2 divergent;<br />
+  NCR four tightly clustered), which is corroborated by the independent PANTHER<br />
+  assignment.</li>
+<li>The zinc-finger detector is a regex, not an HMM; it confirms presence/spacing of<br />
+  the canonical motif but does not by itself prove functional DNA binding.</li>
+</ul>
+<h2 id="reproducibility-checklist">Reproducibility checklist</h2>
+<ul>
+<li>[x] Scripts use no hardcoded inputs/outputs — all results derive from the input FASTA.</li>
+<li>[x] <code>find_gata_zinc_finger.py</code> tested on an unrelated protein (ACT1) → correctly no hit.</li>
+<li>[x] <code>pairwise_dbd_identity.py</code> runs on the 7-factor FASTA and emits matrix + alignment.</li>
+<li>[x] Direct script outputs are in <code>results/</code> (JSON, TSV, DBD FASTA, MAFFT alignment).</li>
+<li>[x] Conclusions live only in this RESULTS.md, not in code.</li>
+<li>[x] Two orthogonal lines of evidence (DBD identity + PANTHER) agree.</li>
+<li>Conclusions are <strong>supported</strong> (all checklist items satisfied), with the stated<br />
+  short-window caveat.</li>
+</ul>
+<h2 id="tools-provenance">Tools / provenance</h2>
+<ul>
+<li>UniProt REST (sequences), MAFFT v7 (<code>--auto</code>), Biopython 1.87, Python 3.12 via <code>uv</code>.</li>
+<li>Analysis date: 2026-07.</li>
+</ul>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: P40209
+gene_symbol: GAT2
+product_type: PROTEIN
+status: COMPLETE
+taxon:
+  id: NCBITaxon:559292
+  label: Saccharomyces cerevisiae
+description: &gt;-
+  GAT2 (systematic name YMR136W) is a 560-residue Saccharomyces cerevisiae protein
+  belonging to the GATA family of Cys4 (type-IV) zinc-finger transcription factors.
+  It has a single, canonical C-terminal GATA-type zinc finger (residues 472-497)
+  with the hallmark C-X2-C ... C-X2-C spacing, preceded by an extensive intrinsically
+  disordered, low-complexity region that spans most of the protein. On domain grounds
+  the zinc finger is expected to coordinate zinc and to bind GATA-type
+  (5&#39;-GATA-3&#39;/5&#39;-GAT-3&#39;) DNA sequence motifs, consistent with a role as a
+  sequence-specific DNA-binding transcription factor acting in the nucleus. GAT2 is
+  one of several yeast GATA-family proteins; the best-characterized members are the
+  nitrogen-catabolite-repression regulators Gln3, Gat1 (activators), Dal80 and Gzf3
+  (repressors), together with the smaller Gat3 and Gat4. GAT2 itself is poorly
+  characterized: its direct DNA targets, the physiological condition in which it
+  operates, and its specific biological role have not been experimentally established.
+  GAT2 transcription is condition-responsive (repressed by leucine), and large-scale
+  deletion studies report mild, pleiotropic phenotypes including decreased invasive
+  growth and abnormal bud and vacuolar morphology.
+references:
+- id: GO_REF:0000002
+  title: Gene Ontology annotation through association of InterPro records with GO terms
+  findings: []
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: &gt;-
+      InterPro2GO electronic pipeline. Correctly transfers GATA/zinc-finger domain
+      terms (zinc ion binding, sequence-specific DNA binding, regulation of
+      transcription) from IPR000679/IPR013088, which GAT2 genuinely carries. Domain-
+      level, not GAT2-specific functional evidence.
+- id: GO_REF:0000015
+  title: Use of the ND evidence code for Gene Ontology (GO) terms
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Standard GO_REF documenting the ND (no biological data) evidence code, used
+      here for the root cellular_component placeholder.
+- id: GO_REF:0000033
+  title: Annotation inferences using phylogenetic trees
+  findings: []
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PAINT/IBA phylogenetic pipeline. The IBA terms on GAT2 propagate from PANTHER
+      family PTHR45658 (with_from lists Arabidopsis AGI codes and Dictyostelium
+      genes), i.e. from the plant/Dictyostelium GATA cluster, NOT from the yeast NCR
+      GATA factors (which are in the separate family PTHR10071). Appropriate for
+      generic GATA-TF terms; does not establish GAT2&#39;s specific process.
+- id: PMID:10392447
+  title: Genome-wide transcriptional analysis in S. cerevisiae by mini-array membrane hybridization.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Methods paper (Cox, Pinchak &amp; Cooper 1999) validating mini-array membrane
+      hybridization using the GATA-factor/nitrogen-control network as a test case.
+      Abstract-only in cache. It does not demonstrate GAT2-specific function; SGD used
+      it as the anchor for ISA (inferred from sequence alignment) annotations whose
+      with_from fields point to OTHER GATA-factor genes. Correctly cited but only
+      weakly relevant to GAT2&#39;s own function.
+- id: PMID:30358795
+  title: The cellular economy of the Saccharomyces cerevisiae zinc proteome.
+  findings: []
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Wang et al. 2018 (Metallomics). Bioinformatic + mass-spec survey defining the
+      yeast zinc proteome via combined domain and motif searches. GAT2&#39;s inclusion as
+      a zinc-binding protein is a reasonable computational (RCA) inference from its
+      GATA zinc finger; not a direct GAT2 metal-binding measurement.
+- id: file:yeast/GAT2/GAT2-bioinformatics/RESULTS.md
+  title: &gt;-
+    GAT2 bioinformatics — GATA zinc-finger confirmation and paralog relationships
+  findings:
+    - statement: &gt;-
+        GAT2 carries a complete, canonical GATA-type Cys4 zinc finger at residues
+        472-497 (C-X3-C-X19-C-X3-C spacing), matching the UniProt ZN_FING feature; a
+        non-GATA negative control (actin ACT1) yields no hit.
+    - statement: &gt;-
+        By DNA-binding-domain identity GAT2 is the most divergent yeast GATA factor
+        (37-52% to any single paralog) and does not cluster with the four tightly
+        related nitrogen-catabolite-repression factors (Gln3/Gat1/Dal80/Gzf3, 58-68%
+        among themselves), corroborating the independent PANTHER assignment of GAT2 to
+        family PTHR45658 (versus PTHR10071 for the NCR factors).
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      In-repo reproducible analysis (this review). Confirms domain presence and
+      quantifies paralog divergence; supports the MF domain terms while cautioning
+      against transferring NCR-factor process functions to GAT2. file: reference — not
+      auto quote-checked; quotes verified by hand against RESULTS.md.
+existing_annotations:
+- term:
+    id: GO:0000976
+    label: transcription cis-regulatory region binding
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Phylogenetic (IBA) inference that GAT2, as a GATA-family zinc-finger protein,
+      binds cis-regulatory DNA regions. GAT2 does carry a complete GATA zinc finger,
+      so binding a GATA-type cis-regulatory sequence is domain-plausible.
+    action: ACCEPT
+    reason: &gt;-
+      The GATA zinc finger is present and canonical (confirmed at 472-497), and DNA
+      binding via this finger is a well-established property of the family. Accepting
+      the generic cis-regulatory-region-binding term is defensible on domain grounds.
+      Note the IBA propagates from PTHR45658 (plant/Dictyostelium GATA cluster), not
+      from the yeast NCR factors, so it supports a generic DNA-binding capacity rather
+      than a specific target set. This term is retained alongside GO:0043565
+      (sequence-specific DNA binding): the two are complementary rather than redundant —
+      GO:0043565 asserts the finger recognizes a specific sequence, while this term
+      places that binding at a cis-regulatory (promoter/UAS) region.
+    supported_by:
+    - reference_id: file:yeast/GAT2/GAT2-bioinformatics/RESULTS.md
+      supporting_text: &gt;-
+        GAT2 carries a bona fide GATA-type Cys4 zinc finger at residues 472 to 497
+        matching the UniProt ZN_FING GATA-type feature.
+- term:
+    id: GO:0005634
+    label: nucleus
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: is_active_in
+  review:
+    summary: &gt;-
+      Phylogenetic (IBA) inference of nuclear localization, expected for a DNA-binding
+      transcription factor. There is no experimental localization for GAT2 (SGD lists
+      cellular component as unknown), but a nuclear site of action is the parsimonious
+      expectation for a GATA zinc-finger TF.
+    action: ACCEPT
+    reason: &gt;-
+      Consistent with GAT2&#39;s DNA-binding zinc finger and TF classification. Retained as
+      a reasonable, if inferred, location. The absence of a direct localization assay is
+      recorded as a knowledge gap rather than a reason to reject the term.
+- term:
+    id: GO:0006357
+    label: regulation of transcription by RNA polymerase II
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Phylogenetic (IBA) inference that GAT2 participates in regulation of RNA Pol II
+      transcription, the generic process for GATA-family TFs.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      The generic process term is domain-appropriate for a GATA zinc-finger TF, but no
+      GAT2-specific target gene or regulatory event has been demonstrated (all evidence
+      is homology/phylogeny). Keeping it as a non-core, generic capability rather than a
+      demonstrated core function is the honest interpretation for this dark gene.
+- term:
+    id: GO:0006355
+    label: regulation of DNA-templated transcription
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      InterPro2GO electronic transfer of a generic transcription-regulation process
+      from the GATA/zinc-finger domains (IPR000679, IPR013088).
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Domain-based and broadly correct, but it is the DNA-templated-transcription parent
+      of the more specific RNA-Pol-II term already present via IBA. Redundant and generic;
+      retained as non-core. Not a GAT2-specific demonstrated function.
+- term:
+    id: GO:0008270
+    label: zinc ion binding
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: enables
+  review:
+    summary: &gt;-
+      InterPro2GO electronic transfer of zinc ion binding from the GATA zinc-finger
+      domain (IPR013088).
+    action: ACCEPT
+    reason: &gt;-
+      GAT2 has a complete Cys4 GATA zinc finger whose four cysteines coordinate a
+      structural zinc ion; zinc binding is a robust, well-supported domain-level
+      property.
+    supported_by:
+    - reference_id: file:yeast/GAT2/GAT2-bioinformatics/RESULTS.md
+      supporting_text: &gt;-
+        The four coordinating cysteines with C-X3-C ... C-X3-C spacing are the hallmark
+        of the DNA-binding GATA finger.
+- term:
+    id: GO:0043565
+    label: sequence-specific DNA binding
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: enables
+  review:
+    summary: &gt;-
+      InterPro2GO electronic transfer of sequence-specific DNA binding from the GATA
+      zinc-finger domain (IPR000679).
+    action: ACCEPT
+    reason: &gt;-
+      Sequence-specific (GATA-motif) DNA binding is the defining activity of the GATA
+      zinc finger, which GAT2 carries intact. Accepted on domain grounds; the specific
+      target sequences bound by GAT2 in vivo remain undetermined (recorded as a
+      knowledge gap).
+- term:
+    id: GO:0008270
+    label: zinc ion binding
+  evidence_type: RCA
+  original_reference_id: PMID:30358795
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Reviewed-computational-analysis (RCA) inclusion of GAT2 in the yeast zinc
+      proteome (Wang et al. 2018), based on combined domain and motif searches for
+      zinc-binding proteins.
+    action: ACCEPT
+    reason: &gt;-
+      Independent computational support for zinc binding, consistent with the GATA
+      zinc-finger domain. Concordant with the IEA zinc-binding annotation. Not a direct
+      GAT2 metal-binding measurement, but a reasonable inference.
+    supported_by:
+    - reference_id: PMID:30358795
+      supporting_text: &gt;-
+        yeast zinc proteome of 582 known or potential zinc-binding proteins was
+- term:
+    id: GO:0005575
+    label: cellular_component
+  evidence_type: ND
+  original_reference_id: GO_REF:0000015
+  qualifier: is_active_in
+  review:
+    summary: &gt;-
+      Root cellular_component placeholder with ND (no data) evidence, reflecting that
+      GAT2&#39;s subcellular localization has not been experimentally determined.
+    action: REMOVE
+    reason: &gt;-
+      An IBA nucleus annotation (GO:0005634) is already present and is the more
+      informative, domain-consistent cellular-component call. The uninformative root
+      placeholder is superseded and can be removed. (The genuine absence of an
+      experimental localization is captured as a knowledge gap.)
+- term:
+    id: GO:0000981
+    label: DNA-binding transcription factor activity, RNA polymerase II-specific
+  evidence_type: ISA
+  original_reference_id: PMID:10392447
+  qualifier: enables
+  review:
+    summary: &gt;-
+      SGD ISA (inferred from sequence alignment) annotation classifying GAT2 as an RNA
+      Pol II DNA-binding transcription factor, anchored to PMID:10392447 with with_from
+      pointing to other GATA-factor genes.
+    action: ACCEPT
+    reason: &gt;-
+      The molecular activity — a GATA-type, RNA-Pol-II DNA-binding transcription factor —
+      is well supported by the intact GATA zinc finger and the family classification.
+      This is the most defensible molecular-function statement for GAT2. It rests on
+      sequence similarity (ISA), not a direct GAT2 assay; the reference is a methods
+      paper about the GATA network rather than a GAT2-specific functional study, which
+      is why the target genes and regulatory role remain a knowledge gap.
+    supported_by:
+    - reference_id: file:yeast/GAT2/GAT2-bioinformatics/RESULTS.md
+      supporting_text: &gt;-
+        GAT2 carries a bona fide GATA-type Cys4 zinc finger at residues 472 to 497
+        matching the UniProt ZN_FING GATA-type feature.
+- term:
+    id: GO:0006357
+    label: regulation of transcription by RNA polymerase II
+  evidence_type: ISA
+  original_reference_id: PMID:10392447
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      SGD ISA annotation that GAT2 is involved in regulation of RNA Pol II
+      transcription, inferred by sequence alignment to other GATA factors (with_from
+      lists several GATA-factor SGD ids).
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Domain- and family-appropriate as a generic capability, but the specific genes
+      GAT2 regulates and the condition under which it does so are unknown. As with the
+      IBA process term, this is retained as a non-core, inferred process rather than a
+      demonstrated GAT2 function.
+core_functions:
+- description: &gt;-
+    Sequence-specific DNA-binding transcription factor of the GATA family. GAT2&#39;s
+    single, canonical C-terminal GATA-type Cys4 zinc finger (472-497) is expected to
+    coordinate a structural zinc ion and to bind GATA-type DNA sequence motifs, giving
+    GAT2 the molecular capacity to act as an RNA polymerase II DNA-binding
+    transcription factor in the nucleus. This is a domain- and homology-supported
+    capability; the specific target genes, DNA sites, and regulatory outcome for GAT2
+    have not been experimentally determined.
+  molecular_function:
+    id: GO:0000981
+    label: DNA-binding transcription factor activity, RNA polymerase II-specific
+  directly_involved_in:
+  - id: GO:0006357
+    label: regulation of transcription by RNA polymerase II
+  locations:
+  - id: GO:0005634
+    label: nucleus
+  supported_by:
+  - reference_id: file:yeast/GAT2/GAT2-bioinformatics/RESULTS.md
+    supporting_text: &gt;-
+      GAT2 carries a bona fide GATA-type Cys4 zinc finger at residues 472 to 497
+      matching the UniProt ZN_FING GATA-type feature.
+  - reference_id: GO_REF:0000002
+    supporting_text: &gt;-
+      Gene Ontology annotation through association of InterPro records with GO terms
+knowledge_gaps:
+- gap_statement: &gt;-
+    The direct DNA target genes of Gat2, the specific GATA DNA sites it occupies in
+    vivo, and the physiological condition under which it acts are undetermined. It is
+    also unresolved whether Gat2 functions as a transcriptional activator or repressor.
+  boundary: &gt;-
+    Gat2 is a bona fide GATA-family protein with a complete, canonical Cys4 zinc finger
+    (472-497) that supports zinc binding and sequence-specific (GATA-motif) DNA binding
+    on domain grounds; it is classified as an RNA Pol II DNA-binding transcription
+    factor. Its own transcription is condition-responsive (repressed by leucine;
+    regulated by Sut2/Rgr1/Ume6/Fkh1). All molecular- and biological-process
+    annotations are inferred from sequence similarity (ISA), domain (IEA), phylogeny
+    (IBA) or computation (RCA); none derives from a direct Gat2 functional assay, and
+    SGD lists no characterized target genes.
+  gap_kind:
+    - BIOLOGY
+  dark_aspect: BP_DARK
+  status: OPEN
+  significance: &gt;-
+    Gat2 is one of the few S. cerevisiae GATA factors with no assigned biological role,
+    in a family (Gln3/Gat1/Dal80/Gzf3) that is central to nitrogen-responsive gene
+    regulation. Defining Gat2&#39;s targets and condition would establish whether the yeast
+    GATA network has an unrecognized fifth regulatory node or whether Gat2 acts in an
+    unrelated process.
+  provenance:
+    - reference_id: PMID:10392447
+      supporting_text: &gt;-
+        identify genes not previously reported to be associated with this nitrogen
+      reference_section_type: ABSTRACT
+    - reference_id: file:yeast/GAT2/GAT2-bioinformatics/RESULTS.md
+      supporting_text: &gt;-
+        The specific DNA target sites, condition, and biological process of GAT2 remain
+        undetermined by this analysis and by the literature.
+  resolution: &gt;-
+    ChIP-seq / ChIP-exo of tagged Gat2 across nitrogen sources and stress conditions to
+    map direct sites and targets; RNA-seq of gat2-delta and GAT2-overexpression strains
+    (singly and in combination with gln3/gat1/dal80/gzf3 mutants) to test activator vs
+    repressor role and redundancy.
+- gap_statement: &gt;-
+    Whether Gat2 is functionally redundant with, antagonistic to, or independent of the
+    canonical nitrogen-catabolite-repression GATA factors (Gln3, Gat1, Dal80, Gzf3) is
+    unknown, and its DNA-binding specificity relative to theirs has not been measured.
+  boundary: &gt;-
+    The four NCR GATA factors form a tightly related group both phylogenetically
+    (PANTHER family PTHR10071) and by DNA-binding-domain identity (58-68% among
+    themselves). Gat2 is the most divergent yeast GATA factor at the DBD level (37-52%
+    to any single paralog) and is assigned to a separate PANTHER family (PTHR45658);
+    SGD nonetheless notes it is &#34;similar to Gln3p and Dal80p.&#34; No genetic-interaction or
+    biochemical study has directly tested Gat2&#39;s relationship to the NCR quartet.
+  gap_kind:
+    - BIOLOGY
+  dark_aspect: RESIDUAL_SUBGAP
+  status: OPEN
+  significance: &gt;-
+    Resolving this would show whether Gat2 has been overlooked because it is redundant
+    with the NCR factors (buffered, hence phenotype-poor) or because it operates in a
+    distinct regulatory context, guiding where to look for its function.
+  provenance:
+    - reference_id: file:yeast/GAT2/GAT2-bioinformatics/RESULTS.md
+      supporting_text: &gt;-
+        GAT2 does not join either tight cluster
+  resolution: &gt;-
+    In vitro DNA-binding-specificity assays (e.g. protein-binding microarray / SELEX) to
+    compare Gat2&#39;s site preference with the NCR factors; combinatorial deletion/epistasis
+    analysis (gat2 in gln3/gat1/dal80/gzf3 backgrounds) under nitrogen limitation and
+    other stresses.
+- gap_statement: &gt;-
+    Gat2&#39;s subcellular localization and its regulation (e.g. nuclear/cytoplasmic
+    partitioning in response to nitrogen or TORC1 signaling, as seen for Gln3 and Gat1)
+    have not been experimentally determined.
+  boundary: &gt;-
+    Nuclear action is inferred (IBA) from GAT2&#39;s DNA-binding TF classification, but SGD
+    records cellular component as unknown and no GFP-localization compartment call is
+    represented in GOA. The NCR activators Gln3 and Gat1 are known to shuttle between
+    cytoplasm and nucleus under nitrogen/TORC1 control; whether Gat2 is similarly
+    regulated is untested.
+  gap_kind:
+    - BIOLOGY
+    - CURATION
+  dark_aspect: CC_DARK
+  status: OPEN
+  significance: &gt;-
+    Localization and its conditional control are the entry point to Gat2&#39;s regulation:
+    demonstrating regulated nuclear entry would connect Gat2 to a signaling pathway and
+    a condition, both currently unknown.
+  provenance:
+    - reference_id: file:yeast/GAT2/GAT2-bioinformatics/RESULTS.md
+      supporting_text: &gt;-
+        GAT2 has no experimentally determined subcellular localization in the accessible
+        resources.
+  resolution: &gt;-
+    GFP/mNeonGreen tagging of Gat2 with live-cell imaging across nitrogen sources and
+    rapamycin treatment; nuclear-fractionation immunoblots to test regulated
+    nucleocytoplasmic partitioning.
+suggested_questions:
+- question: &gt;-
+    Does Gat2 bind GATA DNA sites in vivo, and which genes does it directly regulate?
+- question: &gt;-
+    Under what physiological condition (nitrogen source, stress, growth phase) is Gat2
+    functionally active, and is it an activator or a repressor?
+- question: &gt;-
+    Is Gat2 redundant with or distinct from the canonical NCR GATA factors
+    (Gln3/Gat1/Dal80/Gzf3), and does its divergent DNA-binding domain read a different
+    sequence?
+suggested_experiments:
+- description: &gt;-
+    ChIP-seq/ChIP-exo of epitope-tagged Gat2 across nitrogen sources, stress and growth
+    phases to identify direct binding sites and target genes.
+- description: &gt;-
+    RNA-seq of gat2-delta and GAT2-overexpression strains, alone and in combination with
+    gln3/gat1/dal80/gzf3 mutants, to define Gat2&#39;s regulatory role and test redundancy
+    with the NCR factors.
+- description: &gt;-
+    Live-cell imaging of a functional Gat2-GFP fusion under varying nitrogen and TORC1
+    (rapamycin) conditions to determine localization and whether nuclear entry is
+    conditionally regulated as for Gln3/Gat1.
+- description: &gt;-
+    In vitro DNA-binding-specificity profiling (protein-binding microarray or SELEX) of
+    the Gat2 zinc finger to compare its recognized sequence with those of the other yeast
+    GATA factors.
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/genes/yeast/KDX1/KDX1-ai-review.html
+++ b/genes/yeast/KDX1/KDX1-ai-review.html
@@ -1,0 +1,4244 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>KDX1 - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        .propagation-review {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f8fafc;
+            border-left: 3px solid #64748b;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .propagation-title {
+            font-weight: 600;
+            color: #334155;
+            margin-bottom: 0.25rem;
+        }
+
+        .propagation-row {
+            margin-top: 0.25rem;
+        }
+
+        .propagation-source {
+            margin-top: 0.5rem;
+            padding-top: 0.5rem;
+            border-top: 1px solid #e5e7eb;
+        }
+
+        .propagation-source-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #1d4ed8;
+        }
+
+        .propagation-comment {
+            color: #4b5563;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>KDX1</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/P36005" target="_blank" class="term-link">
+                        P36005
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Saccharomyces cerevisiae</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-complete">
+                    COMPLETE
+                </span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Aliases:</span>
+                <div class="aliases">
+
+                    <span class="badge">MLP1</span>
+
+                    <span class="badge">YKL161C</span>
+
+                </div>
+            </div>
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "KDX1";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="P36005" data-a="DESCRIPTION: KDX1 (commonly called MLP1 in the primary literatu..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>KDX1 (commonly called MLP1 in the primary literature; systematic name YKL161C) is a degenerate protein-kinase-fold protein of budding yeast, a paralog of the cell wall integrity (CWI) MAP kinase SLT2/MPK1 that arose from the whole-genome duplication. Despite retaining a recognizable protein-kinase domain, KDX1 is a catalytically inactive pseudokinase: its activation-loop DFG motif is degenerate (Asp-&gt;Asn) and it lacks the MAPK TEY dual-phosphorylation motif that activates SLT2, so it cannot function as a conventional MAP kinase. KDX1 acts in the CWI signaling pathway downstream of the Mkk1/Mkk2 MEKs. Its best-characterized activity is non-catalytic: activated (phosphorylated) KDX1, like activated SLT2, binds the DNA-binding transcription factor Swi4 and, together with Swi6 (the SBF complex), drives transcription of cell wall stress genes such as FKS2, functioning redundantly with SLT2 in this branch. KDX1 was originally identified as an Rlm1-associated protein and physically interacts with the MADS-box transcription factor Rlm1. KDX1 protein is scarce under normal growth but accumulates strongly when the cell wall is stressed, because MLP1 is itself a transcriptional target of the SLT2-&gt;Rlm1 arm of the same pathway.</p>
+    </div>
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Proposed New Ontology Terms</h2>
+
+        <div class="proposed-term">
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>pseudokinase scaffold activity in transcription factor activation</h3>
+                <span class="vote-buttons" data-g="P36005" data-a="pseudokinase scaffold activity in transcription factor activation" data-r="" data-act="NEW">
+                    <button class="vote-btn" data-v="up" title="Agree this term should be created">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with creating this term">👎</button>
+                </span>
+            </div>
+
+
+            <p><strong>Definition:</strong> A molecular function in which a catalytically inactive protein-kinase-fold protein (pseudokinase), typically upon activating post-translational modification, binds a DNA-binding transcription factor and confers or enhances its DNA-binding/transcription-activating competence, thereby contributing to transcriptional activation without protein kinase catalytic activity.</p>
+
+
+
+            <p><strong>Justification:</strong> KDX1/Mlp1 exemplifies a pseudokinase whose molecular function is non-catalytic: as an activated (phosphorylated) protein it binds the DNA-binding transcription factor Swi4 and confers DNA-binding competence, contributing to transcriptional activation of FKS2 and related genes. GO:0140297 (DNA-binding transcription factor binding) captures the binding but not the activating scaffold role, and GO:0003713 (transcription coactivator activity) is normally applied to the direct coactivator. A dedicated term would express KDX1&#39;s characterized function precisely.</p>
+
+
+
+
+
+
+
+            <p><strong>Supporting Evidence:</strong></p>
+            <ul style="margin-left: 1rem;">
+
+                <li>
+
+                    <a href="https://pubmed.ncbi.nlm.nih.gov/18268013" target="_blank" class="term-link">
+                        PMID:18268013
+                    </a>
+
+
+                    : Activated (phosphorylated) Mpk1 and Mlp1 were detected in a complex with Swi4 and Swi6 at the FKS2 promoter.
+
+                </li>
+
+            </ul>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005634" target="_blank" class="term-link">
+                                    GO:0005634
+                                </a>
+                            </span>
+                            <span class="term-label">nucleus</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P36005" data-a="GO:0005634" data-r="GO_REF:0000033" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Nuclear localization is consistent with KDX1&#39;s characterized non-catalytic role at cell-wall-stress gene promoters (FKS2 etc.), where activated KDX1 associates with Swi4/Swi6 (SBF). Reasonable but not a core molecular function; retained as a localization annotation.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> KDX1/Mlp1 forms part of the Swi4-Swi6 complex at the FKS2 promoter, so nuclear activity is supported. IBA from the MAPK family tree; consistent with the experimental non-catalytic transcriptional role.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/18268013" target="_blank" class="term-link">
+                                        PMID:18268013
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Activated (phosphorylated) Mpk1 and Mlp1 were detected in a complex with Swi4 and Swi6 at the FKS2 promoter.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
+                                    GO:0005737
+                                </a>
+                            </span>
+                            <span class="term-label">cytoplasm</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P36005" data-a="GO:0005737" data-r="GO_REF:0000033" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Cytoplasmic localization is plausible for a MAPK-like protein acting in the CWI cascade before its stress-induced accumulation and nuclear/promoter activity. Retained as a non-core localization annotation.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> IBA from the MAPK family tree. Consistent with a terminal-MAPK-like protein of the CWI pathway; not a core molecular function.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051726" target="_blank" class="term-link">
+                                    GO:0051726
+                                </a>
+                            </span>
+                            <span class="term-label">regulation of cell cycle</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P36005" data-a="GO:0051726" data-r="GO_REF:0000033" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> This is a phylogenetic propagation from the broad MAPK/CDK-containing family tree (PTHR24055). There is no KDX1/Mlp1-specific evidence for a cell-cycle regulatory role; the characterized function is in cell-wall-stress transcription, not cell-cycle control.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Over-propagation from CDK/MAPK relatives in the family tree. No experimental support for a KDX1 cell-cycle role in S. cerevisiae.
+                        </div>
+
+
+
+                        <div class="propagation-review">
+                            <div class="propagation-title">Propagation Review</div>
+                            <div class="propagation-row">
+                                <strong>Root cause:</strong>
+                                <span class="badge">PROPAGATION BAD</span>
+                            </div>
+
+                            <div class="propagation-row">
+                                <strong>Failure modes:</strong>
+
+                                <span class="badge">WRONG ORTHOLOG OR PARALOG</span>
+
+                            </div>
+
+
+                        </div>
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000082" target="_blank" class="term-link">
+                                    GO:0000082
+                                </a>
+                            </span>
+                            <span class="term-label">G1/S transition of mitotic cell cycle</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P36005" data-a="GO:0000082" data-r="GO_REF:0000033" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetic propagation from cell-cycle CDK members of the family tree; not supported by any KDX1-specific evidence. KDX1 is a CWI pseudokinase, not a cell-cycle CDK.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> IBA over-annotation inherited from CDK relatives (e.g. CDC28-like) in PTHR24055; no yeast KDX1 evidence for G1/S control.
+                        </div>
+
+
+
+                        <div class="propagation-review">
+                            <div class="propagation-title">Propagation Review</div>
+                            <div class="propagation-row">
+                                <strong>Root cause:</strong>
+                                <span class="badge">PROPAGATION BAD</span>
+                            </div>
+
+                            <div class="propagation-row">
+                                <strong>Failure modes:</strong>
+
+                                <span class="badge">WRONG ORTHOLOG OR PARALOG</span>
+
+                            </div>
+
+
+                        </div>
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000307" target="_blank" class="term-link">
+                                    GO:0000307
+                                </a>
+                            </span>
+                            <span class="term-label">cyclin-dependent protein kinase holoenzyme complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P36005" data-a="GO:0000307" data-r="GO_REF:0000033" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> There is no evidence KDX1/Mlp1 is a component of a cyclin-dependent kinase holoenzyme. This is an incorrect phylogenetic propagation from CDK members of the family; KDX1&#39;s documented complexes are with the transcription factors Swi4/Swi6 and Rlm1, not cyclin-CDK.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Wrong-complex over-propagation from CDK relatives in PTHR24055. KDX1 associates with Swi4/Swi6 (SBF) and Rlm1, not with cyclins/CDK holoenzyme.
+                        </div>
+
+
+
+                        <div class="propagation-review">
+                            <div class="propagation-title">Propagation Review</div>
+                            <div class="propagation-row">
+                                <strong>Root cause:</strong>
+                                <span class="badge">PROPAGATION BAD</span>
+                            </div>
+
+                            <div class="propagation-row">
+                                <strong>Failure modes:</strong>
+
+                                <span class="badge">WRONG ORTHOLOG OR PARALOG</span>
+
+                                <span class="badge">COMPARTMENT OR COMPLEX MISMATCH</span>
+
+                            </div>
+
+
+                        </div>
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000086" target="_blank" class="term-link">
+                                    GO:0000086
+                                </a>
+                            </span>
+                            <span class="term-label">G2/M transition of mitotic cell cycle</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P36005" data-a="GO:0000086" data-r="GO_REF:0000033" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetic propagation from cell-cycle CDK members of the family tree; not supported by any KDX1-specific evidence.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> IBA over-annotation inherited from CDK relatives in PTHR24055; no yeast KDX1 evidence for G2/M control.
+                        </div>
+
+
+
+                        <div class="propagation-review">
+                            <div class="propagation-title">Propagation Review</div>
+                            <div class="propagation-row">
+                                <strong>Root cause:</strong>
+                                <span class="badge">PROPAGATION BAD</span>
+                            </div>
+
+                            <div class="propagation-row">
+                                <strong>Failure modes:</strong>
+
+                                <span class="badge">WRONG ORTHOLOG OR PARALOG</span>
+
+                            </div>
+
+
+                        </div>
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004693" target="_blank" class="term-link">
+                                    GO:0004693
+                                </a>
+                            </span>
+                            <span class="term-label">cyclin-dependent protein serine/threonine kinase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P36005" data-a="GO:0004693" data-r="GO_REF:0000033" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> KDX1 is a catalytically inactive pseudokinase (degenerate DFG; no TEY motif) and is not a cyclin-dependent kinase. This MF is a doubly-wrong phylogenetic propagation: it asserts both catalytic kinase activity (which KDX1 lacks) and a CDK identity (which KDX1 is not).
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Over-propagation from CDK members of PTHR24055. The pseudokinase evidence (DFG-&gt;NFG, no TEY, literature &#34;catalytically inactive paralog&#34;) contradicts a catalytic CDK activity.
+                        </div>
+
+
+
+                        <div class="propagation-review">
+                            <div class="propagation-title">Propagation Review</div>
+                            <div class="propagation-row">
+                                <strong>Root cause:</strong>
+                                <span class="badge">PROPAGATION BAD</span>
+                            </div>
+
+                            <div class="propagation-row">
+                                <strong>Failure modes:</strong>
+
+                                <span class="badge">WRONG ORTHOLOG OR PARALOG</span>
+
+                                <span class="badge">PSEUDO OR SUBACTIVITY LOSS</span>
+
+                            </div>
+
+
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/20641022" target="_blank" class="term-link">
+                                        PMID:20641022
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Induction was only partially dependent on the Mlp1 pseudokinase (Figure 2), a catalytically inactive paralog of Mpk1 (Kim et al., 2008).</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0007165" target="_blank" class="term-link">
+                                    GO:0007165
+                                </a>
+                            </span>
+                            <span class="term-label">signal transduction</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-modify">
+                            MODIFY
+                        </span>
+                        <span class="vote-buttons" data-g="P36005" data-a="GO:0007165" data-r="GO_REF:0000033" data-act="MODIFY">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> KDX1 does act within the cell wall integrity (CWI) signaling cascade, so a signal transduction annotation is defensible. It is very general, however; the specific process is the cell integrity MAPK cascade / CWI transcriptional output.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct in spirit but non-specific. A more informative term is cell integrity MAPK cascade (GO:0000196), whose definition explicitly names SLT2 (the paralog KDX1 acts with).
+                        </div>
+
+
+
+                        <div class="propagation-review">
+                            <div class="propagation-title">Propagation Review</div>
+                            <div class="propagation-row">
+                                <strong>Root cause:</strong>
+                                <span class="badge">TERM SCOPING PROBLEM</span>
+                            </div>
+
+                            <div class="propagation-row">
+                                <strong>Failure modes:</strong>
+
+                                <span class="badge">GRANULARITY MISMATCH</span>
+
+                            </div>
+
+
+                        </div>
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000196" target="_blank" class="term-link">
+                                    cell integrity MAPK cascade
+                                </a>
+                            </span>
+
+                        </div>
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004672" target="_blank" class="term-link">
+                                    GO:0004672
+                                </a>
+                            </span>
+                            <span class="term-label">protein kinase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P36005" data-a="GO:0004672" data-r="GO_REF:0000002" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Family/domain-based electronic annotation (InterPro protein-kinase domain). KDX1 retains the kinase fold but is a catalytically inactive pseudokinase (degenerate DFG, HRD-&gt;HCD, no TEY), so an unqualified &#34;protein kinase activity&#34; is an over-annotation of catalytic function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> IEA from InterPro domain presence; the fold is real but catalytic activity is not KDX1-supported and is contradicted by the pseudokinase evidence.
+                        </div>
+
+
+
+                        <div class="propagation-review">
+                            <div class="propagation-title">Propagation Review</div>
+                            <div class="propagation-row">
+                                <strong>Root cause:</strong>
+                                <span class="badge">PROPAGATION BAD</span>
+                            </div>
+
+                            <div class="propagation-row">
+                                <strong>Failure modes:</strong>
+
+                                <span class="badge">PSEUDO OR SUBACTIVITY LOSS</span>
+
+                            </div>
+
+
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/18268013" target="_blank" class="term-link">
+                                        PMID:18268013
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">its pseudokinase paralog (Mlp1) use a noncatalytic mechanism to activate transcription of the FKS2 gene</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004674" target="_blank" class="term-link">
+                                    GO:0004674
+                                </a>
+                            </span>
+                            <span class="term-label">protein serine/threonine kinase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000120
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P36005" data-a="GO:0004674" data-r="GO_REF:0000120" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> ARBA/EC-based electronic annotation propagating a Ser/Thr kinase catalytic activity from family homology. Contradicted by the pseudokinase evidence for KDX1 (degenerate DFG; no demonstrated phosphotransfer; field consensus &#34;catalytically inactive&#34;).
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Electronic catalytic-activity propagation not supported by KDX1-specific data; KDX1 is a pseudokinase.
+                        </div>
+
+
+
+                        <div class="propagation-review">
+                            <div class="propagation-title">Propagation Review</div>
+                            <div class="propagation-row">
+                                <strong>Root cause:</strong>
+                                <span class="badge">PROPAGATION BAD</span>
+                            </div>
+
+                            <div class="propagation-row">
+                                <strong>Failure modes:</strong>
+
+                                <span class="badge">PSEUDO OR SUBACTIVITY LOSS</span>
+
+                            </div>
+
+
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/35420390" target="_blank" class="term-link">
+                                        PMID:35420390
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">triggered by the binding of phosphorylated forms of both Slt2 and a catalytically inactive pseudokinase (Mlp1)</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005524" target="_blank" class="term-link">
+                                    GO:0005524
+                                </a>
+                            </span>
+                            <span class="term-label">ATP binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P36005" data-a="GO:0005524" data-r="GO_REF:0000002" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic annotation from the kinase ATP-binding motif. KDX1 retains the beta3 lysine (K55, UniProt BINDING) and the Gly-rich loop, so ATP binding is plausible, but it has never been demonstrated for KDX1 and, given the degenerate DFG, is not part of a catalytic cycle. Retained as a non-core, unverified biochemical property.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> IEA from InterPro; the ATP-anchoring Lys is present so nucleotide binding is not excluded, but it is untested for KDX1 and not a core function of a pseudokinase.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0007165" target="_blank" class="term-link">
+                                    GO:0007165
+                                </a>
+                            </span>
+                            <span class="term-label">signal transduction</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000117
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-modify">
+                            MODIFY
+                        </span>
+                        <span class="vote-buttons" data-g="P36005" data-a="GO:0007165" data-r="GO_REF:0000117" data-act="MODIFY">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Duplicate (electronic) of the signal transduction annotation; same rationale. KDX1 acts in the CWI cascade; the term is correct but general.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> ARBA electronic annotation; correct but non-specific. A more informative term is cell integrity MAPK cascade (GO:0000196).
+                        </div>
+
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000196" target="_blank" class="term-link">
+                                    cell integrity MAPK cascade
+                                </a>
+                            </span>
+
+                        </div>
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0009272" target="_blank" class="term-link">
+                                    GO:0009272
+                                </a>
+                            </span>
+                            <span class="term-label">fungal-type cell wall biogenesis</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000117
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P36005" data-a="GO:0009272" data-r="GO_REF:0000117" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> KDX1 contributes to the transcriptional response that maintains/remodels the cell wall under stress (e.g. FKS2 induction with SBF), so a role in fungal-type cell wall biogenesis is defensible, if indirect. Retained as a non-core biological-process annotation.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> ARBA electronic annotation consistent with KDX1&#39;s non-catalytic role in inducing cell wall stress genes (FKS2 encodes a beta-1,3-glucan synthase subunit). Indirect/contributory, not a core molecular function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/20641022" target="_blank" class="term-link">
+                                        PMID:20641022
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">a common mechanism that involves activation of Mpk1 and Mlp1 to engage Swi4 and Swi6</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0106310" target="_blank" class="term-link">
+                                    GO:0106310
+                                </a>
+                            </span>
+                            <span class="term-label">protein serine kinase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000116
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P36005" data-a="GO:0106310" data-r="GO_REF:0000116" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> RHEA/reaction-based electronic annotation of Ser-directed kinase catalytic activity, propagated from the family reaction mapping. Contradicted by the pseudokinase evidence for KDX1.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Electronic catalytic-activity propagation (RHEA:17989) not supported by KDX1-specific data; KDX1 is a catalytically inactive pseudokinase.
+                        </div>
+
+
+
+                        <div class="propagation-review">
+                            <div class="propagation-title">Propagation Review</div>
+                            <div class="propagation-row">
+                                <strong>Root cause:</strong>
+                                <span class="badge">PROPAGATION BAD</span>
+                            </div>
+
+                            <div class="propagation-row">
+                                <strong>Failure modes:</strong>
+
+                                <span class="badge">PSEUDO OR SUBACTIVITY LOSS</span>
+
+                            </div>
+
+
+                        </div>
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008150" target="_blank" class="term-link">
+                                    GO:0008150
+                                </a>
+                            </span>
+                            <span class="term-label">biological_process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ND</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000015
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-remove">
+                            REMOVE
+                        </span>
+                        <span class="vote-buttons" data-g="P36005" data-a="GO:0008150" data-r="GO_REF:0000015" data-act="REMOVE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Root-level placeholder (ND) indicating no biological-process data at time of assignment. Superseded by the specific CWI/transcription annotations in this review.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Uninformative root placeholder; standard handling is removal once specific annotations exist.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004674" target="_blank" class="term-link">
+                                    GO:0004674
+                                </a>
+                            </span>
+                            <span class="term-label">protein serine/threonine kinase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ISS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/20489023" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:20489023
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    A global protein kinase and phosphatase interaction network ...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P36005" data-a="GO:0004674" data-r="PMID:20489023" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> ISS transfer of Ser/Thr kinase activity to KDX1 from its paralog SLT2 (with: SGD:S000001072) based on sequence similarity. Because KDX1 is a catalytically inactive pseudokinase, transferring SLT2&#39;s catalytic activity by similarity is exactly the over-annotation the pseudokinase literature warns against; the fold similarity is real but the catalytic residues are degenerate.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> ISS from the active paralog SLT2 does not hold: KDX1&#39;s DFG motif is degenerate and the field explicitly calls Mlp1 a &#34;catalytically inactive paralog of Mpk1&#34;. Not REMOVE, since the kinase fold is genuinely present, but the catalytic MF is an over-annotation.
+                        </div>
+
+
+
+                        <div class="propagation-review">
+                            <div class="propagation-title">Propagation Review</div>
+                            <div class="propagation-row">
+                                <strong>Root cause:</strong>
+                                <span class="badge">PROPAGATION BAD</span>
+                            </div>
+
+                            <div class="propagation-row">
+                                <strong>Failure modes:</strong>
+
+                                <span class="badge">WRONG ORTHOLOG OR PARALOG</span>
+
+                                <span class="badge">PSEUDO OR SUBACTIVITY LOSS</span>
+
+                            </div>
+
+
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/20641022" target="_blank" class="term-link">
+                                        PMID:20641022
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Induction was only partially dependent on the Mlp1 pseudokinase (Figure 2), a catalytically inactive paralog of Mpk1 (Kim et al., 2008).</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005575" target="_blank" class="term-link">
+                                    GO:0005575
+                                </a>
+                            </span>
+                            <span class="term-label">cellular_component</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ND</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000015
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-remove">
+                            REMOVE
+                        </span>
+                        <span class="vote-buttons" data-g="P36005" data-a="GO:0005575" data-r="GO_REF:0000015" data-act="REMOVE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Root-level placeholder (ND). Superseded by the nucleus/cytoplasm localization annotations.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Uninformative root placeholder; standard handling is removal once specific annotations exist.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0140297" target="_blank" class="term-link">
+                                    GO:0140297
+                                </a>
+                            </span>
+                            <span class="term-label">DNA-binding transcription factor binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/18268013" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:18268013
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Yeast Mpk1 mitogen-activated protein kinase activates transc...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-new">
+                            NEW
+                        </span>
+                        <span class="vote-buttons" data-g="P36005" data-a="GO:0140297" data-r="PMID:18268013" data-act="NEW">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Proposed new annotation capturing KDX1/Mlp1&#39;s actual, experimentally supported molecular function: activated (phosphorylated) KDX1 binds the DNA-binding transcription factor Swi4 (and is detected in a Swi4/Swi6 complex at the FKS2 promoter), a non-catalytic scaffold role that replaces the mis-propagated catalytic kinase functions. This is the MF used in core_functions.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> KDX1 is a pseudokinase whose characterized function is binding a DNA-binding transcription factor (Swi4) rather than phosphotransfer; this term expresses that function and avoids the uninformative &#34;protein binding&#34;.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/18268013" target="_blank" class="term-link">
+                                        PMID:18268013
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Activated (phosphorylated) Mpk1 and Mlp1 were detected in a complex with Swi4 and Swi6 at the FKS2 promoter.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/20641022" target="_blank" class="term-link">
+                                        PMID:20641022
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">the binding of activated (phosphorylated) Mpk1, or its pseudokinase paralog, Mlp1, to the Swi4 transcription factor</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>Non-catalytic transcriptional co-activation of cell-wall-stress genes: activated (phosphorylated) KDX1 binds the DNA-binding transcription factor Swi4, conferring DNA-binding ability, and together with Swi6 (the SBF complex) drives transcription of FKS2 and related genes in response to cell wall stress. KDX1 performs this function redundantly with its active paralog SLT2/MPK1, without any requirement for protein kinase catalytic activity.</h3>
+                <span class="vote-buttons" data-g="P36005" data-a="FUNCTION: Non-catalytic transcriptional co-activation of cel..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0140297" target="_blank" class="term-link">
+                            DNA-binding transcription factor binding
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000196" target="_blank" class="term-link">
+                                cell integrity MAPK cascade
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005634" target="_blank" class="term-link">
+                                nucleus
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/18268013" target="_blank" class="term-link">
+                                PMID:18268013
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">Activated (phosphorylated) Mpk1 and Mlp1 were detected in a complex with Swi4 and Swi6 at the FKS2 promoter.</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/20641022" target="_blank" class="term-link">
+                                PMID:20641022
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">the binding of activated (phosphorylated) Mpk1, or its pseudokinase paralog, Mlp1, to the Swi4 transcription factor</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000002.md" target="_blank" class="term-link">
+                            GO_REF:0000002
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation through association of InterPro records with GO terms</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000015.md" target="_blank" class="term-link">
+                            GO_REF:0000015
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Use of the ND evidence code for Gene Ontology (GO) terms</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
+                            GO_REF:0000033
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Annotation inferences using phylogenetic trees</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000116.md" target="_blank" class="term-link">
+                            GO_REF:0000116
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Automatic Gene Ontology annotation based on Rhea mapping</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000117.md" target="_blank" class="term-link">
+                            GO_REF:0000117
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Electronic Gene Ontology annotations created by ARBA machine learning models</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000120.md" target="_blank" class="term-link">
+                            GO_REF:0000120
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Combined Automated Annotation using Multiple IEA Methods</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/20489023" target="_blank" class="term-link">
+                            PMID:20489023
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">A global protein kinase and phosphatase interaction network in yeast.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Large-scale mass-spectrometric mapping of the yeast kinase/phosphatase interaction (KPI) network; the basis for the SGD ISS annotation transferring a Ser/Thr kinase molecular function to KDX1 from its paralog SLT2. Abstract-only in cache; no KDX1-specific catalytic demonstration is available from the abstract.</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/9111331" target="_blank" class="term-link">
+                            PMID:9111331
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Characterization of a serum response factor-like protein in Saccharomyces cerevisiae, Rlm1, which has transcriptional activity regulated by the Mpk1 (Slt2) mitogen-activated protein kinase pathway.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Original identification of Mlp1 (KDX1) as an Rlm1-associated protein by yeast two-hybrid; overexpression of MLP1 suppresses the caffeine sensitivity of bck1-delta, and mlp1-delta is additive with mpk1-delta, indicating Rlm1 activity is regulated by both Mpk1 and the &#34;Mlp1 MAP kinase-like kinase&#34;.</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/18055054" target="_blank" class="term-link">
+                            PMID:18055054
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">A yeast strain biosensor to detect cell wall-perturbing agents.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">MLP1/YKL161c is almost undetectable under normal growth but its protein accumulates in large amounts when cell wall integrity is compromised, making the MLP1 promoter an ideal cell-wall-stress reporter.</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/18268013" target="_blank" class="term-link">
+                            PMID:18268013
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Yeast Mpk1 mitogen-activated protein kinase activates transcription through Swi4/Swi6 by a noncatalytic mechanism that requires upstream signal.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Mpk1 and its pseudokinase paralog Mlp1 (KDX1) use a noncatalytic mechanism to activate FKS2 transcription; activated (phosphorylated) Mpk1 and Mlp1 were detected in a complex with Swi4 and Swi6 at the FKS2 promoter, conferring DNA-binding ability to Swi4 which then recruits Swi6.</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/20641022" target="_blank" class="term-link">
+                            PMID:20641022
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Transcriptional reporters for genes activated by cell wall stress through a non-catalytic mechanism involving Mpk1 and SBF.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Explicitly describes Mlp1 (KDX1) as &#34;a catalytically inactive paralog of Mpk1&#34;; cell wall stress induction of FKS2/CHA1/YKR013w/YLR042c is only partially dependent on Mlp1 but fully blocked in an mpk1-delta mlp1-delta double mutant, and MLP1 is itself transcriptionally induced by Mpk1 through Rlm1.</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/35420390" target="_blank" class="term-link">
+                            PMID:35420390
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Hsp90 and phosphorylation of the Slt2(Mpk1) MAP kinase activation loop are essential for catalytic, but not non-catalytic, Slt2-mediated transcription in yeast.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Swi4/Swi6 (SBF) activation in response to cell wall stress is noncatalytic and triggered by binding of phosphorylated forms of both Slt2 and the catalytically inactive pseudokinase Mlp1 (KDX1).</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Questions for Experts</h2>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Does KDX1/Mlp1 retain any Mg-ATP-dependent phosphotransfer activity in vitro, or is it biochemically catalytically dead as its degenerate DFG motif and the pseudokinase literature predict?</p>
+
+                    <p style="margin-top: 0.5rem;"><em>Suggested experts: Yeast cell wall integrity / MAP kinase signaling biologists, Pseudokinase biochemists</em></p>
+
+                </div>
+                <span class="vote-buttons" data-g="P36005" data-a="Q: Does KDX1/Mlp1 retain any Mg-ATP-dependent phospho..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Beyond redundancy with SLT2 in the SBF branch, does KDX1 have any non-overlapping, stress-specific function that explains retention of this whole-genome-duplication paralog?</p>
+
+                    <p style="margin-top: 0.5rem;"><em>Suggested experts: Yeast CWI signaling biologists</em></p>
+
+                </div>
+                <span class="vote-buttons" data-g="P36005" data-a="Q: Beyond redundancy with SLT2 in the SBF branch, doe..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Experiments</h2>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Purify recombinant KDX1 (and, as a positive control, active SLT2) and assay Mg-ATP-dependent autophosphorylation and phosphorylation of candidate substrates (e.g. Rlm1, generic MAPK substrates) in vitro, including a nucleotide-binding assay to test whether the intact beta3 lysine still supports ATP binding despite the degenerate DFG.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: KDX1/Mlp1 is catalytically inactive and cannot phosphorylate protein substrates.</em></p>
+
+
+                    <p style="margin-top: 0.5rem;">Type: in vitro kinase / nucleotide-binding assay</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P36005" data-a="EXPERIMENT: Purify recombinant KDX1 (and, as a positive contro..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Complement an mpk1-delta mlp1-delta strain with wild-type KDX1 versus a KDX1 variant mutated at its (pseudo)active site or at the MEK-phosphoacceptor residues, and measure FKS2/CHA1/ YLR042c reporter induction under cell wall stress to separate the requirement for KDX1 binding from any residual catalysis.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: KDX1 activates Swi4/Swi6-dependent transcription purely non-catalytically, via its ability to bind Swi4 when phosphorylated by the upstream MEKs.</em></p>
+
+
+                    <p style="margin-top: 0.5rem;">Type: genetic complementation with transcriptional reporters</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P36005" data-a="EXPERIMENT: Complement an mpk1-delta mlp1-delta strain with wi..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Knowledge Gaps</h2>
+        <p style="color: #555; font-size: 0.92rem; margin-top: -0.3rem;">
+            What is <em>not</em> known — curated, literature-grounded statements of the open
+            unknowns (the inverse of core functions).
+        </p>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> Whether KDX1/Mlp1 has any residual protein kinase catalytic (phosphotransfer) activity in vivo is undetermined; no physiological substrate has been demonstrated and the field treats it as catalytically dead.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">MF_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> The protein retains a recognizable kinase fold and the beta3 ATP-anchoring lysine (K55), but the activation-loop DFG Mg2+-binding aspartate is replaced by asparagine (DFG-&gt;NFG), the HRD catalytic-loop arginine is lost (HRD-&gt;HCD, though the catalytic Asp D153 is retained), and the MAPK TEY dual-phosphorylation motif is absent. Multiple papers explicitly call Mlp1 a &#34;catalytically inactive pseudokinase&#34;. Its characterized biological function (SBF-dependent transcription) is explicitly non-catalytic.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> UniProt and several electronic pipelines still assign catalytic Ser/Thr kinase activity and EC 2.7.11.1 to KDX1 by family homology. A direct biochemical test (or its documented absence) would settle whether these catalytic annotations should be removed outright rather than flagged as over-annotations, and would clarify whether KDX1 retains any ATP/nucleotide- dependent conformational role.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> In vitro kinase assay with recombinant KDX1 (and active SLT2 as positive control) testing autophosphorylation and phosphorylation of candidate substrates, plus a nucleotide-binding assay.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"Induction was only partially dependent on the Mlp1 pseudokinase (Figure 2), a catalytically inactive paralog of Mpk1 (Kim et al., 2008)."</em> — PMID:20641022</li>
+
+                <li><em>"its pseudokinase paralog (Mlp1) use a noncatalytic mechanism to activate transcription of the FKS2 gene"</em> — PMID:18268013</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The full set of KDX1/Mlp1 direct binding partners and any additional (non-Swi4, non-Rlm1) scaffolding targets are unknown.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span><span class="badge">CURATION</span>
+                <span class="badge">MF_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> KDX1 is documented to bind Swi4 (contributing to SBF-dependent FKS2 transcription) and to physically associate with the MADS-box transcription factor Rlm1, and it appears in the global yeast kinase/phosphatase interaction network. A comprehensive, KDX1-specific interactome distinguishing direct from indirect partners has not been reported.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Identifying KDX1&#39;s direct partners would define whether its scaffolding role extends beyond the Swi4/Swi6 and Rlm1 branches of CWI signaling and could reveal a function not shared with SLT2.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Targeted affinity-purification/proximity-labeling of tagged KDX1 under cell wall stress, with validation of direct interactions.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"We identified a Mpk1-like protein kinase, Mlp1, as an Rlm1-associated protein by using the yeast two-hybrid system."</em> — PMID:9111331</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The non-redundant (unique) biological role of KDX1/Mlp1 relative to SLT2/MPK1 is undefined: no phenotype has been shown to depend on KDX1 with SLT2 intact.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">BP_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> In every characterized context KDX1 is only partially required and functionally overlaps with SLT2; the non-catalytic SBF branch is fully abolished only in an mpk1-delta mlp1-delta double mutant, and KDX1&#39;s own expression depends on the SLT2-&gt;Rlm1 arm, so little KDX1 protein is present unless SLT2 signaling is active.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Whether KDX1 provides genuine redundancy/robustness, dosage amplification, or a distinct stress-specific function determines why the whole-genome-duplication paralog was retained and whether it has any non-overlapping role worth targeting or curating separately from SLT2.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Systematic phenotyping of mlp1-delta (with SLT2 intact) across cell wall and other stresses, and identification of any KDX1-only-dependent transcriptional or phenotypic output.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"all induction was blocked in an mpk1Δ mlp1Δ double mutant, reflecting the partial overlap in function of Mpk1 and Mlp1 in this context."</em> — PMID:20641022</li>
+
+            </ul>
+
+
+        </div>
+
+    </div>
+
+
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Deep Research Sections -->
+
+    <div class="section">
+        <h2 class="section-title">Deep Research</h2>
+
+        <details class="deep-research-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; gap: 1rem;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Falcon</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(KDX1-deep-research-falcon.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="P36005" data-a="DEEP_RESEARCH: Falcon" data-r="" data-act="DEEP_RESEARCH" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This deep research is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This deep research needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+
+                <div class="report-meta">
+
+                    <span class="report-meta-text">Comprehensive Research Report: KDX1/MLP1 (YKL161C) in *Saccharomyces cerevisiae*</span>
+
+
+                    <span class="report-badge">Falcon</span>
+
+
+                    <span class="report-badge">Edison Scientific Literature</span>
+
+
+                    <span class="report-badge">20 citations</span>
+
+
+                    <span class="report-badge">1 artifacts</span>
+
+
+                    <span class="report-meta-text">2026-07-05T01:31:49.581666</span>
+
+
+
+                </div>
+
+
+                <div class="artifact-list">
+
+
+
+                    <div class="artifact-link">
+                        <a href="KDX1-deep-research-falcon_artifacts/artifact-00.md" class="term-link">Edison artifact artifact-00</a>
+                        <span>(text/markdown)</span>
+                    </div>
+
+
+                </div>
+
+                <p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h1 id="comprehensive-research-report-kdx1mlp1-ykl161c-in-saccharomyces-cerevisiae">Comprehensive Research Report: KDX1/MLP1 (YKL161C) in <em>Saccharomyces cerevisiae</em></h1>
+<h2 id="gene-identity-verification">Gene Identity Verification</h2>
+<p>The gene symbol <strong>KDX1</strong> corresponds to the <em>Saccharomyces cerevisiae</em> gene <strong>MLP1</strong> (Mpk1-Like Protein kinase 1), with the systematic name <strong>YKL161C</strong>. The protein is also designated as "Kinase Dead X-talker protein 1" (UniProt: P36005). It belongs to the protein kinase superfamily and contains MAP kinase-like domains (IPR050117, IPR000719), consistent with its identity as a pseudokinase paralog of the Slt2/Mpk1 MAPK in the cell wall integrity (CWI) signaling pathway (levin2011regulationofcell pages 15-16).</p>
+<h2 id="1-primary-function-a-pseudokinase-transcriptional-regulator">1. Primary Function: A Pseudokinase Transcriptional Regulator</h2>
+<p>KDX1/MLP1 encodes a <strong>pseudokinase</strong> — a protein that adopts a kinase-like fold but is catalytically inactive. Despite its annotation as a serine/threonine protein kinase (EC 2.7.11.1), extensive biochemical studies have failed to detect protein kinase activity for Mlp1 (levin2011regulationofcell pages 15-16). The protein lacks several residues recognized as critical for protein kinase catalytic function. Most notably, the conserved Thr residue within the canonical MAPK dual phosphorylation site (Thr-X-Tyr) of the activation loop is replaced by a <strong>Lys residue</strong> in Mlp1, rendering it unable to undergo the dual phosphorylation required for typical MAPK catalytic activation (levin2011regulationofcell pages 15-16).</p>
+<p>Rather than functioning as a kinase, Mlp1 serves as a <strong>noncatalytic transcriptional regulator</strong> in the CWI signaling pathway, where it is redundant with Mpk1/Slt2 specifically for noncatalytic transcriptional functions (levin2011regulationofcell pages 15-16, levin2011regulationofcell pages 16-18). It does not phosphorylate substrates; instead, it regulates gene expression through direct protein-protein interactions at gene promoters and coding regions.</p>
+<h2 id="2-activation-mechanism">2. Activation Mechanism</h2>
+<p>Despite lacking kinase activity, Mlp1 requires activation through phosphorylation to carry out its signaling functions. It is phosphorylated by the upstream MAP kinase kinases (MAPKKs) <strong>Mkk1 and Mkk2</strong> of the CWI pathway (levin2011regulationofcell pages 16-18, levin2011regulationofcell pages 8-9). However, unlike canonical MAPKs that require dual phosphorylation of both Thr and Tyr residues in their activation loop, Mlp1 is activated by <strong>single phosphorylation at Tyr192</strong> (levin2011regulationofcell pages 16-18). This phosphorylation induces an active conformation that is essential for its downstream signaling functions, even though the protein itself does not catalyze phosphotransfer reactions. Like other MAPKs, Mlp1 associates with its targets and regulators through a canonical <strong>D (docking) motif</strong> (levin2011regulationofcell pages 8-9).</p>
+<h2 id="3-role-in-the-cell-wall-integrity-cwi-signaling-pathway">3. Role in the Cell Wall Integrity (CWI) Signaling Pathway</h2>
+<h3 id="31-pathway-context">3.1 Pathway Context</h3>
+<p>The CWI pathway is a MAPK cascade in <em>S. cerevisiae</em> that responds to cell wall damage and other stresses threatening cell integrity. The canonical cascade proceeds from cell surface sensors through Rho1 GTPase → Pkc1 → Bck1 (MAPKKK) → Mkk1/Mkk2 (MAPKKs) → Slt2/Mpk1 (MAPK). Mlp1 functions at the level of the MAPK as a <strong>pseudokinase paralog of Slt2/Mpk1</strong>, receiving the same upstream activating signal from Mkk1/Mkk2 (levin2011regulationofcell pages 15-16, heinisch2018proteinkinasec pages 9-13).</p>
+<h3 id="32-noncatalytic-transcriptional-functions">3.2 Noncatalytic Transcriptional Functions</h3>
+<p>The CWI pathway controls gene expression through two principal transcription factors: <strong>Rlm1</strong> and <strong>SBF (Swi4/Swi6)</strong>. While Rlm1 is activated by direct catalytic phosphorylation by Mpk1, the activation of SBF occurs through a remarkable <strong>noncatalytic mechanism</strong> that both Mpk1 and Mlp1 carry out redundantly (levin2011regulationofcell pages 16-18, levin2011regulationofcell pages 15-16).</p>
+<p>This noncatalytic mechanism involves two essential steps:</p>
+<p><strong>Step 1 — Transcription Initiation:</strong> Activated Mlp1 (or Mpk1) binds to a D motif on the <strong>Swi4</strong> subunit of SBF that is adjacent to the C-terminal Swi6-binding site. This binding relieves the auto-inhibitory intramolecular association within Swi4, allowing it to bind DNA at SBF-binding sites (SCB elements) in the promoters of cell wall stress-activated genes (levin2011regulationofcell pages 16-18). Although Mlp1/Mpk1 substitutes for Swi6 in enabling Swi4 DNA binding, <strong>Swi6 must subsequently be recruited</strong> to the Mlp1–Swi4 complex to form a functional trimeric complex on the promoter. This trimeric Mlp1–Swi4–Swi6 complex is required for recruitment of RNA polymerase II (Pol II) to the promoter (levin2011regulationofcell pages 16-18).</p>
+<p><strong>Step 2 — Antitermination/Transcription Elongation:</strong> After the initiation complex is assembled, Mlp1/Mpk1 moves from the promoter to the coding region of the gene through a "hand-off" from Swi4 to the <strong>Paf1 complex (Paf1C)</strong>, which is associated with the elongating RNA Pol II (levin2011regulationofcell pages 18-19, levin2011regulationofcell pages 16-18). The interaction between Mpk1/Mlp1 and the Paf1 subunit of Paf1C occurs via a D motif in Paf1. This interaction is critical because it <strong>blocks recruitment of the Sen1–Nrd1–Nab3 termination complex</strong> to the elongating polymerase, thereby overcoming transcriptional attenuation that would otherwise lead to premature termination (levin2011regulationofcell pages 18-19). Under non-inducing conditions, a single Nab3-binding site within the FKS2 promoter-proximal region mediates transcriptional attenuation, minimizing FKS2 expression in the absence of stress (levin2011regulationofcell pages 18-19).</p>
+<p>Importantly, this mechanism does <strong>not require kinase catalytic activity</strong> — a mutation in the ATP-binding site of Mpk1 (mpk1-K54R) does not impair FKS2 transcription, and FKS2 expression was actually slightly enhanced in this catalytically inactive mutant (levin2011regulationofcell pages 18-19). However, the active phosphorylated conformation is required: a mutation blocking activation loop phosphorylation (mpk1-TA/YF) abolished transcription (levin2011regulationofcell pages 16-18).</p>
+<h3 id="33-target-genes">3.3 Target Genes</h3>
+<p>Genes under the control of this noncatalytic SBF-dependent pathway branch include <strong>FKS2</strong> (encoding β-1,3-glucan synthase, critical for cell wall biosynthesis), <strong>CHA1</strong>, <strong>YLR042C</strong>, and <strong>YKR013W</strong>, though this is likely not a complete list (levin2011regulationofcell pages 16-18).</p>
+<h2 id="4-transcriptional-regulation-of-mlp1-and-the-positive-feedback-loop">4. Transcriptional Regulation of MLP1 and the Positive Feedback Loop</h2>
+<p>The <em>MLP1</em> gene is itself a transcriptional target of the CWI pathway, creating a biologically significant <strong>positive feedback loop</strong>. Mpk1 catalytically phosphorylates and activates the <strong>Rlm1</strong> transcription factor at two residues (Ser427 and Thr439) within its activation domain (levin2011regulationofcell pages 15-16). Activated Rlm1 then directly induces <em>MLP1</em> expression by binding to at least <strong>two functional Rlm1-binding sites</strong> (BOX1 and BOX2) in the <em>MLP1</em> promoter (sanz2012chromatinremodelingby pages 5-7, sanz2012chromatinremodelingby pages 9-10). This transcriptional activation requires coordination between Rlm1 and the <strong>SWI/SNF chromatin remodeling complex</strong>: upon cell wall stress, Slt2 activates Rlm1, which recruits SWI/SNF to the <em>MLP1</em> promoter, leading to nucleosome displacement and histone H3 eviction that expose the Rlm1-binding sites (sanz2012chromatinremodelingby pages 9-10, sanz2012chromatinremodelingby pages 7-8). Additionally, the SAGA complex cooperates with SWI/SNF for full gene expression at CWI-responsive genes (sanz2012chromatinremodelingby pages 5-7).</p>
+<p>Because <em>MLP1</em> encodes a protein that then reinforces the noncatalytic transcriptional branch of the pathway, this creates a feedback loop that <strong>selectively amplifies the SBF-dependent transcriptional output</strong> (levin2011regulationofcell pages 15-16). <em>MLP1</em> is one of the most strongly induced genes in the CWI pathway: in response to cell wall damage, <em>MLP1</em> transcript levels increase approximately <strong>4.2-fold at 2 hours, 9.4-fold at 4 hours</strong>, and up to <strong>24.4-fold</strong> upon zymolyase treatment (garcia2004theglobaltranscriptional pages 3-4). At the protein level, Mlp1 levels increase by approximately <strong>~100-fold</strong> during cell wall stress (levin2011regulationofcell pages 15-16).</p>
+<p>The robustness of <em>MLP1</em> induction has made the <em>MLP1</em> promoter a widely used <strong>reporter system for CWI pathway activation</strong>. Fusions of the <em>MLP1</em> promoter Rlm1-binding elements to minimal promoter-lacZ constructs create functional reporters that are strongly induced by cell wall stress agents (sanz2012chromatinremodelingby pages 5-7, sellersmoya2021clotrimazoleinducedoxidativestress pages 10-12).</p>
+<h2 id="5-subcellular-localization">5. Subcellular Localization</h2>
+<p>The site of Mlp1 function is primarily <strong>nuclear</strong>, at the chromatin of cell wall stress-responsive gene promoters and coding regions. Chromatin immunoprecipitation (ChIP) experiments have demonstrated that activated Mlp1 (like Mpk1) forms complexes with Swi4 at SBF-binding sites in the promoters of target genes, then moves to coding regions during transcription elongation (levin2011regulationofcell pages 16-18). By analogy with Mpk1 — which is predominantly nuclear under non-stress conditions but can relocalize to the cytoplasm and to sites of polarized cell growth upon stress (levin2005cellwallintegrity pages 13-14, levin2005cellwallintegrity pages 2-3) — Mlp1 likely also shuttles between nuclear and cytoplasmic compartments. Activated Mlp1 can also mediate <strong>Swi6 recruitment to the nucleus</strong> through a noncatalytic mechanism, further supporting its nuclear function during stress-induced transcription (levin2011regulationofcell pages 18-19).</p>
+<p>In addition, <em>MLP1</em> mRNA itself is subject to post-transcriptional regulation: during cell wall stress, <em>MLP1</em> mRNA becomes concentrated in cytoplasmic <strong>P-bodies</strong> (processing bodies) that colocalize with the decapping factor Dcp2, suggesting regulated mRNA turnover or storage as part of the stress response (garcia2019signallingthroughthe pages 7-8).</p>
+<h2 id="6-broader-stress-responses-and-applications">6. Broader Stress Responses and Applications</h2>
+<p>Beyond the classical cell wall stress response to agents such as Congo red, Calcofluor white, and zymolyase, Mlp1/<em>MLP1</em> induction has been documented in response to <strong>clotrimazole</strong> (an imidazole antifungal). Even minimal induction of the <em>MLP1</em> promoter by clotrimazole is sufficient to activate an <strong>Integrity Pathway Activation Circuit (IPAC)</strong> that amplifies CWI pathway signals and renders cells hypersensitive to CWI-activating agents (sellersmoya2021clotrimazoleinducedoxidativestress pages 10-12). This highlights <em>MLP1</em> as a functional amplifier of CWI stress signaling circuitry beyond classical cell wall-damaging agents.</p>
+<h2 id="7-evolutionary-conservation">7. Evolutionary Conservation</h2>
+<p>The noncatalytic transcriptional mechanism carried out by Mpk1/Mlp1 is evolutionarily conserved. Both noncatalytic functions of Mpk1/Mlp1 — transcription initiation at SBF-dependent promoters and antitermination via the Paf1C — are <strong>complemented by human ERK5 MAPK</strong>, and the MAPK–Paf1 interaction is conserved between yeast Mpk1 and human ERK5/Paf1 (levin2011regulationofcell pages 18-19). This conservation underscores the fundamental biological importance of noncatalytic MAPK signaling mechanisms.</p>
+<h2 id="summary">Summary</h2>
+<p>The following table provides a consolidated overview of the key properties and evidence for KDX1/MLP1:</p>
+<table>
+<thead>
+<tr>
+<th>Property</th>
+<th>Summary</th>
+<th>Evidence</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Gene / protein identity</td>
+<td><strong>KDX1</strong> in the prompt matches the budding yeast gene <strong>MLP1 / KDX1 / YKL161C</strong> encoding <strong>Mpk1-like protein kinase 1</strong>, a kinase-dead MAPK-like protein in <em>Saccharomyces cerevisiae</em> S288c. It is described as a paralog of <strong>Slt2/Mpk1</strong> in the cell wall integrity (CWI) pathway.</td>
+<td>(levin2011regulationofcell pages 15-16, levin2011regulationofcell pages 8-9)</td>
+</tr>
+<tr>
+<td>Organism</td>
+<td><strong>Saccharomyces cerevisiae</strong> (baker’s yeast), strain background S288c in the cited reviews and functional studies.</td>
+<td>(levin2011regulationofcell pages 15-16)</td>
+</tr>
+<tr>
+<td>Primary function</td>
+<td>Mlp1 is <strong>not a catalytically active MAP kinase</strong>; instead, it acts as a <strong>pseudokinase transcriptional regulator</strong> that functions redundantly with Mpk1 for the <strong>noncatalytic branch</strong> of CWI signaling, especially activation of <strong>SBF (Swi4/Swi6)-dependent</strong> cell wall stress genes.</td>
+<td>(levin2011regulationofcell pages 15-16, levin2011regulationofcell pages 16-18, levin2011regulationofcell pages 8-9)</td>
+</tr>
+<tr>
+<td>Enzymatic activity / substrate specificity</td>
+<td>Despite UniProt kinase annotation, the literature indicates <strong>no demonstrable protein kinase catalytic activity</strong> for Mlp1; therefore, no bona fide catalytic substrate specificity has been established. Its biologically supported role is <strong>signaling by protein interaction rather than phosphotransfer</strong>.</td>
+<td>(levin2011regulationofcell pages 8-9, levin2011regulationofcell pages 15-16)</td>
+</tr>
+<tr>
+<td>Pseudokinase-defining features</td>
+<td>Mlp1 lacks several residues critical for kinase catalysis, and the canonical MAPK activation-loop <strong>Thr-X-Tyr</strong> motif is altered: the <strong>Thr is replaced by Lys</strong>. These changes explain why it is considered a <strong>pseudokinase</strong> / “kinase-dead” paralog rather than a true MAPK.</td>
+<td>(levin2011regulationofcell pages 15-16)</td>
+</tr>
+<tr>
+<td>Activation mechanism</td>
+<td>Mlp1 is activated downstream of the CWI MAPKKs <strong>Mkk1/Mkk2</strong>. Unlike canonical MAPKs, it is activated by <strong>single phosphorylation at Tyr192</strong>, not by dual Thr/Tyr phosphorylation. Its signaling output requires the <strong>phosphorylated active conformation</strong>, even though it lacks catalytic activity.</td>
+<td>(levin2011regulationofcell pages 16-18)</td>
+</tr>
+<tr>
+<td>Relationship to Slt2/Mpk1</td>
+<td>Mlp1 is a <strong>pseudokinase paralog</strong> of <strong>Slt2/Mpk1</strong>. It is largely redundant with Mpk1 for <strong>noncatalytic transcriptional functions</strong>, while Mpk1 additionally has catalytic functions such as phosphorylation of other substrates. Mlp1 therefore expands or reinforces the transcriptional arm of the CWI pathway rather than replacing all Slt2 functions.</td>
+<td>(levin2011regulationofcell pages 15-16, levin2011regulationofcell pages 16-18, heinisch2018proteinkinasec pages 9-13)</td>
+</tr>
+<tr>
+<td>Key interaction: Swi4</td>
+<td>Activated Mlp1 binds <strong>Swi4</strong> at SBF-regulated promoters through MAPK docking interactions, relieving Swi4 autoinhibition and allowing promoter occupancy at cell wall stress genes such as <strong>FKS2</strong>.</td>
+<td>(levin2011regulationofcell pages 16-18)</td>
+</tr>
+<tr>
+<td>Key interaction: Swi6</td>
+<td>Mlp1 participates with Swi4 and Swi6 in a <strong>trimeric promoter complex</strong> needed for SBF-mediated transcription. Swi6 is required for productive transcriptional activation and RNA Pol II recruitment.</td>
+<td>(levin2011regulationofcell pages 16-18)</td>
+</tr>
+<tr>
+<td>Key interaction: Paf1 / Paf1C</td>
+<td>After promoter recruitment, Mpk1/Mlp1 move into coding regions and engage the <strong>Paf1 complex (Paf1C)</strong> to support transcription elongation and <strong>prevent premature Sen1-Nrd1-Nab3-dependent termination</strong>. This is a core part of the noncatalytic mechanism driving <strong>FKS2</strong> expression.</td>
+<td>(levin2011regulationofcell pages 16-18, levin2011regulationofcell pages 18-19)</td>
+</tr>
+<tr>
+<td>Key interaction: Mkk1/Mkk2</td>
+<td>The upstream MAPKKs <strong>Mkk1/Mkk2</strong> are the activating kinases for both Mpk1 and Mlp1 in the CWI cascade; for Mlp1 the relevant documented activating event is <strong>Tyr192 phosphorylation</strong>.</td>
+<td>(levin2011regulationofcell pages 16-18)</td>
+</tr>
+<tr>
+<td>Key interaction: Rlm1</td>
+<td><strong>Rlm1</strong> is primarily an upstream transcription factor relative to MLP1 gene expression: Mpk1 activates Rlm1, and <strong>Rlm1 directly induces MLP1 transcription</strong>. Earlier transcriptomic work also noted MLP1 among SLT2-pathway genes and reported interaction context with Rlm1.</td>
+<td>(garcia2004theglobaltranscriptional pages 3-4, sanz2012chromatinremodelingby pages 5-7, sanz2012chromatinremodelingby pages 9-10, levin2011regulationofcell pages 15-16)</td>
+</tr>
+<tr>
+<td>Major regulated / associated target genes</td>
+<td>Best-characterized SBF/CWI targets supported for Mpk1/Mlp1 noncatalytic control include <strong>FKS2</strong>, and reported pathway-branch genes include <strong>CHA1, YLR042C, and YKR013W</strong>. MLP1 itself is also a strongly induced <strong>Rlm1 target gene</strong> in cell wall stress.</td>
+<td>(levin2011regulationofcell pages 16-18, levin2011regulationofcell pages 15-16)</td>
+</tr>
+<tr>
+<td>Subcellular localization / site of action</td>
+<td>Direct evidence places Mlp1 at <strong>promoters and coding regions</strong> of stress-induced genes during transcription. By analogy with the coupled Mpk1 system, the relevant functional compartment is largely <strong>nuclear chromatin-associated transcription complexes</strong>, though Mpk1 itself also shuttles between nucleus and cytoplasm under stress.</td>
+<td>(levin2011regulationofcell pages 16-18, levin2005cellwallintegrity pages 13-14, levin2005cellwallintegrity pages 2-3, levin2011regulationofcell pages 18-19)</td>
+</tr>
+<tr>
+<td>Biological pathway</td>
+<td>Mlp1 functions in the <strong>cell wall integrity (CWI) MAPK pathway</strong>, especially the transcriptional response to cell wall damage and related stresses. It contributes to expression of genes needed for <strong>cell wall remodeling, integrity maintenance, and stress adaptation</strong>.</td>
+<td>(levin2011regulationofcell pages 15-16, heinisch2018proteinkinasec pages 9-13)</td>
+</tr>
+<tr>
+<td>Positive-feedback role in CWI signaling</td>
+<td><strong>MLP1 is induced by Rlm1</strong>, which is activated by Mpk1. Because Mlp1 then reinforces the <strong>noncatalytic transcriptional branch</strong> of the pathway, this creates a <strong>positive feedback loop</strong> that selectively amplifies CWI transcriptional output.</td>
+<td>(levin2011regulationofcell pages 15-16)</td>
+</tr>
+<tr>
+<td>Induction magnitude during cell wall stress</td>
+<td>MLP1 is one of the most strongly induced CWI-pathway genes. Reported induction after transient cell wall damage reached about <strong>4.2-fold at 2 h</strong>, <strong>9.4-fold at 4 h</strong>, and <strong>24.4-fold</strong> after zymolyase treatment in one transcriptomic study; review literature further notes that <strong>Mlp1 protein levels increase ~100-fold</strong> under cell wall stress.</td>
+<td>(garcia2004theglobaltranscriptional pages 3-4, levin2011regulationofcell pages 15-16)</td>
+</tr>
+<tr>
+<td>Promoter architecture / reporter use</td>
+<td>The <strong>MLP1 promoter</strong> contains at least <strong>two functional Rlm1-binding sites</strong> and is stress responsive in reporter assays. Because of its robust induction, it has been used as a <strong>readout of CWI pathway activation</strong>.</td>
+<td>(sanz2012chromatinremodelingby pages 5-7, sanz2012chromatinremodelingby pages 9-10, sanz2012chromatinremodelingby pages 7-8)</td>
+</tr>
+<tr>
+<td>Recent / applied context</td>
+<td>In newer work, low-level <strong>MLP1 induction</strong> was sufficient to engage an <strong>Integrity Pathway Activation Circuit (IPAC)</strong> that amplifies signaling in response to <strong>clotrimazole</strong>, highlighting MLP1 as a practical amplifier/readout of CWI stress circuitry beyond classic wall-damaging agents.</td>
+<td>(sellersmoya2021clotrimazoleinducedoxidativestress pages 10-12)</td>
+</tr>
+<tr>
+<td>Evolutionary perspective</td>
+<td>The unusual <strong>noncatalytic transcriptional mechanism</strong> carried out by Mpk1/Mlp1 is functionally conserved enough that yeast studies found complementation by <strong>human ERK5</strong>, and the MAPK–Paf1 interaction is evolutionarily conserved.</td>
+<td>(levin2011regulationofcell pages 18-19)</td>
+</tr>
+</tbody>
+</table>
+<p><em>Table: This table summarizes the verified identity, molecular function, pseudokinase features, pathway role, interactions, localization, and stress-inducible regulation of yeast KDX1/MLP1 (YKL161C). It is useful as a compact evidence map for the gene’s primary annotation in the cell wall integrity pathway.</em></p>
+<p>In summary, KDX1/MLP1 (YKL161C) encodes a pseudokinase in <em>Saccharomyces cerevisiae</em> that, despite its kinase-like domain architecture, functions exclusively through noncatalytic mechanisms in the cell wall integrity MAPK signaling pathway. Activated by single tyrosine phosphorylation via the MAPKKs Mkk1/Mkk2, Mlp1 acts redundantly with the catalytically active MAPK Slt2/Mpk1 to drive SBF-dependent transcription of cell wall stress genes through a two-step mechanism involving transcription initiation (via interaction with Swi4/Swi6) and antitermination (via interaction with the Paf1 complex). Its expression is strongly induced by cell wall stress through an Rlm1-dependent transcriptional mechanism requiring SWI/SNF-mediated chromatin remodeling, establishing a positive feedback loop that selectively amplifies the noncatalytic transcriptional branch of the CWI pathway. KDX1/MLP1 thus represents a paradigmatic example of a pseudokinase with a precisely defined biological role: it functions as a stress-inducible transcriptional cofactor that amplifies cell wall integrity signaling output.</p>
+<p>References</p>
+<ol>
+<li>
+<p>(levin2011regulationofcell pages 15-16): David E Levin. Regulation of cell wall biogenesis in saccharomyces cerevisiae: the cell wall integrity signaling pathway. Genetics, 189:1145-1175, Dec 2011. URL: https://doi.org/10.1534/genetics.111.128264, doi:10.1534/genetics.111.128264. This article has 1081 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(levin2011regulationofcell pages 16-18): David E Levin. Regulation of cell wall biogenesis in saccharomyces cerevisiae: the cell wall integrity signaling pathway. Genetics, 189:1145-1175, Dec 2011. URL: https://doi.org/10.1534/genetics.111.128264, doi:10.1534/genetics.111.128264. This article has 1081 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(levin2011regulationofcell pages 8-9): David E Levin. Regulation of cell wall biogenesis in saccharomyces cerevisiae: the cell wall integrity signaling pathway. Genetics, 189:1145-1175, Dec 2011. URL: https://doi.org/10.1534/genetics.111.128264, doi:10.1534/genetics.111.128264. This article has 1081 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(heinisch2018proteinkinasec pages 9-13): Jürgen J Heinisch and Rosaura Rodicio. Protein kinase c in fungi-more than just cell wall integrity. FEMS microbiology reviews, Oct 2018. URL: https://doi.org/10.1093/femsre/fux051, doi:10.1093/femsre/fux051. This article has 112 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(levin2011regulationofcell pages 18-19): David E Levin. Regulation of cell wall biogenesis in saccharomyces cerevisiae: the cell wall integrity signaling pathway. Genetics, 189:1145-1175, Dec 2011. URL: https://doi.org/10.1534/genetics.111.128264, doi:10.1534/genetics.111.128264. This article has 1081 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(sanz2012chromatinremodelingby pages 5-7): A. Belén Sanz, Raúl García, Jose Manuel Rodríguez-Peña, Sonia Díez-Muñiz, César Nombela, Craig L. Peterson, and Javier Arroyo. Chromatin remodeling by the swi/snf complex is essential for transcription mediated by the yeast cell wall integrity mapk pathway. Molecular Biology of the Cell, 23:2805-2817, Jul 2012. URL: https://doi.org/10.1091/mbc.e12-04-0278, doi:10.1091/mbc.e12-04-0278. This article has 88 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(sanz2012chromatinremodelingby pages 9-10): A. Belén Sanz, Raúl García, Jose Manuel Rodríguez-Peña, Sonia Díez-Muñiz, César Nombela, Craig L. Peterson, and Javier Arroyo. Chromatin remodeling by the swi/snf complex is essential for transcription mediated by the yeast cell wall integrity mapk pathway. Molecular Biology of the Cell, 23:2805-2817, Jul 2012. URL: https://doi.org/10.1091/mbc.e12-04-0278, doi:10.1091/mbc.e12-04-0278. This article has 88 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(sanz2012chromatinremodelingby pages 7-8): A. Belén Sanz, Raúl García, Jose Manuel Rodríguez-Peña, Sonia Díez-Muñiz, César Nombela, Craig L. Peterson, and Javier Arroyo. Chromatin remodeling by the swi/snf complex is essential for transcription mediated by the yeast cell wall integrity mapk pathway. Molecular Biology of the Cell, 23:2805-2817, Jul 2012. URL: https://doi.org/10.1091/mbc.e12-04-0278, doi:10.1091/mbc.e12-04-0278. This article has 88 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(garcia2004theglobaltranscriptional pages 3-4): Raúl García, Clara Bermejo, Cecilia Grau, Rosa Pérez, Jose Manuel Rodríguez-Peña, Jean Francois, César Nombela, and Javier Arroyo. The global transcriptional response to transient cell wall damage in saccharomyces cerevisiae and its regulation by the cell integrity signaling pathway*. Journal of Biological Chemistry, 279:15183-15195, Apr 2004. URL: https://doi.org/10.1074/jbc.m312954200, doi:10.1074/jbc.m312954200. This article has 418 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(sellersmoya2021clotrimazoleinducedoxidativestress pages 10-12): Ángela Sellers-Moya, Marcos Nuévalos, María Molina, and Humberto Martín. Clotrimazole-induced oxidative stress triggers novel yeast pkc1-independent cell wall integrity mapk pathway circuitry. Journal of Fungi, 7:647, Aug 2021. URL: https://doi.org/10.3390/jof7080647, doi:10.3390/jof7080647. This article has 26 citations.</p>
+</li>
+<li>
+<p>(levin2005cellwallintegrity pages 13-14): David E. Levin. Cell wall integrity signaling in saccharomyces cerevisiae. Microbiology and Molecular Biology Reviews, 69:262-291, Jun 2005. URL: https://doi.org/10.1128/mmbr.69.2.262-291.2005, doi:10.1128/mmbr.69.2.262-291.2005. This article has 1478 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(levin2005cellwallintegrity pages 2-3): David E. Levin. Cell wall integrity signaling in saccharomyces cerevisiae. Microbiology and Molecular Biology Reviews, 69:262-291, Jun 2005. URL: https://doi.org/10.1128/mmbr.69.2.262-291.2005, doi:10.1128/mmbr.69.2.262-291.2005. This article has 1478 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(garcia2019signallingthroughthe pages 7-8): Raúl García, Verónica Pulido, Sara Orellana-Muñoz, César Nombela, Carlos R. Vázquez de Aldana, José M. Rodríguez-Peña, and Javier Arroyo. Signalling through the yeast mapk cell wall integrity pathway controls p-body assembly upon cell wall stress. Scientific Reports, Feb 2019. URL: https://doi.org/10.1038/s41598-019-40112-9, doi:10.1038/s41598-019-40112-9. This article has 40 citations and is from a peer-reviewed journal.</p>
+</li>
+</ol>
+<h2 id="artifacts">Artifacts</h2>
+<ul>
+<li><a href="KDX1-deep-research-falcon_artifacts/artifact-00.md">Edison artifact artifact-00</a></li>
+</ul>
+<h2 id="citations">Citations</h2>
+<ol>
+<li>levin2011regulationofcell pages 15-16</li>
+<li>levin2011regulationofcell pages 16-18</li>
+<li>levin2011regulationofcell pages 8-9</li>
+<li>levin2011regulationofcell pages 18-19</li>
+<li>sanz2012chromatinremodelingby pages 5-7</li>
+<li>garcia2004theglobaltranscriptional pages 3-4</li>
+<li>garcia2019signallingthroughthe pages 7-8</li>
+<li>sellersmoya2021clotrimazoleinducedoxidativestress pages 10-12</li>
+<li>heinisch2018proteinkinasec pages 9-13</li>
+<li>sanz2012chromatinremodelingby pages 9-10</li>
+<li>sanz2012chromatinremodelingby pages 7-8</li>
+<li>levin2005cellwallintegrity pages 13-14</li>
+<li>levin2005cellwallintegrity pages 2-3</li>
+<li>https://doi.org/10.1534/genetics.111.128264,</li>
+<li>https://doi.org/10.1093/femsre/fux051,</li>
+<li>https://doi.org/10.1091/mbc.e12-04-0278,</li>
+<li>https://doi.org/10.1074/jbc.m312954200,</li>
+<li>https://doi.org/10.3390/jof7080647,</li>
+<li>https://doi.org/10.1128/mmbr.69.2.262-291.2005,</li>
+<li>https://doi.org/10.1038/s41598-019-40112-9,</li>
+</ol>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(KDX1-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="P36005" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="kdx1-mlp1-ykl161c-curation-notes">KDX1 (MLP1 / YKL161C) — curation notes</h1>
+<p><em>S. cerevisiae</em> KDX1 (systematic name YKL161C; commonly called MLP1 in the primary literature).<br />
+UniProt P36005. This is a poorly-characterized ("dark") paralog of the cell-wall-integrity (CWI)<br />
+MAP kinase SLT2/MPK1. This journal separates what is genuinely KNOWN about <strong>KDX1/Mlp1 itself</strong><br />
+from what is known about the well-studied paralog <strong>SLT2/MPK1</strong>, and records inline provenance.</p>
+<h2 id="identity-and-nomenclature">Identity and nomenclature</h2>
+<ul>
+<li>SGD standard name: <strong>KDX1</strong>; the primary literature almost always uses <strong>MLP1</strong><br />
+  ("Mpk1-like protein kinase 1"). Systematic name <strong>YKL161C</strong> [uniprot P36005].</li>
+<li>UniProt AltName is telling: <strong>"Kinase dead X-talker protein 1"</strong> — the "KDX" of the SGD name<br />
+  literally encodes "<strong>K</strong>inase <strong>d</strong>ea<strong>d</strong> <strong>X</strong>-talker", i.e. the community regards it as a<br />
+  catalytically dead (pseudo)kinase that cross-talks with signaling/transcription machinery<br />
+  [file:yeast/KDX1/KDX1-uniprot.txt "AltName: Full=Kinase dead X-talker protein 1"].</li>
+<li>Paralog of <strong>SLT2/MPK1</strong> (UniProt Q00772). KDX1 and SLT2 arose from the whole-genome<br />
+  duplication; both are terminal-MAPK-like components of CWI signaling.</li>
+</ul>
+<h2 id="domain-sequence-analysis-done-inline-pseudokinase-determination">Domain / sequence analysis (done inline; pseudokinase determination)</h2>
+<p>The protein is 433 aa with a single protein-kinase domain (UniProt DOMAIN 23–318). I aligned<br />
+the three catalytic motifs of KDX1 (P36005) against its active paralog SLT2/MPK1 (Q00772);<br />
+the two align residue-for-residue at each anchor (both HRD-loop at position 151, DFG at ~171):</p>
+<table>
+<thead>
+<tr>
+<th>Catalytic element (subdomain)</th>
+<th>SLT2/MPK1 (active)</th>
+<th>KDX1/Mlp1</th>
+<th>Interpretation</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Gly-rich P-loop (I)</td>
+<td>GHGAYGIV (G30…)</td>
+<td>GRGSHS (G30, G32)</td>
+<td>Gly-rich loop present</td>
+</tr>
+<tr>
+<td>β3 VAIK lysine (II)</td>
+<td>VAIK<strong>K</strong> (K54/55)</td>
+<td>VAIR<strong>K</strong> (R54, <strong>K55</strong>)</td>
+<td>The invariant ATP-anchoring Lys is present (UniProt BINDING K55)</td>
+</tr>
+<tr>
+<td><strong>HRD catalytic loop (VIb)</strong></td>
+<td><strong>H</strong>R<strong>D</strong>LKPGN (H151-R152-D153)</td>
+<td><strong>H</strong>C<strong>D</strong>LKPKN (H151-<strong>C152</strong>-D153)</td>
+<td><strong>HRD→HCD</strong>: the catalytic-loop Arg is lost; the catalytic Asp <strong>D153 is retained</strong> (UniProt ACT_SITE 153 "Proton acceptor")</td>
+</tr>
+<tr>
+<td><strong>DFG Mg²⁺-binding (VII)</strong></td>
+<td>C<strong>D</strong>FGLAR (<strong>D171</strong>-F172-G173)</td>
+<td>C<strong>N</strong>FGLSC (<strong>N171</strong>-F172-G173)</td>
+<td><strong>DFG→NFG</strong>: the Mg²⁺-chelating Asp is replaced by Asn — a canonical pseudokinase-defining substitution</td>
+</tr>
+<tr>
+<td>MAPK activation-loop T-x-Y</td>
+<td>LT<strong>E</strong>Y (Thr-Glu-Tyr dual phosphoacceptor)</td>
+<td><em>absent</em> (no TxY at the aligned position)</td>
+<td>The MAPK-defining TEY dual-phosphorylation motif is <strong>not present</strong> in KDX1</td>
+</tr>
+</tbody>
+</table>
+<p><strong>Conclusion (inline domain reasoning):</strong> KDX1/Mlp1 is a <strong>degenerate protein-kinase-fold<br />
+protein / pseudokinase</strong>. The DFG Asp→Asn substitution removes the essential Mg²⁺-coordinating<br />
+residue, and the HRD Arg (which orients the catalytic loop) is also lost. Although the fold and<br />
+the catalytic Asp (D153) are retained, loss of the DFG aspartate is on its own strongly<br />
+predictive of loss of Mg-ATP–dependent phosphotransfer. In addition, the MAPK TEY<br />
+activation-loop dual-phosphorylation motif is absent, so KDX1 cannot be activated as a canonical<br />
+MAP kinase the way SLT2 is. This structural prediction is <strong>directly confirmed by the<br />
+literature</strong>, which repeatedly and explicitly calls Mlp1 a "catalytically inactive pseudokinase"<br />
+(see below). UniProt still carries EC 2.7.11.1 and Ser/Thr-kinase MF terms by family homology<br />
+(PROSITE PRU00159), but these are family-propagated, not KDX1-specific evidence.</p>
+<p>NB: UniProt annotates K55, not K54, as the ATP-binding Lys; the alignment above shows SLT2 has<br />
+the classic "VAIKK" (two lysines) whereas KDX1 has "VAIRK", but the functionally invariant β3<br />
+lysine is conserved in both. So the ATP-binding lysine is not the degenerate element; the DFG<br />
+Asp and HRD Arg are.</p>
+<h2 id="what-is-known-about-kdx1mlp1-with-provenance">What is KNOWN about KDX1/Mlp1 (with provenance)</h2>
+<ol>
+<li><strong>Mlp1 is a catalytically inactive pseudokinase paralog of Mpk1/Slt2.</strong> Stated explicitly<br />
+   in multiple Levin-lab papers:</li>
+<li><a href="https://pubmed.ncbi.nlm.nih.gov/18268013" title="We show that the MAPK of this pathway (Mpk1) and its pseudokinase paralog (Mlp1) use a noncatalytic mechanism to activate transcription of the FKS2 gene.">PMID:18268013</a></li>
+<li><a href="https://pubmed.ncbi.nlm.nih.gov/20641022" title="Induction was only partially dependent on the Mlp1 pseudokinase (Figure 2), a catalytically inactive paralog of Mpk1 (Kim et al., 2008).">PMID:20641022</a></li>
+<li>
+<p><a href="https://pubmed.ncbi.nlm.nih.gov/35420390" title="the Swi4/Swi6 activation is noncatalytic and triggered by the binding of phosphorylated forms of both Slt2 and a catalytically inactive pseudokinase (Mlp1).">PMID:35420390</a></p>
+</li>
+<li>
+<p><strong>Mlp1 acts non-catalytically with SBF (Swi4/Swi6) to drive FKS2 (and related genes)<br />
+   transcription under cell wall stress.</strong> Activated (phosphorylated) Mpk1 <em>or</em> Mlp1 binds Swi4<br />
+   and confers DNA-binding ability, then recruits Swi6.</p>
+</li>
+<li><a href="https://pubmed.ncbi.nlm.nih.gov/18268013" title="Activated (phosphorylated) Mpk1 and Mlp1 were detected in a complex with Swi4 and Swi6 at the FKS2 promoter.">PMID:18268013</a></li>
+<li><a href="https://pubmed.ncbi.nlm.nih.gov/20641022" title="the binding of activated (phosphorylated) Mpk1, or its pseudokinase paralog, Mlp1, to the Swi4 transcription factor. This dimer binds to the FKS2 promoter, but requires the further binding of the Swi6 transcriptional activator for transcriptional initiation.">PMID:20641022</a></li>
+<li>
+<p>The same non-catalytic mechanism drives CHA1, YKR013w, YLR042c <a href="https://pubmed.ncbi.nlm.nih.gov/20641022" title="a common mechanism that involves activation of Mpk1 and Mlp1 to engage Swi4 and Swi6.">PMID:20641022</a>.</p>
+</li>
+<li>
+<p><strong>Mlp1 is itself a transcriptional target of the CWI pathway (Mpk1→Rlm1), i.e. its<br />
+   expression is induced by cell wall stress</strong>, which is why it is only partially required<br />
+   (little Mlp1 present unless the pathway is on).</p>
+</li>
+<li><a href="https://pubmed.ncbi.nlm.nih.gov/20641022" title="The greater dependence on Mpk1 over Mlp1 results from the fact that MLP1 is transcriptionally induced by Mpk1 through the Rlm1 factor (Jung and Levin, 1999; Jung et al., 2002). Therefore, in the absence of Mpk1, very little Mlp1 is present">PMID:20641022</a>.</li>
+<li>
+<p>Mlp1 protein "accumulated in large amounts when cell wall integrity was compromised" and is "almost undetectable under normal growth conditions" — the basis of the MLP1-promoter cell-wall-stress biosensor <a href="https://pubmed.ncbi.nlm.nih.gov/18055054" title="One of these activated genes, namely MLP1/YKL161c, is an ideal indicator of cell wall perturbations, Mlp1p, being almost undetectable under normal growth conditions, accumulated in large amounts when cell wall integrity was compromised.">PMID:18055054</a>.</p>
+</li>
+<li>
+<p><strong>Mlp1 physically associates with the transcription factor Rlm1</strong> and genetically<br />
+   contributes to Rlm1-dependent output; the original identification was as an Rlm1-associated<br />
+   protein in a two-hybrid screen. The 1997 paper carefully calls it a "MAP kinase-like kinase"<br />
+   (not a kinase) and shows genetic additivity with mpk1Δ.</p>
+</li>
+<li><a href="https://pubmed.ncbi.nlm.nih.gov/9111331" title="We identified a Mpk1-like protein kinase, Mlp1, as an Rlm1-associated protein by using the yeast two-hybrid system.">PMID:9111331</a></li>
+<li><a href="https://pubmed.ncbi.nlm.nih.gov/9111331" title="the activity of Rlm1 is regulated independently by Mpk1 MAP kinase and the Mlp1 MAP kinase-like kinase.">PMID:9111331</a></li>
+<li><a href="https://pubmed.ncbi.nlm.nih.gov/9111331" title="Overexpression of MLP1 suppresses the caffeine-sensitive phenotype of the bck1 delta mutation.">PMID:9111331</a></li>
+<li>
+<p>UniProt SUBUNIT: "Interacts with RLM1" [uniprot P36005, ECO:0000269|PubMed:9111331].</p>
+</li>
+<li>
+<p><strong>Mlp1 functionally partially overlaps with (is redundant with) Mpk1 in the non-catalytic<br />
+   SBF branch</strong>; loss of both, but not either alone, abolishes non-catalytic FKS2/CHA1/…<br />
+   induction. <a href="https://pubmed.ncbi.nlm.nih.gov/20641022" title="all induction was blocked in an mpk1Δ mlp1Δ double mutant, reflecting the partial overlap in function of Mpk1 and Mlp1 in this context.">PMID:20641022</a></p>
+</li>
+<li>
+<p><strong>Mlp1 appears in a global kinase/phosphatase interaction (KPI) network</strong> (large-scale<br />
+   MS/AP-MS study), the basis for the ISS MF annotation transferred from Slt2.<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/20489023">PMID:20489023</a> (abstract-only; the SGD ISS annotation GO:0004674 with:SGD:S000001072<br />
+   (=SLT2) is a family/paralog inference from Slt2, NOT direct demonstration of KDX1 catalysis.)</p>
+</li>
+</ol>
+<h2 id="what-is-not-known-about-kdx1mlp1-knowledge-gaps">What is NOT known about KDX1/Mlp1 (knowledge gaps)</h2>
+<ul>
+<li><strong>Does Mlp1 have any residual catalytic (kinase) activity in vivo?</strong> The consensus is NO<br />
+  (pseudokinase; DFG→NFG; the community name is "kinase dead"). No study demonstrates<br />
+  Mlp1-catalyzed phosphotransfer on a physiological substrate. The UniProt EC 2.7.11.1 /<br />
+  Ser-Thr-kinase / ATP-binding annotations are family-homology propagations. (Whether it even<br />
+  binds ATP/nucleotide is untested; the β3 Lys is present, so ATP binding is not excluded, but<br />
+  Mg-ATP catalysis is predicted lost.)</li>
+<li><strong>What are Mlp1's direct partners/substrates beyond Swi4 and Rlm1?</strong> Its non-catalytic role<br />
+  is a scaffold/adaptor at SBF-dependent promoters, but a complete interaction/target set is<br />
+  unknown.</li>
+<li><strong>What is Mlp1's non-redundant (unique) role vs Mpk1?</strong> In every characterized context Mlp1<br />
+  is only <em>partially</em> required and overlaps with Mpk1; a phenotype uniquely dependent on Mlp1<br />
+  (with Mpk1 intact) has not been clearly defined. mlp1Δ single mutants have subtle phenotypes.</li>
+<li><strong>The cell-cycle / CDK-holoenzyme IBA annotations</strong> (G1/S, G2/M, cyclin-dependent kinase<br />
+  holoenzyme, CDK activity) are phylogenetic propagations from the broad PTHR24055 MAPK/CDK<br />
+  family tree and are NOT supported by any KDX1-specific experiment; there is no evidence KDX1<br />
+  is a cell-cycle CDK. These are over-annotations for this pseudokinase.</li>
+</ul>
+<h2 id="annotation-review-reasoning-summary">Annotation-review reasoning summary</h2>
+<ul>
+<li>MF kinase terms (protein kinase activity, protein Ser/Thr kinase activity ×2, protein serine<br />
+  kinase activity, cyclin-dependent kinase activity): all propagated (IEA InterPro/ARBA/RHEA/EC,<br />
+  ISS from Slt2, IBA). Given the pseudokinase evidence, these are over-annotations →<br />
+  MARK_AS_OVER_ANNOTATED (or MODIFY toward a non-catalytic MF). Not REMOVE outright for the<br />
+  family-level ones since the fold is real, but the catalytic claim is not KDX1-supported.</li>
+<li>ATP binding (IEA): the β3 Lys is intact so ATP binding is plausible, but untested and<br />
+  family-propagated → KEEP_AS_NON_CORE / MARK_AS_OVER_ANNOTATED (not a core function).</li>
+<li>CDK holoenzyme / G1/S / G2/M / regulation of cell cycle / CDK activity (IBA): wrong-branch<br />
+  phylogenetic over-propagation from the MAPK/CDK superfamily; no yeast KDX1 evidence →<br />
+  MARK_AS_OVER_ANNOTATED.</li>
+<li>nucleus (IBA), cytoplasm (IBA): plausible; Mlp1 acts at promoters (nucleus) with SBF and is a<br />
+  cytoplasmic-then-nuclear MAPK-like protein. KEEP_AS_NON_CORE (localization, not core function).</li>
+<li>signal transduction (IBA, IEA) / fungal-type cell wall biogenesis (IEA ARBA): correct in<br />
+  spirit but general; KDX1 acts in the cell-integrity MAPK cascade / CWI transcriptional output<br />
+  → KEEP_AS_NON_CORE or MODIFY toward cell integrity MAPK cascade (GO:0000196).</li>
+<li>ND placeholders (GO:0008150, GO:0005575): uninformative root placeholders → REMOVE per<br />
+  standard handling (superseded by specific annotations).</li>
+</ul>
+<h2 id="candidate-go-terms-for-core_functions-validated-ids">Candidate GO terms for core_functions (validated ids)</h2>
+<ul>
+<li>MF: <strong>GO:0140297</strong> DNA-binding transcription factor binding (binds Swi4) — non-catalytic scaffold role.</li>
+<li>BP: <strong>GO:0000196</strong> cell integrity MAPK cascade (mentions SLT2 in its definition).</li>
+<li>(proposed/alt MF: GO:0003713 transcription coactivator activity — definition fits the<br />
+  Swi4-binding/DNA-binding-conferring role well.)</li>
+</ul>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: P36005
+gene_symbol: KDX1
+aliases:
+- MLP1
+- YKL161C
+product_type: PROTEIN
+status: COMPLETE
+taxon:
+  id: NCBITaxon:559292
+  label: Saccharomyces cerevisiae
+description: &gt;-
+  KDX1 (commonly called MLP1 in the primary literature; systematic name YKL161C) is a
+  degenerate protein-kinase-fold protein of budding yeast, a paralog of the cell wall
+  integrity (CWI) MAP kinase SLT2/MPK1 that arose from the whole-genome duplication. Despite
+  retaining a recognizable protein-kinase domain, KDX1 is a catalytically inactive
+  pseudokinase: its activation-loop DFG motif is degenerate (Asp-&gt;Asn) and it lacks the MAPK
+  TEY dual-phosphorylation motif that activates SLT2, so it cannot function as a conventional
+  MAP kinase. KDX1 acts in the CWI signaling pathway downstream of the Mkk1/Mkk2 MEKs. Its
+  best-characterized activity is non-catalytic: activated (phosphorylated) KDX1, like activated
+  SLT2, binds the DNA-binding transcription factor Swi4 and, together with Swi6 (the SBF
+  complex), drives transcription of cell wall stress genes such as FKS2, functioning
+  redundantly with SLT2 in this branch. KDX1 was originally identified as an Rlm1-associated
+  protein and physically interacts with the MADS-box transcription factor Rlm1. KDX1 protein is
+  scarce under normal growth but accumulates strongly when the cell wall is stressed, because
+  MLP1 is itself a transcriptional target of the SLT2-&gt;Rlm1 arm of the same pathway.
+references:
+- id: GO_REF:0000002
+  title: Gene Ontology annotation through association of InterPro records with GO terms
+  findings: []
+- id: GO_REF:0000015
+  title: Use of the ND evidence code for Gene Ontology (GO) terms
+  findings: []
+- id: GO_REF:0000033
+  title: Annotation inferences using phylogenetic trees
+  findings: []
+- id: GO_REF:0000116
+  title: Automatic Gene Ontology annotation based on Rhea mapping
+  findings: []
+- id: GO_REF:0000117
+  title: Electronic Gene Ontology annotations created by ARBA machine learning models
+  findings: []
+- id: GO_REF:0000120
+  title: Combined Automated Annotation using Multiple IEA Methods
+  findings: []
+- id: PMID:20489023
+  title: A global protein kinase and phosphatase interaction network in yeast.
+  findings:
+  - statement: &gt;-
+      Large-scale mass-spectrometric mapping of the yeast kinase/phosphatase interaction (KPI)
+      network; the basis for the SGD ISS annotation transferring a Ser/Thr kinase molecular
+      function to KDX1 from its paralog SLT2. Abstract-only in cache; no KDX1-specific catalytic
+      demonstration is available from the abstract.
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PubMed-verified (Breitkreutz et al., Science 2010). A proteome-scale interaction study, not
+      a KDX1-focused paper. It underpins an ISS molecular-function transfer from SLT2 (with:
+      SGD:S000001072); given the pseudokinase evidence for KDX1, that inferred catalytic MF is an
+      over-annotation. Abstract-only in cache.
+- id: PMID:9111331
+  title: &gt;-
+    Characterization of a serum response factor-like protein in Saccharomyces cerevisiae, Rlm1,
+    which has transcriptional activity regulated by the Mpk1 (Slt2) mitogen-activated protein
+    kinase pathway.
+  findings:
+  - statement: &gt;-
+      Original identification of Mlp1 (KDX1) as an Rlm1-associated protein by yeast two-hybrid;
+      overexpression of MLP1 suppresses the caffeine sensitivity of bck1-delta, and mlp1-delta is
+      additive with mpk1-delta, indicating Rlm1 activity is regulated by both Mpk1 and the &#34;Mlp1
+      MAP kinase-like kinase&#34;.
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PubMed-verified (Watanabe et al., MCB 1997). Establishes the KDX1(Mlp1)-Rlm1 physical
+      interaction (UniProt SUBUNIT) and its genetic role in CWI signaling. Notably the authors
+      hedge on catalysis, calling Mlp1 a &#34;MAP kinase-like kinase&#34; rather than a kinase.
+- id: PMID:18055054
+  title: A yeast strain biosensor to detect cell wall-perturbing agents.
+  findings:
+  - statement: &gt;-
+      MLP1/YKL161c is almost undetectable under normal growth but its protein accumulates in
+      large amounts when cell wall integrity is compromised, making the MLP1 promoter an ideal
+      cell-wall-stress reporter.
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PubMed-verified (Rodriguez-Pena et al., J Biotechnol 2008). Directly documents stress-
+      inducible KDX1/Mlp1 accumulation and its use as a CWI biosensor; supports the INDUCTION
+      annotation in UniProt.
+- id: PMID:18268013
+  title: &gt;-
+    Yeast Mpk1 mitogen-activated protein kinase activates transcription through Swi4/Swi6 by a
+    noncatalytic mechanism that requires upstream signal.
+  findings:
+  - statement: &gt;-
+      Mpk1 and its pseudokinase paralog Mlp1 (KDX1) use a noncatalytic mechanism to activate
+      FKS2 transcription; activated (phosphorylated) Mpk1 and Mlp1 were detected in a complex
+      with Swi4 and Swi6 at the FKS2 promoter, conferring DNA-binding ability to Swi4 which then
+      recruits Swi6.
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PubMed-verified (Kim, Truman &amp; Levin, MCB 2008). The pivotal paper establishing KDX1/Mlp1
+      as a &#34;pseudokinase paralog&#34; that activates transcription non-catalytically via Swi4/Swi6.
+      Cached abstract-only, but the abstract itself carries the load-bearing statements quoted.
+- id: PMID:20641022
+  title: &gt;-
+    Transcriptional reporters for genes activated by cell wall stress through a non-catalytic
+    mechanism involving Mpk1 and SBF.
+  findings:
+  - statement: &gt;-
+      Explicitly describes Mlp1 (KDX1) as &#34;a catalytically inactive paralog of Mpk1&#34;; cell wall
+      stress induction of FKS2/CHA1/YKR013w/YLR042c is only partially dependent on Mlp1 but fully
+      blocked in an mpk1-delta mlp1-delta double mutant, and MLP1 is itself transcriptionally
+      induced by Mpk1 through Rlm1.
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PubMed-verified (Kim &amp; Levin, Yeast 2011). Full text cached. States KDX1/Mlp1 is
+      catalytically inactive, redundant with Mpk1 in the non-catalytic SBF branch, and itself an
+      Mpk1-&gt;Rlm1 target. Strongly informs both core function and the redundancy knowledge gap.
+- id: PMID:35420390
+  title: &gt;-
+    Hsp90 and phosphorylation of the Slt2(Mpk1) MAP kinase activation loop are essential for
+    catalytic, but not non-catalytic, Slt2-mediated transcription in yeast.
+  findings:
+  - statement: &gt;-
+      Swi4/Swi6 (SBF) activation in response to cell wall stress is noncatalytic and triggered
+      by binding of phosphorylated forms of both Slt2 and the catalytically inactive pseudokinase
+      Mlp1 (KDX1).
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PubMed-verified (Millson, Truman &amp; Piper, Cell Stress Chaperones 2022). Full text cached.
+      Independently corroborates KDX1/Mlp1 as a catalytically inactive pseudokinase participating
+      in the non-catalytic SBF transcriptional branch.
+existing_annotations:
+- term:
+    id: GO:0005634
+    label: nucleus
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: is_active_in
+  review:
+    summary: &gt;-
+      Nuclear localization is consistent with KDX1&#39;s characterized non-catalytic role at
+      cell-wall-stress gene promoters (FKS2 etc.), where activated KDX1 associates with Swi4/Swi6
+      (SBF). Reasonable but not a core molecular function; retained as a localization annotation.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      KDX1/Mlp1 forms part of the Swi4-Swi6 complex at the FKS2 promoter, so nuclear activity is
+      supported. IBA from the MAPK family tree; consistent with the experimental non-catalytic
+      transcriptional role.
+    supported_by:
+    - reference_id: PMID:18268013
+      supporting_text: &gt;-
+        Activated (phosphorylated) Mpk1 and Mlp1 were detected in a complex with Swi4 and Swi6 at
+        the FKS2 promoter.
+- term:
+    id: GO:0005737
+    label: cytoplasm
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: is_active_in
+  review:
+    summary: &gt;-
+      Cytoplasmic localization is plausible for a MAPK-like protein acting in the CWI cascade
+      before its stress-induced accumulation and nuclear/promoter activity. Retained as a
+      non-core localization annotation.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      IBA from the MAPK family tree. Consistent with a terminal-MAPK-like protein of the CWI
+      pathway; not a core molecular function.
+- term:
+    id: GO:0051726
+    label: regulation of cell cycle
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      This is a phylogenetic propagation from the broad MAPK/CDK-containing family tree
+      (PTHR24055). There is no KDX1/Mlp1-specific evidence for a cell-cycle regulatory role; the
+      characterized function is in cell-wall-stress transcription, not cell-cycle control.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      Over-propagation from CDK/MAPK relatives in the family tree. No experimental support for a
+      KDX1 cell-cycle role in S. cerevisiae.
+    propagation_review:
+      root_cause: PROPAGATION_BAD
+      failure_modes:
+      - WRONG_ORTHOLOG_OR_PARALOG
+- term:
+    id: GO:0000082
+    label: G1/S transition of mitotic cell cycle
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Phylogenetic propagation from cell-cycle CDK members of the family tree; not supported by
+      any KDX1-specific evidence. KDX1 is a CWI pseudokinase, not a cell-cycle CDK.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      IBA over-annotation inherited from CDK relatives (e.g. CDC28-like) in PTHR24055; no yeast
+      KDX1 evidence for G1/S control.
+    propagation_review:
+      root_cause: PROPAGATION_BAD
+      failure_modes:
+      - WRONG_ORTHOLOG_OR_PARALOG
+- term:
+    id: GO:0000307
+    label: cyclin-dependent protein kinase holoenzyme complex
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: part_of
+  review:
+    summary: &gt;-
+      There is no evidence KDX1/Mlp1 is a component of a cyclin-dependent kinase holoenzyme. This
+      is an incorrect phylogenetic propagation from CDK members of the family; KDX1&#39;s documented
+      complexes are with the transcription factors Swi4/Swi6 and Rlm1, not cyclin-CDK.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      Wrong-complex over-propagation from CDK relatives in PTHR24055. KDX1 associates with
+      Swi4/Swi6 (SBF) and Rlm1, not with cyclins/CDK holoenzyme.
+    propagation_review:
+      root_cause: PROPAGATION_BAD
+      failure_modes:
+      - WRONG_ORTHOLOG_OR_PARALOG
+      - COMPARTMENT_OR_COMPLEX_MISMATCH
+- term:
+    id: GO:0000086
+    label: G2/M transition of mitotic cell cycle
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Phylogenetic propagation from cell-cycle CDK members of the family tree; not supported by
+      any KDX1-specific evidence.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      IBA over-annotation inherited from CDK relatives in PTHR24055; no yeast KDX1 evidence for
+      G2/M control.
+    propagation_review:
+      root_cause: PROPAGATION_BAD
+      failure_modes:
+      - WRONG_ORTHOLOG_OR_PARALOG
+- term:
+    id: GO:0004693
+    label: cyclin-dependent protein serine/threonine kinase activity
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: enables
+  review:
+    summary: &gt;-
+      KDX1 is a catalytically inactive pseudokinase (degenerate DFG; no TEY motif) and is not a
+      cyclin-dependent kinase. This MF is a doubly-wrong phylogenetic propagation: it asserts both
+      catalytic kinase activity (which KDX1 lacks) and a CDK identity (which KDX1 is not).
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      Over-propagation from CDK members of PTHR24055. The pseudokinase evidence (DFG-&gt;NFG, no TEY,
+      literature &#34;catalytically inactive paralog&#34;) contradicts a catalytic CDK activity.
+    supported_by:
+    - reference_id: PMID:20641022
+      supporting_text: &gt;-
+        Induction was only partially dependent on the Mlp1 pseudokinase (Figure 2), a
+        catalytically inactive paralog of Mpk1 (Kim et al., 2008).
+    propagation_review:
+      root_cause: PROPAGATION_BAD
+      failure_modes:
+      - WRONG_ORTHOLOG_OR_PARALOG
+      - PSEUDO_OR_SUBACTIVITY_LOSS
+- term:
+    id: GO:0007165
+    label: signal transduction
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      KDX1 does act within the cell wall integrity (CWI) signaling cascade, so a signal
+      transduction annotation is defensible. It is very general, however; the specific process is
+      the cell integrity MAPK cascade / CWI transcriptional output.
+    action: MODIFY
+    reason: &gt;-
+      Correct in spirit but non-specific. A more informative term is cell integrity MAPK cascade
+      (GO:0000196), whose definition explicitly names SLT2 (the paralog KDX1 acts with).
+    proposed_replacement_terms:
+    - id: GO:0000196
+      label: cell integrity MAPK cascade
+    propagation_review:
+      root_cause: TERM_SCOPING_PROBLEM
+      failure_modes:
+      - GRANULARITY_MISMATCH
+- term:
+    id: GO:0004672
+    label: protein kinase activity
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Family/domain-based electronic annotation (InterPro protein-kinase domain). KDX1 retains
+      the kinase fold but is a catalytically inactive pseudokinase (degenerate DFG, HRD-&gt;HCD, no
+      TEY), so an unqualified &#34;protein kinase activity&#34; is an over-annotation of catalytic
+      function.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      IEA from InterPro domain presence; the fold is real but catalytic activity is not
+      KDX1-supported and is contradicted by the pseudokinase evidence.
+    supported_by:
+    - reference_id: PMID:18268013
+      supporting_text: &gt;-
+        its pseudokinase paralog (Mlp1) use a noncatalytic mechanism to activate transcription of
+        the FKS2 gene
+    propagation_review:
+      root_cause: PROPAGATION_BAD
+      failure_modes:
+      - PSEUDO_OR_SUBACTIVITY_LOSS
+- term:
+    id: GO:0004674
+    label: protein serine/threonine kinase activity
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000120
+  qualifier: enables
+  review:
+    summary: &gt;-
+      ARBA/EC-based electronic annotation propagating a Ser/Thr kinase catalytic activity from
+      family homology. Contradicted by the pseudokinase evidence for KDX1 (degenerate DFG; no
+      demonstrated phosphotransfer; field consensus &#34;catalytically inactive&#34;).
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      Electronic catalytic-activity propagation not supported by KDX1-specific data; KDX1 is a
+      pseudokinase.
+    supported_by:
+    - reference_id: PMID:35420390
+      supporting_text: &gt;-
+        triggered by the binding of phosphorylated forms of both Slt2 and a catalytically
+        inactive pseudokinase (Mlp1)
+    propagation_review:
+      root_cause: PROPAGATION_BAD
+      failure_modes:
+      - PSEUDO_OR_SUBACTIVITY_LOSS
+- term:
+    id: GO:0005524
+    label: ATP binding
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Electronic annotation from the kinase ATP-binding motif. KDX1 retains the beta3 lysine
+      (K55, UniProt BINDING) and the Gly-rich loop, so ATP binding is plausible, but it has never
+      been demonstrated for KDX1 and, given the degenerate DFG, is not part of a catalytic cycle.
+      Retained as a non-core, unverified biochemical property.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      IEA from InterPro; the ATP-anchoring Lys is present so nucleotide binding is not excluded,
+      but it is untested for KDX1 and not a core function of a pseudokinase.
+- term:
+    id: GO:0007165
+    label: signal transduction
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000117
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Duplicate (electronic) of the signal transduction annotation; same rationale. KDX1 acts in
+      the CWI cascade; the term is correct but general.
+    action: MODIFY
+    reason: &gt;-
+      ARBA electronic annotation; correct but non-specific. A more informative term is cell
+      integrity MAPK cascade (GO:0000196).
+    proposed_replacement_terms:
+    - id: GO:0000196
+      label: cell integrity MAPK cascade
+- term:
+    id: GO:0009272
+    label: fungal-type cell wall biogenesis
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000117
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      KDX1 contributes to the transcriptional response that maintains/remodels the cell wall
+      under stress (e.g. FKS2 induction with SBF), so a role in fungal-type cell wall biogenesis
+      is defensible, if indirect. Retained as a non-core biological-process annotation.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      ARBA electronic annotation consistent with KDX1&#39;s non-catalytic role in inducing cell wall
+      stress genes (FKS2 encodes a beta-1,3-glucan synthase subunit). Indirect/contributory, not
+      a core molecular function.
+    supported_by:
+    - reference_id: PMID:20641022
+      supporting_text: &gt;-
+        a common mechanism that involves activation of Mpk1 and Mlp1 to engage Swi4 and Swi6
+- term:
+    id: GO:0106310
+    label: protein serine kinase activity
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000116
+  qualifier: enables
+  review:
+    summary: &gt;-
+      RHEA/reaction-based electronic annotation of Ser-directed kinase catalytic activity,
+      propagated from the family reaction mapping. Contradicted by the pseudokinase evidence for
+      KDX1.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      Electronic catalytic-activity propagation (RHEA:17989) not supported by KDX1-specific data;
+      KDX1 is a catalytically inactive pseudokinase.
+    propagation_review:
+      root_cause: PROPAGATION_BAD
+      failure_modes:
+      - PSEUDO_OR_SUBACTIVITY_LOSS
+- term:
+    id: GO:0008150
+    label: biological_process
+  evidence_type: ND
+  original_reference_id: GO_REF:0000015
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Root-level placeholder (ND) indicating no biological-process data at time of assignment.
+      Superseded by the specific CWI/transcription annotations in this review.
+    action: REMOVE
+    reason: &gt;-
+      Uninformative root placeholder; standard handling is removal once specific annotations
+      exist.
+- term:
+    id: GO:0004674
+    label: protein serine/threonine kinase activity
+  evidence_type: ISS
+  original_reference_id: PMID:20489023
+  qualifier: enables
+  review:
+    summary: &gt;-
+      ISS transfer of Ser/Thr kinase activity to KDX1 from its paralog SLT2 (with:
+      SGD:S000001072) based on sequence similarity. Because KDX1 is a catalytically inactive
+      pseudokinase, transferring SLT2&#39;s catalytic activity by similarity is exactly the
+      over-annotation the pseudokinase literature warns against; the fold similarity is real but
+      the catalytic residues are degenerate.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      ISS from the active paralog SLT2 does not hold: KDX1&#39;s DFG motif is degenerate and the
+      field explicitly calls Mlp1 a &#34;catalytically inactive paralog of Mpk1&#34;. Not REMOVE, since
+      the kinase fold is genuinely present, but the catalytic MF is an over-annotation.
+    supported_by:
+    - reference_id: PMID:20641022
+      supporting_text: &gt;-
+        Induction was only partially dependent on the Mlp1 pseudokinase (Figure 2), a
+        catalytically inactive paralog of Mpk1 (Kim et al., 2008).
+    propagation_review:
+      root_cause: PROPAGATION_BAD
+      failure_modes:
+      - WRONG_ORTHOLOG_OR_PARALOG
+      - PSEUDO_OR_SUBACTIVITY_LOSS
+- term:
+    id: GO:0005575
+    label: cellular_component
+  evidence_type: ND
+  original_reference_id: GO_REF:0000015
+  qualifier: is_active_in
+  review:
+    summary: &gt;-
+      Root-level placeholder (ND). Superseded by the nucleus/cytoplasm localization annotations.
+    action: REMOVE
+    reason: &gt;-
+      Uninformative root placeholder; standard handling is removal once specific annotations
+      exist.
+- term:
+    id: GO:0140297
+    label: DNA-binding transcription factor binding
+  evidence_type: IPI
+  original_reference_id: PMID:18268013
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Proposed new annotation capturing KDX1/Mlp1&#39;s actual, experimentally supported molecular
+      function: activated (phosphorylated) KDX1 binds the DNA-binding transcription factor Swi4
+      (and is detected in a Swi4/Swi6 complex at the FKS2 promoter), a non-catalytic scaffold role
+      that replaces the mis-propagated catalytic kinase functions. This is the MF used in
+      core_functions.
+    action: NEW
+    reason: &gt;-
+      KDX1 is a pseudokinase whose characterized function is binding a DNA-binding transcription
+      factor (Swi4) rather than phosphotransfer; this term expresses that function and avoids the
+      uninformative &#34;protein binding&#34;.
+    supported_by:
+    - reference_id: PMID:18268013
+      supporting_text: &gt;-
+        Activated (phosphorylated) Mpk1 and Mlp1 were detected in a complex with Swi4 and Swi6 at
+        the FKS2 promoter.
+    - reference_id: PMID:20641022
+      supporting_text: &gt;-
+        the binding of activated (phosphorylated) Mpk1, or its pseudokinase paralog, Mlp1, to the
+        Swi4 transcription factor
+core_functions:
+- description: &gt;-
+    Non-catalytic transcriptional co-activation of cell-wall-stress genes: activated
+    (phosphorylated) KDX1 binds the DNA-binding transcription factor Swi4, conferring DNA-binding
+    ability, and together with Swi6 (the SBF complex) drives transcription of FKS2 and related
+    genes in response to cell wall stress. KDX1 performs this function redundantly with its
+    active paralog SLT2/MPK1, without any requirement for protein kinase catalytic activity.
+  molecular_function:
+    id: GO:0140297
+    label: DNA-binding transcription factor binding
+  directly_involved_in:
+  - id: GO:0000196
+    label: cell integrity MAPK cascade
+  locations:
+  - id: GO:0005634
+    label: nucleus
+  supported_by:
+  - reference_id: PMID:18268013
+    supporting_text: &gt;-
+      Activated (phosphorylated) Mpk1 and Mlp1 were detected in a complex with Swi4 and Swi6 at
+      the FKS2 promoter.
+  - reference_id: PMID:20641022
+    supporting_text: &gt;-
+      the binding of activated (phosphorylated) Mpk1, or its pseudokinase paralog, Mlp1, to the
+      Swi4 transcription factor
+knowledge_gaps:
+- gap_statement: &gt;-
+    Whether KDX1/Mlp1 has any residual protein kinase catalytic (phosphotransfer) activity in
+    vivo is undetermined; no physiological substrate has been demonstrated and the field treats
+    it as catalytically dead.
+  boundary: &gt;-
+    The protein retains a recognizable kinase fold and the beta3 ATP-anchoring lysine (K55), but
+    the activation-loop DFG Mg2+-binding aspartate is replaced by asparagine (DFG-&gt;NFG), the HRD
+    catalytic-loop arginine is lost (HRD-&gt;HCD, though the catalytic Asp D153 is retained), and the
+    MAPK TEY dual-phosphorylation motif is absent. Multiple papers explicitly call Mlp1 a
+    &#34;catalytically inactive pseudokinase&#34;. Its characterized biological function (SBF-dependent
+    transcription) is explicitly non-catalytic.
+  gap_kind:
+  - BIOLOGY
+  dark_aspect: MF_DARK
+  status: OPEN
+  significance: &gt;-
+    UniProt and several electronic pipelines still assign catalytic Ser/Thr kinase activity and
+    EC 2.7.11.1 to KDX1 by family homology. A direct biochemical test (or its documented absence)
+    would settle whether these catalytic annotations should be removed outright rather than
+    flagged as over-annotations, and would clarify whether KDX1 retains any ATP/nucleotide-
+    dependent conformational role.
+  resolution: &gt;-
+    In vitro kinase assay with recombinant KDX1 (and active SLT2 as positive control) testing
+    autophosphorylation and phosphorylation of candidate substrates, plus a nucleotide-binding
+    assay.
+  provenance:
+  - reference_id: PMID:20641022
+    supporting_text: &gt;-
+      Induction was only partially dependent on the Mlp1 pseudokinase (Figure 2), a catalytically
+      inactive paralog of Mpk1 (Kim et al., 2008).
+  - reference_id: PMID:18268013
+    supporting_text: &gt;-
+      its pseudokinase paralog (Mlp1) use a noncatalytic mechanism to activate transcription of
+      the FKS2 gene
+- gap_statement: &gt;-
+    The full set of KDX1/Mlp1 direct binding partners and any additional (non-Swi4, non-Rlm1)
+    scaffolding targets are unknown.
+  boundary: &gt;-
+    KDX1 is documented to bind Swi4 (contributing to SBF-dependent FKS2 transcription) and to
+    physically associate with the MADS-box transcription factor Rlm1, and it appears in the
+    global yeast kinase/phosphatase interaction network. A comprehensive, KDX1-specific
+    interactome distinguishing direct from indirect partners has not been reported.
+  gap_kind:
+  - BIOLOGY
+  - CURATION
+  dark_aspect: MF_DARK
+  status: OPEN
+  significance: &gt;-
+    Identifying KDX1&#39;s direct partners would define whether its scaffolding role extends beyond
+    the Swi4/Swi6 and Rlm1 branches of CWI signaling and could reveal a function not shared with
+    SLT2.
+  resolution: &gt;-
+    Targeted affinity-purification/proximity-labeling of tagged KDX1 under cell wall stress, with
+    validation of direct interactions.
+  provenance:
+  - reference_id: PMID:9111331
+    supporting_text: &gt;-
+      We identified a Mpk1-like protein kinase, Mlp1, as an Rlm1-associated protein by using the
+      yeast two-hybrid system.
+- gap_statement: &gt;-
+    The non-redundant (unique) biological role of KDX1/Mlp1 relative to SLT2/MPK1 is undefined:
+    no phenotype has been shown to depend on KDX1 with SLT2 intact.
+  boundary: &gt;-
+    In every characterized context KDX1 is only partially required and functionally overlaps with
+    SLT2; the non-catalytic SBF branch is fully abolished only in an mpk1-delta mlp1-delta double
+    mutant, and KDX1&#39;s own expression depends on the SLT2-&gt;Rlm1 arm, so little KDX1 protein is
+    present unless SLT2 signaling is active.
+  gap_kind:
+  - BIOLOGY
+  dark_aspect: BP_DARK
+  status: OPEN
+  significance: &gt;-
+    Whether KDX1 provides genuine redundancy/robustness, dosage amplification, or a distinct
+    stress-specific function determines why the whole-genome-duplication paralog was retained and
+    whether it has any non-overlapping role worth targeting or curating separately from SLT2.
+  resolution: &gt;-
+    Systematic phenotyping of mlp1-delta (with SLT2 intact) across cell wall and other stresses,
+    and identification of any KDX1-only-dependent transcriptional or phenotypic output.
+  provenance:
+  - reference_id: PMID:20641022
+    supporting_text: &gt;-
+      all induction was blocked in an mpk1Δ mlp1Δ double mutant, reflecting the partial overlap
+      in function of Mpk1 and Mlp1 in this context.
+proposed_new_terms:
+- proposed_name: pseudokinase scaffold activity in transcription factor activation
+  proposed_definition: &gt;-
+    A molecular function in which a catalytically inactive protein-kinase-fold protein
+    (pseudokinase), typically upon activating post-translational modification, binds a DNA-binding
+    transcription factor and confers or enhances its DNA-binding/transcription-activating
+    competence, thereby contributing to transcriptional activation without protein kinase
+    catalytic activity.
+  justification: &gt;-
+    KDX1/Mlp1 exemplifies a pseudokinase whose molecular function is non-catalytic: as an
+    activated (phosphorylated) protein it binds the DNA-binding transcription factor Swi4 and
+    confers DNA-binding competence, contributing to transcriptional activation of FKS2 and related
+    genes. GO:0140297 (DNA-binding transcription factor binding) captures the binding but not the
+    activating scaffold role, and GO:0003713 (transcription coactivator activity) is normally
+    applied to the direct coactivator. A dedicated term would express KDX1&#39;s characterized
+    function precisely.
+  supported_by:
+  - reference_id: PMID:18268013
+    supporting_text: &gt;-
+      Activated (phosphorylated) Mpk1 and Mlp1 were detected in a complex with Swi4 and Swi6 at
+      the FKS2 promoter.
+suggested_questions:
+- question: &gt;-
+    Does KDX1/Mlp1 retain any Mg-ATP-dependent phosphotransfer activity in vitro, or is it
+    biochemically catalytically dead as its degenerate DFG motif and the pseudokinase literature
+    predict?
+  experts:
+  - Yeast cell wall integrity / MAP kinase signaling biologists
+  - Pseudokinase biochemists
+- question: &gt;-
+    Beyond redundancy with SLT2 in the SBF branch, does KDX1 have any non-overlapping,
+    stress-specific function that explains retention of this whole-genome-duplication paralog?
+  experts:
+  - Yeast CWI signaling biologists
+suggested_experiments:
+- hypothesis: &gt;-
+    KDX1/Mlp1 is catalytically inactive and cannot phosphorylate protein substrates.
+  description: &gt;-
+    Purify recombinant KDX1 (and, as a positive control, active SLT2) and assay Mg-ATP-dependent
+    autophosphorylation and phosphorylation of candidate substrates (e.g. Rlm1, generic MAPK
+    substrates) in vitro, including a nucleotide-binding assay to test whether the intact beta3
+    lysine still supports ATP binding despite the degenerate DFG.
+  experiment_type: in vitro kinase / nucleotide-binding assay
+- hypothesis: &gt;-
+    KDX1 activates Swi4/Swi6-dependent transcription purely non-catalytically, via its ability to
+    bind Swi4 when phosphorylated by the upstream MEKs.
+  description: &gt;-
+    Complement an mpk1-delta mlp1-delta strain with wild-type KDX1 versus a KDX1 variant mutated
+    at its (pseudo)active site or at the MEK-phosphoacceptor residues, and measure FKS2/CHA1/
+    YLR042c reporter induction under cell wall stress to separate the requirement for KDX1 binding
+    from any residual catalysis.
+  experiment_type: genetic complementation with transcriptional reporters
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/genes/yeast/LEE1/LEE1-ai-review.html
+++ b/genes/yeast/LEE1/LEE1-ai-review.html
@@ -1,0 +1,3005 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>LEE1 - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        .propagation-review {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f8fafc;
+            border-left: 3px solid #64748b;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .propagation-title {
+            font-weight: 600;
+            color: #334155;
+            margin-bottom: 0.25rem;
+        }
+
+        .propagation-row {
+            margin-top: 0.25rem;
+        }
+
+        .propagation-source {
+            margin-top: 0.5rem;
+            padding-top: 0.5rem;
+            border-top: 1px solid #e5e7eb;
+        }
+
+        .propagation-source-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #1d4ed8;
+        }
+
+        .propagation-comment {
+            color: #4b5563;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>LEE1</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/Q02799" target="_blank" class="term-link">
+                        Q02799
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Saccharomyces cerevisiae</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-initialized">
+                    INITIALIZED
+                </span>
+            </div>
+
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "LEE1";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="Q02799" data-a="DESCRIPTION: LEE1 (YPL054W) is a 301-residue Saccharomyces cere..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>LEE1 (YPL054W) is a 301-residue Saccharomyces cerevisiae protein whose only well-supported molecular property is the presence of two tandem CCCH-type (C3H1) zinc fingers, which coordinate zinc. CCCH zinc fingers are canonically nucleic-acid-binding (most often RNA-binding) modules, and LEE1 was independently identified in a proteome-wide survey as a predicted zinc-binding protein of the yeast zinc proteome. Beyond zinc coordination, its molecular activity, physiological substrate or binding target, and biological role remain uncharacterized; global GFP studies report a cytoplasmic localization. The protein is phosphorylated at several serine residues (Ser-21, Ser-30, Ser-282) and has a disordered, polar-residue-rich N-terminus. It is a non-essential protein; deletion is viable and yields only pleiotropic, high-throughput-screen phenotypes (including in a minisatellite-stability screen) with no defined pathway assignment. Its transcription is nitrogen-source responsive (a nitrogen catabolite repression target). LEE1 belongs to the makorin-related family (PANTHER PTHR11224 / InterPro MKRN-like) by sequence of its zinc fingers, but unlike the metazoan makorin E3 ubiquitin ligases it lacks the catalytic RING domain that those proteins use for ubiquitin transfer.</p>
+    </div>
+
+
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0061630" target="_blank" class="term-link">
+                                    GO:0061630
+                                </a>
+                            </span>
+                            <span class="term-label">ubiquitin protein ligase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q02799" data-a="GO:0061630" data-r="GO_REF:0000033" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetic (IBA) propagation of E3 ubiquitin ligase activity from the makorin family (PANTHER PTHR11224, node PTN000131854). The IBD seeds are metazoan makorins that carry a catalytic C3HC4 RING domain (human MKRN1 Q9UHC7, human MKRN3 Q13064, mouse Mkrn2 MGI:1914277). LEE1 possesses only the CCCH zinc fingers and has NO RING domain, which is the module that actually catalyzes ubiquitin transfer in makorins. Ubiquitin ligase activity is therefore an over-annotation for LEE1: the catalytic domain required for the function is absent, so this is a family/subfamily over-propagation of a catalytic activity to a member lacking the catalytic module.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> LEE1 lacks the RING (zf-C3HC4) domain that carries makorin E3 ligase catalysis; only CCCH zinc fingers are present (verified by direct InterPro query on Q02799, which returns no RING/IPR001841 signature). Zinc-finger membership in the makorin family does not confer the ligase activity, and there is no experimental evidence LEE1 is a ubiquitin ligase.
+                        </div>
+
+
+
+                        <div class="propagation-review">
+                            <div class="propagation-title">Propagation Review</div>
+                            <div class="propagation-row">
+                                <strong>Root cause:</strong>
+                                <span class="badge">PROPAGATION BAD</span>
+                            </div>
+
+                            <div class="propagation-row">
+                                <strong>Failure modes:</strong>
+
+                                <span class="badge">PSEUDO OR SUBACTIVITY LOSS</span>
+
+                                <span class="badge">WRONG ORTHOLOG OR PARALOG</span>
+
+                            </div>
+
+
+                            <div class="propagation-source">
+                                <strong>Sources checked:</strong>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">UniProtKB:Q9UHC7</span>
+
+                                    &middot; human MKRN1
+
+
+                                    <span class="badge">SUPPORTS SOURCE BUT NOT TARGET</span>
+
+
+                                    <div class="propagation-comment">RING-containing makorin E3 ligase; catalytic RING absent in LEE1</div>
+
+                                </div>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">UniProtKB:Q13064</span>
+
+                                    &middot; human MKRN3
+
+
+                                    <span class="badge">SUPPORTS SOURCE BUT NOT TARGET</span>
+
+
+                                    <div class="propagation-comment">RING-containing makorin; LEE1 has no RING module</div>
+
+                                </div>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">MGI:MGI:1914277</span>
+
+                                    &middot; mouse Mkrn2
+
+
+                                    <span class="badge">SUPPORTS SOURCE BUT NOT TARGET</span>
+
+
+                                    <div class="propagation-comment">RING-containing makorin; ligase catalysis not transferable to LEE1</div>
+
+                                </div>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">PANTHER:PTN000131854</span>
+
+                                    &middot; PTHR11224 makorin family node
+
+
+                                    <span class="badge">SUPPORTS SOURCE BUT NOT TARGET</span>
+
+
+                                    <div class="propagation-comment">family node seeded by RING makorins; subfamily SF10 also contains RING-less members</div>
+
+                                </div>
+
+                            </div>
+
+                        </div>
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016567" target="_blank" class="term-link">
+                                    GO:0016567
+                                </a>
+                            </span>
+                            <span class="term-label">protein ubiquitination</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q02799" data-a="GO:0016567" data-r="GO_REF:0000033" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetic (IBA) propagation of the ubiquitination process that accompanies the makorin family ligase-activity assignment. It rests on the same makorin RING E3 ligase inference that does not apply to LEE1, because LEE1 lacks the catalytic RING domain. Without support for LEE1 acting as a ubiquitin ligase, participation in protein ubiquitination is an over-annotation.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> This process term is the biological-process shadow of the makorin ligase activity that does not transfer to LEE1 (no RING domain). No experimental evidence links LEE1 to protein ubiquitination.
+                        </div>
+
+
+
+                        <div class="propagation-review">
+                            <div class="propagation-title">Propagation Review</div>
+                            <div class="propagation-row">
+                                <strong>Root cause:</strong>
+                                <span class="badge">PROPAGATION BAD</span>
+                            </div>
+
+                            <div class="propagation-row">
+                                <strong>Failure modes:</strong>
+
+                                <span class="badge">PSEUDO OR SUBACTIVITY LOSS</span>
+
+                                <span class="badge">WRONG ORTHOLOG OR PARALOG</span>
+
+                            </div>
+
+
+                            <div class="propagation-source">
+                                <strong>Sources checked:</strong>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">PANTHER:PTN000131854</span>
+
+                                    &middot; PTHR11224 makorin family node
+
+
+                                    <span class="badge">SUPPORTS SOURCE BUT NOT TARGET</span>
+
+
+                                    <div class="propagation-comment">process co-propagated with RING-dependent ligase activity absent in LEE1</div>
+
+                                </div>
+
+                            </div>
+
+                        </div>
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000209" target="_blank" class="term-link">
+                                    GO:0000209
+                                </a>
+                            </span>
+                            <span class="term-label">protein polyubiquitination</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q02799" data-a="GO:0000209" data-r="GO_REF:0000002" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> InterPro-to-GO (IEA) mapping of protein polyubiquitination from the MKRN-like signature (IPR045072). The mapping reflects the makorin family&#39;s RING-dependent E3 ligase role. LEE1 matches the MKRN-like/CCCH signatures by its zinc fingers but lacks the RING domain, so the polyubiquitination process is not supportable for it and represents an over-annotation.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> IEA mapping derives from the makorin RING E3 ligase function; the RING catalytic domain is absent in LEE1, so polyubiquitination should not be inferred. No experimental support exists.
+                        </div>
+
+
+
+                        <div class="propagation-review">
+                            <div class="propagation-title">Propagation Review</div>
+                            <div class="propagation-row">
+                                <strong>Root cause:</strong>
+                                <span class="badge">PROPAGATION BAD</span>
+                            </div>
+
+                            <div class="propagation-row">
+                                <strong>Failure modes:</strong>
+
+                                <span class="badge">PSEUDO OR SUBACTIVITY LOSS</span>
+
+                            </div>
+
+
+                            <div class="propagation-source">
+                                <strong>Sources checked:</strong>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">InterPro:IPR045072</span>
+
+                                    &middot; MKRN-like
+
+
+                                    <span class="badge">SUPPORTS SOURCE BUT NOT TARGET</span>
+
+
+                                    <div class="propagation-comment">family signature maps polyubiquitination via RING makorins; RING absent in LEE1</div>
+
+                                </div>
+
+                            </div>
+
+                        </div>
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0046872" target="_blank" class="term-link">
+                                    GO:0046872
+                                </a>
+                            </span>
+                            <span class="term-label">metal ion binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q02799" data-a="GO:0046872" data-r="GO_REF:0000002" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> InterPro-to-GO (IEA) mapping of metal ion binding from the CCCH zinc finger signatures (IPR000571, IPR036855). This is correct and domain-defensible: LEE1 has two CCCH-type zinc fingers that coordinate zinc. It is a generic parent of the more specific zinc ion binding, which is also annotated.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> LEE1&#39;s two CCCH zinc fingers coordinate a metal ion (zinc); the term is correct though generic. The more specific GO:0008270 (zinc ion binding) is the preferred core term.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0061630" target="_blank" class="term-link">
+                                    GO:0061630
+                                </a>
+                            </span>
+                            <span class="term-label">ubiquitin protein ligase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q02799" data-a="GO:0061630" data-r="GO_REF:0000002" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> InterPro-to-GO (IEA) mapping of ubiquitin protein ligase activity from the MKRN-like signature (IPR045072). As with the IBA duplicate of this term, the activity depends on the makorin RING domain, which LEE1 does not have. This is an over-annotation for a RING-less family member.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Same over-propagation as the IBA ligase-activity annotation, arriving via the InterPro MKRN-like signature. LEE1 lacks the catalytic RING domain, so the ligase activity is not supportable.
+                        </div>
+
+
+
+                        <div class="propagation-review">
+                            <div class="propagation-title">Propagation Review</div>
+                            <div class="propagation-row">
+                                <strong>Root cause:</strong>
+                                <span class="badge">PROPAGATION BAD</span>
+                            </div>
+
+                            <div class="propagation-row">
+                                <strong>Failure modes:</strong>
+
+                                <span class="badge">PSEUDO OR SUBACTIVITY LOSS</span>
+
+                                <span class="badge">WRONG ORTHOLOG OR PARALOG</span>
+
+                            </div>
+
+
+                            <div class="propagation-source">
+                                <strong>Sources checked:</strong>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">InterPro:IPR045072</span>
+
+                                    &middot; MKRN-like
+
+
+                                    <span class="badge">SUPPORTS SOURCE BUT NOT TARGET</span>
+
+
+                                    <div class="propagation-comment">signature maps ligase activity from RING makorins; RING absent in LEE1</div>
+
+                                </div>
+
+                            </div>
+
+                        </div>
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008270" target="_blank" class="term-link">
+                                    GO:0008270
+                                </a>
+                            </span>
+                            <span class="term-label">zinc ion binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">RCA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/30358795" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:30358795
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The cellular economy of the Saccharomyces cerevisiae zinc pr...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q02799" data-a="GO:0008270" data-r="PMID:30358795" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reviewed computational analysis (RCA) assignment of zinc ion binding, sourced from the proteome-wide yeast zinc-proteome study that catalogued LEE1 among predicted zinc-binding proteins. This is fully consistent with LEE1&#39;s two CCCH-type (C3H1) zinc fingers (each coordinating Zn2+ via three Cys and one His). This is the best-supported molecular function of LEE1 and is retained as core.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> LEE1 has two CCCH-type zinc fingers (UniProt ZN_FING 87-114 and 123-145) and was independently classified as a zinc-binding protein in a proteome-wide zinc-proteome analysis. Zinc coordination is the best-supported molecular property of the protein.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005575" target="_blank" class="term-link">
+                                    GO:0005575
+                                </a>
+                            </span>
+                            <span class="term-label">cellular_component</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ND</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000015
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q02799" data-a="GO:0005575" data-r="GO_REF:0000015" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Root cellular_component term with the ND (No biological Data available) evidence code, correctly signalling that LEE1&#39;s subcellular localization is not known. This is the appropriate placeholder for an uncharacterized protein and should be retained until localization data exist.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> ND root term accurately records that no localization data are available for LEE1; standard practice is to keep it.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008150" target="_blank" class="term-link">
+                                    GO:0008150
+                                </a>
+                            </span>
+                            <span class="term-label">biological_process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ND</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000015
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q02799" data-a="GO:0008150" data-r="GO_REF:0000015" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Root biological_process term with the ND evidence code, correctly signalling that LEE1&#39;s biological role is unknown. Existing deletion phenotypes are pleiotropic high-throughput readouts that do not define a pathway, so the ND placeholder remains appropriate.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> ND root term accurately records the absence of biological-process data; retained as the honest placeholder for a dark gene.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>Zinc coordination by two tandem CCCH-type (C3H1) zinc fingers. This is the only molecular function of LEE1 that is supported by both its domain architecture and an independent proteome-wide analysis. The physiological consequence of this zinc binding (e.g. a nucleic-acid-binding activity) is not established.</h3>
+                <span class="vote-buttons" data-g="Q02799" data-a="FUNCTION: Zinc coordination by two tandem CCCH-type (C3H1) z..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008270" target="_blank" class="term-link">
+                            zinc ion binding
+                        </a>
+                    </span>
+                </div>
+
+
+
+
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/30358795" target="_blank" class="term-link">
+                                PMID:30358795
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">The yeast zinc proteome of 582 known or potential zinc-binding proteins was identified using a bioinformatics analysis that combined global domain searches with local motif searches.</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000002.md" target="_blank" class="term-link">
+                            GO_REF:0000002
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation through association of InterPro records with GO terms</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000015.md" target="_blank" class="term-link">
+                            GO_REF:0000015
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Use of the ND evidence code for Gene Ontology (GO) terms</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
+                            GO_REF:0000033
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Annotation inferences using phylogenetic trees</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/30358795" target="_blank" class="term-link">
+                            PMID:30358795
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">The cellular economy of the Saccharomyces cerevisiae zinc proteome.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">LEE1 was identified as one of 582 known or potential zinc-binding proteins of the yeast zinc proteome, using a bioinformatic domain/motif survey; this is the basis of the RCA zinc ion binding annotation.</div>
+
+                        <div class="finding-text">"The yeast zinc proteome of 582 known or potential zinc-binding proteins was identified using a bioinformatics analysis that combined global domain searches with local motif searches."</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/19779198" target="_blank" class="term-link">
+                            PMID:19779198
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Global analysis of Cdk1 substrate phosphorylation sites provides insights into evolution.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/17308034" target="_blank" class="term-link">
+                            PMID:17308034
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Effect of 21 different nitrogen sources on global gene expression in the yeast Saccharomyces cerevisiae.</div>
+
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Questions for Experts</h2>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Do the two CCCH zinc fingers of LEE1 bind RNA (or DNA) in vivo, and if so what are the target transcripts or sites?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q02799" data-a="Q: Do the two CCCH zinc fingers of LEE1 bind RNA (or ..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Given the absence of a RING domain, does LEE1 have any role in ubiquitination (e.g. as a substrate-recruiting adaptor), or is the makorin-family ubiquitin-ligase annotation a family-level over-annotation for this member?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q02799" data-a="Q: Given the absence of a RING domain, does LEE1 have..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Where in the cell does LEE1 act, and which biological process explains its deletion/overexpression phenotypes (chemical resistance, competitive fitness, sporulation, invasive growth)?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q02799" data-a="Q: Where in the cell does LEE1 act, and which biologi..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Experiments</h2>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Perform UV-crosslinking RNA interactome capture / CLIP-seq (or RIP-seq) on tagged LEE1 to test for RNA binding and identify bound transcripts; complement with in vitro EMSA using recombinant LEE1 and candidate RNAs, and mutate the zinc-coordinating Cys/His residues to confirm zinc-finger dependence.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: LEE1 is an RNA-binding protein via its tandem CCCH zinc fingers.</em></p>
+
+
+                    <p style="margin-top: 0.5rem;">Type: RNA-protein interaction mapping</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q02799" data-a="EXPERIMENT: Perform UV-crosslinking RNA interactome capture / ..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Reconstitute in vitro ubiquitination assays (E1, a panel of E2s, ubiquitin) with recombinant LEE1 and assay for autoubiquitination or substrate ubiquitination; in parallel, monitor bulk/target ubiquitin-conjugate levels in LEE1 deletion vs wild-type cells.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: LEE1 does not act as an E3 ubiquitin ligase because it lacks a RING domain.</em></p>
+
+
+                    <p style="margin-top: 0.5rem;">Type: in vitro/in vivo ubiquitination assay</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q02799" data-a="EXPERIMENT: Reconstitute in vitro ubiquitination assays (E1, a..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Determine LEE1 subcellular localization by fluorescent tagging under native and stress conditions; validate top high-throughput interactors by co-immunoprecipitation; run condition-matched phenotypic assays to connect the screen phenotypes to a pathway.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: LEE1 localizes to a specific compartment consistent with a defined biological process.</em></p>
+
+
+                    <p style="margin-top: 0.5rem;">Type: localization and interaction validation</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q02799" data-a="EXPERIMENT: Determine LEE1 subcellular localization by fluores..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Knowledge Gaps</h2>
+        <p style="color: #555; font-size: 0.92rem; margin-top: -0.3rem;">
+            What is <em>not</em> known — curated, literature-grounded statements of the open
+            unknowns (the inverse of core functions).
+        </p>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The molecular function of LEE1 beyond metal (zinc) coordination is unknown. No catalytic activity or specific binding activity has been demonstrated experimentally. In particular, whether the two CCCH zinc fingers bind nucleic acid — and, if so, whether the target is RNA or DNA and what its sequence or identity is — has not been tested.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">MF_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> Firmly established: LEE1 is a 301-aa protein with two CCCH-type (C3H1) zinc fingers (residues 87-114 and 123-145) that coordinate zinc, and it is a predicted member of the yeast zinc proteome. CCCH tandem zinc fingers are canonically nucleic-acid-binding (frequently RNA-binding) modules, making RNA/nucleic-acid binding a reasonable but unproven hypothesis.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> A defined molecular activity would convert LEE1 from a fully uncharacterized zinc-finger protein into an assignable factor (e.g. an RNA-binding protein), enabling downstream mechanistic and pathway placement.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Direct binding assays for the CCCH fingers: RNA interactome capture / CLIP or RIP-seq to test for and identify RNA targets, and EMSA / protein-binding microarray for possible DNA binding; structural or biophysical confirmation of zinc-dependent fold.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"The yeast zinc proteome of 582 known or potential zinc-binding proteins was identified using a bioinformatics analysis that combined global domain searches with local motif searches."</em> — PMID:30358795</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> Whether LEE1 has any role in protein ubiquitination is unresolved. The makorin-family (PTHR11224 / MKRN-like) ubiquitin-ligase annotations are propagated from RING-domain-containing metazoan makorins, but LEE1 lacks the catalytic RING domain, so it is unknown whether LEE1 participates in ubiquitination through any non-canonical mechanism or not at all.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">MF_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> Firmly established: LEE1 is classified in the makorin-related family by its CCCH zinc fingers, yet direct InterPro analysis of Q02799 shows no RING (zf-C3HC4) domain, the module that carries makorin E3 ligase catalysis.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Resolving this determines whether the widely propagated ubiquitin-ligase annotation is a genuine (RING-independent) function or a family-level over-annotation to be discounted for this member.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> In vitro ubiquitination (E1/E2/E3) assays with LEE1 and candidate E2s; in vivo tests for ubiquitin-conjugate accumulation dependent on LEE1; assessment of any adaptor role bringing substrates to a separate RING/E3.</p>
+
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The biological process(es) in which LEE1 acts are unknown. Reported deletion and overexpression phenotypes (altered chemical resistance/accumulation, decreased competitive fitness, increased sporulation efficiency, altered invasive/vegetative growth, and a hit in a minisatellite-stability screen) come from high-throughput screens and do not define a pathway; and its nitrogen-source-responsive (nitrogen catabolite repression) expression is a regulatory observation, not a mechanism.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">WHOLLY_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> Firmly established: LEE1 is non-essential (viable null); it is transcriptionally responsive to nitrogen source and is reported cytoplasmic in global GFP studies; its GO biological process is recorded with the ND evidence code; it has numerous high-throughput physical/genetic interactors but no curated functional GO annotation.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Placing LEE1 in a pathway and compartment is prerequisite to interpreting its pleiotropic screen phenotypes and to any mechanistic model of its function.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> GFP/fluorescent-tag localization; condition-resolved phenotyping to identify the process(es) underlying the screen phenotypes; validation of high-confidence interactors by co-IP; epistasis analysis.</p>
+
+
+
+        </div>
+
+    </div>
+
+
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Deep Research Sections -->
+
+    <div class="section">
+        <h2 class="section-title">Deep Research</h2>
+
+        <details class="deep-research-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; gap: 1rem;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Falcon</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(LEE1-deep-research-falcon.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="Q02799" data-a="DEEP_RESEARCH: Falcon" data-r="" data-act="DEEP_RESEARCH" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This deep research is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This deep research needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+
+                <div class="report-meta">
+
+                    <span class="report-meta-text">Comprehensive Research Report: LEE1/YPL054W in *Saccharomyces cerevisiae*</span>
+
+
+                    <span class="report-badge">Falcon</span>
+
+
+                    <span class="report-badge">Edison Scientific Literature</span>
+
+
+                    <span class="report-badge">25 citations</span>
+
+
+                    <span class="report-badge">2 artifacts</span>
+
+
+                    <span class="report-meta-text">2026-07-05T01:35:40.565637</span>
+
+
+
+                </div>
+
+
+                <div class="artifact-list">
+
+
+
+                    <div class="artifact-link">
+                        <a href="LEE1-deep-research-falcon_artifacts/artifact-00.md" class="term-link">Edison artifact artifact-00</a>
+                        <span>(text/markdown)</span>
+                    </div>
+
+
+
+
+                    <div class="artifact-link">
+                        <a href="LEE1-deep-research-falcon_artifacts/artifact-01.md" class="term-link">Edison artifact artifact-01</a>
+                        <span>(text/markdown)</span>
+                    </div>
+
+
+                </div>
+
+                <p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h1 id="comprehensive-research-report-lee1ypl054w-in-saccharomyces-cerevisiae">Comprehensive Research Report: LEE1/YPL054W in <em>Saccharomyces cerevisiae</em></h1>
+<h2 id="1-gene-identity-and-protein-overview">1. Gene Identity and Protein Overview</h2>
+<p>LEE1 (systematic name YPL054W; UniProt Q02799) encodes a zinc finger protein in <em>Saccharomyces cerevisiae</em> (strain ATCC 204508 / S288c). The protein is classified as a makorin-like (MKRN-like) protein based on its domain architecture, which includes tandem CCCH-type zinc finger domains (InterPro: IPR000571, IPR041367) and an MKRN-like region (IPR045072). LEE1 is a non-essential gene; deletion mutants are viable. Despite its conserved domain architecture suggesting important regulatory functions, LEE1 remains one of the most poorly characterized genes in budding yeast, with no dedicated biochemical study published to date.</p>
+<p>The following table summarizes the key features of LEE1/YPL054W:</p>
+<table>
+<thead>
+<tr>
+<th>Gene name</th>
+<th>Systematic name</th>
+<th>UniProt ID</th>
+<th>Organism</th>
+<th>Protein length</th>
+<th>Key domains</th>
+<th>Expression regulation</th>
+<th>Subcellular localization</th>
+<th>Deletion phenotype</th>
+<th>Predicted function</th>
+<th>Ortholog family</th>
+<th>Key references</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>LEE1</td>
+<td>YPL054W</td>
+<td>Q02799</td>
+<td><em>Saccharomyces cerevisiae</em> strain S288c (baker’s yeast)</td>
+<td>Not established in the retrieved literature; UniProt accession corresponds to yeast zinc finger protein Lee1</td>
+<td>MKRN-like region; tandem CCCH-type zinc finger repeats / zf-CCCH domains; domain architecture is consistent with makorin-family RNA-binding ubiquitin ligases (godard2007effectof21 pages 15-16, wang2022mrknsgenefunctions pages 2-4, hildebrandt2019characterizingtherole pages 28-31)</td>
+<td>Identified as a putative nitrogen catabolite repression (P-NCR) target gene; expression varies with nitrogen source, and the gene was highlighted as one of a few differentially expressed regulator-encoding genes of unknown function (godard2007effectof21 pages 11-12, godard2007effectof21 pages 15-16, godard2007effectof21 pages 16-17)</td>
+<td>Reported as cytoplasmic in yeast GFP-localization resources based on Huh et al. 2003/SGD annotation; direct primary-study evidence was not retrieved here, so this should be treated as database-supported rather than directly re-read from the paper (godard2007effectof21 pages 15-16)</td>
+<td>Nonessential/viable deletion implied by inclusion in genome-wide deletion screens; <strong>lee1Δ / ypl054wΔ</strong> was identified in a stationary-phase minisatellite stability screen affecting the ade2-h7.5 reporter, indicating a role in genome repeat stability under that assay (alver2013awholegenome pages 10-11)</td>
+<td>Poorly characterized experimentally; best-supported inference is an RNA-binding regulatory protein acting in post-transcriptional control, potentially analogous to makorin-family RNA-binding E3 ubiquitin ligases. CCCH zinc fingers support RNA binding, while MKRN-family RING domains in homologs support ubiquitin ligase activity; direct ligase activity has <strong>not</strong> been demonstrated for yeast Lee1 in the retrieved literature (godard2007effectof21 pages 15-16, wang2022mrknsgenefunctions pages 2-4, hildebrandt2019thernabindingubiquitin pages 8-11, hildebrandt2019thernabindingubiquitin pages 1-2)</td>
+<td>Makorin / MKRN-like family; makorins are conserved across fungi, plants, invertebrates, and vertebrates and combine CCCH zinc fingers with ubiquitin-ligase-associated architecture (bohne2010thevertebratemakorin pages 1-3, wang2022mrknsgenefunctions pages 1-2, hildebrandt2019characterizingtherole pages 28-31)</td>
+<td>Godard et al. 2007 for nitrogen-responsive expression and zinc-finger annotation (godard2007effectof21 pages 11-12, godard2007effectof21 pages 15-16, godard2007effectof21 pages 16-17); Alver et al. 2013 for minisatellite-stability phenotype (alver2013awholegenome pages 10-11); Wang et al. 2022 and Hildebrandt et al. 2019 for MKRN family/domain-function inference (wang2022mrknsgenefunctions pages 2-4, hildebrandt2019thernabindingubiquitin pages 1-2)</td>
+</tr>
+</tbody>
+</table>
+<p><em>Table: This table summarizes the key curated features of the yeast gene LEE1/YPL054W, integrating direct evidence on regulation and phenotype with cautious functional inference from its MKRN-like/CCCH domain architecture. It is useful as a compact reference for annotation-focused gene reports.</em></p>
+<h2 id="2-domain-architecture-and-functional-inference">2. Domain Architecture and Functional Inference</h2>
+<p>Lee1 contains two tandem repeats of the CCCH-type zinc finger domain, a hallmark of RNA-binding proteins (godard2007effectof21 pages 15-16). This domain architecture places Lee1 within the makorin (MKRN) protein family, a group of evolutionarily conserved proteins found in fungi, plants, invertebrates, and vertebrates that characteristically combine CCCH zinc finger motifs with ubiquitin-ligase-associated structural features (bohne2010thevertebratemakorin pages 1-3, wang2022mrknsgenefunctions pages 1-2, hildebrandt2019characterizingtherole pages 28-31).</p>
+<p>In metazoan MKRN family members, the CCCH zinc fingers mediate RNA binding—particularly to poly(A) tails and A-rich sequences—while the C3HC4-type RING domain functions as an E3 ubiquitin ligase, enabling these proteins to couple RNA recognition with post-translational regulation of target substrates (wang2022mrknsgenefunctions pages 2-4, dold2020investigatingthefunction pages 155-157, wang2022mrknsgenefunctions pages 1-2). The MKRN gene family encodes proteins with C3H zinc finger motifs associated with RNA-binding capability, a Cys-His motif, and a RING finger domain that serves as a signature of E3 ubiquitin ligases mediating substrate degradation through the ubiquitin-proteasome system (wang2022mrknsgenefunctions pages 2-4, wang2022mrknsgenefunctions pages 1-2).</p>
+<p>Godard et al. (2007) specifically highlighted that the CCCH-type zinc finger domain in Lee1 is shared with Cth2, a well-characterized yeast protein that promotes binding to the 3′ end of mRNA and accelerates mRNA degradation under iron-deficient conditions (godard2007effectof21 pages 15-16). This parallel suggests that Lee1 may similarly function as an RNA-binding regulatory protein involved in post-transcriptional gene regulation, although direct experimental evidence for Lee1's RNA-binding activity is lacking.</p>
+<p>The following blockquote provides a detailed summary of the functional inference from domain architecture:</p>
+<blockquote>
+<p>LEE1/YPL054W from <em>Saccharomyces cerevisiae</em> encodes a poorly characterized protein with MKRN-like and tandem CCCH zinc finger features, placing it within or near the makorin-like class of RNA-binding regulatory proteins; in yeast transcriptome studies it was specifically highlighted as a zinc-finger protein of unknown function regulated by nitrogen source quality (godard2007effectof21 pages 15-16, hildebrandt2019characterizingtherole pages 28-31).</p>
+<p>Across eukaryotes, makorin/MKRN proteins are defined by CCCH-type zinc fingers linked to ubiquitin-ligase-associated architecture, and these domains are interpreted functionally as coupling RNA recognition with post-translational regulation. In MKRN family proteins, CCCH zinc fingers support RNA binding, while the RING region in characterized metazoan homologs confers E3 ubiquitin ligase activity (wang2022mrknsgenefunctions pages 2-4, dold2020investigatingthefunction pages 155-157, wang2022mrknsgenefunctions pages 1-2).</p>
+<p>In metazoans, MKRN1 has been experimentally shown to act as an RNA-binding E3 ubiquitin ligase in ribosome-associated quality control (RQC): it binds PABPC1, is positioned upstream of poly(A) tails and A-rich stretches, associates with polysomes, and promotes ribosome stalling at poly(A) sequences to prevent erroneous translation of prematurely polyadenylated transcripts (hildebrandt2019thernabindingubiquitin pages 1-2, hildebrandt2019thernabindingubiquitin pages 2-4, hildebrandt2019thernabindingubiquitin pages 4-6).</p>
+<p>Mechanistically, MKRN1 ubiquitylates ribosomal protein RPS10 as well as PABPC1, thereby helping create the translational block that prevents damaging poly(A) translation and triggers downstream quality-control responses (hildebrandt2019thernabindingubiquitin pages 8-11, thapa2020ubiquitinsignalingregulates pages 4-5, hildebrandt2019characterizingtherole pages 8-11).</p>
+<p>Whether yeast Lee1 performs an equivalent RQC role has not been experimentally demonstrated. No dedicated biochemical study of Lee1 was found, so any assignment to RQC remains inferential rather than proven; however, its domain architecture is consistent with an RNA-binding regulatory protein and potentially with ubiquitin-ligase-related function by homology to MKRN proteins (godard2007effectof21 pages 15-16, hildebrandt2019characterizingtherole pages 28-31, hildebrandt2019thernabindingubiquitin pages 6-8).</p>
+<p>In budding yeast, the best-established RQC ubiquitin ligase is Hel2, the functional homolog of metazoan ZNF598, whereas Lee1’s possible contribution to this pathway remains unexplored. At present, the strongest direct evidence for Lee1 in yeast is its nitrogen-responsive expression and its appearance in a stationary-phase minisatellite-stability screen, not a defined RQC assay (hildebrandt2019characterizingtherole pages 116-119, alver2013awholegenome pages 10-11).</p>
+</blockquote>
+<p><em>Blockquote: This blockquote summarizes what is directly known about yeast LEE1/YPL054W and what can be inferred from its MKRN-like, CCCH zinc finger architecture. It is useful because it clearly separates experimentally supported facts from homology-based functional hypotheses.</em></p>
+<h2 id="3-transcriptional-regulation-nitrogen-catabolite-repression">3. Transcriptional Regulation: Nitrogen Catabolite Repression</h2>
+<p>The most direct experimental evidence regarding LEE1 comes from genome-wide transcriptomic analyses of nitrogen source utilization. Godard et al. (2007) conducted a systematic analysis of the yeast transcriptome under 21 different nitrogen source conditions and identified LEE1/YPL054W as a putative nitrogen catabolite repression (P-NCR) target gene (godard2007effectof21 pages 11-12).</p>
+<p>Nitrogen catabolite repression (NCR) is a central regulatory mechanism in <em>S. cerevisiae</em> whereby the GATA transcription factors Gln3 and Gat1 activate expression of genes required for utilization of poor nitrogen sources, while these genes are repressed in the presence of preferred nitrogen sources such as glutamine or asparagine (godard2007effectof21 pages 9-11). The study identified 140 NCR-responsive genes, of which 44 were classified as probable novel NCR targets; LEE1 was among 30 "highly probable" P-NCR genes showing expression patterns characteristic of NCR regulation (godard2007effectof21 pages 11-12, godard2007effectof21 pages 9-11).</p>
+<p>Notably, LEE1 was singled out as one of only four differentially expressed regulator-encoding genes of unknown function among the 37 transcription factor and regulatory protein genes that showed nitrogen-dependent expression changes (godard2007effectof21 pages 15-16). The authors stated: "One, encoded by the LEE1/YPL054W gene, codes for a protein containing two tandem repeats of the CCCH-type zinc finger domain" and noted that "further experiments will be required to determine the functions of these potentially interesting putative regulatory proteins" (godard2007effectof21 pages 15-16).</p>
+<h2 id="4-subcellular-localization">4. Subcellular Localization</h2>
+<p>Direct localization data for Lee1 from the retrieved literature is limited. According to the Saccharomyces Genome Database (SGD), which draws on the global GFP-tagging study by Huh et al. (2003), Lee1-GFP has been reported as showing cytoplasmic localization. This is consistent with the localization of its metazoan orthologs: in human cells, MKRN1 localizes to the cytoplasm, where it associates with polysomes and co-sediments with PABPC1 in sucrose gradient centrifugation experiments (hildebrandt2019thernabindingubiquitin pages 1-2, hildebrandt2019thernabindingubiquitin pages 2-4). The cytoplasmic localization is consistent with a role in post-transcriptional RNA regulation, potentially at the interface of translation and mRNA metabolism.</p>
+<h2 id="5-functional-evidence-from-high-throughput-screens">5. Functional Evidence from High-Throughput Screens</h2>
+<h3 id="51-minisatellite-stability">5.1 Minisatellite Stability</h3>
+<p>In a genome-wide screen for genes affecting minisatellite stability in stationary-phase yeast cells, Alver et al. (2013) identified LEE1 (YPL054W) as a hit in the ade2-h7.5 SGA (synthetic genetic array) screen (alver2013awholegenome pages 10-11). The ade2-h7.5 construct consists of seven-and-a-half 28-bp variable repeats inserted into the ADE2 gene, and alterations within this minisatellite tract produce a blebbing phenotype in stationary-phase colonies. The identification of LEE1 in this screen suggests that loss of Lee1 destabilizes complex minisatellite sequences during stationary phase, potentially linking its function to genome maintenance or DNA repair-related processes.</p>
+<h3 id="52-stress-and-environmental-responses">5.2 Stress and Environmental Responses</h3>
+<p>LEE1 has also appeared in genome-wide expression studies examining yeast responses to environmental stresses including chromate exposure (which causes sulfur starvation) and cadmium toxicity, although these studies did not specifically characterize LEE1 function.</p>
+<h2 id="6-relationship-to-the-makorin-mkrn-protein-family">6. Relationship to the Makorin (MKRN) Protein Family</h2>
+<p>The makorin gene family is ancient and highly conserved. Orthologs of MKRN proteins have been identified in fungi, plants, and metazoans (bohne2010thevertebratemakorin pages 1-3, wang2022mrknsgenefunctions pages 1-2). In vertebrates, up to four paralogs exist (MKRN1–4), which arose through large-scale genome duplication and retroposition events (bohne2010thevertebratemakorin pages 1-3). The ancestral makorin gene is believed to have been gonad-specific, with maternal expression in early embryos (bohne2010thevertebratemakorin pages 1-3). The MKRN family has been described as "highly conserved across species including vertebrates, fruit flies, nematodes, plants, and fungi" (hildebrandt2019characterizingtherole pages 28-31).</p>
+<p>The best-characterized family member, MKRN1, has been shown to function as an RNA-binding E3 ubiquitin ligase in ribosome-associated quality control (RQC) of poly(A) translation in human cells (hildebrandt2019thernabindingubiquitin pages 8-11, hildebrandt2019thernabindingubiquitin pages 1-2). Key mechanistic findings include:</p>
+<ul>
+<li><strong>PABPC1 interaction</strong>: MKRN1 directly binds the cytoplasmic poly(A)-binding protein PABPC1 via a conserved PAM2 motif and associates with polysomes (hildebrandt2019thernabindingubiquitin pages 2-4).</li>
+<li><strong>RNA binding</strong>: MKRN1 is positioned upstream of poly(A) tails in mRNAs in a PABPC1-dependent manner, with strong preference for A-rich stretches of 8–30 nucleotides that match the RNA footprint of one RRM domain of PABP (hildebrandt2019characterizingtherole pages 116-119, hildebrandt2019thernabindingubiquitin pages 4-6).</li>
+<li><strong>Ribosome stalling</strong>: MKRN1 promotes ribosome stalling at poly(A) sequences, preventing erroneous translation of prematurely polyadenylated transcripts (hildebrandt2019thernabindingubiquitin pages 8-11, hildebrandt2019thernabindingubiquitin pages 6-8).</li>
+<li><strong>Ubiquitylation</strong>: MKRN1 ubiquitylates ribosomal protein RPS10 (at K107) and PABPC1, triggering downstream RQC events including ribosome collision recognition by ZNF598 (hildebrandt2019thernabindingubiquitin pages 8-11, thapa2020ubiquitinsignalingregulates pages 4-5).</li>
+</ul>
+<p>In <em>Drosophila</em>, Mkrn1 has been shown to control embryonic patterning by activating oskar (osk) translation, competing with the translational repressor Bruno1 for binding to osk 3′ UTR. This function depends on Mkrn1's interaction with pAbp (poly(A) binding protein) and its first zinc finger domain (dold2020investigatingthefunction pages 16-21, dold2020investigatingthefunction pages 32-35).</p>
+<h2 id="7-inferred-function-and-current-knowledge-gaps">7. Inferred Function and Current Knowledge Gaps</h2>
+<p>Based on the available evidence, the following functional model can be proposed for Lee1, though it must be emphasized that this is largely inferential:</p>
+<p><strong>Predicted primary function</strong>: Lee1 is likely an RNA-binding protein, based on its tandem CCCH zinc finger domains. By analogy to its metazoan orthologs in the MKRN family, it may couple RNA recognition with ubiquitin-related regulatory functions. The CCCH zinc finger domains in related proteins mediate binding to AU-rich elements and poly(A) sequences in mRNA 3′ UTRs, promoting mRNA turnover, translational regulation, or both (godard2007effectof21 pages 15-16, wang2022mrknsgenefunctions pages 2-4, wells2017anancientfamily pages 2-4).</p>
+<p><strong>Predicted subcellular site of action</strong>: Cytoplasm, likely associated with mRNA ribonucleoprotein particles or polysomes, consistent with GFP localization data and the localization of MKRN1 orthologs.</p>
+<p><strong>Pathway context</strong>: Lee1 expression is regulated by nitrogen catabolite repression, suggesting it participates in nitrogen-responsive post-transcriptional gene regulation (godard2007effectof21 pages 11-12, godard2007effectof21 pages 15-16). The GATA transcription factors Gln3 and Gat1, which respond to nitrogen availability via the TOR signaling pathway, likely control LEE1 transcription.</p>
+<p><strong>Key knowledge gaps</strong>: (1) No biochemical characterization of Lee1's RNA-binding activity, substrate specificity, or potential ubiquitin ligase activity has been reported. (2) Whether Lee1 participates in ribosome-associated quality control in yeast, analogous to MKRN1 in metazoans, has not been tested. In yeast, the primary RQC E3 ligase is Hel2 (homolog of ZNF598), and Lee1's contribution to this pathway remains unexplored. (3) The biological significance of Lee1's role in minisatellite stability has not been mechanistically investigated. (4) The specific mRNA targets of Lee1 binding are unknown.</p>
+<h2 id="8-conclusions">8. Conclusions</h2>
+<p>LEE1/YPL054W encodes a conserved makorin-like CCCH zinc finger protein in <em>S. cerevisiae</em> that remains functionally uncharacterized at the biochemical level. Its domain architecture—featuring MKRN-like and tandem CCCH zinc finger domains—strongly predicts a role as an RNA-binding regulatory protein, potentially with E3 ubiquitin ligase activity by analogy to the well-studied metazoan MKRN1 (wang2022mrknsgenefunctions pages 2-4, hildebrandt2019thernabindingubiquitin pages 1-2). Its transcriptional regulation as an NCR target gene links it to nitrogen-responsive physiology (godard2007effectof21 pages 11-12, godard2007effectof21 pages 15-16), and its identification in a minisatellite stability screen suggests broader roles in genome maintenance or stress responses during stationary phase (alver2013awholegenome pages 10-11). Dedicated functional studies are needed to determine whether Lee1 operates in ribosome-associated quality control, mRNA turnover, or other post-transcriptional regulatory processes in budding yeast.</p>
+<p>References</p>
+<ol>
+<li>
+<p>(godard2007effectof21 pages 15-16): Patrice Godard, Antonio Urrestarazu, Stéphan Vissers, Kevin Kontos, Gianluca Bontempi, Jacques van Helden, and Bruno André. Effect of 21 different nitrogen sources on global gene expression in the yeast<i>saccharomyces cerevisiae</i>. Apr 2007. URL: https://doi.org/10.1128/mcb.01084-06, doi:10.1128/mcb.01084-06. This article has 339 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(wang2022mrknsgenefunctions pages 2-4): Tongtong Wang, Wenqiang Liu, Changfa Wang, Xuelian Ma, Muhammad Faheem Akhtar, Yubao Li, and Liangliang Li. Mrkns: gene, functions, and role in disease and infection. Frontiers in Oncology, Apr 2022. URL: https://doi.org/10.3389/fonc.2022.862206, doi:10.3389/fonc.2022.862206. This article has 19 citations.</p>
+</li>
+<li>
+<p>(hildebrandt2019characterizingtherole pages 28-31): Characterizing the role of RNA-binding proteins in ubiquitin signaling This article has 0 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(godard2007effectof21 pages 11-12): Patrice Godard, Antonio Urrestarazu, Stéphan Vissers, Kevin Kontos, Gianluca Bontempi, Jacques van Helden, and Bruno André. Effect of 21 different nitrogen sources on global gene expression in the yeast<i>saccharomyces cerevisiae</i>. Apr 2007. URL: https://doi.org/10.1128/mcb.01084-06, doi:10.1128/mcb.01084-06. This article has 339 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(godard2007effectof21 pages 16-17): Patrice Godard, Antonio Urrestarazu, Stéphan Vissers, Kevin Kontos, Gianluca Bontempi, Jacques van Helden, and Bruno André. Effect of 21 different nitrogen sources on global gene expression in the yeast<i>saccharomyces cerevisiae</i>. Apr 2007. URL: https://doi.org/10.1128/mcb.01084-06, doi:10.1128/mcb.01084-06. This article has 339 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(alver2013awholegenome pages 10-11): Bonnie Alver, Peter A Jauert, Laura Brosnan, Melissa O’Hehir, Benjamin VanderSluis, Chad L Myers, and David T Kirkpatrick. A whole genome screen for minisatellite stability genes in stationary-phase yeast cells. G3: Genes|Genomes|Genetics, 3:741-756, Apr 2013. URL: https://doi.org/10.1534/g3.112.005397, doi:10.1534/g3.112.005397. This article has 6 citations.</p>
+</li>
+<li>
+<p>(hildebrandt2019thernabindingubiquitin pages 8-11): Andrea Hildebrandt, Mirko Brüggemann, Cornelia Rücklé, Susan Boerner, Jan B. Heidelberger, Anke Busch, Heike Hänel, Andrea Voigt, Martin M. Möckel, Stefanie Ebersberger, Anica Scholz, Annabelle Dold, Tobias Schmid, Ingo Ebersberger, Jean-Yves Roignant, Kathi Zarnack, Julian König, and Petra Beli. The rna-binding ubiquitin ligase mkrn1 functions in ribosome-associated quality control of poly(a) translation. Genome Biology, Oct 2019. URL: https://doi.org/10.1186/s13059-019-1814-0, doi:10.1186/s13059-019-1814-0. This article has 56 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(hildebrandt2019thernabindingubiquitin pages 1-2): Andrea Hildebrandt, Mirko Brüggemann, Cornelia Rücklé, Susan Boerner, Jan B. Heidelberger, Anke Busch, Heike Hänel, Andrea Voigt, Martin M. Möckel, Stefanie Ebersberger, Anica Scholz, Annabelle Dold, Tobias Schmid, Ingo Ebersberger, Jean-Yves Roignant, Kathi Zarnack, Julian König, and Petra Beli. The rna-binding ubiquitin ligase mkrn1 functions in ribosome-associated quality control of poly(a) translation. Genome Biology, Oct 2019. URL: https://doi.org/10.1186/s13059-019-1814-0, doi:10.1186/s13059-019-1814-0. This article has 56 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(bohne2010thevertebratemakorin pages 1-3): Astrid Böhne, Amandine Darras, Helena D'Cotta, Jean-Francois Baroiller, Delphine Galiana-Arnoux, and Jean-Nicolas Volff. The vertebrate makorin ubiquitin ligase gene family has been shaped by large-scale duplication and retroposition from an ancestral gonad-specific, maternal-effect gene. BMC Genomics, 11:721-721, Dec 2010. URL: https://doi.org/10.1186/1471-2164-11-721, doi:10.1186/1471-2164-11-721. This article has 59 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(wang2022mrknsgenefunctions pages 1-2): Tongtong Wang, Wenqiang Liu, Changfa Wang, Xuelian Ma, Muhammad Faheem Akhtar, Yubao Li, and Liangliang Li. Mrkns: gene, functions, and role in disease and infection. Frontiers in Oncology, Apr 2022. URL: https://doi.org/10.3389/fonc.2022.862206, doi:10.3389/fonc.2022.862206. This article has 19 citations.</p>
+</li>
+<li>
+<p>(dold2020investigatingthefunction pages 155-157): Annabelle Cynthia Elisabeth Dold. Investigating the function of makorin 1 in drosophila oogenesis. Text, Jan 2020. URL: https://doi.org/10.25358/openscience-2684, doi:10.25358/openscience-2684. This article has 0 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(hildebrandt2019thernabindingubiquitin pages 2-4): Andrea Hildebrandt, Mirko Brüggemann, Cornelia Rücklé, Susan Boerner, Jan B. Heidelberger, Anke Busch, Heike Hänel, Andrea Voigt, Martin M. Möckel, Stefanie Ebersberger, Anica Scholz, Annabelle Dold, Tobias Schmid, Ingo Ebersberger, Jean-Yves Roignant, Kathi Zarnack, Julian König, and Petra Beli. The rna-binding ubiquitin ligase mkrn1 functions in ribosome-associated quality control of poly(a) translation. Genome Biology, Oct 2019. URL: https://doi.org/10.1186/s13059-019-1814-0, doi:10.1186/s13059-019-1814-0. This article has 56 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(hildebrandt2019thernabindingubiquitin pages 4-6): Andrea Hildebrandt, Mirko Brüggemann, Cornelia Rücklé, Susan Boerner, Jan B. Heidelberger, Anke Busch, Heike Hänel, Andrea Voigt, Martin M. Möckel, Stefanie Ebersberger, Anica Scholz, Annabelle Dold, Tobias Schmid, Ingo Ebersberger, Jean-Yves Roignant, Kathi Zarnack, Julian König, and Petra Beli. The rna-binding ubiquitin ligase mkrn1 functions in ribosome-associated quality control of poly(a) translation. Genome Biology, Oct 2019. URL: https://doi.org/10.1186/s13059-019-1814-0, doi:10.1186/s13059-019-1814-0. This article has 56 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(thapa2020ubiquitinsignalingregulates pages 4-5): Pankaj Thapa, Nilesh Shanmugam, and Wojciech Pokrzywa. Ubiquitin signaling regulates rna biogenesis, processing, and metabolism. BioEssays, Nov 2020. URL: https://doi.org/10.1002/bies.201900171, doi:10.1002/bies.201900171. This article has 33 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(hildebrandt2019characterizingtherole pages 8-11): Characterizing the role of RNA-binding proteins in ubiquitin signaling This article has 0 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(hildebrandt2019thernabindingubiquitin pages 6-8): Andrea Hildebrandt, Mirko Brüggemann, Cornelia Rücklé, Susan Boerner, Jan B. Heidelberger, Anke Busch, Heike Hänel, Andrea Voigt, Martin M. Möckel, Stefanie Ebersberger, Anica Scholz, Annabelle Dold, Tobias Schmid, Ingo Ebersberger, Jean-Yves Roignant, Kathi Zarnack, Julian König, and Petra Beli. The rna-binding ubiquitin ligase mkrn1 functions in ribosome-associated quality control of poly(a) translation. Genome Biology, Oct 2019. URL: https://doi.org/10.1186/s13059-019-1814-0, doi:10.1186/s13059-019-1814-0. This article has 56 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(hildebrandt2019characterizingtherole pages 116-119): Characterizing the role of RNA-binding proteins in ubiquitin signaling This article has 0 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(godard2007effectof21 pages 9-11): Patrice Godard, Antonio Urrestarazu, Stéphan Vissers, Kevin Kontos, Gianluca Bontempi, Jacques van Helden, and Bruno André. Effect of 21 different nitrogen sources on global gene expression in the yeast<i>saccharomyces cerevisiae</i>. Apr 2007. URL: https://doi.org/10.1128/mcb.01084-06, doi:10.1128/mcb.01084-06. This article has 339 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(dold2020investigatingthefunction pages 16-21): Annabelle Cynthia Elisabeth Dold. Investigating the function of makorin 1 in drosophila oogenesis. Text, Jan 2020. URL: https://doi.org/10.25358/openscience-2684, doi:10.25358/openscience-2684. This article has 0 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(dold2020investigatingthefunction pages 32-35): Annabelle Cynthia Elisabeth Dold. Investigating the function of makorin 1 in drosophila oogenesis. Text, Jan 2020. URL: https://doi.org/10.25358/openscience-2684, doi:10.25358/openscience-2684. This article has 0 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(wells2017anancientfamily pages 2-4): Melissa L. Wells, Lalith Perera, and Perry J. Blackshear. An ancient family of rna-binding proteins: still important! Trends in biochemical sciences, 42 4:285-296, Apr 2017. URL: https://doi.org/10.1016/j.tibs.2016.12.003, doi:10.1016/j.tibs.2016.12.003. This article has 83 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+</ol>
+<h2 id="artifacts">Artifacts</h2>
+<ul>
+<li><a href="LEE1-deep-research-falcon_artifacts/artifact-00.md">Edison artifact artifact-00</a></li>
+<li><a href="LEE1-deep-research-falcon_artifacts/artifact-01.md">Edison artifact artifact-01</a></li>
+</ul>
+<h2 id="citations">Citations</h2>
+<ol>
+<li>alver2013awholegenome pages 10-11</li>
+<li>bohne2010thevertebratemakorin pages 1-3</li>
+<li>hildebrandt2019characterizingtherole pages 28-31</li>
+<li>hildebrandt2019thernabindingubiquitin pages 2-4</li>
+<li>wang2022mrknsgenefunctions pages 2-4</li>
+<li>hildebrandt2019thernabindingubiquitin pages 8-11</li>
+<li>hildebrandt2019thernabindingubiquitin pages 1-2</li>
+<li>wang2022mrknsgenefunctions pages 1-2</li>
+<li>dold2020investigatingthefunction pages 155-157</li>
+<li>hildebrandt2019thernabindingubiquitin pages 4-6</li>
+<li>thapa2020ubiquitinsignalingregulates pages 4-5</li>
+<li>hildebrandt2019characterizingtherole pages 8-11</li>
+<li>hildebrandt2019thernabindingubiquitin pages 6-8</li>
+<li>hildebrandt2019characterizingtherole pages 116-119</li>
+<li>dold2020investigatingthefunction pages 16-21</li>
+<li>dold2020investigatingthefunction pages 32-35</li>
+<li>wells2017anancientfamily pages 2-4</li>
+<li>https://doi.org/10.1128/mcb.01084-06,</li>
+<li>https://doi.org/10.3389/fonc.2022.862206,</li>
+<li>https://doi.org/10.1534/g3.112.005397,</li>
+<li>https://doi.org/10.1186/s13059-019-1814-0,</li>
+<li>https://doi.org/10.1186/1471-2164-11-721,</li>
+<li>https://doi.org/10.25358/openscience-2684,</li>
+<li>https://doi.org/10.1002/bies.201900171,</li>
+<li>https://doi.org/10.1016/j.tibs.2016.12.003,</li>
+</ol>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(LEE1-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="Q02799" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="lee1-ypl054w-gene-review-notes">LEE1 (YPL054W) — Gene Review Notes</h1>
+<p>Systematic name: YPL054W. SGD standard name: LEE1. SGD ID: S000005975. UniProt: Q02799.<br />
+Organism: <em>Saccharomyces cerevisiae</em> (S288c), NCBITaxon:559292.</p>
+<p>This is an UNDERSTUDIED ("dark") gene. Primary deliverable is an honest <code>knowledge_gaps</code><br />
+section, with <code>description</code>/<code>core_functions</code> grounded strictly in domain architecture,<br />
+orthology, and the (sparse) literature. No invented function.</p>
+<h2 id="summary-of-what-is-known-vs-not-known">Summary of what is KNOWN vs NOT known</h2>
+<h3 id="known-well-supported">KNOWN (well-supported)</h3>
+<ul>
+<li><strong>301-aa protein</strong> with <strong>two CCCH-type (C3H1) zinc fingers</strong>: ZN_FING 87–114 (C3H1-type 1)<br />
+  and ZN_FING 123–145 (C3H1-type 2) [UniProt Q02799, FT ZN_FING records; PROSITE PS50103 ZF_C3H1 x2;<br />
+  SMART SM00356 ZnF_C3H1 x2]. Pfam PF00642 (zf-CCCH) and PF18044 (zf-CCCH_4).</li>
+<li><strong>Zinc/metal-binding is domain-defensible</strong>: CCCH zinc fingers coordinate Zn2+ via 3 Cys + 1 His.<br />
+  KW: Metal-binding, Zinc, Zinc-finger. LEE1 was independently identified as one of 582 known/potential<br />
+  zinc-binding proteins in a proteome-wide bioinformatic+MS survey of the yeast zinc proteome<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/30358795" title="The yeast zinc proteome of 582 known or potential zinc-binding proteins was identified   using a bioinformatics analysis that combined global domain searches with local motif searches.">PMID:30358795</a> —<br />
+  this is the source of the RCA GO:0008270 (zinc ion binding) annotation.</li>
+<li><strong>Phosphoprotein</strong>: phosphoserine at Ser-21, Ser-30, Ser-282 detected in large-scale phosphoproteomics.<br />
+  Ser-21/30/282 are Cdk1-substrate-related sites [PMID:19779198, "Global analysis of Cdk1 substrate<br />
+  phosphorylation sites"]. N-terminal region (1–25) is disordered (MobiDB-lite), polar-residue biased.</li>
+<li><strong>PANTHER family</strong>: PTHR11224 MAKORIN-RELATED; subfamily <strong>PTHR11224:SF10</strong> (IP09428P-RELATED)<br />
+  [interpro/panther/PTHR11224 cached data]. eggNOG KOG1039.</li>
+<li><strong>Viable null</strong>; documented deletion phenotypes at SGD (all from high-throughput screens): altered<br />
+  chemical resistance/accumulation, decreased competitive fitness, increased sporulation efficiency;<br />
+  overexpression -&gt; increased invasive growth, decreased vegetative growth [SGD YPL054W phenotype summary,<br />
+  yeastgenome.org]. ~74 interactors / 82 interactions at BioGRID, essentially all high-throughput; 0<br />
+  curated GO function/process/component annotations at BioGRID [thebiogrid.org/36126].</li>
+</ul>
+<h3 id="not-known-the-real-knowledge-gaps">NOT known (the real knowledge gaps)</h3>
+<ul>
+<li><strong>Molecular function beyond zinc coordination is unknown.</strong> No experimental demonstration of a<br />
+  catalytic or binding activity. CCCH zinc fingers are canonically <strong>nucleic-acid (frequently RNA)<br />
+  binding</strong> modules, so RNA/nucleic-acid binding is a reasonable domain-based hypothesis — but there is<br />
+  no direct experimental evidence (LEE1 was not specifically reported as a hit in the yeast RNA<br />
+  interactome-capture datasets I checked).</li>
+<li><strong>Whether LEE1 is a ubiquitin ligase is unresolved — and there is a strong biological argument<br />
+  against it.</strong> See "Makorin/E3-ligase over-propagation" below.</li>
+<li><strong>Biological process is unknown.</strong> SGD/GO: biological_process = ND. Deletion phenotypes are<br />
+  pleiotropic HTP-screen readouts, not a defined pathway.</li>
+<li><strong>Subcellular localization is unknown</strong> (GO cellular_component = ND).</li>
+<li><strong>What (if anything) it binds</strong> (RNA? DNA? which targets?) is unknown.</li>
+</ul>
+<h2 id="makorin-e3-ligase-over-propagation-analysis-the-central-curation-issue">Makorin / E3-ligase over-propagation analysis (the central curation issue)</h2>
+<p>The GOA annotations <code>ubiquitin protein ligase activity</code> (GO:0061630) and the ubiquitination process<br />
+terms (<code>protein ubiquitination</code> GO:0016567, <code>protein polyubiquitination</code> GO:0000209) all trace to the<br />
+<strong>MAKORIN family (PANTHER PTHR11224 / InterPro IPR045072 MKRN-like)</strong>:</p>
+<ul>
+<li>IBA (GO_REF:0000033): propagated from PANTHER node PTN000131854, seeded (IBD) from<br />
+<strong>UniProtKB:Q9UHC7 (human MKRN1)</strong>, <strong>UniProtKB:Q13064 (human MKRN3)</strong>, <strong>MGI:1914277 (mouse Mkrn2)</strong><br />
+  [PTHR11224-paint.tsv]. All three seed proteins are metazoan <strong>makorins that possess a catalytic RING<br />
+  domain</strong>.</li>
+<li>IEA (GO_REF:0000002 / InterPro): from IPR045072 (MKRN-like) and IPR041367 ("E3 ligase, CCCH-type<br />
+  zinc finger").</li>
+</ul>
+<p><strong>Makorins are RING-finger E3 ubiquitin ligases</strong>: their domain architecture is multiple CCCH zinc<br />
+fingers + a <strong>C3HC4 RING</strong> domain that is the actual ubiquitin-transfer (catalytic) module.</p>
+<p><strong>Critical finding: LEE1 has NO RING domain.</strong> Its full InterPro/Pfam complement is only CCCH zinc<br />
+fingers (IPR000571, IPR036855, IPR041367, PF00642, PF18044) plus MKRN-like (IPR045072). Direct<br />
+InterPro API query on Q02799 returns <strong>no zf-C3HC4 / RING-type (IPR001841) signature</strong><br />
+[EBI InterPro API entry/all/protein/uniprot/Q02799, verified 2026-07-05: "this protein does not<br />
+contain a RING domain"]. LEE1 is 301 aa; the metazoan makorin seeds are longer (MKRN1/2/3 ~400+ aa)<br />
+and carry the RING.</p>
+<p>LEE1's PANTHER subfamily <strong>SF10</strong> is heterogeneous — it contains true RING-makorins (plant MKRN,<br />
+<em>C. elegans</em> lep-2, rice MKRN) AND poxvirus host-range factor p28 — so subfamily membership does not<br />
+confer the ligase function. <strong>Because the catalytic RING module is absent in LEE1, propagating<br />
+"ubiquitin protein ligase activity" to it is a domain-based over-annotation</strong> (the specific catalytic<br />
+domain required for the function is not present). This is a Type-6-style paralog/subfamily<br />
+over-propagation of a catalytic activity onto a protein lacking the catalytic domain.</p>
+<p>Curation consequence:<br />
+- GO:0061630 (ubiquitin protein ligase activity), both IBA and IEA -&gt; <strong>MARK_AS_OVER_ANNOTATED</strong><br />
+  (RING absent; catalytic activity not supportable). Per project rules, I do not REMOVE IBA outright,<br />
+  but flag as over-annotation on biological grounds (no catalytic domain).<br />
+- GO:0016567 (protein ubiquitination) IBA and GO:0000209 (protein polyubiquitination) IEA -&gt; the<br />
+  associated <em>process</em> likewise over-propagated from the ligase function -&gt; <strong>MARK_AS_OVER_ANNOTATED</strong>.<br />
+- GO:0046872 (metal ion binding) IEA / GO:0008270 (zinc ion binding) RCA -&gt; domain-defensible -&gt;<br />
+<strong>ACCEPT</strong> (zinc binding is real per CCCH fingers; keep zinc as the more specific term). Metal ion<br />
+  binding is the generic parent; keep but note zinc is more precise.<br />
+- GO:0005575 (cellular_component ND), GO:0008150 (biological_process ND) -&gt; <strong>ACCEPT</strong> as<br />
+  root/ND placeholders (correctly signal "unknown"; standard practice to keep ND roots).</p>
+<h2 id="references-checked">References checked</h2>
+<ul>
+<li>PMID:30358795 — Wang et al. 2018 Metallomics, yeast zinc proteome. Abstract-only cached; supports<br />
+  LEE1 as a (predicted) zinc-binding protein; source of RCA zinc-binding annotation. Relevance MEDIUM,<br />
+  VERIFIED (title matches PubMed; supports zinc-binding classification, not a specific function).</li>
+<li>PMID:19779198 — Holt et al. 2009 Science, Cdk1 substrate phosphosites (UniProt ref for phosphosites).</li>
+<li>SGD YPL054W (yeastgenome.org) — "Zinc-finger protein of unknown function"; phenotype summary.</li>
+<li>BioGRID 36126 — 74 interactors, HTP only, 0 curated GO.</li>
+<li>InterPro Q02799 (EBI API) — domain complement; confirms NO RING.</li>
+<li>PANTHER PTHR11224 (cached) — MAKORIN-RELATED family; SF10; IBA seeds are RING makorins.</li>
+</ul>
+<h2 id="domain-reasoning-for-core_functions-description">Domain reasoning for core_functions / description</h2>
+<ul>
+<li>Confident: zinc ion binding (GO:0008270) via 2 CCCH zinc fingers — the ONLY molecular activity<br />
+  supportable.</li>
+<li>Reasonable hypothesis (NOT asserted as core; put in knowledge_gaps): nucleic-acid / RNA binding<br />
+  (GO:0003676 / GO:0003723), the canonical role of CCCH zinc-finger tandems.</li>
+<li>NOT supportable: ubiquitin ligase activity (no RING), specific transcription-factor role.</li>
+</ul>
+<h2 id="falcon-deep-research-lee1-deep-research-falconmd-corroborating-findings">Falcon deep research (LEE1-deep-research-falcon.md) — corroborating findings</h2>
+<p>Falcon deep research completed (~28 min). It strongly corroborates the analysis above and adds<br />
+grounded, literature-anchored findings (citations are DOI/deep-research style; primary PMIDs noted):</p>
+<ul>
+<li><strong>Nitrogen catabolite repression (NCR) target</strong>: Godard et al. 2007 (PMID:17308034,<br />
+  Mol Cell Biol 27:3065-3086) highlighted LEE1/YPL054W as one of only a few differentially<br />
+  expressed regulator-encoding genes of unknown function among nitrogen-responsive genes, and<br />
+  described it as "a protein containing two tandem repeats of the CCCH-type zinc finger domain"<br />
+  with "further experiments will be required to determine the functions" (per falcon, quoting the<br />
+  full text; the LEE1-specific text is in the full text, NOT in the abstract-only cached record,<br />
+  so it cannot be used as a verbatim supporting_text quote). This is an EXPRESSION/regulation<br />
+  observation, not a molecular-function assignment.</li>
+<li><strong>Minisatellite stability screen</strong>: Alver et al. 2013 — lee1Δ/ypl054wΔ appeared in a<br />
+  stationary-phase minisatellite (ade2-h7.5 reporter) stability screen, hinting at a role in<br />
+  genome repeat stability under that assay. HTP-screen level evidence.</li>
+<li><strong>CCCH parallel to Cth2</strong>: Godard et al. noted LEE1's CCCH domain is shared with Cth2, a<br />
+  characterized yeast tandem-CCCH RBP that binds 3' ends of mRNAs and accelerates their decay<br />
+  (iron-deficiency regulon). Supports the RNA-binding hypothesis (still unproven for LEE1).</li>
+<li><strong>Cytoplasmic localization</strong>: reported from the Huh et al. 2003 global GFP study via SGD<br />
+  (database-supported, not primary-re-read). Consistent with post-transcriptional RNA regulation.</li>
+<li><strong>No RING / no ligase demonstrated</strong>: falcon explicitly states makorin RING E3 ligase activity<br />
+  is a metazoan-homolog feature and "direct ligase activity has not been demonstrated for yeast<br />
+  Lee1" — consistent with my MARK_AS_OVER_ANNOTATED call on the ubiquitin-ligase terms. Best RQC<br />
+  E3 in yeast is Hel2 (ZNF598 homolog); LEE1's contribution unexplored.</li>
+</ul>
+<p>Provenance policy: I do NOT add falcon-sourced supporting_text quotes to supporting_text fields<br />
+(validator skips file: quotes; fabrication risk). Godard 2007 (PMID:17308034) added to references<br />
+with correctness UNVERIFIED because the LEE1-specific claim is not verifiable in the cached<br />
+abstract-only record. These findings inform the description prose and knowledge_gap boundaries<br />
+(reviewer synthesis), not verbatim-quoted supporting_text.</p>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: Q02799
+gene_symbol: LEE1
+product_type: PROTEIN
+status: INITIALIZED
+taxon:
+  id: NCBITaxon:559292
+  label: Saccharomyces cerevisiae
+description: &gt;-
+  LEE1 (YPL054W) is a 301-residue Saccharomyces cerevisiae protein whose only
+  well-supported molecular property is the presence of two tandem CCCH-type
+  (C3H1) zinc fingers, which coordinate zinc. CCCH zinc fingers are canonically
+  nucleic-acid-binding (most often RNA-binding) modules, and LEE1 was
+  independently identified in a proteome-wide survey as a predicted zinc-binding
+  protein of the yeast zinc proteome. Beyond zinc coordination, its molecular
+  activity, physiological substrate or binding target, and biological role remain
+  uncharacterized; global GFP studies report a cytoplasmic localization. The
+  protein is phosphorylated at several serine residues (Ser-21, Ser-30, Ser-282)
+  and has a disordered, polar-residue-rich N-terminus. It is a non-essential
+  protein; deletion is viable and yields only pleiotropic, high-throughput-screen
+  phenotypes (including in a minisatellite-stability screen) with no defined
+  pathway assignment. Its transcription is nitrogen-source responsive
+  (a nitrogen catabolite repression target). LEE1 belongs to the makorin-related
+  family (PANTHER PTHR11224 / InterPro MKRN-like) by sequence of its zinc fingers,
+  but unlike the metazoan makorin E3 ubiquitin ligases it lacks the catalytic RING
+  domain that those proteins use for ubiquitin transfer.
+references:
+- id: GO_REF:0000002
+  title: Gene Ontology annotation through association of InterPro records with GO
+    terms
+  findings: []
+- id: GO_REF:0000015
+  title: Use of the ND evidence code for Gene Ontology (GO) terms
+  findings: []
+- id: GO_REF:0000033
+  title: Annotation inferences using phylogenetic trees
+  findings: []
+- id: PMID:30358795
+  title: The cellular economy of the Saccharomyces cerevisiae zinc proteome.
+  findings:
+  - statement: &gt;-
+      LEE1 was identified as one of 582 known or potential zinc-binding proteins
+      of the yeast zinc proteome, using a bioinformatic domain/motif survey; this
+      is the basis of the RCA zinc ion binding annotation.
+    supporting_text: &gt;-
+      The yeast zinc proteome of 582 known or potential zinc-binding proteins was
+      identified using a bioinformatics analysis that combined global domain
+      searches with local motif searches.
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PubMed-verified (title matches). Proteome-wide zinc-proteome survey; supports
+      LEE1&#39;s classification as a predicted zinc-binding protein via its CCCH zinc
+      fingers, but does not assign a specific molecular or biological function. It
+      is the assigned SGD source for the RCA GO:0008270 (zinc ion binding)
+      annotation. Cached entry is abstract-only.
+- id: PMID:19779198
+  title: Global analysis of Cdk1 substrate phosphorylation sites provides insights
+    into evolution.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: &gt;-
+      UniProt source for the LEE1 phosphoserine sites (Ser-21, Ser-30, Ser-282)
+      from large-scale phosphoproteomics; contextual, does not define LEE1
+      function.
+- id: PMID:17308034
+  title: Effect of 21 different nitrogen sources on global gene expression in the yeast
+    Saccharomyces cerevisiae.
+  findings: []
+  reference_review:
+    relevance: MEDIUM
+    correctness: UNVERIFIED
+    review_notes: &gt;-
+      Transcriptome study that (per its full text, surfaced by deep research)
+      highlighted LEE1/YPL054W as one of a few nitrogen-responsive
+      regulator-encoding genes of unknown function, describing it as a protein
+      with two tandem CCCH-type zinc fingers. Marked UNVERIFIED because the cached
+      record is abstract-only and the LEE1-specific statement is in the full text,
+      which could not be re-read here; it is the best current source for LEE1&#39;s
+      nitrogen-source-responsive (NCR) expression but assigns no molecular
+      function.
+existing_annotations:
+- term:
+    id: GO:0061630
+    label: ubiquitin protein ligase activity
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Phylogenetic (IBA) propagation of E3 ubiquitin ligase activity from the
+      makorin family (PANTHER PTHR11224, node PTN000131854). The IBD seeds are
+      metazoan makorins that carry a catalytic C3HC4 RING domain (human MKRN1
+      Q9UHC7, human MKRN3 Q13064, mouse Mkrn2 MGI:1914277). LEE1 possesses only
+      the CCCH zinc fingers and has NO RING domain, which is the module that
+      actually catalyzes ubiquitin transfer in makorins. Ubiquitin ligase
+      activity is therefore an over-annotation for LEE1: the catalytic domain
+      required for the function is absent, so this is a family/subfamily
+      over-propagation of a catalytic activity to a member lacking the catalytic
+      module.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      LEE1 lacks the RING (zf-C3HC4) domain that carries makorin E3 ligase
+      catalysis; only CCCH zinc fingers are present (verified by direct InterPro
+      query on Q02799, which returns no RING/IPR001841 signature). Zinc-finger
+      membership in the makorin family does not confer the ligase activity, and
+      there is no experimental evidence LEE1 is a ubiquitin ligase.
+    propagation_review:
+      root_cause: PROPAGATION_BAD
+      failure_modes:
+      - PSEUDO_OR_SUBACTIVITY_LOSS
+      - WRONG_ORTHOLOG_OR_PARALOG
+      source_entities:
+      - source_id: UniProtKB:Q9UHC7
+        source_label: human MKRN1
+        source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
+        comment: RING-containing makorin E3 ligase; catalytic RING absent in LEE1
+      - source_id: UniProtKB:Q13064
+        source_label: human MKRN3
+        source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
+        comment: RING-containing makorin; LEE1 has no RING module
+      - source_id: MGI:MGI:1914277
+        source_label: mouse Mkrn2
+        source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
+        comment: RING-containing makorin; ligase catalysis not transferable to LEE1
+      - source_id: PANTHER:PTN000131854
+        source_label: PTHR11224 makorin family node
+        source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
+        comment: family node seeded by RING makorins; subfamily SF10 also contains RING-less members
+- term:
+    id: GO:0016567
+    label: protein ubiquitination
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Phylogenetic (IBA) propagation of the ubiquitination process that
+      accompanies the makorin family ligase-activity assignment. It rests on the
+      same makorin RING E3 ligase inference that does not apply to LEE1, because
+      LEE1 lacks the catalytic RING domain. Without support for LEE1 acting as a
+      ubiquitin ligase, participation in protein ubiquitination is an
+      over-annotation.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      This process term is the biological-process shadow of the makorin ligase
+      activity that does not transfer to LEE1 (no RING domain). No experimental
+      evidence links LEE1 to protein ubiquitination.
+    propagation_review:
+      root_cause: PROPAGATION_BAD
+      failure_modes:
+      - PSEUDO_OR_SUBACTIVITY_LOSS
+      - WRONG_ORTHOLOG_OR_PARALOG
+      source_entities:
+      - source_id: PANTHER:PTN000131854
+        source_label: PTHR11224 makorin family node
+        source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
+        comment: process co-propagated with RING-dependent ligase activity absent in LEE1
+- term:
+    id: GO:0000209
+    label: protein polyubiquitination
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      InterPro-to-GO (IEA) mapping of protein polyubiquitination from the
+      MKRN-like signature (IPR045072). The mapping reflects the makorin family&#39;s
+      RING-dependent E3 ligase role. LEE1 matches the MKRN-like/CCCH signatures
+      by its zinc fingers but lacks the RING domain, so the polyubiquitination
+      process is not supportable for it and represents an over-annotation.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      IEA mapping derives from the makorin RING E3 ligase function; the RING
+      catalytic domain is absent in LEE1, so polyubiquitination should not be
+      inferred. No experimental support exists.
+    propagation_review:
+      root_cause: PROPAGATION_BAD
+      failure_modes:
+      - PSEUDO_OR_SUBACTIVITY_LOSS
+      source_entities:
+      - source_id: InterPro:IPR045072
+        source_label: MKRN-like
+        source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
+        comment: family signature maps polyubiquitination via RING makorins; RING absent in LEE1
+- term:
+    id: GO:0046872
+    label: metal ion binding
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: enables
+  review:
+    summary: &gt;-
+      InterPro-to-GO (IEA) mapping of metal ion binding from the CCCH zinc
+      finger signatures (IPR000571, IPR036855). This is correct and
+      domain-defensible: LEE1 has two CCCH-type zinc fingers that coordinate
+      zinc. It is a generic parent of the more specific zinc ion binding, which
+      is also annotated.
+    action: ACCEPT
+    reason: &gt;-
+      LEE1&#39;s two CCCH zinc fingers coordinate a metal ion (zinc); the term is
+      correct though generic. The more specific GO:0008270 (zinc ion binding) is
+      the preferred core term.
+- term:
+    id: GO:0061630
+    label: ubiquitin protein ligase activity
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: enables
+  review:
+    summary: &gt;-
+      InterPro-to-GO (IEA) mapping of ubiquitin protein ligase activity from the
+      MKRN-like signature (IPR045072). As with the IBA duplicate of this term,
+      the activity depends on the makorin RING domain, which LEE1 does not have.
+      This is an over-annotation for a RING-less family member.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      Same over-propagation as the IBA ligase-activity annotation, arriving via
+      the InterPro MKRN-like signature. LEE1 lacks the catalytic RING domain, so
+      the ligase activity is not supportable.
+    propagation_review:
+      root_cause: PROPAGATION_BAD
+      failure_modes:
+      - PSEUDO_OR_SUBACTIVITY_LOSS
+      - WRONG_ORTHOLOG_OR_PARALOG
+      source_entities:
+      - source_id: InterPro:IPR045072
+        source_label: MKRN-like
+        source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
+        comment: signature maps ligase activity from RING makorins; RING absent in LEE1
+- term:
+    id: GO:0008270
+    label: zinc ion binding
+  evidence_type: RCA
+  original_reference_id: PMID:30358795
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Reviewed computational analysis (RCA) assignment of zinc ion binding,
+      sourced from the proteome-wide yeast zinc-proteome study that catalogued
+      LEE1 among predicted zinc-binding proteins. This is fully consistent with
+      LEE1&#39;s two CCCH-type (C3H1) zinc fingers (each coordinating Zn2+ via three
+      Cys and one His). This is the best-supported molecular function of LEE1 and
+      is retained as core.
+    action: ACCEPT
+    reason: &gt;-
+      LEE1 has two CCCH-type zinc fingers (UniProt ZN_FING 87-114 and 123-145)
+      and was independently classified as a zinc-binding protein in a
+      proteome-wide zinc-proteome analysis. Zinc coordination is the
+      best-supported molecular property of the protein.
+- term:
+    id: GO:0005575
+    label: cellular_component
+  evidence_type: ND
+  original_reference_id: GO_REF:0000015
+  qualifier: is_active_in
+  review:
+    summary: &gt;-
+      Root cellular_component term with the ND (No biological Data available)
+      evidence code, correctly signalling that LEE1&#39;s subcellular localization is
+      not known. This is the appropriate placeholder for an uncharacterized
+      protein and should be retained until localization data exist.
+    action: ACCEPT
+    reason: &gt;-
+      ND root term accurately records that no localization data are available for
+      LEE1; standard practice is to keep it.
+- term:
+    id: GO:0008150
+    label: biological_process
+  evidence_type: ND
+  original_reference_id: GO_REF:0000015
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Root biological_process term with the ND evidence code, correctly
+      signalling that LEE1&#39;s biological role is unknown. Existing deletion
+      phenotypes are pleiotropic high-throughput readouts that do not define a
+      pathway, so the ND placeholder remains appropriate.
+    action: ACCEPT
+    reason: &gt;-
+      ND root term accurately records the absence of biological-process data;
+      retained as the honest placeholder for a dark gene.
+core_functions:
+- description: &gt;-
+    Zinc coordination by two tandem CCCH-type (C3H1) zinc fingers. This is the
+    only molecular function of LEE1 that is supported by both its domain
+    architecture and an independent proteome-wide analysis. The physiological
+    consequence of this zinc binding (e.g. a nucleic-acid-binding activity) is
+    not established.
+  molecular_function:
+    id: GO:0008270
+    label: zinc ion binding
+  supported_by:
+  - reference_id: PMID:30358795
+    supporting_text: &gt;-
+      The yeast zinc proteome of 582 known or potential zinc-binding proteins was
+      identified using a bioinformatics analysis that combined global domain
+      searches with local motif searches.
+knowledge_gaps:
+- gap_statement: &gt;-
+    The molecular function of LEE1 beyond metal (zinc) coordination is unknown.
+    No catalytic activity or specific binding activity has been demonstrated
+    experimentally. In particular, whether the two CCCH zinc fingers bind nucleic
+    acid — and, if so, whether the target is RNA or DNA and what its sequence or
+    identity is — has not been tested.
+  boundary: &gt;-
+    Firmly established: LEE1 is a 301-aa protein with two CCCH-type (C3H1) zinc
+    fingers (residues 87-114 and 123-145) that coordinate zinc, and it is a
+    predicted member of the yeast zinc proteome. CCCH tandem zinc fingers are
+    canonically nucleic-acid-binding (frequently RNA-binding) modules, making
+    RNA/nucleic-acid binding a reasonable but unproven hypothesis.
+  gap_kind:
+  - BIOLOGY
+  dark_aspect: MF_DARK
+  status: OPEN
+  significance: &gt;-
+    A defined molecular activity would convert LEE1 from a fully uncharacterized
+    zinc-finger protein into an assignable factor (e.g. an RNA-binding protein),
+    enabling downstream mechanistic and pathway placement.
+  resolution: &gt;-
+    Direct binding assays for the CCCH fingers: RNA interactome capture / CLIP or
+    RIP-seq to test for and identify RNA targets, and EMSA / protein-binding
+    microarray for possible DNA binding; structural or biophysical confirmation
+    of zinc-dependent fold.
+  provenance:
+  - reference_id: PMID:30358795
+    supporting_text: &gt;-
+      The yeast zinc proteome of 582 known or potential zinc-binding proteins was
+      identified using a bioinformatics analysis that combined global domain
+      searches with local motif searches.
+- gap_statement: &gt;-
+    Whether LEE1 has any role in protein ubiquitination is unresolved. The
+    makorin-family (PTHR11224 / MKRN-like) ubiquitin-ligase annotations are
+    propagated from RING-domain-containing metazoan makorins, but LEE1 lacks the
+    catalytic RING domain, so it is unknown whether LEE1 participates in
+    ubiquitination through any non-canonical mechanism or not at all.
+  boundary: &gt;-
+    Firmly established: LEE1 is classified in the makorin-related family by its
+    CCCH zinc fingers, yet direct InterPro analysis of Q02799 shows no RING
+    (zf-C3HC4) domain, the module that carries makorin E3 ligase catalysis.
+  gap_kind:
+  - BIOLOGY
+  dark_aspect: MF_DARK
+  status: OPEN
+  significance: &gt;-
+    Resolving this determines whether the widely propagated ubiquitin-ligase
+    annotation is a genuine (RING-independent) function or a family-level
+    over-annotation to be discounted for this member.
+  resolution: &gt;-
+    In vitro ubiquitination (E1/E2/E3) assays with LEE1 and candidate E2s; in
+    vivo tests for ubiquitin-conjugate accumulation dependent on LEE1; assessment
+    of any adaptor role bringing substrates to a separate RING/E3.
+- gap_statement: &gt;-
+    The biological process(es) in which LEE1 acts are unknown. Reported deletion
+    and overexpression phenotypes (altered chemical resistance/accumulation,
+    decreased competitive fitness, increased sporulation efficiency, altered
+    invasive/vegetative growth, and a hit in a minisatellite-stability screen)
+    come from high-throughput screens and do not define a pathway; and its
+    nitrogen-source-responsive (nitrogen catabolite repression) expression is a
+    regulatory observation, not a mechanism.
+  boundary: &gt;-
+    Firmly established: LEE1 is non-essential (viable null); it is
+    transcriptionally responsive to nitrogen source and is reported cytoplasmic in
+    global GFP studies; its GO biological process is recorded with the ND evidence
+    code; it has numerous high-throughput physical/genetic interactors but no
+    curated functional GO annotation.
+  gap_kind:
+  - BIOLOGY
+  dark_aspect: WHOLLY_DARK
+  status: OPEN
+  significance: &gt;-
+    Placing LEE1 in a pathway and compartment is prerequisite to interpreting its
+    pleiotropic screen phenotypes and to any mechanistic model of its function.
+  resolution: &gt;-
+    GFP/fluorescent-tag localization; condition-resolved phenotyping to identify
+    the process(es) underlying the screen phenotypes; validation of
+    high-confidence interactors by co-IP; epistasis analysis.
+suggested_questions:
+- question: &gt;-
+    Do the two CCCH zinc fingers of LEE1 bind RNA (or DNA) in vivo, and if so what
+    are the target transcripts or sites?
+- question: &gt;-
+    Given the absence of a RING domain, does LEE1 have any role in ubiquitination
+    (e.g. as a substrate-recruiting adaptor), or is the makorin-family
+    ubiquitin-ligase annotation a family-level over-annotation for this member?
+- question: &gt;-
+    Where in the cell does LEE1 act, and which biological process explains its
+    deletion/overexpression phenotypes (chemical resistance, competitive fitness,
+    sporulation, invasive growth)?
+suggested_experiments:
+- hypothesis: &gt;-
+    LEE1 is an RNA-binding protein via its tandem CCCH zinc fingers.
+  description: &gt;-
+    Perform UV-crosslinking RNA interactome capture / CLIP-seq (or RIP-seq) on
+    tagged LEE1 to test for RNA binding and identify bound transcripts; complement
+    with in vitro EMSA using recombinant LEE1 and candidate RNAs, and mutate the
+    zinc-coordinating Cys/His residues to confirm zinc-finger dependence.
+  experiment_type: RNA-protein interaction mapping
+- hypothesis: &gt;-
+    LEE1 does not act as an E3 ubiquitin ligase because it lacks a RING domain.
+  description: &gt;-
+    Reconstitute in vitro ubiquitination assays (E1, a panel of E2s, ubiquitin)
+    with recombinant LEE1 and assay for autoubiquitination or substrate
+    ubiquitination; in parallel, monitor bulk/target ubiquitin-conjugate levels in
+    LEE1 deletion vs wild-type cells.
+  experiment_type: in vitro/in vivo ubiquitination assay
+- hypothesis: &gt;-
+    LEE1 localizes to a specific compartment consistent with a defined biological
+    process.
+  description: &gt;-
+    Determine LEE1 subcellular localization by fluorescent tagging under native
+    and stress conditions; validate top high-throughput interactors by
+    co-immunoprecipitation; run condition-matched phenotypic assays to connect the
+    screen phenotypes to a pathway.
+  experiment_type: localization and interaction validation
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/genes/yeast/MCH2/MCH2-ai-review.html
+++ b/genes/yeast/MCH2/MCH2-ai-review.html
@@ -1,0 +1,2990 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>MCH2 - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        .propagation-review {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f8fafc;
+            border-left: 3px solid #64748b;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .propagation-title {
+            font-weight: 600;
+            color: #334155;
+            margin-bottom: 0.25rem;
+        }
+
+        .propagation-row {
+            margin-top: 0.25rem;
+        }
+
+        .propagation-source {
+            margin-top: 0.5rem;
+            padding-top: 0.5rem;
+            border-top: 1px solid #e5e7eb;
+        }
+
+        .propagation-source-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #1d4ed8;
+        }
+
+        .propagation-comment {
+            color: #4b5563;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>MCH2</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/P36032" target="_blank" class="term-link">
+                        P36032
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Saccharomyces cerevisiae</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-complete">
+                    COMPLETE
+                </span>
+            </div>
+
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "MCH2";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="P36032" data-a="DESCRIPTION: MCH2 (YKL221W) is a 473-residue polytopic plasma/e..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>MCH2 (YKL221W) is a 473-residue polytopic plasma/endo-membrane protein of the Major Facilitator Superfamily (MFS), classified in the monocarboxylate porter (MCT/SLC16-like; TC 2.A.1.13) family by sequence homology. It is one of five paralogous &#34;monocarboxylate transporter homologues&#34; (MCH1-MCH5) in budding yeast. It adopts the canonical 12-transmembrane- helix MFS fold with cytoplasmic N- and C-termini, but has no demonstrated transport substrate, no measured transport activity, and no defined physiological role. Experimental analysis of the whole Mch family showed that these proteins do not transport monocarboxylic acids (lactate, pyruvate, acetate) across the plasma membrane, and only the paralog Mch5p has an assigned substrate (riboflavin/vitamin B2). MCH2 diverges from characterized transporting MCTs at key residues (it lacks the conserved TM1 lysine and a recognizable MFS motif A), so no substrate can be inferred from homology; its transported substrate, transport direction and mechanism, and biological process remain unknown.</p>
+    </div>
+
+
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005886" target="_blank" class="term-link">
+                                    GO:0005886
+                                </a>
+                            </span>
+                            <span class="term-label">plasma membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P36032" data-a="GO:0005886" data-r="GO_REF:0000033" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetic (IBA) assignment of plasma-membrane localization from the SLC16/MCT tree. MFS transporters of this family are typically at the plasma membrane, and the only paralog with a demonstrated location, Mch5p, is a plasma-membrane protein; but MCH2&#39;s own localization is not directly demonstrated, and the one study of Mch cellular distribution indicated at least some Mch proteins reside in intracellular membranes. Kept as a plausible, phylogenetically supported localization but not treated as a solved core fact.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Localization is inferred by phylogeny, not directly measured for MCH2; the family study explicitly noted some Mch proteins are intracellular, so the plasma-membrane call is plausible but not established for this paralog.
+                        </div>
+
+
+
+                        <div class="propagation-review">
+                            <div class="propagation-title">Propagation Review</div>
+                            <div class="propagation-row">
+                                <strong>Root cause:</strong>
+                                <span class="badge">NO FAILURE NON CORE</span>
+                            </div>
+
+                            <div class="propagation-row">
+                                <strong>Failure modes:</strong>
+
+                                <span class="badge">COMPARTMENT OR COMPLEX MISMATCH</span>
+
+                            </div>
+
+
+                            <div class="propagation-source">
+                                <strong>Sources checked:</strong>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">SGD:S000005833</span>
+
+                                    &middot; MCH5
+
+
+                                    <span class="badge">SUPPORTS SOURCE BUT NOT TARGET</span>
+
+
+                                    <div class="propagation-comment">Mch5p (riboflavin transporter) is plasma-membrane, but PMID:16204239 states the other MCH paralogs &#34;appear to have unrelated functions&#34;; PMID:11536335 places at least some Mch proteins in intracellular membranes, so PM localization is not firmly transferable to MCH2.</div>
+
+                                </div>
+
+                            </div>
+
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/11536335" target="_blank" class="term-link">
+                                        PMID:11536335
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">intracellular localization studies indicated that at least some of the Mch proteins reside in intracellular membranes.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/16204239" target="_blank" class="term-link">
+                                        PMID:16204239
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">localize the protein to the plasma membrane</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0022857" target="_blank" class="term-link">
+                                    GO:0022857
+                                </a>
+                            </span>
+                            <span class="term-label">transmembrane transporter activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P36032" data-a="GO:0022857" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Generic transmembrane-transporter molecular function, assigned by phylogenetic inference from the MFS/SLC16 tree. This is well supported by the confirmed 12-TMS MFS fold and is the most specific molecular function that can be defended: MCH2 diverges from transporting MCTs at key functional residues and its substrate is unknown, so a more specific &#34;monocarboxylate transmembrane transporter activity&#34; term is NOT supported. Accepted at this generic level.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The 12-TMS MFS fold supports a generic transporter molecular function; but no substrate is assignable (MCH2 lacks the conserved TM1 lysine and MFS motif A of transporting MCTs and is distant from all characterized transporters), so the annotation must stay generic and must not be specialized to a monocarboxylate term.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:yeast/MCH2/MCH2-bioinformatics/RESULTS.md
+
+                                </span>
+
+                                <div class="support-text">MCH2 is a bona fide polytopic MFS membrane protein of the monocarboxylate-porter (SLC16/MCT-like) family.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/11536335" target="_blank" class="term-link">
+                                        PMID:11536335
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">We could not find any evidence that the monocarboxylate transporter-homologous (Mch) proteins of S. cerevisiae are involved in the uptake or secretion of monocarboxylates such as lactate, pyruvate or acetate across the plasma membrane.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016020" target="_blank" class="term-link">
+                                    GO:0016020
+                                </a>
+                            </span>
+                            <span class="term-label">membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000044
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P36032" data-a="GO:0016020" data-r="GO_REF:0000044" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Broad membrane localization from the UniProt Subcellular Location mapping. Correct and consistent with the experimentally constrained multi-pass topology; retained as a general, non-core localization statement (the more informative membrane identity is the still-unresolved plasma vs. intracellular question addressed above).
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> MCH2 is unambiguously an integral multi-pass membrane protein (12 TMS, N/C-in topology experimentally constrained), so the generic membrane term is directly supported and correct; it is broad but accurately captures the compartment in which this transporter acts.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/16847258" target="_blank" class="term-link">
+                                        PMID:16847258
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">present experimentally constrained topology models for 546 proteins</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0022857" target="_blank" class="term-link">
+                                    GO:0022857
+                                </a>
+                            </span>
+                            <span class="term-label">transmembrane transporter activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P36032" data-a="GO:0022857" data-r="GO_REF:0000002" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Same generic transmembrane-transporter molecular function, reached independently via the InterPro (MFS, IPR011701) to GO mapping. Correct at this generality and consistent with the IBA route above; substrate/direction remain unknown, so it stays generic.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> InterPro MFS-domain evidence justifies a generic transporter molecular function; the annotation is appropriately unspecific given that no substrate is inferable for MCH2.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:yeast/MCH2/MCH2-bioinformatics/RESULTS.md
+
+                                </span>
+
+                                <div class="support-text">Domain assignments already in UniProt/InterPro (MFS PF07690 / IPR011701; CDD MFS_MCT_SLC16 cd17352; PANTHER PTHR11360 Proton-linked MCT) are consistent with this.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0055085" target="_blank" class="term-link">
+                                    GO:0055085
+                                </a>
+                            </span>
+                            <span class="term-label">transmembrane transport</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P36032" data-a="GO:0055085" data-r="GO_REF:0000002" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Generic transmembrane-transport biological process from the InterPro (MFS) to GO mapping. Consistent with the fold; the specific substrate and direction of transport are unknown, so the annotation is kept at this generic BP level.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> A generic transmembrane-transport process is the appropriate BP for a confirmed MFS transporter whose substrate is undetermined; specializing it would over-annotate.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:yeast/MCH2/MCH2-bioinformatics/RESULTS.md
+
+                                </span>
+
+                                <div class="support-text">the molecular function is defensible only at the generic &#34;transmembrane transporter&#34; level; the substrate and biological process remain genuine knowledge gaps.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003674" target="_blank" class="term-link">
+                                    GO:0003674
+                                </a>
+                            </span>
+                            <span class="term-label">molecular_function</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ND</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000015
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-remove">
+                            REMOVE
+                        </span>
+                        <span class="vote-buttons" data-g="P36032" data-a="GO:0003674" data-r="GO_REF:0000015" data-act="REMOVE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Root molecular_function placeholder (No Data) assigned by SGD. It is superseded by the generic but informative transmembrane transporter activity (GO:0022857) annotations already present from the IBA and InterPro routes, so the uninformative root term should be removed.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> ND root-term placeholder that is now redundant: the molecular-function aspect is already covered, more informatively, by the GO:0022857 transmembrane transporter activity annotations.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008150" target="_blank" class="term-link">
+                                    GO:0008150
+                                </a>
+                            </span>
+                            <span class="term-label">biological_process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ND</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000015
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-remove">
+                            REMOVE
+                        </span>
+                        <span class="vote-buttons" data-g="P36032" data-a="GO:0008150" data-r="GO_REF:0000015" data-act="REMOVE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Root biological_process placeholder (No Data) assigned by SGD. It is superseded by the generic transmembrane transport (GO:0055085) biological-process annotation already present from the InterPro route, so the uninformative root term should be removed.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> ND root-term placeholder that is now redundant: the biological-process aspect is already covered by the GO:0055085 transmembrane transport annotation.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>MCH2 is a 12-transmembrane-helix Major Facilitator Superfamily (MFS) membrane transporter of the monocarboxylate-porter (SLC16/MCT-like; TC 2.A.1.13) family. Its confirmed fold supports a generic transmembrane transporter activity, but no substrate can be assigned: MCH2 lacks the conserved TM1 lysine and the MFS motif A of the transporting MCTs, is distant (&lt;=23% identity) from every functionally characterized transporter examined (including the classical lactate/pyruvate MCT1-MCT4 and yeast JEN1), and experimental analysis of the Mch family established that these proteins do not transport monocarboxylic acids. The transported substrate, transport direction/mechanism, and biological process therefore remain undetermined.</h3>
+                <span class="vote-buttons" data-g="P36032" data-a="FUNCTION: MCH2 is a 12-transmembrane-helix Major Facilitator..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0022857" target="_blank" class="term-link">
+                            transmembrane transporter activity
+                        </a>
+                    </span>
+                </div>
+
+
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016020" target="_blank" class="term-link">
+                                membrane
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:yeast/MCH2/MCH2-bioinformatics/RESULTS.md
+
+                        </span>
+
+                        <div class="finding-text">MCH2 is a bona fide polytopic MFS membrane protein of the monocarboxylate-porter (SLC16/MCT-like) family.</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/11536335" target="_blank" class="term-link">
+                                PMID:11536335
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">It is concluded that the yeast monocarboxylate transporter-homologous proteins perform other functions than do their mammalian counterparts.</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000002.md" target="_blank" class="term-link">
+                            GO_REF:0000002
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation through association of InterPro records with GO terms</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000015.md" target="_blank" class="term-link">
+                            GO_REF:0000015
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Use of the ND evidence code for Gene Ontology (GO) terms</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
+                            GO_REF:0000033
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Annotation inferences using phylogenetic trees</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
+                            GO_REF:0000044
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/11536335" target="_blank" class="term-link">
+                            PMID:11536335
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">The putative monocarboxylate permeases of the yeast Saccharomyces cerevisiae do not transport monocarboxylic acids across the plasma membrane.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">A yeast mch1-5 quintuple deletion showed no growth defect on monocarboxylic acids and wild-type-like monocarboxylate uptake/secretion; the yeast Mch proteins do not transport monocarboxylic acids and perform other functions than their mammalian counterparts. Some Mch proteins reside in intracellular membranes; the mch1-5 mutant had reduced chemostat biomass but pyruvate uptake into isolated mitochondria was unaffected.</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/16204239" target="_blank" class="term-link">
+                            PMID:16204239
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">The monocarboxylate transporter homolog Mch5p catalyzes riboflavin (vitamin B2) uptake in Saccharomyces cerevisiae.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Mch5p is a plasma-membrane riboflavin (vitamin B2) transporter (facilitated diffusion, Km ~17 uM); the other members of the MCH gene family appear to have unrelated functions, so MCH2&#39;s substrate is not expected to be riboflavin.</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/16847258" target="_blank" class="term-link">
+                            PMID:16847258
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">A global topology map of the Saccharomyces cerevisiae membrane proteome.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Genome-scale study presenting experimentally constrained topology models for 546 yeast membrane proteins, supporting the multi-pass membrane topology of MCH2.</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/8091865" target="_blank" class="term-link">
+                            PMID:8091865
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Sequencing of a 13.2 kb segment next to the left telomere of yeast chromosome XI revealed five open reading frames and recent recombination events with the right arms of chromosomes III and V.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Original chromosome-XI sequencing paper; the ORF (later MCH2/YKL221W) is similar to the mammalian putative mevalonate transporter and has the structure of membrane transporters.</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        file:yeast/MCH2/MCH2-bioinformatics/RESULTS.md
+
+                    </span>
+                </div>
+
+                <div class="reference-title">MCH2 (YKL221W / P36032) bioinformatics analysis</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Reproducible comparative/structural analysis confirming MCH2 is a 12-TMS MFS monocarboxylate-porter (SLC16/MCT-like) protein, but showing it lacks the conserved TM1 lysine and MFS motif A of transporting MCTs and is distant (&lt;=23% identity) from all characterized transporters, so no substrate can be inferred from homology.</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Questions for Experts</h2>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> What is the physiological substrate of MCH2, given that monocarboxylic acids are excluded and riboflavin is transported by the paralog Mch5p?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P36032" data-a="Q: What is the physiological substrate of MCH2, given..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Does MCH2 reside in the plasma membrane, an endomembrane, or both, and does its location change with growth condition?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P36032" data-a="Q: Does MCH2 reside in the plasma membrane, an endome..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Are the five MCH paralogs functionally redundant, and does MCH2 contribute to the reduced chemostat biomass phenotype seen in the mch1-5 quintuple mutant?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P36032" data-a="Q: Are the five MCH paralogs functionally redundant, ..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Experiments</h2>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Heterologously express and purify MCH2 (or use tightly controlled overexpression in yeast) and perform substrate-agnostic transport/uptake screens and comparative metabolomics of mch2 deletion vs. overexpression strains to identify candidate substrates.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: MCH2 transports a small solute other than a monocarboxylic acid; loss and gain of MCH2 will shift the intracellular/extracellular pool of that solute.</em></p>
+
+
+                </div>
+                <span class="vote-buttons" data-g="P36032" data-a="EXPERIMENT: Heterologously express and purify MCH2 (or use tig..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Construct combinatorial mch single and multiple deletions (including a jen1 background) and phenotype them across carbon, nitrogen, and vitamin conditions and in glucose-limited chemostats to resolve paralog redundancy and MCH2&#39;s contribution.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: The MCH paralogs are partially redundant, and MCH2 contributes to the mch1-5 chemostat biomass phenotype only in combination with other paralogs.</em></p>
+
+
+                </div>
+                <span class="vote-buttons" data-g="P36032" data-a="EXPERIMENT: Construct combinatorial mch single and multiple de..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Determine the subcellular localization of endogenously tagged MCH2 (GFP) under multiple growth conditions, with plasma-membrane and endomembrane markers.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: MCH2 localizes at least partly to intracellular membranes rather than exclusively to the plasma membrane.</em></p>
+
+
+                </div>
+                <span class="vote-buttons" data-g="P36032" data-a="EXPERIMENT: Determine the subcellular localization of endogeno..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Knowledge Gaps</h2>
+        <p style="color: #555; font-size: 0.92rem; margin-top: -0.3rem;">
+            What is <em>not</em> known — curated, literature-grounded statements of the open
+            unknowns (the inverse of core functions).
+        </p>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The transported substrate, transport direction (uniport/symport/antiport), driving force (proton-coupled vs. facilitated diffusion), and physiological/biological role of MCH2 are all undetermined. It is one of the &#34;dark&#34; conserved yeast transporters: a bona fide MFS transporter with no assignable cargo and no dedicated phenotype.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">WHOLLY_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> MCH2 is firmly established as a 12-TMS MFS membrane protein of the monocarboxylate-porter (SLC16/MCT-like) family with an experimentally constrained N/C-in topology. What is excluded: transport of monocarboxylic acids across the plasma membrane (shown for the Mch family as a whole). What is known for a paralog only: Mch5p transports riboflavin, and the remaining MCH proteins &#34;appear to have unrelated functions&#34;. The one functional phenotype (strongly reduced biomass in glucose-limited chemostats) is of the mch1-5 quintuple mutant, not of mch2 alone, and no direct mitochondrial transport role was demonstrated (pyruvate uptake into isolated mitochondria was unaffected).</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> MCH2 is a conserved, ORF-named MFS transporter that has resisted functional assignment for decades; closing this gap would remove a dark node from yeast solute-transport metabolism and clarify whether the five MCH paralogs are functionally redundant or specialized.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Substrate-agnostic transport/metabolomic screening of mch2 loss- and gain-of-function strains; individual (not just quintuple) mch deletion phenotyping under diverse carbon, nitrogen and vitamin conditions to resolve paralog redundancy with MCH1/MCH3/MCH4/MCH5 and JEN1; direct GFP localization to settle plasma-membrane vs. endomembrane residence.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"It is concluded that the yeast monocarboxylate transporter-homologous proteins perform other functions than do their mammalian counterparts."</em> — PMID:11536335</li>
+
+                <li><em>"However, pyruvate uptake into isolated mitochondria was not affected in the mch1-5 mutant strain."</em> — PMID:11536335</li>
+
+                <li><em>"MCH2 lacks the conserved TM1 lysine and the MFS motif A of the transporting MCTs, and is distant (≤23%) from every functionally characterized transporter in the panel"</em> — file:yeast/MCH2/MCH2-bioinformatics/RESULTS.md</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> Whether MCH2 contributes to the mch1-5 quintuple-mutant chemostat biomass phenotype, and whether the five MCH paralogs (and JEN1) act redundantly, is unresolved. No mch2-single phenotype has been established.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">RESIDUAL_SUBGAP</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> The only reported Mch loss-of-function phenotype (strongly reduced biomass yield in aerobic glucose-limited chemostat cultures) is from the mch1-5 quintuple deletion, interpreted as a possible role in mitochondrial metabolism; however, direct pyruvate uptake into isolated mitochondria was not affected in that strain, so no direct mitochondrial transport role was demonstrated, and the contribution of MCH2 specifically is unknown.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Distinguishing paralog redundancy from specialization is required before any MCH2-specific biological process can be annotated, and before the family&#39;s link to central carbon metabolism can be interpreted.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Combinatorial mch single/double/triple deletions (with and without jen1) scored for the chemostat biomass and metabolic phenotypes; complementation of the mch1-5 phenotype by MCH2 alone.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"The mch1-5 mutant strain showed strongly reduced biomass yields in aerobic glucose-limited chemostat cultures, pointing to the involvement of Mch transporters in mitochondrial metabolism."</em> — PMID:11536335</li>
+
+            </ul>
+
+
+        </div>
+
+    </div>
+
+
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Deep Research Sections -->
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(MCH2-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="P36032" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="mch2-ykl221w-research-notes">MCH2 (YKL221W) research notes</h1>
+<p>UniProt: P36032 (MCH2_YEAST) · Systematic name: YKL221W · SGD: S000001704<br />
+Standard name: MCH2 (Monocarboxylate transporter Homologue 2)</p>
+<h2 id="one-line-summary">One-line summary</h2>
+<p>MCH2 is a <strong>dark</strong> <em>Saccharomyces cerevisiae</em> gene: a 473-aa polytopic membrane protein<br />
+of the Major Facilitator Superfamily (MFS), classified in the monocarboxylate porter<br />
+(MCT/TC 2.A.1.13) family by sequence homology, but with <strong>no demonstrated transport<br />
+substrate, no measured transport activity, and no defined physiological role</strong>. It is one<br />
+of five paralogous "monocarboxylate transporter homologues" (MCH1–MCH5) in budding yeast;<br />
+only Mch5p has an assigned substrate (riboflavin). MCH2's own substrate and direction are<br />
+unknown.</p>
+<h2 id="what-is-known-with-provenance">What is KNOWN (with provenance)</h2>
+<h3 id="sequence-domain-architecture-high-confidence">Sequence / domain architecture (high confidence)</h3>
+<ul>
+<li>473 aa, 52.3 kDa; predicted N-glycosylation site at Asn72.<br />
+  [UniProt:P36032 sequence &amp; feature table]</li>
+<li>Belongs to the Major Facilitator Superfamily; UniProt SIMILARITY:<br />
+  "Belongs to the major facilitator superfamily. Monocarboxylate porter (TC 2.A.1.13)<br />
+  family." (ECO:0000305 — sequence-model inference, not experimental)<br />
+  [UniProt:P36032]</li>
+<li>InterPro: IPR011701 (MFS), IPR036259 (MFS_trans_sf), IPR050327 (Proton-linked_MCT).<br />
+  CDD cd17352 (MFS_MCT_SLC16). PANTHER PTHR11360 "Proton-linked Monocarboxylate<br />
+  Transporter", subfamily PTHR11360:SF315 "TRANSPORTER MCH2-RELATED". Pfam PF07690<br />
+  (MFS_1). TCDB 2.A.1.13.18. [UniProt:P36032 DR lines]</li>
+<li>The founding chromosome-XI sequencing paper described the ORF as having "the structure<br />
+  of membrane transporters" with similarity to a mammalian putative mevalonate transporter:<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/8091865" title="The fourth one, part of which is similar to the mammalian putative   transporter of mevalonate, has the structure of membrane transporters.">PMID:8091865</a></li>
+</ul>
+<h3 id="membrane-topology-experimental-moderate-confidence-for-the-specific-residue-map">Membrane topology (experimental, moderate confidence for the specific residue map)</h3>
+<ul>
+<li>UniProt annotates 12 transmembrane helices with cytoplasmic N- and C-termini<br />
+  (a canonical 12-TMS MFS fold). [UniProt:P36032 TRANSMEM/TOPO_DOM features]</li>
+<li>MCH2 was one of the 546 proteins in the global yeast membrane-proteome topology map;<br />
+  the C-terminus location was experimentally constrained by the glycosylation/growth<br />
+  reporter fusion assay. [PMID:16847258 — the study reporting experimentally constrained<br />
+  topology models for 546 S. cerevisiae membrane proteins]</li>
+</ul>
+<h3 id="localization">Localization</h3>
+<ul>
+<li>UniProt: "Membrane; Multi-pass membrane protein." [UniProt:P36032]</li>
+<li>IBA (GO_Central) assigns plasma membrane (GO:0005886) by phylogenetic inference from<br />
+  the MCT/SLC16 tree. This is inference, not a direct MCH2 localization result.</li>
+<li>The functional study noted that at least some Mch proteins reside in intracellular<br />
+  membranes (a family-level statement, not MCH2-specific):<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/11536335" title="intracellular localization studies indicated that at least some of the   Mch proteins reside in intracellular membranes.">PMID:11536335</a></li>
+</ul>
+<h3 id="function-the-negative-result-this-is-the-load-bearing-experimental-finding">Function — the negative result (this is the load-bearing experimental finding)</h3>
+<ul>
+<li>A quintuple deletion of all five MCH genes (mch1-5Δ) showed <strong>no growth defect</strong> on<br />
+  monocarboxylic acids as sole carbon sources, and monocarboxylate uptake/secretion rates<br />
+  were indistinguishable from wild type:<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/11536335" title="A yeast mutant strain deleted for all five MCH genes exhibited no growth   defects on monocarboxylic acids as the sole carbon and energy sources. Moreover, the   uptake and secretion rates of monocarboxylic acids were indistinguishable from the   wild-type strain.">PMID:11536335</a></li>
+<li>Conclusion of that paper: the yeast Mch proteins do NOT transport monocarboxylates and<br />
+  "perform other functions than do their mammalian counterparts":<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/11536335" title="It is concluded that the yeast monocarboxylate transporter-homologous   proteins perform other functions than do their mammalian counterparts.">PMID:11536335</a></li>
+<li>UniProt encodes this negative result directly:<br />
+  [UniProt:P36032 "FUNCTION: Probable transporter. Does not act in the transport of<br />
+  monocarboxylic acids across the plasma membrane."]</li>
+<li>The mch1-5Δ strain had strongly reduced biomass yields in aerobic glucose-limited<br />
+  chemostat cultures, which the authors interpreted as pointing to involvement of Mch<br />
+  transporters in mitochondrial metabolism — but pyruvate uptake into isolated mitochondria<br />
+  was NOT affected in mch1-5Δ, so no direct mitochondrial transport role was established:<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/11536335" title="The mch1-5 mutant strain showed strongly reduced biomass yields in   aerobic glucose-limited chemostat cultures, pointing to the involvement of Mch   transporters in mitochondrial metabolism. ... However, pyruvate uptake into isolated   mitochondria was not affected in the mch1-5 mutant strain.">PMID:11536335</a><br />
+  NB: this is a phenotype of the <em>quintuple</em> mutant, not of mch2Δ alone; paralog redundancy<br />
+  is unresolved.</li>
+</ul>
+<h3 id="paralog-context-family-level">Paralog context (family-level)</h3>
+<ul>
+<li>Five MCH paralogs (MCH1–MCH5) were named for their similarity to mammalian MCTs.<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/11536335" title="We have characterized the monocarboxylate permease family of   Saccharomyces cerevisiae comprising five proteins.">PMID:11536335</a></li>
+<li>Only Mch5p has a demonstrated substrate: it is a plasma-membrane <strong>riboflavin (vitamin<br />
+  B2)</strong> transporter (facilitated diffusion, Km ≈ 17 µM).<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/16204239" title="characterize the protein as a plasma membrane transporter for   riboflavin">PMID:16204239</a></li>
+<li>The riboflavin paper explicitly states the other MCH paralogs have unrelated functions:<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/16204239" title="the other members of the MCH gene family appear to have unrelated   functions.">PMID:16204239</a><br />
+  =&gt; MCH2's substrate is NOT expected to be riboflavin, and remains unassigned.</li>
+</ul>
+<h2 id="what-is-not-known-the-gap">What is NOT known (the gap)</h2>
+<ol>
+<li><strong>Transported substrate</strong> — undetermined. Ruled OUT: monocarboxylic acids (lactate,<br />
+   pyruvate, acetate). Not expected to be riboflavin (that is Mch5p; paralogs "unrelated").</li>
+<li><strong>Transport direction / mechanism / driving force</strong> — unknown (uniport / symport /<br />
+   antiport; proton-coupled vs facilitated). The UniProt "Symport" keyword and the IEA<br />
+   symporter-activity term come from family/keyword mapping, not from an MCH2 assay.</li>
+<li><strong>Physiological role / biological process</strong> — unknown. GOA carries ND for both MF and<br />
+   BP from SGD. No individual mch2Δ phenotype is established.</li>
+<li><strong>Subcellular compartment of action</strong> — the plasma-membrane IBA call is a phylogenetic<br />
+   inference; direct MCH2 localization (plasma membrane vs endomembrane) is not firmly<br />
+   established in the files available here.</li>
+<li><strong>Paralog redundancy</strong> — the only functional phenotype (reduced chemostat biomass) is<br />
+   from the mch1-5Δ quintuple mutant; whether MCH2 contributes, and whether the paralogs<br />
+   are redundant, is unresolved.</li>
+</ol>
+<h2 id="existing-goa-annotations-7-and-disposition-planned">Existing GOA annotations (7) and disposition (planned)</h2>
+<ol>
+<li>GO:0005886 plasma membrane — IBA (GO_REF:0000033) — KEEP_AS_NON_CORE (phylogenetic<br />
+   inference; MFS transporters are typically PM, but MCH2's own localization is not directly<br />
+   demonstrated; keep but do not treat as a solved core fact).</li>
+<li>GO:0022857 transmembrane transporter activity — IBA (GO_REF:0000033) — ACCEPT<br />
+   (generic; well supported by 12-TMS MFS fold; the ONLY defensible MF given no substrate).</li>
+<li>GO:0016020 membrane — IEA (GO_REF:0000044, SubCell) — ACCEPT (broad, correct).</li>
+<li>GO:0022857 transmembrane transporter activity — IEA (GO_REF:0000002, InterPro) — ACCEPT<br />
+   (same generic MF, InterPro route; correct at this generality).</li>
+<li>GO:0055085 transmembrane transport — IEA (GO_REF:0000002, InterPro) — ACCEPT<br />
+   (generic BP consistent with the fold; substrate/direction unknown so keep generic).</li>
+<li>GO:0003674 molecular_function — ND (GO_REF:0000015, SGD) — REMOVE (superseded by the<br />
+   generic transmembrane transporter activity terms already present; ND root is now<br />
+   redundant and less informative).</li>
+<li>GO:0008150 biological_process — ND (GO_REF:0000015, SGD) — REMOVE (superseded by the<br />
+   generic transmembrane transport BP term already present).</li>
+</ol>
+<p>Note on the UniProt DR block: GO:0015293 symporter activity (IEA, UniProtKB-KW) appears in<br />
+the UniProt cross-references but is NOT in the QuickGO GOA TSV pulled here, so it is not one<br />
+of the seven review rows. The "Symport" keyword is a family-level inference; there is no<br />
+MCH2 symport assay.</p>
+<h2 id="sources-consulted">Sources consulted</h2>
+<ul>
+<li>PMID:11536335 (Makuc et al. 2001, Yeast) — the functional/negative study. Abstract-only.</li>
+<li>PMID:16204239 (Reihl &amp; Stolz 2005, JBC) — Mch5p riboflavin; family "unrelated functions".<br />
+  Abstract-only.</li>
+<li>PMID:16847258 (Kim et al. 2006, PNAS) — global topology map; MCH2 topology constrained.<br />
+  Full text (HTML).</li>
+<li>PMID:8091865 (Alexandraki &amp; Tzermia 1994, Yeast) — original chromosome-XI sequencing;<br />
+  ORF has "structure of membrane transporters". Abstract-only.</li>
+<li>UniProt:P36032 — record with negative FUNCTION statement, MFS/MCT similarity, 12 TM.</li>
+<li>file:yeast/MCH2/MCH2-bioinformatics/RESULTS.md — local fold/TM/motif analysis (see file).</li>
+</ul>
+<h2 id="review-completion-annotation-dispositions-final">Review completion (annotation dispositions, final)</h2>
+<p>All 7 GOA annotations reviewed (no monocarboxylate-specific term was actually present in GOA;<br />
+the two transporter-activity rows are already generic GO:0022857, which is the defensible level):</p>
+<ol>
+<li>GO:0005886 plasma membrane (IBA) — KEEP_AS_NON_CORE (phylogenetic inference; PM not directly<br />
+   demonstrated for MCH2; family study places some Mch proteins in intracellular membranes;<br />
+   propagation_review: NO_FAILURE_NON_CORE / COMPARTMENT_OR_COMPLEX_MISMATCH).</li>
+<li>GO:0022857 transmembrane transporter activity (IBA) — ACCEPT (generic MF; the only defensible<br />
+   MF given no substrate; explicitly NOT specialized to a monocarboxylate term — no TM1 Lys, no<br />
+   motif A, experimental negative).</li>
+<li>GO:0016020 membrane (IEA/SubCell) — ACCEPT (correct; confirmed 12-TMS integral membrane protein).</li>
+<li>GO:0022857 transmembrane transporter activity (IEA/InterPro) — ACCEPT (same generic MF, InterPro route).</li>
+<li>GO:0055085 transmembrane transport (IEA/InterPro) — ACCEPT (generic BP; substrate/direction unknown).</li>
+<li>GO:0003674 molecular_function (ND/SGD) — REMOVE (root placeholder superseded by GO:0022857).</li>
+<li>GO:0008150 biological_process (ND/SGD) — REMOVE (root placeholder superseded by GO:0055085).</li>
+</ol>
+<p>core_functions: single generic transmembrane transporter (GO:0022857) in membrane (GO:0016020);<br />
+substrate deliberately left open. knowledge_gaps: unknown substrate/direction/mechanism/biological<br />
+role (WHOLLY_DARK), substrate-level BP_DARK on the core function, and paralog-redundancy residual<br />
+sub-gap (mch1-5 quintuple-only phenotype). Validation clean: schema, references, terms all pass.</p>
+            </div>
+        </details>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Bioinformatics Results</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(RESULTS.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="P36032" data-a="DOC: Bioinformatics Results" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="mch2-ykl221w-p36032-bioinformatics-analysis">MCH2 (YKL221W / P36032) bioinformatics analysis</h1>
+<p>Comparative and structural bioinformatics supporting the GO-annotation review of<br />
+<em>Saccharomyces cerevisiae</em> MCH2, a "dark" monocarboxylate-transporter (MCT/MFS)<br />
+homolog with no demonstrated transport substrate.</p>
+<h2 id="objectives">Objectives</h2>
+<ol>
+<li>Confirm the MFS / monocarboxylate-porter (SLC16-like, TC 2.A.1.13) fold and the<br />
+   transmembrane-helix count.</li>
+<li>Test whether conserved MCT/SLC16 functional residues and the MFS "motif A" are<br />
+   retained in MCH2, and whether a substrate can be inferred from motifs.</li>
+<li>Place MCH2 within its family: pairwise identity to yeast paralogs (MCH1–MCH5,<br />
+   JEN1) and to the human SLC16/MCT family, and its closest relatives.</li>
+</ol>
+<h2 id="methods-reproducible">Methods (reproducible)</h2>
+<ul>
+<li>Sequences fetched programmatically from UniProt (<code>scripts/fetch_sequences.py</code>;<br />
+  accession lists in <code>data/accessions.tsv</code>, <code>data/accessions_test.tsv</code>). The fetched<br />
+  MCH2 sequence was byte-for-byte identical to the local <code>MCH2-uniprot.txt</code> sequence<br />
+  (473 aa) — verified.</li>
+<li>MSA with MAFFT (<code>--auto</code>).</li>
+<li>Pairwise % identity over columns where both sequences have a residue<br />
+  (<code>scripts/pairwise_identity.py</code>).</li>
+<li>Neighbor-joining tree, identity distance (Biopython; <code>scripts/build_tree.py</code>).</li>
+<li>UniProt TM/topology features parsed from the flat file<br />
+  (<code>scripts/parse_uniprot_topology.py</code>).</li>
+<li>Kyte–Doolittle hydropathy profile used ONLY to corroborate the hydrophobicity of<br />
+  each annotated TM helix (<code>scripts/hydropathy_corroboration.py</code>), not to count<br />
+  helices de novo (see caveat).</li>
+<li>Conserved-residue / motif scan anchored on human MCT1 (<code>scripts/motif_check.py</code>).</li>
+<li>Run everything with <code>just all</code> (needs <code>uv</code> and <code>mafft</code> on PATH).</li>
+</ul>
+<h2 id="results">Results</h2>
+<h3 id="1-fold-and-transmembrane-topology-confirmed-12-tms-mfs">1. Fold and transmembrane topology — CONFIRMED (12 TMS, MFS)</h3>
+<ul>
+<li>UniProt annotates <strong>12 transmembrane helices</strong> with <strong>cytoplasmic N- and C-termini</strong><br />
+  (<code>results/uniprot_topology.tsv</code>) — the canonical 12-TMS MFS architecture, including a<br />
+  large central cytoplasmic loop between TM6 and TM7 (TOPO_DOM 221–243). The N/C-in,<br />
+  even-TM topology was experimentally constrained for MCH2 in the yeast global topology<br />
+  map (PMID:16847258).</li>
+<li>All <strong>12/12</strong> annotated helices carry a positive Kyte–Doolittle hydropathy peak<br />
+  (<code>results/tm_hydropathy_corroboration.tsv</code>), independently corroborating that each<br />
+  annotated segment is genuinely hydrophobic.</li>
+<li>Domain assignments already in UniProt/InterPro (MFS PF07690 / IPR011701; CDD<br />
+  MFS_MCT_SLC16 cd17352; PANTHER PTHR11360 Proton-linked MCT) are consistent with this.</li>
+<li><strong>Conclusion:</strong> MCH2 is a bona fide polytopic MFS membrane protein of the<br />
+  monocarboxylate-porter (SLC16/MCT-like) family. This is the firm, defensible part.</li>
+</ul>
+<h3 id="2-functional-residue-conservation-mch2-diverges-from-transporting-mcts-substrate-not-inferable">2. Functional-residue conservation — MCH2 DIVERGES from transporting MCTs; substrate NOT inferable</h3>
+<ul>
+<li>The conserved TM1 lysine of human MCT1 (<strong>Lys38</strong>, verified at position 38 of P53985;<br />
+  implicated in the H⁺/lactate translocation pathway) is retained across the transporting<br />
+  monocarboxylate subfamily (MCT1/2/3/4/7 = SLC16A1/7/8/3/6 all have <strong>K</strong> at the aligned<br />
+  column). <strong>MCH2 has Serine at this column</strong> (<code>results/motif_conservation.tsv</code>). All four<br />
+  yeast MCH paralogs also lack the lysine (T/A/N/N), as do the aromatic-amino-acid / thyroid-<br />
+  hormone MCTs (MCT8, MCT10 have N).</li>
+<li>The canonical MFS "motif A" (G-x₃-[DE]-[RK]-x-G-[RK][RK], TM2–TM3 loop) is <strong>not</strong> found in<br />
+  MCH2 by either a strict or a relaxed regex, whereas a recognizable motif-A-like sequence IS<br />
+  present in paralogs MCH3 (<code>GLAGDKFGR</code>) and MCH5 (<code>GYLSDKFGR</code>). MCH2's motif A is degenerate.</li>
+<li>Objectively, MCH2 matches the family consensus at only <strong>35 of 54</strong> highly-conserved<br />
+  (≥70%) alignment columns (<code>results/conserved_columns.tsv</code>) — it retains a core MFS<br />
+  scaffold but is a divergent member.</li>
+<li><strong>Conclusion:</strong> MCH2 does not conserve the residues that define the transporting<br />
+  monocarboxylate MCTs, so a substrate <strong>cannot</strong> be inferred from close motif similarity to<br />
+  any characterized MCT. This is consistent with the experimental finding that yeast Mch<br />
+  proteins do not transport monocarboxylic acids (PMID:11536335).</li>
+<li>CAVEAT: an initial attempt also anchored three further MCT1 residues (numbered 302/306/360<br />
+  from memory); those positions did <strong>not</strong> carry the expected D/R/F in the actual P53985<br />
+  sequence, so they were flagged MISMATCH and <strong>excluded</strong> from all interpretation. Only the<br />
+  independently verified Lys38 is reported. No residue claim rests on an unverified anchor.</li>
+</ul>
+<h3 id="3-family-placement-closest-to-paralog-mch3-distant-from-all-characterized-mcts">3. Family placement — closest to paralog MCH3; distant from all characterized MCTs</h3>
+<p>Pairwise identity to MCH2 (<code>results/mch2_closest.tsv</code>), top hits:</p>
+<table>
+<thead>
+<tr>
+<th>Rank</th>
+<th>Protein</th>
+<th>% identity to MCH2</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>1</td>
+<td>MCH3 (ESBP6, YNL125C)</td>
+<td>30.1</td>
+</tr>
+<tr>
+<td>2</td>
+<td>SLC16A12 / MCT12 (human)</td>
+<td>22.7</td>
+</tr>
+<tr>
+<td>3</td>
+<td>SLC16A10 / MCT10 / TAT1 (human)</td>
+<td>21.5</td>
+</tr>
+<tr>
+<td>4</td>
+<td>SLC16A2 / MCT8 (human)</td>
+<td>20.5</td>
+</tr>
+<tr>
+<td>5</td>
+<td>MCH4</td>
+<td>20.2</td>
+</tr>
+<tr>
+<td>6</td>
+<td>MCH5 (riboflavin transporter)</td>
+<td>19.6</td>
+</tr>
+<tr>
+<td>…</td>
+<td>classical lactate MCT1/2/3/4</td>
+<td>17.0 / 16.9 / 19.3 / 19.0</td>
+</tr>
+<tr>
+<td>18</td>
+<td>JEN1 (yeast lactate transporter)</td>
+<td>15.1</td>
+</tr>
+<tr>
+<td>19</td>
+<td>MCH1</td>
+<td>12.1</td>
+</tr>
+</tbody>
+</table>
+<ul>
+<li>MCH2's single closest relative is its paralog <strong>MCH3/ESBP6</strong> (30%); all other identities<br />
+  are ≤23% (twilight zone).</li>
+<li>MCH2 is <strong>not</strong> specifically close to the well-characterized lactate/pyruvate transporters:<br />
+  human MCT1–MCT4 (SLC16A1/7/8/3) are at 17–19%, and yeast JEN1 (a real carboxylic-acid<br />
+  transporter) is only 15%. Where MCH2 has any preferential human similarity it is to the<br />
+  amino-acid / thyroid-hormone MCTs (MCT8/10/12), not the monocarboxylate ones — but at<br />
+  ~20–23% this is too low to assign substrate.</li>
+<li>The NJ tree (<code>results/panel_nj_ascii.txt</code>) places MCH2 with the yeast MCH paralogs and<br />
+  adjacent to the MCT8/MCT10 (amino-acid) clade, away from the MCT1–4 monocarboxylate clade.<br />
+  NB: at 15–30% identity NJ branch order is not statistically robust; treat the tree as<br />
+  corroborating the identity ranking, not as an independent phylogeny.</li>
+</ul>
+<h2 id="overall-interpretation-for-the-go-review">Overall interpretation (for the GO review)</h2>
+<ul>
+<li><strong>Confirmed:</strong> MCH2 is a 12-TMS MFS protein of the SLC16/MCT (monocarboxylate-porter)<br />
+  family — supports the generic <code>transmembrane transporter activity</code> (GO:0022857),<br />
+<code>transmembrane transport</code> (GO:0055085), and <code>membrane</code> (GO:0016020) annotations.</li>
+<li><strong>Not supported by sequence:</strong> any specific substrate. MCH2 lacks the conserved TM1<br />
+  lysine and the MFS motif A of the transporting MCTs, and is distant (≤23%) from every<br />
+  functionally characterized transporter in the panel, including the classical<br />
+  monocarboxylate MCTs and yeast JEN1. Sequence analysis therefore <strong>cannot</strong> rescue a<br />
+  specific substrate, direction, or symport/uniport mechanism — consistent with the<br />
+  experimental negative result that yeast Mch proteins do not transport monocarboxylates<br />
+  (PMID:11536335) and with Mch5p (riboflavin) being the only paralog with a known substrate.</li>
+<li><strong>Net:</strong> the molecular function is defensible only at the generic "transmembrane<br />
+  transporter" level; the substrate and biological process remain genuine knowledge gaps.</li>
+</ul>
+<h2 id="analysis-checklist">Analysis checklist</h2>
+<ul>
+<li>[x] Scripts contain NO hardcoded input sequences or hardcoded results (only UniProt<br />
+      accession IDs and literature-anchored residue positions are specified; all sequence<br />
+      data is fetched/aligned at run time).</li>
+<li>[x] Scripts tested on independent inputs: HXT1 UniProt file → 12 TM parsed correctly;<br />
+      MCH2-vs-HXT1 (13.4%) and MCH2-vs-CYC1 non-MFS control (12.5%) both correctly lower<br />
+      than MCH2's real relatives, confirming the identity metric discriminates.</li>
+<li>[x] Analyses completed as expected (<code>just all</code> runs clean end-to-end).</li>
+<li>[x] Direct script outputs are in <code>results/</code> (topology, hydropathy corroboration,<br />
+      identity matrix, ranked relatives, NJ tree, motif/conservation tables).</li>
+<li>[x] Summary includes provenance and justification, and is explicit about uncertainty.</li>
+<li>[~] De novo TM COUNTING by hydropathy is UNRELIABLE for closely packed MFS helices<br />
+      (the sliding-window method under-counts, calling 3–10 rather than 12 across the whole<br />
+      panel including known 12-TMS transporters). We therefore do NOT report a de novo TM<br />
+      count; the 12-TMS call rests on UniProt (ECO:0000255) + experimental topology<br />
+      (PMID:16847258), corroborated by 12/12 hydrophobic peaks. This limitation is by design,<br />
+      not a failure.</li>
+</ul>
+<h2 id="files">Files</h2>
+<ul>
+<li><code>data/accessions.tsv</code>, <code>data/accessions_test.tsv</code> — accession lists (inputs; IDs only)</li>
+<li><code>data/panel.fasta</code>, <code>data/test_panel.fasta</code> — fetched sequences</li>
+<li><code>results/uniprot_topology.tsv</code> — 12 annotated TM helices + topology</li>
+<li><code>results/tm_hydropathy_corroboration.tsv</code> — 12/12 helices hydrophobic</li>
+<li><code>results/tm_predictions.tsv</code>, <code>results/tm_predictions_test.tsv</code> — de novo hydropathy TM (unreliable; see caveat)</li>
+<li><code>results/panel_aln.fasta</code> — MAFFT alignment</li>
+<li><code>results/identity_matrix.tsv</code>, <code>results/mch2_closest.tsv</code> — pairwise identity</li>
+<li><code>results/panel_nj.nwk</code>, <code>results/panel_nj_ascii.txt</code> — NJ tree</li>
+<li><code>results/motif_conservation.tsv</code>, <code>results/conserved_columns.tsv</code> — residue/motif conservation</li>
+</ul>
+<h2 id="tool-versions-citations">Tool versions / citations</h2>
+<ul>
+<li>MAFFT (v7, <code>--auto</code>); Biopython 1.81; Kyte &amp; Doolittle (1982) J Mol Biol 157:105.</li>
+<li>Functional MCT1 residue context: Wilson et al. (2009) J Biol Chem 284:20011.</li>
+<li>Sequence source: UniProt (2026 release).</li>
+</ul>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: P36032
+gene_symbol: MCH2
+product_type: PROTEIN
+status: COMPLETE
+taxon:
+  id: NCBITaxon:559292
+  label: Saccharomyces cerevisiae
+description: &gt;-
+  MCH2 (YKL221W) is a 473-residue polytopic plasma/endo-membrane protein of the Major
+  Facilitator Superfamily (MFS), classified in the monocarboxylate porter (MCT/SLC16-like;
+  TC 2.A.1.13) family by sequence homology. It is one of five paralogous &#34;monocarboxylate
+  transporter homologues&#34; (MCH1-MCH5) in budding yeast. It adopts the canonical 12-transmembrane-
+  helix MFS fold with cytoplasmic N- and C-termini, but has no demonstrated transport substrate,
+  no measured transport activity, and no defined physiological role. Experimental analysis of
+  the whole Mch family showed that these proteins do not transport monocarboxylic acids (lactate,
+  pyruvate, acetate) across the plasma membrane, and only the paralog Mch5p has an assigned
+  substrate (riboflavin/vitamin B2). MCH2 diverges from characterized transporting MCTs at
+  key residues (it lacks the conserved TM1 lysine and a recognizable MFS motif A), so no
+  substrate can be inferred from homology; its transported substrate, transport direction and
+  mechanism, and biological process remain unknown.
+existing_annotations:
+- term:
+    id: GO:0005886
+    label: plasma membrane
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: is_active_in
+  review:
+    summary: &gt;-
+      Phylogenetic (IBA) assignment of plasma-membrane localization from the SLC16/MCT
+      tree. MFS transporters of this family are typically at the plasma membrane, and the
+      only paralog with a demonstrated location, Mch5p, is a plasma-membrane protein; but
+      MCH2&#39;s own localization is not directly demonstrated, and the one study of Mch cellular
+      distribution indicated at least some Mch proteins reside in intracellular membranes.
+      Kept as a plausible, phylogenetically supported localization but not treated as a
+      solved core fact.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Localization is inferred by phylogeny, not directly measured for MCH2; the family
+      study explicitly noted some Mch proteins are intracellular, so the plasma-membrane
+      call is plausible but not established for this paralog.
+    supported_by:
+    - reference_id: PMID:11536335
+      supporting_text: &gt;-
+        intracellular localization studies indicated that at least some of the Mch
+        proteins reside in intracellular membranes.
+      reference_section_type: ABSTRACT
+    - reference_id: PMID:16204239
+      supporting_text: &gt;-
+        localize the protein to the plasma membrane
+      reference_section_type: ABSTRACT
+    propagation_review:
+      root_cause: NO_FAILURE_NON_CORE
+      failure_modes:
+        - COMPARTMENT_OR_COMPLEX_MISMATCH
+      source_entities:
+        - source_id: SGD:S000005833
+          source_label: MCH5
+          source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
+          comment: &gt;-
+            Mch5p (riboflavin transporter) is plasma-membrane, but PMID:16204239 states the
+            other MCH paralogs &#34;appear to have unrelated functions&#34;; PMID:11536335 places at
+            least some Mch proteins in intracellular membranes, so PM localization is not
+            firmly transferable to MCH2.
+- term:
+    id: GO:0022857
+    label: transmembrane transporter activity
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Generic transmembrane-transporter molecular function, assigned by phylogenetic
+      inference from the MFS/SLC16 tree. This is well supported by the confirmed 12-TMS MFS
+      fold and is the most specific molecular function that can be defended: MCH2 diverges
+      from transporting MCTs at key functional residues and its substrate is unknown, so a
+      more specific &#34;monocarboxylate transmembrane transporter activity&#34; term is NOT
+      supported. Accepted at this generic level.
+    action: ACCEPT
+    reason: &gt;-
+      The 12-TMS MFS fold supports a generic transporter molecular function; but no substrate
+      is assignable (MCH2 lacks the conserved TM1 lysine and MFS motif A of transporting
+      MCTs and is distant from all characterized transporters), so the annotation must stay
+      generic and must not be specialized to a monocarboxylate term.
+    supported_by:
+    - reference_id: file:yeast/MCH2/MCH2-bioinformatics/RESULTS.md
+      supporting_text: &gt;-
+        MCH2 is a bona fide polytopic MFS membrane protein of the
+        monocarboxylate-porter (SLC16/MCT-like) family.
+    - reference_id: PMID:11536335
+      supporting_text: &gt;-
+        We could not find any evidence that the
+        monocarboxylate transporter-homologous (Mch) proteins of S. cerevisiae are
+        involved in the uptake or secretion of monocarboxylates such as lactate,
+        pyruvate or acetate across the plasma membrane.
+      reference_section_type: ABSTRACT
+- term:
+    id: GO:0016020
+    label: membrane
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000044
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Broad membrane localization from the UniProt Subcellular Location mapping. Correct and
+      consistent with the experimentally constrained multi-pass topology; retained as a
+      general, non-core localization statement (the more informative membrane identity is
+      the still-unresolved plasma vs. intracellular question addressed above).
+    action: ACCEPT
+    reason: &gt;-
+      MCH2 is unambiguously an integral multi-pass membrane protein (12 TMS, N/C-in topology
+      experimentally constrained), so the generic membrane term is directly supported and
+      correct; it is broad but accurately captures the compartment in which this transporter acts.
+    supported_by:
+    - reference_id: PMID:16847258
+      supporting_text: &gt;-
+        present experimentally
+        constrained topology models for 546 proteins
+      reference_section_type: ABSTRACT
+- term:
+    id: GO:0022857
+    label: transmembrane transporter activity
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Same generic transmembrane-transporter molecular function, reached independently via
+      the InterPro (MFS, IPR011701) to GO mapping. Correct at this generality and consistent
+      with the IBA route above; substrate/direction remain unknown, so it stays generic.
+    action: ACCEPT
+    reason: &gt;-
+      InterPro MFS-domain evidence justifies a generic transporter molecular function; the
+      annotation is appropriately unspecific given that no substrate is inferable for MCH2.
+    supported_by:
+    - reference_id: file:yeast/MCH2/MCH2-bioinformatics/RESULTS.md
+      supporting_text: &gt;-
+        Domain assignments already in UniProt/InterPro (MFS PF07690 / IPR011701; CDD
+        MFS_MCT_SLC16 cd17352; PANTHER PTHR11360 Proton-linked MCT) are consistent with this.
+- term:
+    id: GO:0055085
+    label: transmembrane transport
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Generic transmembrane-transport biological process from the InterPro (MFS) to GO
+      mapping. Consistent with the fold; the specific substrate and direction of transport
+      are unknown, so the annotation is kept at this generic BP level.
+    action: ACCEPT
+    reason: &gt;-
+      A generic transmembrane-transport process is the appropriate BP for a confirmed MFS
+      transporter whose substrate is undetermined; specializing it would over-annotate.
+    supported_by:
+    - reference_id: file:yeast/MCH2/MCH2-bioinformatics/RESULTS.md
+      supporting_text: &gt;-
+        the molecular function is defensible only at the generic &#34;transmembrane
+        transporter&#34; level; the substrate and biological process remain genuine knowledge gaps.
+- term:
+    id: GO:0003674
+    label: molecular_function
+  evidence_type: ND
+  original_reference_id: GO_REF:0000015
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Root molecular_function placeholder (No Data) assigned by SGD. It is superseded by the
+      generic but informative transmembrane transporter activity (GO:0022857) annotations
+      already present from the IBA and InterPro routes, so the uninformative root term should
+      be removed.
+    action: REMOVE
+    reason: &gt;-
+      ND root-term placeholder that is now redundant: the molecular-function aspect is
+      already covered, more informatively, by the GO:0022857 transmembrane transporter
+      activity annotations.
+- term:
+    id: GO:0008150
+    label: biological_process
+  evidence_type: ND
+  original_reference_id: GO_REF:0000015
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Root biological_process placeholder (No Data) assigned by SGD. It is superseded by the
+      generic transmembrane transport (GO:0055085) biological-process annotation already
+      present from the InterPro route, so the uninformative root term should be removed.
+    action: REMOVE
+    reason: &gt;-
+      ND root-term placeholder that is now redundant: the biological-process aspect is
+      already covered by the GO:0055085 transmembrane transport annotation.
+core_functions:
+- description: &gt;-
+    MCH2 is a 12-transmembrane-helix Major Facilitator Superfamily (MFS) membrane transporter
+    of the monocarboxylate-porter (SLC16/MCT-like; TC 2.A.1.13) family. Its confirmed fold
+    supports a generic transmembrane transporter activity, but no substrate can be assigned:
+    MCH2 lacks the conserved TM1 lysine and the MFS motif A of the transporting MCTs, is
+    distant (&lt;=23% identity) from every functionally characterized transporter examined
+    (including the classical lactate/pyruvate MCT1-MCT4 and yeast JEN1), and experimental
+    analysis of the Mch family established that these proteins do not transport monocarboxylic
+    acids. The transported substrate, transport direction/mechanism, and biological process
+    therefore remain undetermined.
+  molecular_function:
+    id: GO:0022857
+    label: transmembrane transporter activity
+  locations:
+  - id: GO:0016020
+    label: membrane
+  supported_by:
+  - reference_id: file:yeast/MCH2/MCH2-bioinformatics/RESULTS.md
+    supporting_text: &gt;-
+      MCH2 is a bona fide polytopic MFS membrane protein of the
+      monocarboxylate-porter (SLC16/MCT-like) family.
+  - reference_id: PMID:11536335
+    supporting_text: &gt;-
+      It is
+      concluded that the yeast monocarboxylate transporter-homologous proteins perform
+      other functions than do their mammalian counterparts.
+    reference_section_type: ABSTRACT
+  knowledge_gaps:
+  - gap_statement: &gt;-
+      The direct transported substrate of MCH2 is unknown, and consequently no molecular
+      function more specific than the generic &#34;transmembrane transporter activity&#34; can be
+      assigned. Monocarboxylic acids (lactate, pyruvate, acetate) are experimentally excluded,
+      and riboflavin (the substrate of the paralog Mch5p) is not expected, but no positive
+      substrate has been identified.
+    boundary: &gt;-
+      MCH2 is a confirmed 12-TMS MFS protein of the SLC16/MCT (monocarboxylate-porter) family.
+      Sequence analysis places it in the twilight zone (&lt;=23% identity) relative to all
+      characterized transporters and shows it lacks the conserved TM1 lysine and MFS motif A
+      of transporting MCTs, so a substrate cannot be inferred from homology.
+    gap_kind:
+      - BIOLOGY
+    dark_aspect: BP_DARK
+    status: OPEN
+    significance: &gt;-
+      Without a substrate, MCH2 cannot be placed in a metabolic or transport pathway, and its
+      molecular function stays at an uninformative generic level; identifying the substrate is
+      the rate-limiting step for annotating this dark transporter.
+    resolution: &gt;-
+      Substrate screening of purified/heterologously expressed MCH2 (e.g. transport assays or
+      metabolomic profiling of mch2 deletion/overexpression); structure-guided identification
+      of the binding cavity.
+    provenance:
+    - reference_id: PMID:11536335
+      supporting_text: &gt;-
+        We could not find any evidence that the
+        monocarboxylate transporter-homologous (Mch) proteins of S. cerevisiae are
+        involved in the uptake or secretion of monocarboxylates such as lactate,
+        pyruvate or acetate across the plasma membrane.
+      reference_section_type: ABSTRACT
+    - reference_id: PMID:16204239
+      supporting_text: &gt;-
+        the other members of the MCH gene family appear to have unrelated functions.
+      reference_section_type: ABSTRACT
+knowledge_gaps:
+- gap_statement: &gt;-
+    The transported substrate, transport direction (uniport/symport/antiport), driving force
+    (proton-coupled vs. facilitated diffusion), and physiological/biological role of MCH2 are
+    all undetermined. It is one of the &#34;dark&#34; conserved yeast transporters: a bona fide MFS
+    transporter with no assignable cargo and no dedicated phenotype.
+  boundary: &gt;-
+    MCH2 is firmly established as a 12-TMS MFS membrane protein of the monocarboxylate-porter
+    (SLC16/MCT-like) family with an experimentally constrained N/C-in topology. What is
+    excluded: transport of monocarboxylic acids across the plasma membrane (shown for the Mch
+    family as a whole). What is known for a paralog only: Mch5p transports riboflavin, and the
+    remaining MCH proteins &#34;appear to have unrelated functions&#34;. The one functional phenotype
+    (strongly reduced biomass in glucose-limited chemostats) is of the mch1-5 quintuple mutant,
+    not of mch2 alone, and no direct mitochondrial transport role was demonstrated (pyruvate
+    uptake into isolated mitochondria was unaffected).
+  gap_kind:
+    - BIOLOGY
+  dark_aspect: WHOLLY_DARK
+  status: OPEN
+  significance: &gt;-
+    MCH2 is a conserved, ORF-named MFS transporter that has resisted functional assignment for
+    decades; closing this gap would remove a dark node from yeast solute-transport metabolism
+    and clarify whether the five MCH paralogs are functionally redundant or specialized.
+  resolution: &gt;-
+    Substrate-agnostic transport/metabolomic screening of mch2 loss- and gain-of-function
+    strains; individual (not just quintuple) mch deletion phenotyping under diverse carbon,
+    nitrogen and vitamin conditions to resolve paralog redundancy with MCH1/MCH3/MCH4/MCH5 and
+    JEN1; direct GFP localization to settle plasma-membrane vs. endomembrane residence.
+  provenance:
+  - reference_id: PMID:11536335
+    supporting_text: &gt;-
+      It is
+      concluded that the yeast monocarboxylate transporter-homologous proteins perform
+      other functions than do their mammalian counterparts.
+    reference_section_type: ABSTRACT
+  - reference_id: PMID:11536335
+    supporting_text: &gt;-
+      However, pyruvate uptake into
+      isolated mitochondria was not affected in the mch1-5 mutant strain.
+    reference_section_type: ABSTRACT
+  - reference_id: file:yeast/MCH2/MCH2-bioinformatics/RESULTS.md
+    supporting_text: &gt;-
+      MCH2 lacks the conserved TM1
+      lysine and the MFS motif A of the transporting MCTs, and is distant (≤23%) from every
+      functionally characterized transporter in the panel
+- gap_statement: &gt;-
+    Whether MCH2 contributes to the mch1-5 quintuple-mutant chemostat biomass phenotype, and
+    whether the five MCH paralogs (and JEN1) act redundantly, is unresolved. No mch2-single
+    phenotype has been established.
+  boundary: &gt;-
+    The only reported Mch loss-of-function phenotype (strongly reduced biomass yield in aerobic
+    glucose-limited chemostat cultures) is from the mch1-5 quintuple deletion, interpreted as a
+    possible role in mitochondrial metabolism; however, direct pyruvate uptake into isolated
+    mitochondria was not affected in that strain, so no direct mitochondrial transport role was
+    demonstrated, and the contribution of MCH2 specifically is unknown.
+  gap_kind:
+    - BIOLOGY
+  dark_aspect: RESIDUAL_SUBGAP
+  status: OPEN
+  significance: &gt;-
+    Distinguishing paralog redundancy from specialization is required before any MCH2-specific
+    biological process can be annotated, and before the family&#39;s link to central carbon
+    metabolism can be interpreted.
+  resolution: &gt;-
+    Combinatorial mch single/double/triple deletions (with and without jen1) scored for the
+    chemostat biomass and metabolic phenotypes; complementation of the mch1-5 phenotype by MCH2
+    alone.
+  provenance:
+  - reference_id: PMID:11536335
+    supporting_text: &gt;-
+      The mch1-5 mutant strain showed strongly
+      reduced biomass yields in aerobic glucose-limited chemostat cultures, pointing
+      to the involvement of Mch transporters in mitochondrial metabolism.
+    reference_section_type: ABSTRACT
+proposed_new_terms: []
+suggested_questions:
+- question: &gt;-
+    What is the physiological substrate of MCH2, given that monocarboxylic acids are excluded
+    and riboflavin is transported by the paralog Mch5p?
+- question: &gt;-
+    Does MCH2 reside in the plasma membrane, an endomembrane, or both, and does its location
+    change with growth condition?
+- question: &gt;-
+    Are the five MCH paralogs functionally redundant, and does MCH2 contribute to the reduced
+    chemostat biomass phenotype seen in the mch1-5 quintuple mutant?
+suggested_experiments:
+- description: &gt;-
+    Heterologously express and purify MCH2 (or use tightly controlled overexpression in yeast)
+    and perform substrate-agnostic transport/uptake screens and comparative metabolomics of
+    mch2 deletion vs. overexpression strains to identify candidate substrates.
+  hypothesis: &gt;-
+    MCH2 transports a small solute other than a monocarboxylic acid; loss and gain of MCH2 will
+    shift the intracellular/extracellular pool of that solute.
+- description: &gt;-
+    Construct combinatorial mch single and multiple deletions (including a jen1 background) and
+    phenotype them across carbon, nitrogen, and vitamin conditions and in glucose-limited
+    chemostats to resolve paralog redundancy and MCH2&#39;s contribution.
+  hypothesis: &gt;-
+    The MCH paralogs are partially redundant, and MCH2 contributes to the mch1-5 chemostat
+    biomass phenotype only in combination with other paralogs.
+- description: &gt;-
+    Determine the subcellular localization of endogenously tagged MCH2 (GFP) under multiple
+    growth conditions, with plasma-membrane and endomembrane markers.
+  hypothesis: &gt;-
+    MCH2 localizes at least partly to intracellular membranes rather than exclusively to the
+    plasma membrane.
+references:
+- id: GO_REF:0000002
+  title: Gene Ontology annotation through association of InterPro records with GO terms
+  findings: []
+- id: GO_REF:0000015
+  title: Use of the ND evidence code for Gene Ontology (GO) terms
+  findings: []
+- id: GO_REF:0000033
+  title: Annotation inferences using phylogenetic trees
+  findings: []
+- id: GO_REF:0000044
+  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary
+    mapping, accompanied by conservative changes to GO terms applied by UniProt
+  findings: []
+- id: PMID:11536335
+  title: The putative monocarboxylate permeases of the yeast Saccharomyces cerevisiae do not
+    transport monocarboxylic acids across the plasma membrane.
+  findings:
+  - statement: &gt;-
+      A yeast mch1-5 quintuple deletion showed no growth defect on monocarboxylic acids and
+      wild-type-like monocarboxylate uptake/secretion; the yeast Mch proteins do not transport
+      monocarboxylic acids and perform other functions than their mammalian counterparts.
+      Some Mch proteins reside in intracellular membranes; the mch1-5 mutant had reduced
+      chemostat biomass but pyruvate uptake into isolated mitochondria was unaffected.
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PubMed-verified (Makuc et al. 2001, Yeast). The load-bearing negative result for the
+      whole Mch family, including MCH2; every supporting_text quote is a verbatim substring of
+      the cached abstract.
+- id: PMID:16204239
+  title: The monocarboxylate transporter homolog Mch5p catalyzes riboflavin (vitamin B2) uptake
+    in Saccharomyces cerevisiae.
+  findings:
+  - statement: &gt;-
+      Mch5p is a plasma-membrane riboflavin (vitamin B2) transporter (facilitated diffusion,
+      Km ~17 uM); the other members of the MCH gene family appear to have unrelated functions,
+      so MCH2&#39;s substrate is not expected to be riboflavin.
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PubMed-verified (Reihl &amp; Stolz 2005, JBC). Establishes the only characterized MCH-family
+      substrate (Mch5p/riboflavin) and states the other paralogs have unrelated functions.
+- id: PMID:16847258
+  title: A global topology map of the Saccharomyces cerevisiae membrane proteome.
+  findings:
+  - statement: &gt;-
+      Genome-scale study presenting experimentally constrained topology models for 546 yeast
+      membrane proteins, supporting the multi-pass membrane topology of MCH2.
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PubMed-verified (Kim et al. 2006, PNAS). Supports the experimentally constrained
+      multi-pass membrane topology underlying the membrane-localization annotations.
+- id: PMID:8091865
+  title: Sequencing of a 13.2 kb segment next to the left telomere of yeast chromosome XI
+    revealed five open reading frames and recent recombination events with the right arms of
+    chromosomes III and V.
+  findings:
+  - statement: &gt;-
+      Original chromosome-XI sequencing paper; the ORF (later MCH2/YKL221W) is similar to the
+      mammalian putative mevalonate transporter and has the structure of membrane transporters.
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PubMed-verified (Alexandraki &amp; Tzermia 1994, Yeast). Background/historical: first
+      description of the ORF as a membrane transporter; no functional characterization.
+- id: file:yeast/MCH2/MCH2-bioinformatics/RESULTS.md
+  title: MCH2 (YKL221W / P36032) bioinformatics analysis
+  findings:
+  - statement: &gt;-
+      Reproducible comparative/structural analysis confirming MCH2 is a 12-TMS MFS
+      monocarboxylate-porter (SLC16/MCT-like) protein, but showing it lacks the conserved TM1
+      lysine and MFS motif A of transporting MCTs and is distant (&lt;=23% identity) from all
+      characterized transporters, so no substrate can be inferred from homology.
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Local reproducible analysis (see RESULTS.md). file: quotes are not auto-checked by the
+      reference validator, so each supporting_text was manually grep-verified against the file.
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/genes/yeast/MOH1/MOH1-ai-review.html
+++ b/genes/yeast/MOH1/MOH1-ai-review.html
@@ -1,0 +1,3220 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>MOH1 - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        .propagation-review {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f8fafc;
+            border-left: 3px solid #64748b;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .propagation-title {
+            font-weight: 600;
+            color: #334155;
+            margin-bottom: 0.25rem;
+        }
+
+        .propagation-row {
+            margin-top: 0.25rem;
+        }
+
+        .propagation-source {
+            margin-top: 0.5rem;
+            padding-top: 0.5rem;
+            border-top: 1px solid #e5e7eb;
+        }
+
+        .propagation-source-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #1d4ed8;
+        }
+
+        .propagation-comment {
+            color: #4b5563;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>MOH1</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/P38191" target="_blank" class="term-link">
+                        P38191
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Saccharomyces cerevisiae</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-complete">
+                    COMPLETE
+                </span>
+            </div>
+
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "MOH1";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="P38191" data-a="DESCRIPTION: MOH1 (YBL049W) is a small (138 aa), low-abundance ..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>MOH1 (YBL049W) is a small (138 aa), low-abundance protein of the Yippee family, the single Saccharomyces cerevisiae representative of the family that expanded to the five YPEL paralogs (YPEL1-YPEL5) in humans. It comprises a Yippee/Mis18/Cereblon (CULT) fold — a zinc-stabilized double beta-meander that coordinates one structural Zn(2+) ion through four conserved cysteines (Cys45, Cys48, Cys101, Cys104) and presents a cradle-shaped pocket implicated in protein or nucleic-acid binding. The fold is a binding/scaffold module rather than a catalytic one, and no enzymatic activity has been demonstrated. Functionally, MOH1 is understudied: it is stress-inducible, and its deletion increases acute resistance to several lethal stresses (UV, methyl methanesulfonate, camptothecin, heat, hyperosmotic shock, hydrogen peroxide and acetic acid) while impairing long-term stationary-phase and chronological survival. Human YPEL genes can partially substitute for MOH1, indicating conservation of function across the family. The direct molecular activity, physical partners, subcellular site of action, and the mechanism linking MOH1 to stress tolerance and quiescence remain undetermined.</p>
+    </div>
+
+
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000151" target="_blank" class="term-link">
+                                    GO:0000151
+                                </a>
+                            </span>
+                            <span class="term-label">ubiquitin ligase complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P38191" data-a="GO:0000151" data-r="GO_REF:0000033" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Family-level phylogenetic propagation (IBA) from PANTHER PTHR13848, seeded by human YPEL5 (UniProtKB:P62699). There is no yeast experimental evidence that Moh1 is a component of a ubiquitin ligase complex. Although the Yippee fold is structurally related to the CULT domain of cereblon (a substrate receptor of a CRL4 E3 ligase), Yippee/YPEL proteins are not themselves established ubiquitin ligase complex subunits, and no such complex has been demonstrated for Moh1. This is an over-propagation from a distant structural relative.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> IBA propagated from a structurally related but functionally distinct neighborhood (Mis18/cereblon-CULT); no experimental or orthology evidence places Moh1 in a ubiquitin ligase complex in yeast. Not a core function.
+                        </div>
+
+
+
+                        <div class="propagation-review">
+                            <div class="propagation-title">Propagation Review</div>
+                            <div class="propagation-row">
+                                <strong>Root cause:</strong>
+                                <span class="badge">PROPAGATION BAD</span>
+                            </div>
+
+                            <div class="propagation-row">
+                                <strong>Failure modes:</strong>
+
+                                <span class="badge">COMPARTMENT OR COMPLEX MISMATCH</span>
+
+                                <span class="badge">FUNCTIONAL DIVERGENCE</span>
+
+                            </div>
+
+
+                            <div class="propagation-source">
+                                <strong>Sources checked:</strong>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">PANTHER:PTN002302768</span>
+
+                                    &middot; Yippee-like ancestral node (PTHR13848)
+
+
+                                    <span class="badge">SUPPORTS SOURCE BUT NOT TARGET</span>
+
+
+                                    <div class="propagation-comment">Node seeded by human YPEL5 (UniProtKB:P62699); the ubiquitin-ligase-complex role does not transfer to the Yippee/YPEL subfamily, which shares only the zinc-binding beta-fold with the Mis18/cereblon(CULT) neighborhood.</div>
+
+                                </div>
+
+                            </div>
+
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:yeast/MOH1/MOH1-bioinformatics/RESULTS.md
+
+                                </span>
+
+                                <div class="support-text">The Yippee fold (two four-stranded β-meanders coordinating one Zn²⁺ at the apex, forming a cradle-shaped pocket) is a **structural/binding scaffold, not a recognized catalytic fold**.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:yeast/MOH1/MOH1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">MOH1 is not an enzyme, transporter, or structural protein in the classical sense</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008270" target="_blank" class="term-link">
+                                    GO:0008270
+                                </a>
+                            </span>
+                            <span class="term-label">zinc ion binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">RCA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/30358795" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:30358795
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The cellular economy of the Saccharomyces cerevisiae zinc pr...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P38191" data-a="GO:0008270" data-r="PMID:30358795" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Zinc ion binding is the single well-supported molecular feature of Moh1. It is predicted by proteome-wide domain/motif analysis (RCA, PMID:30358795), corroborated by the UniProt Zn(2+)-binding features (Cys45, Cys48, Cys101, Cys104) and independently by in-repo bioinformatics, which recovers the canonical Yippee two-CxxC zinc signature and shows perfect conservation of all four cysteines across human YPEL1-5. The bound zinc is structural (folds the Yippee domain); it is not evidence of a catalytic activity. Accepted as the core molecular feature, though the downstream biochemical output remains unknown.
+                        </div>
+
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/30358795" target="_blank" class="term-link">
+                                        PMID:30358795
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">582 known or potential zinc-binding proteins was identified using a bioinformatics analysis that combined global domain searches with local motif searches</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:yeast/MOH1/MOH1-bioinformatics/RESULTS.md
+
+                                </span>
+
+                                <div class="support-text">MOH1 contains exactly the two CxxC motifs that define the Yippee zinc site</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005575" target="_blank" class="term-link">
+                                    GO:0005575
+                                </a>
+                            </span>
+                            <span class="term-label">cellular_component</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ND</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000015
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P38191" data-a="GO:0005575" data-r="GO_REF:0000015" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Root cellular_component annotation with the ND (no data) code, the standard placeholder recording that no experimental localization is available for Moh1. This correctly reflects the state of knowledge; high-throughput localization for this low-abundance protein is not curated.
+                        </div>
+
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008150" target="_blank" class="term-link">
+                                    GO:0008150
+                                </a>
+                            </span>
+                            <span class="term-label">biological_process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ND</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000015
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P38191" data-a="GO:0008150" data-r="GO_REF:0000015" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Root biological_process annotation with the ND (no data) code. Although phenotypes are recorded (stress resistance, stationary-phase survival), no specific molecular biological process has been assigned to Moh1, so the ND placeholder is appropriate.
+                        </div>
+
+
+
+
+
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>Structural zinc binding by the Yippee domain. The conserved Cys45/Cys48/Cys101/ Cys104 tetrad coordinates a single Zn(2+) ion that stabilizes the Yippee/Mis18/ CULT fold. This is the only molecular feature of Moh1 supported by convergent computational and comparative evidence; the resulting protein/nucleic-acid-binding activity of the cradle-shaped pocket, and any biochemical output, are not established.</h3>
+                <span class="vote-buttons" data-g="P38191" data-a="FUNCTION: Structural zinc binding by the Yippee domain. The ..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008270" target="_blank" class="term-link">
+                            zinc ion binding
+                        </a>
+                    </span>
+                </div>
+
+
+
+
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/30358795" target="_blank" class="term-link">
+                                PMID:30358795
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">582 known or potential zinc-binding proteins was identified using a bioinformatics analysis that combined global domain searches with local motif searches</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:yeast/MOH1/MOH1-bioinformatics/RESULTS.md
+
+                        </span>
+
+                        <div class="finding-text">all four zinc-binding cysteines are perfectly conserved</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000015.md" target="_blank" class="term-link">
+                            GO_REF:0000015
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Use of the ND evidence code for Gene Ontology (GO) terms</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
+                            GO_REF:0000033
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Annotation inferences using phylogenetic trees</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">The ubiquitin ligase complex annotation on MOH1 is a phylogenetically propagated (IBA) inference from PANTHER family PTHR13848, seeded by human YPEL5 (UniProtKB:P62699); there is no yeast-specific experimental support.</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/30358795" target="_blank" class="term-link">
+                            PMID:30358795
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">The cellular economy of the Saccharomyces cerevisiae zinc proteome.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">MOH1 is included among 582 known or potential zinc-binding proteins identified by a proteome-wide bioinformatic domain/motif survey; this is the basis of the RCA zinc ion binding annotation, a prediction rather than a direct metal-binding assay of Moh1.</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/28173693" target="_blank" class="term-link">
+                            PMID:28173693
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Pro-Apoptotic Role of the Human YPEL5 Gene Identified by Functional Complementation of a Yeast moh1Δ Mutation.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">moh1 deletion increases cell viability under multiple lethal stresses (UV, MMS, camptothecin, heat, hyperosmotic shock), and Moh1 is stress-induced; human YPEL genes partially complement moh1delta. Framed by the authors as involvement in DNA-damage-induced, mitochondria-dependent regulated cell death.</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/9748261" target="_blank" class="term-link">
+                            PMID:9748261
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">A role for Saccharomyces cerevisiae fatty acid activation protein 4 in regulating protein N-myristoylation during entry into stationary phase.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">YBL049W (MOH1) was identified as one of nine putative N-myristoylproteins whose deletion reproduces the stationary-phase survival defect of nmt1 mutant cells, linking MOH1 phenotypically to maintenance of proliferative potential during stationary phase.</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/11240639" target="_blank" class="term-link">
+                            PMID:11240639
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">The Drosophila gene Yippee reveals a novel family of putative zinc binding proteins highly conserved among eukaryotes.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Defines the Yippee family as a highly conserved eukaryotic family bearing a putative zinc-finger-like metal-binding domain; even at the family&#39;s founding the molecular function was left open.</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/15456898" target="_blank" class="term-link">
+                            PMID:15456898
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Genomic analysis of stationary-phase and exit in Saccharomyces cerevisiae: gene expression and identification of novel essential genes.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Genome-wide screen that identified MOH1 as one of the stationary-phase-essential genes: moh1 deletion causes a large loss of viability during long-term stationary phase at 37C, yet MOH1 is not required for growth on nonfermentable carbon sources, indicating a specific quiescence-survival role rather than a generic respiratory defect.</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        file:yeast/MOH1/MOH1-deep-research-falcon.md
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Falcon deep research report on S. cerevisiae MOH1 (YBL049W)</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Synthesis concluding MOH1 is a small conserved Yippee-family regulatory/adaptor protein with a zinc-stabilized beta-tent fold and cradle-shaped binding pocket, required for stationary-phase survival, whose precise biochemical activity, substrate, and dedicated pathway remain unresolved in the retrievable literature.</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        file:yeast/MOH1/MOH1-bioinformatics/RESULTS.md
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Bioinformatics analysis of MOH1 (Yippee domain, zinc site, ortholog conservation)</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Independently confirms the Yippee zinc signature (C45-x2-C48 ... C101-x2-C104, 52-residue spacer) matching the UniProt Zn-binding features, ~37-45% identity to human YPEL1-5 with all four Zn-cysteines perfectly conserved, and no sequence-level evidence for catalytic activity.</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Questions for Experts</h2>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> What does the Yippee-domain pocket of Moh1 bind (protein, nucleic acid, small molecule), and does the bound zinc have any role beyond folding the domain?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P38191" data-a="Q: What does the Yippee-domain pocket of Moh1 bind (p..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> By what molecular mechanism does moh1 deletion simultaneously increase acute stress resistance and decrease long-term stationary-phase survival?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P38191" data-a="Q: By what molecular mechanism does moh1 deletion sim..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Is the human YPEL family&#39;s proliferation/senescence role mechanistically the same as the yeast Moh1 stress/quiescence role, given cross-species complementation?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P38191" data-a="Q: Is the human YPEL family&#39;s proliferation/senescenc..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Experiments</h2>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Affinity-purify endogenously tagged Moh1 under basal and stress conditions and identify co-purifying proteins/nucleic acids by mass spectrometry and RNA sequencing; validate top candidates by reciprocal pulldown and epistasis with moh1delta stress phenotypes.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: Moh1 acts as a zinc-dependent binding module for a specific partner that mediates its stress-sensitizing function.</em></p>
+
+
+                    <p style="margin-top: 0.5rem;">Type: interaction proteomics</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P38191" data-a="EXPERIMENT: Affinity-purify endogenously tagged Moh1 under bas..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Construct Cys-to-Ala/Ser substitutions at Cys45/48/101/104, test protein stability and rescue of moh1delta stress phenotypes, to determine whether the zinc site is required for function in vivo.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: The four conserved cysteines are required for Moh1 function via structural zinc coordination.</em></p>
+
+
+                    <p style="margin-top: 0.5rem;">Type: structure-function mutagenesis</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P38191" data-a="EXPERIMENT: Construct Cys-to-Ala/Ser substitutions at Cys45/48..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Measure intracellular ROS, H2O2 uptake kinetics, and membrane lipid/permeability in wild-type vs moh1delta cells, following up the 2025 preprint under peer-reviewed conditions.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: moh1delta hydrogen-peroxide resistance stems from decreased uptake due to altered membrane permeability rather than altered ROS metabolism.</em></p>
+
+
+                    <p style="margin-top: 0.5rem;">Type: cell physiology / permeability assay</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P38191" data-a="EXPERIMENT: Measure intracellular ROS, H2O2 uptake kinetics, a..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Knowledge Gaps</h2>
+        <p style="color: #555; font-size: 0.92rem; margin-top: -0.3rem;">
+            What is <em>not</em> known — curated, literature-grounded statements of the open
+            unknowns (the inverse of core functions).
+        </p>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The molecular activity of Moh1 is undetermined. Beyond structural zinc binding by the Yippee domain, it is not known what Moh1 binds (protein? nucleic acid?) or what biochemical output, if any, the cradle-shaped Yippee pocket produces. No catalytic activity is supported.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">MF_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> The Yippee/Mis18/CULT fold and its structural Zn(2+) site (Cys45/48/101/104) are firmly established by UniProt features, PROSITE/Pfam/InterPro domain calls and independent in-repo bioinformatics; the fold is a zinc-stabilized binding scaffold, not a known catalytic fold.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Moh1 is the single yeast ortholog of the human YPEL family, which is implicated in proliferation, senescence and stress adaptation; defining the yeast protein&#39;s biochemistry would anchor mechanism for the whole conserved family.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Biochemical identification of Moh1 ligands/substrates (e.g. interaction proteomics of tagged Moh1, in vitro binding assays with the purified Yippee domain, structural studies of the pocket) and tests for any enzymatic activity.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"the Hemolin-Yippee interaction remains to be further elucidated"</em> — PMID:11240639</li>
+
+                <li><em>"There is no sequence-level evidence for enzymatic activity"</em> — file:yeast/MOH1/MOH1-bioinformatics/RESULTS.md</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> No functionally validated direct physical partner or substrate of Moh1 is known. Despite ~49 recorded high-throughput interactions, none has been shown to be a direct, function-defining partner, and the Drosophila Yippee-Hemolin interaction has no established yeast counterpart.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">MF_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> Large-scale interaction datasets (affinity-capture-MS, genetic interactions) exist for Moh1, and human YPEL proteins partially complement moh1delta, indicating a conserved but unspecified activity.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Identifying a direct partner would convert the family from &#34;putative binding module&#34; to a defined pathway component.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Targeted co-purification/crosslinking-MS with tagged Moh1, and validation of candidate partners by reciprocal pulldown and phenotype epistasis.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"the Hemolin-Yippee interaction remains to be further elucidated"</em> — PMID:11240639</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The mechanism by which Moh1 shapes stress tolerance and quiescence is unknown. It is unexplained why loss of Moh1 increases acute resistance to several lethal stresses yet decreases long-term stationary-phase/chronological survival, and whether Moh1 acts directly on membranes, metabolism, transcription, or cell death machinery.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">NARROWING</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">BP_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> The phenotypes are reproducible: moh1delta increases viability under UV, MMS, camptothecin, heat and hyperosmotic shock and is stress-induced (PMID:28173693); MOH1 is one of the stationary-phase-essential genes required for long-term survival in quiescence (PMID:15456898, PMID:9748261). A 2025 preprint additionally reports altered membrane permeability and metabolic remodeling in moh1delta.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Resolving the mechanism would explain a conserved stress/aging factor and clarify whether the human YPEL &#34;senescence/stress&#34; phenotypes share this mechanism.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Epistasis of moh1delta with defined stress-response and membrane/metabolic pathways; peer-reviewed follow-up of the 2025 preprint&#39;s permeability and transcriptome findings.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"exhibited enhanced cell viability compared with the WT-MOH1 strain when treated with lethal UV irradiation"</em> — PMID:28173693</li>
+
+                <li><em>"32 genes essential for survival in stationary-phase at"</em> — PMID:15456898</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> Whether &#34;apoptotic process&#34;/regulated cell death is the correct biological-process framing for Moh1 is unresolved. The label derives from a single heterologous complementation study interpreted within the contested yeast programmed-cell-death paradigm.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">BP_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> It is established that Moh1 sensitizes cells to lethal stress (deletion is protective) and that human YPEL5 restores this sensitization; the interpretation as caspase/mitochondria-dependent apoptosis is the uncertain part.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Determines whether GO apoptosis/regulated-cell-death terms are appropriate for this gene and its orthologs.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Independent replication with genetic dissection of the metacaspase (YCA1) and mitochondrial pathways, distinguishing bona fide regulated cell death from passive stress-induced death.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"their involvement in mitochondria-dependent apoptosis induced by DNA damage"</em> — PMID:28173693</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The subcellular site of Moh1 action is unknown; no reliable localization is curated, and the GOA cellular_component annotation is ND.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">CC_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> Moh1 is a low-abundance soluble protein; SGD notes a possible link to vacuolar transport and an abnormal-vacuolar-morphology deletion phenotype, but these are hypotheses, not localization data.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Localization would constrain candidate functions (e.g. membrane vs nuclear vs cytosolic activity).</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Endogenous fluorescent tagging and fractionation of Moh1 under normal and stress conditions.</p>
+
+
+
+        </div>
+
+    </div>
+
+
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Deep Research Sections -->
+
+    <div class="section">
+        <h2 class="section-title">Deep Research</h2>
+
+        <details class="deep-research-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; gap: 1rem;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Falcon</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(MOH1-deep-research-falcon.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="P38191" data-a="DEEP_RESEARCH: Falcon" data-r="" data-act="DEEP_RESEARCH" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This deep research is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This deep research needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+
+                <div class="report-meta">
+
+                    <span class="report-meta-text">Comprehensive Research Report: MOH1 (YBL049W) in *Saccharomyces cerevisiae*</span>
+
+
+                    <span class="report-badge">Falcon</span>
+
+
+                    <span class="report-badge">Edison Scientific Literature</span>
+
+
+                    <span class="report-badge">26 citations</span>
+
+
+                    <span class="report-badge">2 artifacts</span>
+
+
+                    <span class="report-meta-text">2026-07-04T23:49:57.749160</span>
+
+
+
+                </div>
+
+
+                <div class="artifact-list">
+
+
+
+                    <div class="artifact-link">
+                        <a href="MOH1-deep-research-falcon_artifacts/artifact-00.md" class="term-link">Edison artifact artifact-00</a>
+                        <span>(text/markdown)</span>
+                    </div>
+
+
+
+
+                    <div class="artifact-link">
+                        <a href="MOH1-deep-research-falcon_artifacts/artifact-01.md" class="term-link">Edison artifact artifact-01</a>
+                        <span>(text/markdown)</span>
+                    </div>
+
+
+                </div>
+
+                <p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h1 id="comprehensive-research-report-moh1-ybl049w-in-saccharomyces-cerevisiae">Comprehensive Research Report: MOH1 (YBL049W) in <em>Saccharomyces cerevisiae</em></h1>
+<h2 id="1-gene-and-protein-identity">1. Gene and Protein Identity</h2>
+<p>MOH1 (systematic name YBL049W; also referred to as YBL0518) encodes a small protein in <em>Saccharomyces cerevisiae</em> (strain ATCC 204508 / S288c) that is classified as a member of the Yippee protein family. The UniProt accession for this protein is P38191, and it is annotated as "Pro-Apoptotic protein MOH1" and "Protein yippee-like MOH1" (UniProt, ECO:0000303|PubMed:28173693). MOH1 contains a Yippee domain (InterPro: IPR034751, IPR004910, IPR039058; Pfam: PF03226), placing it in the broader Yippee/Mis18/Cereblon superfamily of zinc-binding proteins.</p>
+<h2 id="2-protein-structure-and-domain-architecture">2. Protein Structure and Domain Architecture</h2>
+<h3 id="21-the-yippee-domain-and-tent-fold">2.1. The Yippee Domain and β-Tent Fold</h3>
+<p>MOH1 belongs to the Yippee protein family, whose members share a highly conserved structural fold termed the <strong>β-tent fold</strong>. This fold consists of two four-stranded antiparallel β-meanders that pack at approximately right angles and coordinate a zinc ion at their apex (lupas2015thethalidomidebindingdomain pages 1-2). A β-hairpin inserted into the first β-meander extends across the bottom of the structure toward the second β-meander, forming a characteristic <strong>cradle-shaped binding site</strong> that is topologically conserved across all members of the fold (lupas2015thethalidomidebindingdomain pages 5-6, lupas2015thethalidomidebindingdomain pages 9-10). The fold exhibits internal pseudosymmetry, suggesting it may have arisen through duplication of a subdomain-sized fragment (lupas2015thethalidomidebindingdomain pages 1-2).</p>
+<p>Zinc coordination in yippee domain proteins is mediated by conserved <strong>C-X-X-C motifs</strong> located in specific loops of the structure (subramanian2016centromerelocalizationand pages 1-2). Structural studies on the closely related Mis18 protein have shown that the Yippee-like domain consists of two perpendicular antiparallel β-sheets (one three-stranded and one six-stranded) held together by a single Zn²⁺ ion coordinated through these C-X-X-C zinc-binding motifs (subramanian2016centromerelocalizationand pages 1-2). The binding pocket features conserved aromatic residues (including tyrosines, phenylalanines, and tryptophans) that form an aromatic cage implicated in protein–protein or protein–nucleic acid interactions (lupas2015thethalidomidebindingdomain pages 5-6).</p>
+<h3 id="22-evolutionary-relationship-to-cereblon-mis18-and-other-tent-proteins">2.2. Evolutionary Relationship to Cereblon, Mis18, and Other β-Tent Proteins</h3>
+<p>The Yippee domain is evolutionarily related to several other well-characterized protein families. Lupas et al. (2015) demonstrated that the CULT domain of cereblon (the thalidomide-binding E3 ubiquitin ligase component), Mis18 (a centromere maintenance factor), and Drosophila Yippee are all members of the same β-tent fold superfamily, appearing roughly equidistant from each other in sequence space (lupas2015thethalidomidebindingdomain pages 1-2, lupas2015thethalidomidebindingdomain pages 5-6, lupas2015thethalidomidebindingdomain pages 3-5). The β-tent fold also encompasses methionine sulfoxide reductase B (MsrB), the RIG-I helicase regulatory domain, and glutathione-dependent formaldehyde-activating enzyme (lupas2015thethalidomidebindingdomain pages 2-3). The fold serves primarily as a structural platform for mounting a functional binding site; the specific residues in the cradle-shaped groove determine the individual protein's binding partners and biological function (lupas2015thethalidomidebindingdomain pages 8-9).</p>
+<p>The following table compares MOH1 with its yippee-family relatives across organisms:</p>
+<table>
+<thead>
+<tr>
+<th>Protein name</th>
+<th>Organism</th>
+<th>Key function</th>
+<th>Domain type</th>
+<th>Zinc binding</th>
+<th>Oligomerization</th>
+<th>Key references from gathered evidence</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>MOH1 (YBL049W)</td>
+<td><em>Saccharomyces cerevisiae</em></td>
+<td>Stationary-phase-essential protein; supports long-term survival in quiescence/stationary phase; annotated in UniProt as pro-apoptotic, but direct mechanism was not retrievable from the available primary paper set</td>
+<td>Yippee family domain / Yippee-Mis18-like β-tent fold (inferred from family assignment)</td>
+<td>Predicted yes by family homology, but not directly shown for yeast MOH1 in retrieved papers</td>
+<td>Not directly demonstrated in retrieved MOH1 papers</td>
+<td>(martinez2004genomicanalysisof pages 7-8, martinez2004genomicanalysisof pages 8-9, martinez2004genomicanalysisof pages 9-10, lupas2015thethalidomidebindingdomain pages 5-6, lupas2015thethalidomidebindingdomain pages 1-2)</td>
+</tr>
+<tr>
+<td>Yippee</td>
+<td><em>Drosophila melanogaster</em></td>
+<td>Conserved eukaryotic protein of previously unknown/poorly defined molecular function; serves as the founding member of the Yippee family and structural reference for the fold</td>
+<td>Yippee domain; β-tent fold with cradle-shaped binding site</td>
+<td>Yes; family members typically coordinate Zn via conserved CXXC motifs/structural site</td>
+<td>Family shows propensity for dimerization/oligomerization, though direct oligomeric state for Drosophila Yippee was not the focus of retrieved evidence</td>
+<td>(lupas2015thethalidomidebindingdomain pages 5-6, lupas2015thethalidomidebindingdomain pages 1-2, lupas2015thethalidomidebindingdomain pages 9-10)</td>
+</tr>
+<tr>
+<td>YPEL1-5 (general human Yippee-like family)</td>
+<td><em>Homo sapiens</em></td>
+<td>Conserved regulatory proteins linked to apoptosis/senescence, development, and tumor suppression; family members provide the main orthology-based functional context for MOH1</td>
+<td>Yippee-like domain</td>
+<td>Predicted/expected by family homology; direct zinc biochemistry not retrieved for all YPEL paralogs</td>
+<td>Not established in the retrieved family-wide evidence</td>
+<td>(blancosanchez2020yippeelike3 pages 25-26, blancosanchez2020yippeelike3 pages 2-3, blancosanchez2020yippeelike3 pages 1-2, lupas2015thethalidomidebindingdomain pages 5-6, lupas2015thethalidomidebindingdomain pages 1-2)</td>
+</tr>
+<tr>
+<td>YPEL3</td>
+<td><em>Homo sapiens</em> / vertebrate models</td>
+<td>p53-inducible tumor suppressor; promotes senescence, suppresses EMT/metastasis, and is required for glial development/myelination in zebrafish</td>
+<td>Yippee-like domain</td>
+<td>Inferred from family homology; direct zinc-binding assay not retrieved in the YPEL3 paper</td>
+<td>Not established in retrieved YPEL3 developmental paper</td>
+<td>(blancosanchez2020yippeelike3 pages 25-26, blancosanchez2020yippeelike3 pages 2-3, blancosanchez2020yippeelike3 pages 26-27, blancosanchez2020yippeelike3 pages 1-2)</td>
+</tr>
+<tr>
+<td>Mis18</td>
+<td>Fission yeast and humans</td>
+<td>Centromere maintenance factor; recruits/organizes machinery for CENP-A deposition and centromere identity maintenance</td>
+<td>Yippee-like domain plus C-terminal α-helical region</td>
+<td>Yes; Zn²⁺ coordinated through CXXC motifs in the Yippee-like domain</td>
+<td>Yes; homodimerization/heterodimerization and higher-order oligomerization are central to function</td>
+<td>(subramanian2016centromerelocalizationand pages 1-2, subramanian2016centromerelocalizationand pages 8-9, thamkachy2024structuralbasisfor pages 3-4, thamkachy2024structuralbasisfor pages 1-3, subramanian2016centromerelocalizationand pages 10-11)</td>
+</tr>
+<tr>
+<td>Cereblon CULT domain</td>
+<td>Animals and bacteria (domain family context)</td>
+<td>Ligand-binding domain of cereblon; defines the CULT family and provides a key evolutionary/structural link to Yippee and Mis18</td>
+<td>CULT domain; β-tent fold</td>
+<td>Yes in core structural models via conserved cysteine motifs, though some related β-tent proteins can lose the zinc site</td>
+<td>Not the primary functional feature emphasized in retrieved evidence</td>
+<td>(lupas2015thethalidomidebindingdomain pages 1-2, lupas2015thethalidomidebindingdomain pages 5-6, lupas2015thethalidomidebindingdomain pages 8-9, lupas2015thethalidomidebindingdomain pages 3-5, lupas2015thethalidomidebindingdomain pages 2-3, lupas2015thethalidomidebindingdomain pages 6-8)</td>
+</tr>
+<tr>
+<td>FAM72A-D</td>
+<td><em>Homo sapiens</em></td>
+<td>DNA maintenance/replication stress-associated factors; accumulate on chromatin during replication and genotoxic stress; FAM72B binds UNG and RPA and can suppress BER during class-switch recombination</td>
+<td>MIS18/Yippee domain identified by structural annotation</td>
+<td>Predicted by Yippee/MIS18 family assignment; direct zinc biochemistry was not detailed in retrieved FAM72 evidence</td>
+<td>Yes; homo- and heterodimerization/multimerization reported for FAM72 family</td>
+<td>(schou2024exploringthestructural pages 10-11)</td>
+</tr>
+<tr>
+<td>SPIDR-associated Yippee/MIS18 domain annotation</td>
+<td><em>Homo sapiens</em></td>
+<td>Recent structural annotation places Yippee/MIS18-like domains in additional DNA maintenance proteins, expanding the family’s relevance beyond centromeres</td>
+<td>MIS18/Yippee-like domain annotation</td>
+<td>Predicted by domain assignment</td>
+<td>Not established in the retrieved summary evidence</td>
+<td>(schou2024exploringthestructural pages 10-11)</td>
+</tr>
+</tbody>
+</table>
+<p><em>Table: This table compares yeast MOH1 with structurally or functionally related Yippee-family proteins and domains across fungi, animals, and DNA maintenance systems. It is useful for inferring MOH1 function when direct biochemical characterization is limited.</em></p>
+<h2 id="3-biological-function">3. Biological Function</h2>
+<h3 id="31-stationary-phase-survival-and-quiescence">3.1. Stationary Phase Survival and Quiescence</h3>
+<p>The best-documented function of MOH1 in <em>S. cerevisiae</em> comes from a genome-wide analysis of stationary phase gene expression and viability by Martinez et al. (2004). MOH1 was identified as one of 127 stationary-phase-expressed genes whose transcripts reproducibly accumulate in cells during quiescence. More importantly, deletion of MOH1 resulted in approximately <strong>10-fold loss of viability after 9 days</strong> of growth at 37°C, classifying it as a <strong>stationary-phase-essential (SP-essential) gene</strong> (martinez2004genomicanalysisof pages 7-8, martinez2004genomicanalysisof pages 8-9). This phenotype was specific: MOH1 was among nine SP-essential genes that were <strong>not required for growth on nonfermentable carbon sources</strong>, distinguishing it from the majority of SP-essential genes that encode mitochondrial or respiratory chain components (martinez2004genomicanalysisof pages 9-10). This indicates that MOH1's role in stationary-phase survival is not simply a consequence of respiratory deficiency but rather involves a specific function in maintaining cell viability during quiescence.</p>
+<p>Martinez et al. (2004) described Moh1p as a "myristolated protein of unknown function" and noted that its sequence is related to Snf7p (an ESCRT-III component) according to SGD annotations available at the time (martinez2004genomicanalysisof pages 9-10). The study also established that SP-expressed and SP-essential genes, including MOH1, are more broadly conserved across the three major phylogenetic domains (Eukarya, Bacteria, Archaea) than yeast genes in general (martinez2004genomicanalysisof pages 8-9).</p>
+<h3 id="32-pro-apoptotic-function">3.2. Pro-Apoptotic Function</h3>
+<p>The UniProt annotation of MOH1 as a "Pro-Apoptotic protein" derives from the characterization reported in PubMed:28173693. While this primary publication was not directly retrievable in our literature searches, multiple lines of evidence support this functional assignment:</p>
+<ol>
+<li>
+<p><strong>Human homologues induce apoptosis</strong>: Martinez et al. (2004) specifically noted that "the human homologues of MOH1 and NGR1 are known to induce apoptosis" (martinez2004genomicanalysisof pages 9-10). Of the 32 SP-essential genes identified, 23 have human homologues, and at least 13 of these are involved in apoptosis or are associated with human diseases including cancer.</p>
+</li>
+<li>
+<p><strong>YPEL family as apoptosis-associated proteins</strong>: The closest human orthologs of MOH1 are the YPEL (Yippee-like) protein family members (YPEL1–YPEL5). YPEL3, the best-characterized member, was originally identified as a senescence factor involved in the apoptotic phase of myeloid cell development and functions as a tumor suppressor (blancosanchez2020yippeelike3 pages 2-3). Under genotoxic stress, YPEL3 is an inducible target of p53. Overexpression of YPEL3 causes cell cycle arrest, suppresses epithelial-mesenchymal transition, and can be repressed by estrogen in ER+ mammary tumor cells (blancosanchez2020yippeelike3 pages 25-26, blancosanchez2020yippeelike3 pages 26-27). YPEL protein family members more broadly have been characterized as apoptosis-associated proteins that suppress proliferation of myeloid cells (blancosanchez2020yippeelike3 pages 25-26).</p>
+</li>
+<li>
+<p><strong>MOH1 in fungal stress and cell death pathways</strong>: The MOH1 gene in <em>Candida albicans</em> has been reported to interact genetically with the molecular chaperone Hsp90, and its expression is induced by various stress conditions (singhbabak2012globalanalysisof pages 4-5). A recent study by Wang et al. (2025) directly investigated MOH1 in <em>Candida albicans</em> in the context of ROS-dependent apoptosis in genotoxic stress response, though this paper was not fully accessible for our analysis.</p>
+</li>
+</ol>
+<h3 id="33-role-in-fungal-pathogen-biology">3.3. Role in Fungal Pathogen Biology</h3>
+<p>In <em>Candida glabrata</em>, MOH1 was identified as one of four genes that acquired non-synonymous mutations during clinical evolution of echinocandin resistance. Whole-genome sequencing of serial clinical isolates revealed a MOH1 mutation (Y5H, resulting from a TAC→CAC codon change at position 5) that accompanied an early modest increase in echinocandin resistance (singhbabak2012globalanalysisof pages 4-5, singhbabak2012globalanalysisof pages 17-18). However, when the specific MOH1-T13C(Y5H) allele was cloned into a susceptible laboratory strain, it did not confer any increase in echinocandin resistance, suggesting that MOH1 changes may not directly drive resistance but could instead create a genetic background in which the primary FKS2 resistance mutation is less detrimental to fitness (singhbabak2012globalanalysisof pages 6-8). This finding positions MOH1 as a stress-responsive gene in fungal pathogens without a direct role in drug resistance per se.</p>
+<h2 id="4-subcellular-localization">4. Subcellular Localization</h2>
+<p>According to UniProt annotations, MOH1 localizes to the <strong>cytoplasm</strong>. The dynamic subcellular localization of related yippee-family proteins provides additional context: YPEL3 in vertebrate cells shows dynamic localization during the cell cycle, residing in the nucleus, perinuclear structures, and near centrosomes during mitosis (blancosanchez2020yippeelike3 pages 2-3). This pattern suggests that yippee-family proteins, including potentially MOH1, may function as mobile regulatory factors rather than enzymes with fixed organellar localization.</p>
+<h2 id="5-structural-and-functional-context-from-the-yippeemis18-family">5. Structural and Functional Context from the Yippee/Mis18 Family</h2>
+<h3 id="51-mis18-and-centromere-biology">5.1. Mis18 and Centromere Biology</h3>
+<p>The most extensively structurally characterized yippee-domain protein is Mis18, which functions in centromere maintenance by recruiting the CENP-A chaperone HJURP for centromeric histone deposition. The yippee-like domain of Mis18 mediates <strong>homo- and hetero-oligomerization</strong> that is essential for its centromere localization and function (subramanian2016centromerelocalizationand pages 8-9, subramanian2016centromerelocalizationand pages 1-2). In the human Mis18 complex, Mis18α and Mis18β contain yippee domains that form homodimers (Mis18α/Mis18α) or heterodimers (Mis18α/Mis18β), and their C-terminal helices form a 2:1 heterotrimer, assembling into a hetero-octameric complex (4 Mis18α, 2 Mis18β, 2 Mis18BP1) (thamkachy2024structuralbasisfor pages 3-4, thamkachy2024structuralbasisfor pages 1-3). This complex architecture is cell-cycle regulated and essential for centromere identity maintenance.</p>
+<h3 id="52-fam72-and-dna-damage-response-recent-2024-data">5.2. FAM72 and DNA Damage Response (Recent 2024 Data)</h3>
+<p>Schou et al. (2024) recently identified Yippee/MIS18-like domains in the FAM72A-D protein family through systematic structural annotation of DNA maintenance proteins. FAM72 proteins accumulate on chromatin during DNA replication and in response to genotoxic insults. FAM72B binds UNG (uracil-DNA glycosylase) and RPA subunits involved in DNA repair, and can suppress base excision repair during class-switch recombination in B cells (schou2024exploringthestructural pages 10-11). This expands the functional repertoire of the yippee domain family beyond centromere biology into active DNA damage response and repair pathways, and suggests that MOH1's β-tent fold may similarly function as a protein–protein interaction platform in stress-related processes.</p>
+<h2 id="6-summary-of-key-properties">6. Summary of Key Properties</h2>
+<table>
+<thead>
+<tr>
+<th>Gene / ORF</th>
+<th>UniProt accession</th>
+<th>Organism</th>
+<th>Protein description</th>
+<th>Protein family</th>
+<th>Domain architecture</th>
+<th>Subcellular localization</th>
+<th>Key functions / current interpretation</th>
+<th>Human orthologs / family context</th>
+<th>Key phenotypes from deletion or mutation studies</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><strong>MOH1 / YBL049W</strong></td>
+<td><strong>P38191</strong></td>
+<td><em>Saccharomyces cerevisiae</em> strain S288c</td>
+<td>Pro-apoptotic protein MOH1; protein yippee-like MOH1 (UniProt identity provided in prompt)</td>
+<td>Yippee family; evolutionarily related to Mis18 and cereblon/CULT-domain proteins (lupas2015thethalidomidebindingdomain pages 5-6, lupas2015thethalidomidebindingdomain pages 1-2, subramanian2016centromerelocalizationand pages 1-2)</td>
+<td>Predicted Yippee/Mis18/Cereblon-like <strong>β-tent fold</strong> with zinc-binding CXXC-type motifs and a cradle-shaped binding pocket, based on family-level structural studies; Yippee domains often mediate oligomerization and binding functions (lupas2015thethalidomidebindingdomain pages 5-6, lupas2015thethalidomidebindingdomain pages 1-2, lupas2015thethalidomidebindingdomain pages 9-10, subramanian2016centromerelocalizationand pages 1-2, lupas2015thethalidomidebindingdomain pages 3-5, lupas2015thethalidomidebindingdomain pages 6-8)</td>
+<td>Cytoplasm (from UniProt identity provided in prompt); direct localization evidence from retrieved primary literature was limited</td>
+<td>Best-supported direct yeast function is <strong>required for long-term stationary-phase survival/quiescence maintenance</strong>; MOH1 was identified as a stationary-phase-essential gene. More generally, its family context suggests a small conserved regulatory/adaptor protein rather than an enzyme or transporter. The “pro-apoptotic” annotation is consistent with later characterization and with apoptosis-associated functions of YPEL family orthologs, but mechanism-level evidence in <em>S. cerevisiae</em> was limited in retrievable papers (martinez2004genomicanalysisof pages 8-9, martinez2004genomicanalysisof pages 9-10, blancosanchez2020yippeelike3 pages 25-26, blancosanchez2020yippeelike3 pages 2-3)</td>
+<td>Human YPEL family proteins (<strong>YPEL1–YPEL5</strong>) are the closest family counterparts. YPEL3 is a p53-inducible, tumor-suppressive, apoptosis/senescence-associated yippee-like protein; family members are evolutionarily conserved and linked to development and stress responses (blancosanchez2020yippeelike3 pages 25-26, blancosanchez2020yippeelike3 pages 2-3, blancosanchez2020yippeelike3 pages 1-2, OpenTargets Search: -YPEL1,YPEL2,YPEL3,YPEL4,YPEL5)</td>
+<td>In <em>S. cerevisiae</em>, <strong>moh1Δ</strong> showed about <strong>10-fold loss of viability after 16 days</strong> in stationary phase at 37°C, identifying MOH1 as a stationary-phase-essential gene; notably, it was among SP-essential genes <strong>not required for growth on nonfermentable carbon sources</strong>, suggesting a specific role in persistence/quiescence rather than generic respiratory deficiency (martinez2004genomicanalysisof pages 7-8, martinez2004genomicanalysisof pages 8-9, martinez2004genomicanalysisof pages 9-10)</td>
+</tr>
+<tr>
+<td><strong>Additional comparative evidence relevant to MOH1 interpretation</strong></td>
+<td>—</td>
+<td>Fungal / metazoan comparators</td>
+<td>In <em>Candida glabrata</em>, a <strong>MOH1 Y5H</strong> variant arose during echinocandin-resistance evolution but did <strong>not</strong> confer resistance when tested, implying MOH1 may be stress-responsive without being a primary resistance determinant (singhbabak2012globalanalysisof pages 4-5, singhbabak2012globalanalysisof pages 6-8)</td>
+<td>Conserved yippee-like proteins in fungi and animals</td>
+<td>Related Yippee domains in Mis18 form zinc-stabilized β-sheet structures and mediate homo-/hetero-oligomerization required for centromere function; FAM72 yippee/Mis18 domains were recently implicated in DNA maintenance and replication-stress biology, illustrating broader functional versatility of the fold (subramanian2016centromerelocalizationand pages 8-9, thamkachy2024structuralbasisfor pages 3-4, schou2024exploringthestructural pages 10-11, subramanian2016centromerelocalizationand pages 1-2, thamkachy2024structuralbasisfor pages 1-3)</td>
+<td>YPEL3 localization in vertebrates is dynamic across nucleus, perinuclear structures, and near centrosomes during mitosis, underscoring that family members can act as mobile regulatory proteins rather than fixed metabolic enzymes (blancosanchez2020yippeelike3 pages 2-3)</td>
+<td>Together, current evidence supports MOH1 as a <strong>small conserved yippee-family regulatory protein involved in stress survival and likely cell-death-related signaling</strong>, but its precise biochemical activity in budding yeast remains unresolved in the retrievable literature (martinez2004genomicanalysisof pages 8-9, martinez2004genomicanalysisof pages 9-10, lupas2015thethalidomidebindingdomain pages 5-6, lupas2015thethalidomidebindingdomain pages 8-9)</td>
+<td>YPEL proteins provide the strongest orthology-based functional clues for apoptosis/senescence; Open Targets also links some YPEL genes to human disease phenotypes, though these associations are indirect for yeast MOH1 (blancosanchez2020yippeelike3 pages 25-26, blancosanchez2020yippeelike3 pages 2-3, OpenTargets Search: -YPEL1,YPEL2,YPEL3,YPEL4,YPEL5)</td>
+<td>Comparative evidence strengthens the interpretation of MOH1 as stress- and survival-related, but does not yet define a substrate, catalytic activity, or dedicated signaling pathway in <em>S. cerevisiae</em> (singhbabak2012globalanalysisof pages 4-5, singhbabak2012globalanalysisof pages 6-8, schou2024exploringthestructural pages 10-11)</td>
+</tr>
+</tbody>
+</table>
+<p><em>Table: This table summarizes the identity, family assignment, inferred structure, localization, function, orthology, and phenotypes of yeast MOH1/YBL049W using the gathered evidence. It is useful as a compact reference for functional annotation, especially where direct biochemical characterization remains limited.</em></p>
+<h2 id="7-conclusions-and-current-understanding">7. Conclusions and Current Understanding</h2>
+<p>MOH1 (YBL049W) in <em>S. cerevisiae</em> encodes a small, conserved yippee-family protein whose precise biochemical activity remains to be fully elucidated. The available evidence converges on the following functional interpretation:</p>
+<p><strong>MOH1 is not an enzyme, transporter, or structural protein in the classical sense.</strong> Rather, it appears to function as a small regulatory or adaptor protein, likely acting through its yippee domain-mediated protein–protein interactions. Its β-tent fold contains a conserved zinc-binding site and a cradle-shaped binding pocket that, in homologous proteins, mediates oligomerization and recruitment of binding partners (lupas2015thethalidomidebindingdomain pages 5-6, subramanian2016centromerelocalizationand pages 1-2).</p>
+<p><strong>Its primary biological role is in maintaining cell viability during stationary phase/quiescence</strong>, where its deletion causes significant loss of viability under stress conditions (martinez2004genomicanalysisof pages 7-8, martinez2004genomicanalysisof pages 9-10). The pro-apoptotic annotation is consistent with the known functions of its human orthologs (YPEL1-5), which regulate apoptosis, cellular senescence, and cell cycle control (blancosanchez2020yippeelike3 pages 25-26, blancosanchez2020yippeelike3 pages 2-3, martinez2004genomicanalysisof pages 9-10).</p>
+<p><strong>The protein localizes to the cytoplasm</strong> and its function is likely linked to stress response pathways, potentially involving reactive oxygen species signaling and interactions with the Hsp90 chaperone network (singhbabak2012globalanalysisof pages 4-5). Recent structural and functional work on the broader yippee/Mis18 domain family (2024) has revealed an expanding role for this fold in DNA maintenance and chromatin-associated processes (schou2024exploringthestructural pages 10-11, thamkachy2024structuralbasisfor pages 3-4), which may provide additional avenues for understanding MOH1's specific molecular mechanism in future research.</p>
+<p>The precise signaling pathway in which MOH1 functions in <em>S. cerevisiae</em> remains an open question. Its involvement in stationary-phase survival, combined with the apoptotic functions of its orthologs, suggests it may participate in the cellular decision-making process between survival and programmed cell death during nutrient deprivation and stress—a process that is increasingly recognized as having deep evolutionary roots shared between unicellular and multicellular organisms (martinez2004genomicanalysisof pages 8-9, martinez2004genomicanalysisof pages 9-10).</p>
+<p>References</p>
+<ol>
+<li>
+<p>(lupas2015thethalidomidebindingdomain pages 1-2): Andrei N. Lupas, Hongbo Zhu, and Mateusz Korycinski. The thalidomide-binding domain of cereblon defines the cult domain family and is a new member of the β-tent fold. PLoS Computational Biology, 11:e1004023, Jan 2015. URL: https://doi.org/10.1371/journal.pcbi.1004023, doi:10.1371/journal.pcbi.1004023. This article has 61 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(lupas2015thethalidomidebindingdomain pages 5-6): Andrei N. Lupas, Hongbo Zhu, and Mateusz Korycinski. The thalidomide-binding domain of cereblon defines the cult domain family and is a new member of the β-tent fold. PLoS Computational Biology, 11:e1004023, Jan 2015. URL: https://doi.org/10.1371/journal.pcbi.1004023, doi:10.1371/journal.pcbi.1004023. This article has 61 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(lupas2015thethalidomidebindingdomain pages 9-10): Andrei N. Lupas, Hongbo Zhu, and Mateusz Korycinski. The thalidomide-binding domain of cereblon defines the cult domain family and is a new member of the β-tent fold. PLoS Computational Biology, 11:e1004023, Jan 2015. URL: https://doi.org/10.1371/journal.pcbi.1004023, doi:10.1371/journal.pcbi.1004023. This article has 61 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(subramanian2016centromerelocalizationand pages 1-2): Lakxmi Subramanian, Bethan Medina‐Pritchard, Rachael Barton, Frances Spiller, Raghavendran Kulasegaran‐Shylini, Guoda Radaviciute, Robin C Allshire, and A Arockia Jeyaprakash. Centromere localization and function of mis18 requires yippee‐like domain‐mediated oligomerization. EMBO reports, 17:496-507, Mar 2016. URL: https://doi.org/10.15252/embr.201541520, doi:10.15252/embr.201541520. This article has 54 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(lupas2015thethalidomidebindingdomain pages 3-5): Andrei N. Lupas, Hongbo Zhu, and Mateusz Korycinski. The thalidomide-binding domain of cereblon defines the cult domain family and is a new member of the β-tent fold. PLoS Computational Biology, 11:e1004023, Jan 2015. URL: https://doi.org/10.1371/journal.pcbi.1004023, doi:10.1371/journal.pcbi.1004023. This article has 61 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(lupas2015thethalidomidebindingdomain pages 2-3): Andrei N. Lupas, Hongbo Zhu, and Mateusz Korycinski. The thalidomide-binding domain of cereblon defines the cult domain family and is a new member of the β-tent fold. PLoS Computational Biology, 11:e1004023, Jan 2015. URL: https://doi.org/10.1371/journal.pcbi.1004023, doi:10.1371/journal.pcbi.1004023. This article has 61 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(lupas2015thethalidomidebindingdomain pages 8-9): Andrei N. Lupas, Hongbo Zhu, and Mateusz Korycinski. The thalidomide-binding domain of cereblon defines the cult domain family and is a new member of the β-tent fold. PLoS Computational Biology, 11:e1004023, Jan 2015. URL: https://doi.org/10.1371/journal.pcbi.1004023, doi:10.1371/journal.pcbi.1004023. This article has 61 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(martinez2004genomicanalysisof pages 7-8): M. Juanita Martinez, Sushmita Roy, Amanda B. Archuletta, Peter D. Wentzell, Sonia Santa Anna-Arriola, Angelina L. Rodriguez, Anthony D. Aragon, Gabriel A. Quiñones, Chris Allen, and Margaret Werner-Washburne. Genomic analysis of stationary-phase and exit in saccharomyces cerevisiae: gene expression and identification of novel essential genes. Molecular biology of the cell, 15 12:5295-305, Dec 2004. URL: https://doi.org/10.1091/mbc.e03-11-0856, doi:10.1091/mbc.e03-11-0856. This article has 190 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(martinez2004genomicanalysisof pages 8-9): M. Juanita Martinez, Sushmita Roy, Amanda B. Archuletta, Peter D. Wentzell, Sonia Santa Anna-Arriola, Angelina L. Rodriguez, Anthony D. Aragon, Gabriel A. Quiñones, Chris Allen, and Margaret Werner-Washburne. Genomic analysis of stationary-phase and exit in saccharomyces cerevisiae: gene expression and identification of novel essential genes. Molecular biology of the cell, 15 12:5295-305, Dec 2004. URL: https://doi.org/10.1091/mbc.e03-11-0856, doi:10.1091/mbc.e03-11-0856. This article has 190 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(martinez2004genomicanalysisof pages 9-10): M. Juanita Martinez, Sushmita Roy, Amanda B. Archuletta, Peter D. Wentzell, Sonia Santa Anna-Arriola, Angelina L. Rodriguez, Anthony D. Aragon, Gabriel A. Quiñones, Chris Allen, and Margaret Werner-Washburne. Genomic analysis of stationary-phase and exit in saccharomyces cerevisiae: gene expression and identification of novel essential genes. Molecular biology of the cell, 15 12:5295-305, Dec 2004. URL: https://doi.org/10.1091/mbc.e03-11-0856, doi:10.1091/mbc.e03-11-0856. This article has 190 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(blancosanchez2020yippeelike3 pages 25-26): Bernardo Blanco-Sánchez, Aurélie Clément, Sara J. Stednitz, Jennifer Kyle, Judy L. Peirce, Marcie McFadden, Jeremy Wegner, Jennifer B. Phillips, Ellen Macnamara, Yan Huang, David R. Adams, Camilo Toro, William A. Gahl, May Christine V. Malicdan, Cynthia J. Tifft, Erika M. Zink, Kent J. Bloodsworth, Kelly G. Stratton, David M. Koeller, Thomas O. Metz, Philip Washbourne, and Monte Westerfield. Yippee like 3 (ypel3) is a novel gene required for myelinating and perineurial glia development. PLOS Genetics, 16:e1008841, Jun 2020. URL: https://doi.org/10.1371/journal.pgen.1008841, doi:10.1371/journal.pgen.1008841. This article has 28 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(blancosanchez2020yippeelike3 pages 2-3): Bernardo Blanco-Sánchez, Aurélie Clément, Sara J. Stednitz, Jennifer Kyle, Judy L. Peirce, Marcie McFadden, Jeremy Wegner, Jennifer B. Phillips, Ellen Macnamara, Yan Huang, David R. Adams, Camilo Toro, William A. Gahl, May Christine V. Malicdan, Cynthia J. Tifft, Erika M. Zink, Kent J. Bloodsworth, Kelly G. Stratton, David M. Koeller, Thomas O. Metz, Philip Washbourne, and Monte Westerfield. Yippee like 3 (ypel3) is a novel gene required for myelinating and perineurial glia development. PLOS Genetics, 16:e1008841, Jun 2020. URL: https://doi.org/10.1371/journal.pgen.1008841, doi:10.1371/journal.pgen.1008841. This article has 28 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(blancosanchez2020yippeelike3 pages 1-2): Bernardo Blanco-Sánchez, Aurélie Clément, Sara J. Stednitz, Jennifer Kyle, Judy L. Peirce, Marcie McFadden, Jeremy Wegner, Jennifer B. Phillips, Ellen Macnamara, Yan Huang, David R. Adams, Camilo Toro, William A. Gahl, May Christine V. Malicdan, Cynthia J. Tifft, Erika M. Zink, Kent J. Bloodsworth, Kelly G. Stratton, David M. Koeller, Thomas O. Metz, Philip Washbourne, and Monte Westerfield. Yippee like 3 (ypel3) is a novel gene required for myelinating and perineurial glia development. PLOS Genetics, 16:e1008841, Jun 2020. URL: https://doi.org/10.1371/journal.pgen.1008841, doi:10.1371/journal.pgen.1008841. This article has 28 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(blancosanchez2020yippeelike3 pages 26-27): Bernardo Blanco-Sánchez, Aurélie Clément, Sara J. Stednitz, Jennifer Kyle, Judy L. Peirce, Marcie McFadden, Jeremy Wegner, Jennifer B. Phillips, Ellen Macnamara, Yan Huang, David R. Adams, Camilo Toro, William A. Gahl, May Christine V. Malicdan, Cynthia J. Tifft, Erika M. Zink, Kent J. Bloodsworth, Kelly G. Stratton, David M. Koeller, Thomas O. Metz, Philip Washbourne, and Monte Westerfield. Yippee like 3 (ypel3) is a novel gene required for myelinating and perineurial glia development. PLOS Genetics, 16:e1008841, Jun 2020. URL: https://doi.org/10.1371/journal.pgen.1008841, doi:10.1371/journal.pgen.1008841. This article has 28 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(subramanian2016centromerelocalizationand pages 8-9): Lakxmi Subramanian, Bethan Medina‐Pritchard, Rachael Barton, Frances Spiller, Raghavendran Kulasegaran‐Shylini, Guoda Radaviciute, Robin C Allshire, and A Arockia Jeyaprakash. Centromere localization and function of mis18 requires yippee‐like domain‐mediated oligomerization. EMBO reports, 17:496-507, Mar 2016. URL: https://doi.org/10.15252/embr.201541520, doi:10.15252/embr.201541520. This article has 54 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(thamkachy2024structuralbasisfor pages 3-4): Reshma Thamkachy, Bethan Medina-Pritchard, Sang Ho Park, Carla G Chiodi, Juan Zou, Maria de la Torre-Barranco, Kazuma Shimanaka, Maria Alba Abad, Cristina Gallego Páramo, Regina Feederle, Emilija Ruksenaite, Patrick Heun, Owen R Davies, Juri Rappsilber, Dina Schneidman-Duhovny, Uhn-Soo Cho, and A Arockia Jeyaprakash. Structural basis for mis18 complex assembly and its implications for centromere maintenance. EMBO Reports, 25:3348-3372, Jul 2024. URL: https://doi.org/10.1038/s44319-024-00183-w, doi:10.1038/s44319-024-00183-w. This article has 15 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(thamkachy2024structuralbasisfor pages 1-3): Reshma Thamkachy, Bethan Medina-Pritchard, Sang Ho Park, Carla G Chiodi, Juan Zou, Maria de la Torre-Barranco, Kazuma Shimanaka, Maria Alba Abad, Cristina Gallego Páramo, Regina Feederle, Emilija Ruksenaite, Patrick Heun, Owen R Davies, Juri Rappsilber, Dina Schneidman-Duhovny, Uhn-Soo Cho, and A Arockia Jeyaprakash. Structural basis for mis18 complex assembly and its implications for centromere maintenance. EMBO Reports, 25:3348-3372, Jul 2024. URL: https://doi.org/10.1038/s44319-024-00183-w, doi:10.1038/s44319-024-00183-w. This article has 15 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(subramanian2016centromerelocalizationand pages 10-11): Lakxmi Subramanian, Bethan Medina‐Pritchard, Rachael Barton, Frances Spiller, Raghavendran Kulasegaran‐Shylini, Guoda Radaviciute, Robin C Allshire, and A Arockia Jeyaprakash. Centromere localization and function of mis18 requires yippee‐like domain‐mediated oligomerization. EMBO reports, 17:496-507, Mar 2016. URL: https://doi.org/10.15252/embr.201541520, doi:10.15252/embr.201541520. This article has 54 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(lupas2015thethalidomidebindingdomain pages 6-8): Andrei N. Lupas, Hongbo Zhu, and Mateusz Korycinski. The thalidomide-binding domain of cereblon defines the cult domain family and is a new member of the β-tent fold. PLoS Computational Biology, 11:e1004023, Jan 2015. URL: https://doi.org/10.1371/journal.pcbi.1004023, doi:10.1371/journal.pcbi.1004023. This article has 61 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(schou2024exploringthestructural pages 10-11): Kenneth Bødkter Schou, Samuel Mandacaru, Muhammad Tahir, Nikola Tom, Ann-Sofie Nilsson, Jens S. Andersen, Matteo Tiberti, Elena Papaleo, and Jiri Bartek. Exploring the structural landscape of dna maintenance proteins. Nature Communications, Sep 2024. URL: https://doi.org/10.1038/s41467-024-49983-7, doi:10.1038/s41467-024-49983-7. This article has 7 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(singhbabak2012globalanalysisof pages 4-5): Sheena D. Singh-Babak, Tomas Babak, Stephanie Diezmann, Jessica A. Hill, Jinglin Lucy Xie, Ying-Lien Chen, Susan M. Poutanen, Robert P. Rennie, Joseph Heitman, and Leah E. Cowen. Global analysis of the evolution and mechanism of echinocandin resistance in candida glabrata. PLoS Pathogens, 8:e1002718, May 2012. URL: https://doi.org/10.1371/journal.ppat.1002718, doi:10.1371/journal.ppat.1002718. This article has 240 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(singhbabak2012globalanalysisof pages 17-18): Sheena D. Singh-Babak, Tomas Babak, Stephanie Diezmann, Jessica A. Hill, Jinglin Lucy Xie, Ying-Lien Chen, Susan M. Poutanen, Robert P. Rennie, Joseph Heitman, and Leah E. Cowen. Global analysis of the evolution and mechanism of echinocandin resistance in candida glabrata. PLoS Pathogens, 8:e1002718, May 2012. URL: https://doi.org/10.1371/journal.ppat.1002718, doi:10.1371/journal.ppat.1002718. This article has 240 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(singhbabak2012globalanalysisof pages 6-8): Sheena D. Singh-Babak, Tomas Babak, Stephanie Diezmann, Jessica A. Hill, Jinglin Lucy Xie, Ying-Lien Chen, Susan M. Poutanen, Robert P. Rennie, Joseph Heitman, and Leah E. Cowen. Global analysis of the evolution and mechanism of echinocandin resistance in candida glabrata. PLoS Pathogens, 8:e1002718, May 2012. URL: https://doi.org/10.1371/journal.ppat.1002718, doi:10.1371/journal.ppat.1002718. This article has 240 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(OpenTargets Search: -YPEL1,YPEL2,YPEL3,YPEL4,YPEL5): Open Targets Query (-YPEL1,YPEL2,YPEL3,YPEL4,YPEL5, 13 results). Buniello, A. et al. (2025). Open Targets Platform: facilitating therapeutic hypotheses building in drug discovery. Nucleic Acids Research.</p>
+</li>
+</ol>
+<h2 id="artifacts">Artifacts</h2>
+<ul>
+<li><a href="MOH1-deep-research-falcon_artifacts/artifact-00.md">Edison artifact artifact-00</a></li>
+<li><a href="MOH1-deep-research-falcon_artifacts/artifact-01.md">Edison artifact artifact-01</a></li>
+</ul>
+<h2 id="citations">Citations</h2>
+<ol>
+<li>lupas2015thethalidomidebindingdomain pages 1-2</li>
+<li>subramanian2016centromerelocalizationand pages 1-2</li>
+<li>lupas2015thethalidomidebindingdomain pages 5-6</li>
+<li>lupas2015thethalidomidebindingdomain pages 2-3</li>
+<li>lupas2015thethalidomidebindingdomain pages 8-9</li>
+<li>schou2024exploringthestructural pages 10-11</li>
+<li>martinez2004genomicanalysisof pages 9-10</li>
+<li>martinez2004genomicanalysisof pages 8-9</li>
+<li>singhbabak2012globalanalysisof pages 4-5</li>
+<li>singhbabak2012globalanalysisof pages 6-8</li>
+<li>lupas2015thethalidomidebindingdomain pages 9-10</li>
+<li>lupas2015thethalidomidebindingdomain pages 3-5</li>
+<li>martinez2004genomicanalysisof pages 7-8</li>
+<li>subramanian2016centromerelocalizationand pages 8-9</li>
+<li>thamkachy2024structuralbasisfor pages 3-4</li>
+<li>thamkachy2024structuralbasisfor pages 1-3</li>
+<li>subramanian2016centromerelocalizationand pages 10-11</li>
+<li>lupas2015thethalidomidebindingdomain pages 6-8</li>
+<li>singhbabak2012globalanalysisof pages 17-18</li>
+<li>https://doi.org/10.1371/journal.pcbi.1004023,</li>
+<li>https://doi.org/10.15252/embr.201541520,</li>
+<li>https://doi.org/10.1091/mbc.e03-11-0856,</li>
+<li>https://doi.org/10.1371/journal.pgen.1008841,</li>
+<li>https://doi.org/10.1038/s44319-024-00183-w,</li>
+<li>https://doi.org/10.1038/s41467-024-49983-7,</li>
+<li>https://doi.org/10.1371/journal.ppat.1002718,</li>
+</ol>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(MOH1-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="P38191" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="moh1-ybl049w-p38191-research-notes">MOH1 (YBL049W, P38191) — research notes</h1>
+<p>Research journal for the AI GO-annotation review. MOH1 is a genuinely<br />
+understudied ("dark") <em>S. cerevisiae</em> gene. This file separates what is KNOWN<br />
+from what is NOT known, with inline provenance.</p>
+<h2 id="identity-basic-facts-known">Identity / basic facts (KNOWN)</h2>
+<ul>
+<li>UniProt <strong>P38191</strong>, gene <strong>MOH1</strong>, systematic name <strong>YBL049W</strong> (chromosome II,<br />
+  left arm). 138 aa, 16 kDa. SGD <strong>S000000145</strong>. <strong>Verified ORF, protein of<br />
+  unknown function</strong> (SGD).</li>
+<li>Member of the <strong>Yippee family</strong> (UniProt SIMILARITY: "Belongs to the yippee<br />
+  family"). InterPro: IPR034751 (Yippee), IPR004910 (Yippee/Mis18/Cereblon),<br />
+  IPR039058 (Yippee_fam); Pfam PF03226 (Yippee-Mis18); PROSITE PS51792 (YIPPEE);<br />
+  PANTHER PTHR13848.</li>
+<li><strong>Single yeast ortholog of the human YPEL1–YPEL5 family.</strong> The human paralogs<br />
+  arose by gene duplication; yeast has one member.</li>
+</ul>
+<h2 id="domain-molecular-architecture-known-independently-verified">Domain / molecular architecture (KNOWN, independently verified)</h2>
+<ul>
+<li>UniProt annotates a <strong>Yippee domain (residues 41–138)</strong> with a structural<br />
+<strong>Zn(2+) site coordinated by Cys45, Cys48, Cys101, Cys104</strong> (ProRule<br />
+  PRU01128).</li>
+<li>My own bioinformatics analysis (<code>MOH1-bioinformatics/</code>) independently<br />
+  confirms the Yippee zinc signature: two CxxC pairs <strong>C45-x2-C48 … C101-x2-C104</strong><br />
+  separated by a 52-residue spacer — the canonical Yippee motif<br />
+  (Cys-X₂-Cys-X₅₂-Cys-X₂-Cys). See <code>file:yeast/MOH1/MOH1-bioinformatics/RESULTS.md</code>.</li>
+<li>Conservation vs human YPEL1–5: ~37–45% identity; <strong>all four Zn-cysteines are<br />
+  perfectly conserved in every human ortholog</strong>, supporting a retained structural<br />
+  zinc site. (Bioinformatics RESULTS.md.)</li>
+<li>The Yippee/Mis18/CULT fold is a <strong>zinc-stabilized β-fold with a cradle-shaped<br />
+  pocket implicated in protein/nucleic-acid binding</strong> — a binding/scaffold module,<br />
+<strong>not a recognized catalytic fold</strong>. No EC number; no catalytic motif detected.<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/11240639" title="Yippee contains a putative zinc-finger-like metal binding domain">PMID:11240639</a></li>
+</ul>
+<h2 id="what-the-primary-literature-actually-establishes">What the primary literature actually establishes</h2>
+<h3 id="ashrafi-farazi-gordon-1998-jbc-the-founding-paper-known-but-indirect">Ashrafi, Farazi &amp; Gordon 1998 (JBC) — the founding paper (KNOWN, but indirect)</h3>
+<ul>
+<li>MOH1/YBL049W was identified as a <strong>putative N-myristoylprotein</strong> whose deletion<br />
+  (in NMT1 cells) mimics the starvation-sensitive phenotype of an nmt1 mutant.<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/9748261" title="Removal of any one of the following nine substrates produced a   loss of CFU similar to that observed in nmt1-451Dfaa4Delta cells: Arf1p, Arf2p,   Sip2p, Van1p, Ptc2p, YBL049W (homology to Snf7p), YJR114W, YKR007W, and   YMR077C">PMID:9748261</a></li>
+<li>The paper's parenthetical "(homology to Snf7p)" is an <strong>early, superseded</strong><br />
+  homology guess; the protein was later recognized as a Yippee-family member.</li>
+<li>This links MOH1 (phenotypically) to <strong>maintenance of proliferative potential /<br />
+  survival during stationary phase</strong>, not to a molecular activity.<br />
+  [PMID:9748261 "specific N-myristoylproteins contribute to stationary-phase<br />
+  survival" — paraphrase; verbatim: "These proteins provide opportunities to<br />
+  further define the molecular mechanisms that regulate survival during stationary<br />
+  phase"]</li>
+<li>NOTE: whether Moh1 is genuinely N-myristoylated in vivo was inferred from a<br />
+  genome-wide sequence search for Nmt substrates plus deletion phenotype, not<br />
+  demonstrated biochemically here. Treat "N-myristoylprotein" as predicted.</li>
+</ul>
+<h3 id="lee-et-al-2017-j-microbiol-biotechnol-the-pro-apoptotic-paper-known-moderate-quality">Lee et al. 2017 (J Microbiol Biotechnol) — the "pro-apoptotic" paper (KNOWN, moderate quality)</h3>
+<ul>
+<li>Basis for UniProt's "Pro-Apoptotic protein MOH1" RecName and the Apoptosis<br />
+  keyword. moh1Δ shows <strong>enhanced viability</strong> under apoptogenic stress (UV, MMS,<br />
+  camptothecin, 50°C heat shock, 1.2 M KCl), and Moh1 protein is <strong>up-regulated</strong><br />
+  under stress. <a href="https://pubmed.ncbi.nlm.nih.gov/28173693" title="The moh1Δ mutant exhibited enhanced cell viability   compared with the WT-MOH1 strain when treated with lethal UV irradiation, 1.8 mM   MMS, 100 µ CPT, heat shock at 50°C, or 1.2 M KCl">PMID:28173693</a></li>
+<li>Human <strong>YPEL5</strong> (and other YPELs) partially complement moh1Δ; YPEL5 conferred<br />
+  UV sensitivity similar to WT-MOH1. <a href="https://pubmed.ncbi.nlm.nih.gov/28173693" title="the transformant bearing   pYES2-YPEL5 was more sensitive to lethal UV irradiation and its UV sensitivity   was similar to that of the WT-MOH1 strain">PMID:28173693</a></li>
+<li>Authors frame this as "mitochondria-dependent apoptosis induced by DNA damage."<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/28173693" title="their involvement in mitochondria-dependent apoptosis induced by   DNA damage">PMID:28173693</a></li>
+<li>CAVEAT (my judgment): "yeast apoptosis" / metacaspase-dependent regulated cell<br />
+  death is a <strong>contested framework</strong>; the assay is a heterologous-complementation<br />
+  viability study, abstract-only in our cache. The robust, model-independent<br />
+  observation is that <strong>moh1Δ increases stress resistance and Moh1 is<br />
+  stress-induced</strong> — i.e. Moh1 <em>sensitizes</em> cells to lethal stress. The molecular<br />
+  mechanism is not established. This is a "pro-death phenotype," not a demonstrated<br />
+  molecular activity, and does not by itself justify a GO apoptosis annotation for<br />
+  a yeast gene.</li>
+</ul>
+<h3 id="roxstrom-lindquist-faye-2001-insect-mol-biol-family-founding-paper-known-context">Roxström-Lindquist &amp; Faye 2001 (Insect Mol Biol) — family founding paper (KNOWN, context)</h3>
+<ul>
+<li>Defines the Yippee family; Drosophila Yippee found as interactor of Hemolin;<br />
+  "putative zinc-finger-like metal binding domain"; family conserved slime-mould<br />
+  → human. Human clone 76% identical to Drosophila Yippee.<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/11240639" title="It is the first characterized member of a conserved gene family   of proteins present in diverse eukaryotic organisms">PMID:11240639</a></li>
+<li>Even the founding family paper leaves molecular function open:<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/11240639" title="the Hemolin-Yippee interaction remains to be further   elucidated">PMID:11240639</a>.</li>
+</ul>
+<h3 id="wang-et-al-2018-metallomics-the-rca-zinc-annotation-source-known-computational">Wang et al. 2018 (Metallomics) — the RCA zinc annotation source (KNOWN, computational)</h3>
+<ul>
+<li>GO:0008270 (zinc ion binding, RCA, PMID:30358795) derives from a proteome-wide<br />
+  bioinformatic + MS survey of the yeast zinc proteome; MOH1 is included among 582<br />
+  known/potential zinc-binding proteins by domain/motif prediction, not by direct<br />
+  metal-binding assay of Moh1. <a href="https://pubmed.ncbi.nlm.nih.gov/30358795" title="The yeast zinc proteome of 582   known or potential zinc-binding proteins was identified using a bioinformatics   analysis that combined global domain searches with local motif searches">PMID:30358795</a></li>
+</ul>
+<h3 id="olgun-et-al-2025-biorxiv-preprint-10110120251030685511-most-recent-known-not-peer-reviewed">Olgun et al. 2025 (bioRxiv preprint 10.1101/2025.10.30.685511) — most recent (KNOWN, NOT peer-reviewed)</h3>
+<ul>
+<li>Title: "Yippee-like protein Moh1 links gene expression to metabolism and<br />
+  selective stress resistance in Saccharomyces cerevisiae." Preprint, no PMID.</li>
+<li>Reports: moh1Δ increases sensitivity to sodium azide and sulfuric acid but<br />
+<strong>increases resistance to H2O2 and acetic acid</strong>; H2O2 resistance attributed to<br />
+<strong>decreased cellular uptake from altered membrane permeability</strong>, not lowered<br />
+  mitochondrial ROS; transcriptional reprogramming + metabolic remodeling (lipids,<br />
+  proteins, cell-wall polysaccharides).</li>
+<li>This reinforces a role in <strong>stress resistance / membrane and metabolic<br />
+  remodeling</strong> but still does not assign a molecular activity. Because it is a<br />
+  non-peer-reviewed preprint with no PMID, it is used here for context/knowledge-gap<br />
+  framing only (status CLOSING/NARROWING for some gaps), NOT as the basis of a<br />
+  positive GO core function. Verbatim quoting deferred (no cached full text; the<br />
+  reference validator only checks PMID/file: quotes).</li>
+</ul>
+<h2 id="sgd-curated-phenotypes-known-from-sgd-locus-s000000145">SGD-curated phenotypes (KNOWN, from SGD locus S000000145)</h2>
+<ul>
+<li>Null mutant: <strong>increased innate thermotolerance, increased chemical resistance,<br />
+  increased UV resistance, decreased stationary-phase survival, decreased<br />
+  chronological lifespan, increased competitive fitness</strong>; haploinsufficient;<br />
+  abnormal vacuolar morphology; decreased vegetative growth (large-scale).</li>
+<li>Interactions: ~49 total (11 affinity-capture-MS, 26 negative genetic, 8 positive<br />
+  genetic, etc.) — no single strong, function-defining partner has emerged.</li>
+<li>"Essential for stationary-phase survival; not required for growth on<br />
+  nonfermentable carbon sources; possibly linked with vacuolar transport" (SGD).</li>
+</ul>
+<h2 id="synthesis-of-known">Synthesis of KNOWN</h2>
+<p>MOH1 is a small, low-abundance, cytoplasmic (inferred) Yippee-family zinc-binding<br />
+protein — the single yeast representative of the metazoan YPEL family. Its<br />
+structural Zn(2+) site is intact and deeply conserved. Loss of MOH1 makes cells<br />
+<strong>more resistant</strong> to multiple lethal stresses (UV, MMS, CPT, heat, hyperosmotic,<br />
+H2O2, acetic acid) while impairing <strong>long-term stationary-phase/chronological<br />
+survival</strong>; Moh1 is stress-induced. It is functionally interchangeable enough with<br />
+human YPEL5 for partial cross-complementation.</p>
+<h2 id="what-is-not-known-the-deliverable">What is NOT known (the deliverable)</h2>
+<ol>
+<li><strong>Molecular activity.</strong> No biochemical activity is demonstrated. Zinc binding<br />
+   (GO:0008270) is predicted from the domain, and the fold is a putative<br />
+   binding/scaffold module, but what Moh1 <em>does</em> biochemically (binds what? acts<br />
+   on what?) is unknown. No catalytic activity is supported.</li>
+<li><strong>Direct physical partners / substrates.</strong> Despite ~49 recorded interactions,<br />
+   no functionally validated, direct partner or cargo is established. The<br />
+   Drosophila Yippee–Hemolin interaction has no yeast counterpart.</li>
+<li><strong>Mechanism linking Moh1 to stress resistance and stationary-phase survival.</strong><br />
+   Why does deletion <em>increase</em> acute stress resistance yet <em>decrease</em> long-term<br />
+   survival? The 2025 preprint proposes altered membrane permeability/metabolic<br />
+   remodeling, but the causal molecular step (and whether Moh1 acts directly on<br />
+   membranes, transcription, or metabolism) is undetermined.</li>
+<li><strong>Whether the "pro-apoptotic"/regulated-cell-death framing is the correct<br />
+   biological process.</strong> The apoptosis label rests on one heterologous<br />
+   complementation study in a contested yeast-apoptosis paradigm.</li>
+<li><strong>Subcellular localization.</strong> No reliable curated localization; UniProt/GOA<br />
+   record cellular_component unknown (ND). "Possibly linked with vacuolar<br />
+   transport" (SGD) is a hypothesis.</li>
+<li><strong>Whether Moh1 is actually N-myristoylated in vivo</strong> (predicted in 1998; not<br />
+   biochemically confirmed).</li>
+</ol>
+<h2 id="annotation-review-plan">Annotation-review plan</h2>
+<ul>
+<li>GO:0000151 ubiquitin ligase complex (IBA, GO_REF:0000033, from PANTHER node<br />
+  PTN002302768 seeded by human YPEL5 P62699): <strong>scrutinize.</strong> No yeast evidence<br />
+  places Moh1 in a ubiquitin-ligase complex; the IBA is a family-level<br />
+  propagation from the Mis18/cereblon(CULT) neighborhood. The Yippee fold is<br />
+  related to cereblon's thalidomide-binding CULT domain (which <em>is</em> a substrate<br />
+  receptor of a CRL4 E3), but Moh1/YPEL proteins are not established E3 components.<br />
+  Lean MARK_AS_OVER_ANNOTATED (family over-propagation; not core), unless deep<br />
+  research surfaces yeast evidence.</li>
+<li>GO:0008270 zinc ion binding (RCA, PMID:30358795): <strong>KEEP</strong> — corroborated by<br />
+  UniProt features and my bioinformatics; the only defensible molecular function.<br />
+  Structural zinc, so KEEP_AS_NON_CORE / ACCEPT (it is the core molecular feature<br />
+  even if biochemical output is unknown).</li>
+<li>GO:0005575 cellular_component (ND) and GO:0008150 biological_process (ND):<br />
+  root/placeholder ND annotations — ACCEPT as-is (standard ND practice; they<br />
+  correctly record "unknown").</li>
+</ul>
+<h3 id="martinez-et-al-2004-mol-biol-cell-dedicated-stationary-phase-genetics-known">Martinez et al. 2004 (Mol Biol Cell) — dedicated stationary-phase genetics (KNOWN)</h3>
+<ul>
+<li>Surfaced by the falcon deep-research report and added as PMID:15456898. Genome-wide<br />
+  stationary-phase study that identified 32 genes essential for survival in stationary<br />
+  phase at 37C; MOH1 is among the stationary-phase-essential set and is NOT required<br />
+  for growth on nonfermentable carbon sources — i.e. a specific quiescence-survival<br />
+  role, not a generic respiratory defect. <a href="https://pubmed.ncbi.nlm.nih.gov/15456898" title="32 genes essential for   survival in stationary-phase at">PMID:15456898</a>. (MOH1-specific numbers are in the full text; the<br />
+  cached record is abstract-only.) The paper also (per full text, via falcon) still<br />
+  described Moh1p using the superseded "related to Snf7p" homology and as a<br />
+  "myristolated protein of unknown function."</li>
+</ul>
+<h2 id="deep-research-outcome-falcon">Deep research outcome (falcon)</h2>
+<p>The falcon deep-research job completed successfully (~1553 s, Edison Scientific<br />
+model, 26 citations) → <code>MOH1-deep-research-falcon.md</code>. It is on the correct gene<br />
+and organism and independently corroborates every substantive conclusion here: the<br />
+Yippee/Mis18/Cereblon β-tent fold with a Zn-coordinating CXXC pair and a<br />
+cradle-shaped binding pocket; MOH1 as the single yeast member of the human YPEL1–5<br />
+family; stationary-phase-survival requirement (Martinez 2004); and the explicit<br />
+conclusion that "MOH1 is not an enzyme, transporter, or structural protein in the<br />
+classical sense" but a "small regulatory or adaptor protein" whose "precise<br />
+biochemical activity in budding yeast remains unresolved." It adds context sources<br />
+(Mis18 centromere biology, cereblon/CULT, FAM72, C. glabrata MOH1 Y5H variant that<br />
+did NOT confer echinocandin resistance) but no new yeast molecular function.</p>
+<h2 id="provenance-discipline-note">Provenance discipline note</h2>
+<p>Cached publications are abstract-only (full_text_available: false for<br />
+PMID:9748261, 28173693, 30358795, 11240639, 15456898). All PMID supporting_text<br />
+quotes are verbatim substrings of the cached abstracts (grep-verified). The 2025<br />
+bioRxiv preprint has no PMID and no cached full text; it is cited as context only in<br />
+prose, with no fabricated quotes. file: quotes (bioinformatics RESULTS.md, falcon<br />
+report) were grep-verified as verbatim substrings before use.</p>
+            </div>
+        </details>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Bioinformatics Results</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(RESULTS.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="P38191" data-a="DOC: Bioinformatics Results" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="moh1-ybl049w-p38191-bioinformatics-analysis">MOH1 (YBL049W / P38191) — Bioinformatics analysis</h1>
+<p>Reproducible sequence/domain analysis to ground functional inference for a dark<br />
+gene. All numbers below are produced by the scripts in <code>scripts/</code> from the input<br />
+sequence in <code>data/</code>; nothing is hardcoded. Re-run with <code>just all</code>.</p>
+<h2 id="objectives">Objectives</h2>
+<ol>
+<li>Verify the Yippee/Mis18/Cereblon (CULT) zinc-binding domain and the four<br />
+   putative Zn-coordinating cysteines annotated by UniProt (C45, C48, C101, C104).</li>
+<li>Quantify sequence conservation of MOH1 versus the five human orthologs<br />
+   (YPEL1–YPEL5) and test whether the Zn-cysteines are conserved.</li>
+<li>Assess whether there is any sequence-level evidence for catalytic activity.</li>
+</ol>
+<h2 id="methods">Methods</h2>
+<ul>
+<li><strong>Input</strong>: MOH1 sequence P38191 (<code>data/MOH1.fasta</code>, 138 aa).</li>
+<li><strong>Zinc-ligand scan</strong> (<code>scripts/analyze_yippee.py</code>): enumerates all Cys/His and<br />
+  finds all C-x(2)-C pairs by regex; reports the candidate Yippee zinc site<br />
+  (two CxxC pairs + inter-pair spacer).</li>
+<li><strong>Conservation</strong> (<code>scripts/conservation.py</code>): global BLOSUM62 pairwise<br />
+  alignment (Biopython <code>PairwiseAligner</code>) of MOH1 against each human YPEL; reports<br />
+  percent identity over aligned columns and whether each probed query position is<br />
+  identical/similar/gapped in the homolog.</li>
+<li><strong>Orthologs</strong> (<code>scripts/fetch_orthologs.py</code>): live download of reviewed human<br />
+  YPEL1–5 from UniProt (O60688, Q96QA6, P61236, Q96NS1, P62699).</li>
+<li><strong>Negative control</strong>: yeast pyruvate kinase CDC19 (P00549), a non-Yippee<br />
+  protein, run through both scripts to confirm they are not hardcoded.</li>
+</ul>
+<h2 id="results">Results</h2>
+<h3 id="1-yippee-zinc-site-from-resultsmoh1_yippeetxt">1. Yippee zinc site (from <code>results/moh1_yippee.txt</code>)</h3>
+<div class="codehilite"><pre><span></span><code>length                    138
+cysteine_positions        [45, 48, 97, 101, 104, 135, 137]
+CxxC_pairs                [(45, 48), (101, 104)]
+candidate_zinc_site       C45-x2-C48 ... C101-x2-C104
+inter_pair_spacer_residues 52
+predicted_zn_ligand_count 4
+</code></pre></div>
+
+<p>MOH1 contains exactly the two CxxC motifs that define the Yippee zinc site:<br />
+<strong>C45-x2-C48 … C101-x2-C104</strong>, separated by 52 residues. This is the canonical<br />
+Yippee signature (Cys-X₂-Cys-X₅₂-Cys-X₂-Cys) reported in the literature for the<br />
+family and matches the four UniProt Zn(2+)-binding features (positions 45, 48,<br />
+101, 104) exactly. The additional cysteines (97, 135, 137) do not form the<br />
+site.</p>
+<h3 id="2-ortholog-conservation-from-resultsconservationtsv">2. Ortholog conservation (from <code>results/conservation.tsv</code>)</h3>
+<table>
+<thead>
+<tr>
+<th>Human ortholog</th>
+<th>length</th>
+<th>% identity to MOH1</th>
+<th>C45</th>
+<th>C48</th>
+<th>C101</th>
+<th>C104</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>YPEL1 (O60688)</td>
+<td>119</td>
+<td>44.0</td>
+<td>=</td>
+<td>=</td>
+<td>=</td>
+<td>=</td>
+</tr>
+<tr>
+<td>YPEL2 (Q96QA6)</td>
+<td>119</td>
+<td>44.0</td>
+<td>=</td>
+<td>=</td>
+<td>=</td>
+<td>=</td>
+</tr>
+<tr>
+<td>YPEL3 (P61236)</td>
+<td>119</td>
+<td>44.8</td>
+<td>=</td>
+<td>=</td>
+<td>=</td>
+<td>=</td>
+</tr>
+<tr>
+<td>YPEL4 (Q96NS1)</td>
+<td>127</td>
+<td>44.2</td>
+<td>=</td>
+<td>=</td>
+<td>=</td>
+<td>=</td>
+</tr>
+<tr>
+<td>YPEL5 (P62699)</td>
+<td>121</td>
+<td>37.3</td>
+<td>=</td>
+<td>=</td>
+<td>=</td>
+<td>=</td>
+</tr>
+</tbody>
+</table>
+<ul>
+<li>MOH1 is a <strong>bona fide, moderately conserved (~37–45% identity) ortholog</strong> of<br />
+  the human YPEL family across the Yippee domain.</li>
+<li><strong>All four zinc-binding cysteines are perfectly conserved</strong> in every human<br />
+  ortholog (<code>=</code> in every cell), strongly supporting a structural Zn(2+) site<br />
+  retained from yeast to human.</li>
+<li>Notably, <strong>YPEL5 (P62699) is the <em>least</em> identical</strong> of the five (37.3%), yet<br />
+  it is (a) the PANTHER seed for the IBA "ubiquitin ligase complex" annotation<br />
+  and (b) the human gene shown to functionally complement moh1Δ (PMID:28173693).<br />
+  So MOH1 is the yeast representative of the whole family rather than a specific<br />
+  1:1 ortholog of any single human YPEL.</li>
+</ul>
+<h3 id="3-evidence-regarding-catalytic-activity">3. Evidence regarding catalytic activity</h3>
+<p>The Yippee fold (two four-stranded β-meanders coordinating one Zn²⁺ at the apex,<br />
+forming a cradle-shaped pocket) is a <strong>structural/binding scaffold, not a<br />
+recognized catalytic fold</strong>. The sequence contains no canonical catalytic motif<br />
+and no EC number is assigned in UniProt/GOA. The conserved cysteines are the<br />
+Zn-structural ligands, not a catalytic dyad/triad. <strong>There is no sequence-level<br />
+evidence for enzymatic activity</strong>; the family is best described as a putative<br />
+zinc-dependent protein/nucleic-acid interaction module of unknown biochemical<br />
+output.</p>
+<h3 id="4-negative-control-from-resultscontrol_yippeetxt-resultscontrol_conservationtsv">4. Negative control (from <code>results/control_yippee.txt</code>, <code>results/control_conservation.tsv</code>)</h3>
+<p>Yeast pyruvate kinase CDC19 (P00549, 500 aa) returns<br />
+<code>candidate_zinc_site NONE (fewer than two CxxC pairs)</code> and its residues at the<br />
+probed positions do not match the YPEL cysteines (mostly gaps). This confirms the<br />
+scripts compute results from the actual input rather than emitting a fixed answer.</p>
+<h2 id="conclusions">Conclusions</h2>
+<ul>
+<li><strong>Confirmed</strong>: MOH1 is a Yippee-family protein with an intact, evolutionarily<br />
+  conserved zinc-binding site (C45/C48/C101/C104); the UniProt Zn features and the<br />
+  PROSITE Yippee domain call are corroborated independently here.</li>
+<li><strong>Confirmed</strong>: MOH1 is a genuine ortholog of the human YPEL1–5 family<br />
+  (~37–45% identity), the single yeast member of a family that expanded to five<br />
+  paralogs in humans.</li>
+<li><strong>Inconclusive / unknown (correctly so)</strong>: the analysis provides <strong>no</strong><br />
+  evidence for a specific molecular <em>function</em> (catalytic or otherwise) beyond<br />
+  zinc binding. The biochemical activity and direct partners of MOH1 remain<br />
+  undetermined by sequence analysis — consistent with its status as a<br />
+  functionally dark gene.</li>
+</ul>
+<h2 id="reproducibility-checklist">Reproducibility checklist</h2>
+<ul>
+<li>[x] No script uses hardcoded inputs or outputs (all read <code>data/*.fasta</code>, write <code>results/*</code>).</li>
+<li>[x] Scripts tested on an independent input (CDC19 / P00549 negative control): Yippee scan correctly returns NO site; conservation probe correctly returns non-matching positions.</li>
+<li>[x] Analyses completed as expected.</li>
+<li>[x] Direct script outputs are in <code>results/</code>.</li>
+<li>[x] Summary includes provenance and justification; uncertainty (catalytic activity, specific MF) explicitly flagged as unresolved.</li>
+</ul>
+<h2 id="tools-data">Tools &amp; data</h2>
+<ul>
+<li>Biopython 1.87 (<code>PairwiseAligner</code>, BLOSUM62); Python ≥3.11; requests.</li>
+<li>UniProt REST API (sequences downloaded live).</li>
+<li>Reference sequence: UniProt P38191 (MOH1_YEAST).</li>
+</ul>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: P38191
+gene_symbol: MOH1
+product_type: PROTEIN
+status: COMPLETE
+taxon:
+  id: NCBITaxon:559292
+  label: Saccharomyces cerevisiae
+description: &gt;-
+  MOH1 (YBL049W) is a small (138 aa), low-abundance protein of the Yippee family,
+  the single Saccharomyces cerevisiae representative of the family that expanded to
+  the five YPEL paralogs (YPEL1-YPEL5) in humans. It comprises a Yippee/Mis18/Cereblon
+  (CULT) fold — a zinc-stabilized double beta-meander that coordinates one structural
+  Zn(2+) ion through four conserved cysteines (Cys45, Cys48, Cys101, Cys104) and
+  presents a cradle-shaped pocket implicated in protein or nucleic-acid binding. The
+  fold is a binding/scaffold module rather than a catalytic one, and no enzymatic
+  activity has been demonstrated. Functionally, MOH1 is understudied: it is
+  stress-inducible, and its deletion increases acute resistance to several lethal
+  stresses (UV, methyl methanesulfonate, camptothecin, heat, hyperosmotic shock,
+  hydrogen peroxide and acetic acid) while impairing long-term stationary-phase and
+  chronological survival. Human YPEL genes can partially substitute for MOH1,
+  indicating conservation of function across the family. The direct molecular
+  activity, physical partners, subcellular site of action, and the mechanism linking
+  MOH1 to stress tolerance and quiescence remain undetermined.
+references:
+- id: GO_REF:0000015
+  title: Use of the ND evidence code for Gene Ontology (GO) terms
+  findings: []
+- id: GO_REF:0000033
+  title: Annotation inferences using phylogenetic trees
+  findings:
+  - statement: &gt;-
+      The ubiquitin ligase complex annotation on MOH1 is a phylogenetically
+      propagated (IBA) inference from PANTHER family PTHR13848, seeded by human
+      YPEL5 (UniProtKB:P62699); there is no yeast-specific experimental support.
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: &gt;-
+      GO_REF for IBA propagation. The propagation itself is real, but the resulting
+      ubiquitin ligase complex assignment is a family-level over-propagation for MOH1
+      (see the annotation review).
+- id: PMID:30358795
+  title: The cellular economy of the Saccharomyces cerevisiae zinc proteome.
+  findings:
+  - statement: &gt;-
+      MOH1 is included among 582 known or potential zinc-binding proteins identified
+      by a proteome-wide bioinformatic domain/motif survey; this is the basis of the
+      RCA zinc ion binding annotation, a prediction rather than a direct metal-binding
+      assay of Moh1.
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PubMed-verified. Supports zinc binding by computational (RCA) prediction from
+      the Yippee domain; consistent with UniProt Zn-binding features and my
+      bioinformatics analysis.
+- id: PMID:28173693
+  title: Pro-Apoptotic Role of the Human YPEL5 Gene Identified by Functional Complementation
+    of a Yeast moh1Δ Mutation.
+  findings:
+  - statement: &gt;-
+      moh1 deletion increases cell viability under multiple lethal stresses
+      (UV, MMS, camptothecin, heat, hyperosmotic shock), and Moh1 is stress-induced;
+      human YPEL genes partially complement moh1delta. Framed by the authors as
+      involvement in DNA-damage-induced, mitochondria-dependent regulated cell death.
+  reference_review:
+    relevance: HIGH
+    correctness: LOW_QUALITY
+    review_notes: &gt;-
+      PubMed-verified; the only dedicated functional study of MOH1. Abstract-only in
+      cache. It establishes a robust stress-sensitizing phenotype and cross-species
+      complementation, but the &#34;pro-apoptotic/mitochondria-dependent apoptosis&#34;
+      interpretation rests on a single heterologous-complementation viability study in
+      the contested yeast programmed-cell-death paradigm; it does not establish a
+      molecular activity.
+- id: PMID:9748261
+  title: A role for Saccharomyces cerevisiae fatty acid activation protein 4 in regulating
+    protein N-myristoylation during entry into stationary phase.
+  findings:
+  - statement: &gt;-
+      YBL049W (MOH1) was identified as one of nine putative N-myristoylproteins whose
+      deletion reproduces the stationary-phase survival defect of nmt1 mutant cells,
+      linking MOH1 phenotypically to maintenance of proliferative potential during
+      stationary phase.
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PubMed-verified founding paper for MOH1. Abstract-only. The parenthetical
+      &#34;(homology to Snf7p)&#34; is a superseded homology guess; MOH1 was later recognized
+      as a Yippee-family protein. N-myristoylation of Moh1 is predicted here, not
+      shown biochemically.
+- id: PMID:11240639
+  title: The Drosophila gene Yippee reveals a novel family of putative zinc binding
+    proteins highly conserved among eukaryotes.
+  findings:
+  - statement: &gt;-
+      Defines the Yippee family as a highly conserved eukaryotic family bearing a
+      putative zinc-finger-like metal-binding domain; even at the family&#39;s founding the
+      molecular function was left open.
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PubMed-verified. Family-defining paper; supports the zinc-binding-module framing
+      and the family-wide &#34;function largely unknown&#34; status.
+- id: PMID:15456898
+  title: &#39;Genomic analysis of stationary-phase and exit in Saccharomyces cerevisiae:
+    gene expression and identification of novel essential genes.&#39;
+  findings:
+  - statement: &gt;-
+      Genome-wide screen that identified MOH1 as one of the stationary-phase-essential
+      genes: moh1 deletion causes a large loss of viability during long-term
+      stationary phase at 37C, yet MOH1 is not required for growth on nonfermentable
+      carbon sources, indicating a specific quiescence-survival role rather than a
+      generic respiratory defect.
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PubMed-verified (abstract-only in cache; the MOH1-specific detail is in the full
+      text, surfaced by the falcon deep-research report). Best dedicated genetic
+      evidence that MOH1 is required for stationary-phase/quiescence survival.
+- id: file:yeast/MOH1/MOH1-deep-research-falcon.md
+  title: Falcon deep research report on S. cerevisiae MOH1 (YBL049W)
+  findings:
+  - statement: &gt;-
+      Synthesis concluding MOH1 is a small conserved Yippee-family regulatory/adaptor
+      protein with a zinc-stabilized beta-tent fold and cradle-shaped binding pocket,
+      required for stationary-phase survival, whose precise biochemical activity,
+      substrate, and dedicated pathway remain unresolved in the retrievable literature.
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Falcon report (Edison Scientific), correct gene/organism, 26 citations; corroborates
+      the domain/fold, ortholog and stationary-phase findings independently established
+      here. Used for context; positive GO claims are anchored to PMIDs and the
+      bioinformatics analysis, not to this report.
+- id: file:yeast/MOH1/MOH1-bioinformatics/RESULTS.md
+  title: Bioinformatics analysis of MOH1 (Yippee domain, zinc site, ortholog conservation)
+  findings:
+  - statement: &gt;-
+      Independently confirms the Yippee zinc signature (C45-x2-C48 ... C101-x2-C104,
+      52-residue spacer) matching the UniProt Zn-binding features, ~37-45% identity to
+      human YPEL1-5 with all four Zn-cysteines perfectly conserved, and no
+      sequence-level evidence for catalytic activity.
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Reproducible in-repo analysis; negative control (pyruvate kinase) confirms the
+      scripts are not hardcoded.
+existing_annotations:
+- term:
+    id: GO:0000151
+    label: ubiquitin ligase complex
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: part_of
+  review:
+    summary: &gt;-
+      Family-level phylogenetic propagation (IBA) from PANTHER PTHR13848, seeded by
+      human YPEL5 (UniProtKB:P62699). There is no yeast experimental evidence that
+      Moh1 is a component of a ubiquitin ligase complex. Although the Yippee fold is
+      structurally related to the CULT domain of cereblon (a substrate receptor of a
+      CRL4 E3 ligase), Yippee/YPEL proteins are not themselves established ubiquitin
+      ligase complex subunits, and no such complex has been demonstrated for Moh1.
+      This is an over-propagation from a distant structural relative.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      IBA propagated from a structurally related but functionally distinct neighborhood
+      (Mis18/cereblon-CULT); no experimental or orthology evidence places Moh1 in a
+      ubiquitin ligase complex in yeast. Not a core function.
+    supported_by:
+    - reference_id: file:yeast/MOH1/MOH1-bioinformatics/RESULTS.md
+      supporting_text: &gt;-
+        The Yippee fold (two four-stranded β-meanders coordinating one Zn²⁺ at the
+        apex, forming a cradle-shaped pocket) is a **structural/binding scaffold, not a
+        recognized catalytic fold**.
+    - reference_id: file:yeast/MOH1/MOH1-deep-research-falcon.md
+      supporting_text: &gt;-
+        MOH1 is not an enzyme, transporter, or structural protein in the classical sense
+    propagation_review:
+      root_cause: PROPAGATION_BAD
+      failure_modes:
+      - COMPARTMENT_OR_COMPLEX_MISMATCH
+      - FUNCTIONAL_DIVERGENCE
+      source_entities:
+      - source_id: PANTHER:PTN002302768
+        source_label: Yippee-like ancestral node (PTHR13848)
+        source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
+        comment: &gt;-
+          Node seeded by human YPEL5 (UniProtKB:P62699); the ubiquitin-ligase-complex
+          role does not transfer to the Yippee/YPEL subfamily, which shares only the
+          zinc-binding beta-fold with the Mis18/cereblon(CULT) neighborhood.
+- term:
+    id: GO:0008270
+    label: zinc ion binding
+  evidence_type: RCA
+  original_reference_id: PMID:30358795
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Zinc ion binding is the single well-supported molecular feature of Moh1. It is
+      predicted by proteome-wide domain/motif analysis (RCA, PMID:30358795),
+      corroborated by the UniProt Zn(2+)-binding features (Cys45, Cys48, Cys101,
+      Cys104) and independently by in-repo bioinformatics, which recovers the canonical
+      Yippee two-CxxC zinc signature and shows perfect conservation of all four
+      cysteines across human YPEL1-5. The bound zinc is structural (folds the Yippee
+      domain); it is not evidence of a catalytic activity. Accepted as the core
+      molecular feature, though the downstream biochemical output remains unknown.
+    action: ACCEPT
+    supported_by:
+    - reference_id: PMID:30358795
+      supporting_text: &gt;-
+        582 known or potential zinc-binding proteins was identified using a
+        bioinformatics analysis that combined global domain searches with local motif
+        searches
+    - reference_id: file:yeast/MOH1/MOH1-bioinformatics/RESULTS.md
+      supporting_text: &gt;-
+        MOH1 contains exactly the two CxxC motifs that define the Yippee zinc site
+- term:
+    id: GO:0005575
+    label: cellular_component
+  evidence_type: ND
+  original_reference_id: GO_REF:0000015
+  qualifier: is_active_in
+  review:
+    summary: &gt;-
+      Root cellular_component annotation with the ND (no data) code, the standard
+      placeholder recording that no experimental localization is available for Moh1.
+      This correctly reflects the state of knowledge; high-throughput localization for
+      this low-abundance protein is not curated.
+    action: ACCEPT
+- term:
+    id: GO:0008150
+    label: biological_process
+  evidence_type: ND
+  original_reference_id: GO_REF:0000015
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Root biological_process annotation with the ND (no data) code. Although
+      phenotypes are recorded (stress resistance, stationary-phase survival), no
+      specific molecular biological process has been assigned to Moh1, so the ND
+      placeholder is appropriate.
+    action: ACCEPT
+core_functions:
+- description: &gt;-
+    Structural zinc binding by the Yippee domain. The conserved Cys45/Cys48/Cys101/
+    Cys104 tetrad coordinates a single Zn(2+) ion that stabilizes the Yippee/Mis18/
+    CULT fold. This is the only molecular feature of Moh1 supported by convergent
+    computational and comparative evidence; the resulting protein/nucleic-acid-binding
+    activity of the cradle-shaped pocket, and any biochemical output, are not
+    established.
+  molecular_function:
+    id: GO:0008270
+    label: zinc ion binding
+  supported_by:
+  - reference_id: PMID:30358795
+    supporting_text: &gt;-
+      582 known or potential zinc-binding proteins was identified using a
+      bioinformatics analysis that combined global domain searches with local motif
+      searches
+  - reference_id: file:yeast/MOH1/MOH1-bioinformatics/RESULTS.md
+    supporting_text: &gt;-
+      all four zinc-binding cysteines are perfectly conserved
+knowledge_gaps:
+- gap_statement: &gt;-
+    The molecular activity of Moh1 is undetermined. Beyond structural zinc binding by
+    the Yippee domain, it is not known what Moh1 binds (protein? nucleic acid?) or
+    what biochemical output, if any, the cradle-shaped Yippee pocket produces. No
+    catalytic activity is supported.
+  boundary: &gt;-
+    The Yippee/Mis18/CULT fold and its structural Zn(2+) site (Cys45/48/101/104) are
+    firmly established by UniProt features, PROSITE/Pfam/InterPro domain calls and
+    independent in-repo bioinformatics; the fold is a zinc-stabilized binding scaffold,
+    not a known catalytic fold.
+  gap_kind:
+  - BIOLOGY
+  dark_aspect: MF_DARK
+  status: OPEN
+  significance: &gt;-
+    Moh1 is the single yeast ortholog of the human YPEL family, which is implicated in
+    proliferation, senescence and stress adaptation; defining the yeast protein&#39;s
+    biochemistry would anchor mechanism for the whole conserved family.
+  resolution: &gt;-
+    Biochemical identification of Moh1 ligands/substrates (e.g. interaction proteomics
+    of tagged Moh1, in vitro binding assays with the purified Yippee domain, structural
+    studies of the pocket) and tests for any enzymatic activity.
+  provenance:
+  - reference_id: PMID:11240639
+    supporting_text: the Hemolin-Yippee interaction remains to be further elucidated
+  - reference_id: file:yeast/MOH1/MOH1-bioinformatics/RESULTS.md
+    supporting_text: &gt;-
+      There is no sequence-level evidence for enzymatic activity
+- gap_statement: &gt;-
+    No functionally validated direct physical partner or substrate of Moh1 is known.
+    Despite ~49 recorded high-throughput interactions, none has been shown to be a
+    direct, function-defining partner, and the Drosophila Yippee-Hemolin interaction
+    has no established yeast counterpart.
+  boundary: &gt;-
+    Large-scale interaction datasets (affinity-capture-MS, genetic interactions) exist
+    for Moh1, and human YPEL proteins partially complement moh1delta, indicating a
+    conserved but unspecified activity.
+  gap_kind:
+  - BIOLOGY
+  dark_aspect: MF_DARK
+  status: OPEN
+  significance: &gt;-
+    Identifying a direct partner would convert the family from &#34;putative binding module&#34;
+    to a defined pathway component.
+  resolution: &gt;-
+    Targeted co-purification/crosslinking-MS with tagged Moh1, and validation of
+    candidate partners by reciprocal pulldown and phenotype epistasis.
+  provenance:
+  - reference_id: PMID:11240639
+    supporting_text: the Hemolin-Yippee interaction remains to be further elucidated
+- gap_statement: &gt;-
+    The mechanism by which Moh1 shapes stress tolerance and quiescence is unknown. It
+    is unexplained why loss of Moh1 increases acute resistance to several lethal
+    stresses yet decreases long-term stationary-phase/chronological survival, and
+    whether Moh1 acts directly on membranes, metabolism, transcription, or cell death
+    machinery.
+  boundary: &gt;-
+    The phenotypes are reproducible: moh1delta increases viability under UV, MMS,
+    camptothecin, heat and hyperosmotic shock and is stress-induced (PMID:28173693);
+    MOH1 is one of the stationary-phase-essential genes required for long-term
+    survival in quiescence (PMID:15456898, PMID:9748261). A 2025 preprint
+    additionally reports altered membrane permeability and metabolic remodeling in
+    moh1delta.
+  gap_kind:
+  - BIOLOGY
+  dark_aspect: BP_DARK
+  status: NARROWING
+  significance: &gt;-
+    Resolving the mechanism would explain a conserved stress/aging factor and clarify
+    whether the human YPEL &#34;senescence/stress&#34; phenotypes share this mechanism.
+  resolution: &gt;-
+    Epistasis of moh1delta with defined stress-response and membrane/metabolic pathways;
+    peer-reviewed follow-up of the 2025 preprint&#39;s permeability and transcriptome
+    findings.
+  provenance:
+  - reference_id: PMID:28173693
+    supporting_text: &gt;-
+      exhibited enhanced cell viability compared with the WT-MOH1 strain when treated
+      with lethal UV irradiation
+  - reference_id: PMID:15456898
+    supporting_text: &gt;-
+      32 genes essential for survival in stationary-phase at
+- gap_statement: &gt;-
+    Whether &#34;apoptotic process&#34;/regulated cell death is the correct biological-process
+    framing for Moh1 is unresolved. The label derives from a single heterologous
+    complementation study interpreted within the contested yeast programmed-cell-death
+    paradigm.
+  boundary: &gt;-
+    It is established that Moh1 sensitizes cells to lethal stress (deletion is
+    protective) and that human YPEL5 restores this sensitization; the interpretation as
+    caspase/mitochondria-dependent apoptosis is the uncertain part.
+  gap_kind:
+  - BIOLOGY
+  dark_aspect: BP_DARK
+  status: OPEN
+  significance: &gt;-
+    Determines whether GO apoptosis/regulated-cell-death terms are appropriate for this
+    gene and its orthologs.
+  resolution: &gt;-
+    Independent replication with genetic dissection of the metacaspase (YCA1) and
+    mitochondrial pathways, distinguishing bona fide regulated cell death from passive
+    stress-induced death.
+  provenance:
+  - reference_id: PMID:28173693
+    supporting_text: their involvement in mitochondria-dependent apoptosis induced by DNA damage
+- gap_statement: &gt;-
+    The subcellular site of Moh1 action is unknown; no reliable localization is
+    curated, and the GOA cellular_component annotation is ND.
+  boundary: &gt;-
+    Moh1 is a low-abundance soluble protein; SGD notes a possible link to vacuolar
+    transport and an abnormal-vacuolar-morphology deletion phenotype, but these are
+    hypotheses, not localization data.
+  gap_kind:
+  - BIOLOGY
+  dark_aspect: CC_DARK
+  status: OPEN
+  significance: &gt;-
+    Localization would constrain candidate functions (e.g. membrane vs nuclear vs
+    cytosolic activity).
+  resolution: &gt;-
+    Endogenous fluorescent tagging and fractionation of Moh1 under normal and stress
+    conditions.
+proposed_new_terms: []
+suggested_questions:
+- question: &gt;-
+    What does the Yippee-domain pocket of Moh1 bind (protein, nucleic acid, small
+    molecule), and does the bound zinc have any role beyond folding the domain?
+  experts: []
+- question: &gt;-
+    By what molecular mechanism does moh1 deletion simultaneously increase acute stress
+    resistance and decrease long-term stationary-phase survival?
+  experts: []
+- question: &gt;-
+    Is the human YPEL family&#39;s proliferation/senescence role mechanistically the same
+    as the yeast Moh1 stress/quiescence role, given cross-species complementation?
+  experts: []
+suggested_experiments:
+- hypothesis: &gt;-
+    Moh1 acts as a zinc-dependent binding module for a specific partner that mediates
+    its stress-sensitizing function.
+  description: &gt;-
+    Affinity-purify endogenously tagged Moh1 under basal and stress conditions and
+    identify co-purifying proteins/nucleic acids by mass spectrometry and RNA
+    sequencing; validate top candidates by reciprocal pulldown and epistasis with
+    moh1delta stress phenotypes.
+  experiment_type: interaction proteomics
+- hypothesis: &gt;-
+    The four conserved cysteines are required for Moh1 function via structural zinc
+    coordination.
+  description: &gt;-
+    Construct Cys-to-Ala/Ser substitutions at Cys45/48/101/104, test protein stability
+    and rescue of moh1delta stress phenotypes, to determine whether the zinc site is
+    required for function in vivo.
+  experiment_type: structure-function mutagenesis
+- hypothesis: &gt;-
+    moh1delta hydrogen-peroxide resistance stems from decreased uptake due to altered
+    membrane permeability rather than altered ROS metabolism.
+  description: &gt;-
+    Measure intracellular ROS, H2O2 uptake kinetics, and membrane lipid/permeability in
+    wild-type vs moh1delta cells, following up the 2025 preprint under peer-reviewed
+    conditions.
+  experiment_type: cell physiology / permeability assay
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/genes/yeast/NIT1/NIT1-ai-review.html
+++ b/genes/yeast/NIT1/NIT1-ai-review.html
@@ -1,0 +1,3238 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>NIT1 - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        .propagation-review {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f8fafc;
+            border-left: 3px solid #64748b;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .propagation-title {
+            font-weight: 600;
+            color: #334155;
+            margin-bottom: 0.25rem;
+        }
+
+        .propagation-row {
+            margin-top: 0.25rem;
+        }
+
+        .propagation-source {
+            margin-top: 0.5rem;
+            padding-top: 0.5rem;
+            border-top: 1px solid #e5e7eb;
+        }
+
+        .propagation-source-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #1d4ed8;
+        }
+
+        .propagation-comment {
+            color: #4b5563;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>NIT1</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/P40447" target="_blank" class="term-link">
+                        P40447
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Saccharomyces cerevisiae</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-draft">
+                    DRAFT
+                </span>
+            </div>
+
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "NIT1";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="P40447" data-a="DESCRIPTION: NIT1 (YIL164C) is a small (199 aa) putative member..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>NIT1 (YIL164C) is a small (199 aa) putative member of the carbon-nitrogen hydrolase (nitrilase) superfamily in Saccharomyces cerevisiae. It carries a single CN-hydrolase domain (Pfam PF00795) and retains the superfamily&#39;s conserved Glu-Lys-Cys catalytic triad (E44, K135, C169). No physiological substrate, catalytic activity, biological process, or subcellular localization has been experimentally established for this protein, and it remains functionally uncharacterized. NIT1 corresponds to only the N-terminal ~2/3 of a complete nitrilase fold; the adjacent ORF YIL165C encodes the complementary C-terminal ~1/3, and in related yeasts the two are a single ORF, so YIL164C as annotated is most likely a truncated fragment of a nitrilase-like protein (UniProt flags it as possibly the product of a pseudogene). It is a distinct paralog from the characterized yeast Nit-domain amidase NIT2 (YJL126W), the ortholog of human NIT1, which hydrolyzes deaminated glutathione; that activity has not been shown for YIL164C. The nitrilase superfamily comprises one branch of true nitrilases and many branches of amidases/amide-condensation enzymes, so family membership alone does not imply nitrilase activity.</p>
+    </div>
+
+
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000257" target="_blank" class="term-link">
+                                    GO:0000257
+                                </a>
+                            </span>
+                            <span class="term-label">nitrilase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000117
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P40447" data-a="GO:0000257" data-r="GO_REF:0000117" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> ARBA-predicted specific nitrilase activity. Pace &amp; Brenner do place the S. cerevisiae NIT1 gene in branch 1 (the true-nitrilase branch), so this is not simply a wrong-branch call; however they describe it as &#34;frequently inactivated&#34;, the only demonstrated branch-1 activity is the plant indoleacetonitrile-to-auxin reaction, and no nitrilase substrate has ever been shown for the yeast protein. Combined with the likely truncation (N-terminal 2/3 only), a specific substrate-defining &#34;nitrilase activity&#34; call over-reaches the evidence.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Not wrong at the branch level (branch 1 is the nitrilase branch and yeast NIT1 is placed there), but over-annotated: no nitrilase substrate is demonstrated for this protein, the gene is described as frequently inactivated and appears truncated, and nitrilase-superfamily database annotations are frequently applied without activity data. A specific &#34;nitrilase activity&#34; assertion is stronger than the evidence supports.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/11380987" target="_blank" class="term-link">
+                                        PMID:11380987
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">found in plants, animals (C. elegans), fungi (Saccharomyces cerevisiae&#39;s frequently inactivated NIT1 gene), and many types of bacteria</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/11380987" target="_blank" class="term-link">
+                                        PMID:11380987
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Automated sequence searching easily identifies predicted polypeptides as members of the nitrilase superfamily, but many database annotations have been applied haphazardly.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003824" target="_blank" class="term-link">
+                                    GO:0003824
+                                </a>
+                            </span>
+                            <span class="term-label">catalytic activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P40447" data-a="GO:0003824" data-r="GO_REF:0000002" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Generic InterPro2GO catalytic-activity call. Consistent with the intact catalytic triad but uninformative, and its in-vivo relevance is uncertain given the likely truncation of the fold.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Root-level, non-specific and defensible from family membership plus the conserved triad, but too general to represent a core function and possibly not realized if the protein is a non-functional fragment.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:yeast/NIT1/NIT1-bioinformatics/RESULTS.md
+
+                                </span>
+
+                                <div class="support-text">All three canonical nitrilase-superfamily triad residues are present at the predicted positions.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016836" target="_blank" class="term-link">
+                                    GO:0016836
+                                </a>
+                            </span>
+                            <span class="term-label">hydro-lyase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000117
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-remove">
+                            REMOVE
+                        </span>
+                        <span class="vote-buttons" data-g="P40447" data-a="GO:0016836" data-r="GO_REF:0000117" data-act="REMOVE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> ARBA-predicted hydro-lyase (C-O lyase) activity. This is mechanistically wrong for the nitrilase superfamily, whose members are C-N hydrolases / amidases acting on carbon-nitrogen bonds via the Glu-Lys-Cys triad, not hydro-lyases that cleave carbon-oxygen bonds.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Wrong enzyme class: the carbon-nitrogen hydrolase superfamily hydrolyzes C-N bonds; hydro-lyase (EC 4.2.1.-, C-O lyase) activity is a different catalytic mechanism unsupported by the fold or the conserved triad. This is a spurious ARBA electronic mapping.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:yeast/NIT1/NIT1-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Belongs to the carbon-nitrogen hydrolase superfamily.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/11380987" target="_blank" class="term-link">
+                                        PMID:11380987
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Essentially all members of the nitrilase superfamily have a conserved, apparent catalytic triad of glutamate, lysine and cysteine</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000257" target="_blank" class="term-link">
+                                    GO:0000257
+                                </a>
+                            </span>
+                            <span class="term-label">nitrilase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ISA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/10959838" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:10959838
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Crystal structure of the worm NitFhit Rosetta Stone protein ...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P40447" data-a="GO:0000257" data-r="PMID:10959838" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> SGD ISA &#34;nitrilase activity&#34; annotation whose with/from is Arabidopsis NIT1 (P32961), a bona fide plant branch-1 nitrilase. Yeast NIT1 is placed in branch 1 by Pace &amp; Brenner, so a nitrilase call is not off-branch; but the cited structure paper (PMID:10959838) establishes only the fold and a presumptive triad, not any substrate, and the only demonstrated branch-1 activity is the plant IAN-to-auxin reaction. No nitrilase substrate is shown for the yeast protein, which is &#34;frequently inactivated&#34; and truncated.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Similarity transfer of a specific substrate-defining activity from a plant nitrilase to an uncharacterized, likely-truncated yeast paralog with no demonstrated substrate. The branch-1 placement makes &#34;nitrilase&#34; plausible at the family level, but asserting the specific activity over-reaches; this is a similarity (ISA) annotation, not experimental.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/11380987" target="_blank" class="term-link">
+                                        PMID:11380987
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">found in plants, animals (C. elegans), fungi (Saccharomyces cerevisiae&#39;s frequently inactivated NIT1 gene), and many types of bacteria</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/11380987" target="_blank" class="term-link">
+                                        PMID:11380987
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Automated sequence searching easily identifies predicted polypeptides as members of the nitrilase superfamily, but many database annotations have been applied haphazardly.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005575" target="_blank" class="term-link">
+                                    GO:0005575
+                                </a>
+                            </span>
+                            <span class="term-label">cellular_component</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ND</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000015
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P40447" data-a="GO:0005575" data-r="GO_REF:0000015" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Root cellular_component with ND (no data). No localization has been determined for NIT1 (no GFP datum curated).
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct use of the ND placeholder given the absence of localization data; flags a genuine knowledge gap.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008150" target="_blank" class="term-link">
+                                    GO:0008150
+                                </a>
+                            </span>
+                            <span class="term-label">biological_process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ND</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000015
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P40447" data-a="GO:0008150" data-r="GO_REF:0000015" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Root biological_process with ND (no data). No biological process has been established for NIT1.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct use of the ND placeholder given no process data; flags a genuine knowledge gap.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000002.md" target="_blank" class="term-link">
+                            GO_REF:0000002
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation through association of InterPro records with GO terms</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000015.md" target="_blank" class="term-link">
+                            GO_REF:0000015
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Use of the ND evidence code for Gene Ontology (GO) terms</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000117.md" target="_blank" class="term-link">
+                            GO_REF:0000117
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Electronic Gene Ontology annotations created by ARBA machine learning models</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/10959838" target="_blank" class="term-link">
+                            PMID:10959838
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Crystal structure of the worm NitFhit Rosetta Stone protein reveals a Nit tetramer binding two Fhit dimers.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Nit-domain proteins of the nitrilase superfamily have a presumptive Cys-Glu-Lys catalytic triad; this is a structure paper on C. elegans NitFhit and does not demonstrate any catalytic substrate.</div>
+
+                        <div class="finding-text">"Nit monomers possess a new alpha-beta-beta-alpha sandwich fold with a presumptive Cys-Glu-Lys catalytic triad"</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/11380987" target="_blank" class="term-link">
+                            PMID:11380987
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">The nitrilase superfamily: classification, structure and function.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Only branch 1 of the nitrilase superfamily has demonstrated nitrilase activity; most branches are amidases or amide-condensation enzymes, so family membership does not imply nitrilase activity.</div>
+
+                        <div class="finding-text">"Despite historical classification of all of these sequences as nitrilase-related, only one branch is known to have nitrilase activity, whereas eight branches have apparent amidase or amide-condensation activities."</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Nitrilase-superfamily database annotations are frequently applied without supporting activity data.</div>
+
+                        <div class="finding-text">"Automated sequence searching easily identifies predicted polypeptides as members of the nitrilase superfamily, but many database annotations have been applied haphazardly."</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <div class="finding-statement">The superfamily shares a conserved Glu-Lys-Cys catalytic triad.</div>
+
+                        <div class="finding-text">"Essentially all members of the nitrilase superfamily have a conserved, apparent catalytic triad of glutamate, lysine and cysteine"</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/28373563" target="_blank" class="term-link">
+                            PMID:28373563
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Nit1 is a metabolite repair enzyme that hydrolyzes deaminated glutathione.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Human NIT1 and its characterized yeast ortholog are deaminated-glutathione amidases (metabolite repair), not nitrilases; the yeast enzyme studied is the gene named NIT2 (YJL126W), a distinct paralog from YIL164C.</div>
+
+                        <div class="finding-text">"both the mammalian Nit1 and its yeast ortholog are amidases highly active toward deaminated glutathione (dGSH; i.e., a form of glutathione in which the free amino group has been replaced by a carbonyl group)"</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Even the closest characterized relatives are amidases whose function was long unresolved; nitrilase activity is not their function.</div>
+
+                        <div class="finding-text">"the Nit1 protein does not hydrolyze efficiently α-ketoglutaramate (a known physiological substrate of Nit2), and its actual enzymatic function has so far remained a puzzle"</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        file:yeast/NIT1/NIT1-uniprot.txt
+
+                    </span>
+                </div>
+
+                <div class="reference-title">UniProt entry P40447 (NIT1_YEAST), Saccharomyces cerevisiae</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">NIT1 belongs to the carbon-nitrogen hydrolase superfamily (nitrilase family) and PROSITE predicts a Glu/Lys/Cys catalytic triad.</div>
+
+                        <div class="finding-text">"Belongs to the carbon-nitrogen hydrolase superfamily."</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <div class="finding-statement">UniProt cautions that NIT1 may be the product of a pseudogene and appears to be the N-terminal part of a nitrilase-like protein formed with YIL165C.</div>
+
+                        <div class="finding-text">"Could be the product of a pseudogene. NIT1/YIL164C seems to be"</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        file:yeast/NIT1/NIT1-bioinformatics/RESULTS.md
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Bioinformatics analysis of NIT1 (catalytic triad, truncation, orthology)</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">The Glu-Lys-Cys catalytic triad (E44,K135,C169) is present and correctly positioned in NIT1, aligning to the triad of human NIT1/NIT2 and Arabidopsis NIT1; NIT1 is not a triad-loss pseudoenzyme.</div>
+
+                        <div class="finding-text">"All three canonical nitrilase-superfamily triad residues are present at the predicted positions."</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <div class="finding-statement">NIT1 (YIL164C) covers only the N-terminal ~2/3 of a nitrilase fold and YIL165C the C-terminal ~1/3; their concatenation spans a full-length domain.</div>
+
+                        <div class="finding-text">"NIT1 (cols 1-270) and YIL165C (cols 271-406) tile the domain almost exactly end-to-end with no overlap"</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Both yeast ORFs fall in the uncharacterized PANTHER subfamily PTHR46044:SF1, not in any substrate-defined branch; no specific substrate can be assigned.</div>
+
+                        <div class="finding-text">"No specific catalytic substrate can be assigned."</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        file:yeast/NIT1/NIT1-deep-research-falcon.md
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Falcon deep research report for NIT1 (YIL164C)</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">The report incorrectly equates YIL164C (&#34;scNit1&#34;) with the characterized deaminated-glutathione amidase and transfers that function, kinetics and crystal structure to YIL164C. This is a paralog conflation: the dGSH amidase is the yeast gene NIT2 (YJL126W) per Peracchi 2017 Table 1 and SGD, whose triad numbering (Glu45-Lys127-Cys169) differs from YIL164C&#39;s predicted Glu44-Lys135-Cys169.</div>
+
+                        <div class="finding-text">"*S. cerevisiae* NIT1 (YIL164C, P40447) encodes a deaminated glutathione (dGSH) amidase"</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Questions for Experts</h2>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Does NIT1 (YIL164C) have any hydrolase/amidase activity, and on what substrate, when assayed alone versus reconstituted with the YIL165C fragment?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P40447" data-a="Q: Does NIT1 (YIL164C) have any hydrolase/amidase act..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Is YIL164C a functional gene, a truncated fragment, or a pseudogene in S288C, and is a full-length YIL164C+YIL165C protein ever translated?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P40447" data-a="Q: Is YIL164C a functional gene, a truncated fragment..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Does NIT1 have a biological role distinct from the paralogous dGSH-amidase NIT2 (YJL126W), or is it functionally inert/redundant?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P40447" data-a="Q: Does NIT1 have a biological role distinct from the..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Experiments</h2>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Express and purify (i) YIL164C alone and (ii) the YIL164C+YIL165C fusion, and screen both against nitrile and amide substrate panels (including deaminated glutathione and α-ketoglutaramate as paralog controls), measuring kinetics and confirming triad dependence with active-site mutants.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: NIT1 retains the ancestral C-N hydrolase/amidase activity but only as the reconstituted full-length YIL164C+YIL165C protein.</em></p>
+
+
+                    <p style="margin-top: 0.5rem;">Type: recombinant enzyme substrate profiling</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P40447" data-a="EXPERIMENT: Express and purify (i) YIL164C alone and (ii) the ..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Compare untargeted metabolomes of nit1-delta, nit2-delta, nit3-delta and double mutants under standard and starvation/anaerobic conditions to detect a NIT1-specific accumulating substrate.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: NIT1 loss perturbs a specific metabolite pool distinct from that of NIT2.</em></p>
+
+
+                    <p style="margin-top: 0.5rem;">Type: comparative metabolomics of deletion strains</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P40447" data-a="EXPERIMENT: Compare untargeted metabolomes of nit1-delta, nit2..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Use ribosome profiling and targeted proteomics to detect the YIL164C product and determine whether translation extends into YIL165C.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: YIL164C is translated (functional ORF) rather than being a silent pseudogene.</em></p>
+
+
+                    <p style="margin-top: 0.5rem;">Type: ribosome profiling / targeted proteomics</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P40447" data-a="EXPERIMENT: Use ribosome profiling and targeted proteomics to ..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Knowledge Gaps</h2>
+        <p style="color: #555; font-size: 0.92rem; margin-top: -0.3rem;">
+            What is <em>not</em> known — curated, literature-grounded statements of the open
+            unknowns (the inverse of core functions).
+        </p>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The physiological substrate and catalytic activity of NIT1 (YIL164C) are unknown. It has never been shown to hydrolyze a nitrile or any amide/other C-N bond in vitro or in vivo, and it is unresolved whether the protein is catalytically active at all.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">MF_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> Established: NIT1 is a carbon-nitrogen hydrolase (nitrilase) superfamily member with a single CN-hydrolase domain and an intact, correctly positioned Glu-Lys-Cys catalytic triad (E44/K135/C169); Pace &amp; Brenner place the yeast NIT1 gene in branch 1 (the true-nitrilase branch, EC 3.5.5.1) but call it &#34;frequently inactivated&#34;. Unknown: which C-N bond it acts on (if any) and whether catalytic competence is realized in this protein. Even within branch 1 the only demonstrated activity is the plant indoleacetonitrile-to-auxin reaction, so branch placement does not fix a substrate for the yeast protein.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> NIT1 is a conserved-family enzyme candidate with no assigned function; it is also an archetype of nitrilase-superfamily over-annotation, where generic &#34;nitrilase activity&#34; is asserted without a demonstrated substrate.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Biochemical substrate profiling of recombinant protein (nitrile and amide panels, including deaminated glutathione and omega-amidase substrates as negative/positive controls), and metabolomic comparison of a clean deletion strain.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"Despite historical classification of all of these sequences as nitrilase-related, only one branch is known to have nitrilase activity, whereas eight branches have apparent amidase or amide-condensation activities."</em> — PMID:11380987</li>
+
+                <li><em>"No specific catalytic substrate can be assigned."</em> — file:yeast/NIT1/NIT1-bioinformatics/RESULTS.md</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> It is unresolved whether YIL164C is a functional gene or a truncated/pseudogene fragment, and whether YIL164C and YIL165C are translated as one protein in S. cerevisiae S288C.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span><span class="badge">CURATION</span>
+                <span class="badge">MF_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> Established: YIL164C encodes the N-terminal ~2/3 of a nitrilase fold and YIL165C the C-terminal ~1/3; together they equal a full-length domain, and in related yeasts/strains they form a single ORF. UniProt lists PE=5 (Uncertain) and flags possible pseudogene status. Unknown: the actual translated product in S288C and whether a functional full-length enzyme is ever made.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Determines whether NIT1 should be curated as a functional enzyme, a fragment, or a pseudogene, and whether activity assays should use YIL164C alone or the YIL164C+YIL165C concatenation.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Ribosome-profiling / proteomics to establish the translated product(s), and activity testing of the reconstituted full-length YIL164C+YIL165C protein versus YIL164C alone.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"Could be the product of a pseudogene. NIT1/YIL164C seems to be"</em> — file:yeast/NIT1/NIT1-uniprot.txt</li>
+
+                <li><em>"NIT1 (cols 1-270) and YIL165C (cols 271-406) tile the domain almost exactly end-to-end with no overlap"</em> — file:yeast/NIT1/NIT1-bioinformatics/RESULTS.md</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The biological process and subcellular localization of NIT1 are unknown; its high-throughput deletion phenotypes have no established mechanistic link to a molecular function.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">WHOLLY_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> Established: SGD curates BP and CC as unknown (ND); deletion screens report pleiotropic phenotypes. Unknown: the pathway NIT1 acts in and where in the cell it acts. The characterized dGSH-amidase / metabolite-repair role belongs to the paralog NIT2 (YJL126W), not to YIL164C.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Without a process or localization, NIT1 cannot be placed in any pathway or GO-CAM; distinguishing its role from the paralogous NIT2 amidase is required to avoid mis-attribution.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> GFP localization, targeted metabolomics of the deletion, and epistasis with NIT2/NIT3 to test for a distinct (non-redundant) role.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"both the mammalian Nit1 and its yeast ortholog are amidases highly active toward deaminated glutathione (dGSH; i.e., a form of glutathione in which the free amino group has been replaced by a carbonyl group)"</em> — PMID:28373563</li>
+
+            </ul>
+
+
+        </div>
+
+    </div>
+
+
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Deep Research Sections -->
+
+    <div class="section">
+        <h2 class="section-title">Deep Research</h2>
+
+        <details class="deep-research-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; gap: 1rem;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Falcon</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(NIT1-deep-research-falcon.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="P40447" data-a="DEEP_RESEARCH: Falcon" data-r="" data-act="DEEP_RESEARCH" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This deep research is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This deep research needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+
+                <div class="report-meta">
+
+                    <span class="report-meta-text">Comprehensive Research Report: *Saccharomyces cerevisiae* NIT1 (YIL164C / P40447)</span>
+
+
+                    <span class="report-badge">Falcon</span>
+
+
+                    <span class="report-badge">Edison Scientific Literature</span>
+
+
+                    <span class="report-badge">10 citations</span>
+
+
+                    <span class="report-badge">1 artifacts</span>
+
+
+                    <span class="report-meta-text">2026-07-04T23:41:48.330693</span>
+
+
+
+                </div>
+
+
+                <div class="artifact-list">
+
+
+
+                    <div class="artifact-link">
+                        <a href="NIT1-deep-research-falcon_artifacts/artifact-00.md" class="term-link">Edison artifact artifact-00</a>
+                        <span>(text/markdown)</span>
+                    </div>
+
+
+                </div>
+
+                <p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h1 id="comprehensive-research-report-saccharomyces-cerevisiae-nit1-yil164c-p40447">Comprehensive Research Report: <em>Saccharomyces cerevisiae</em> NIT1 (YIL164C / P40447)</h1>
+<h2 id="gene-identity-verification">Gene Identity Verification</h2>
+<p>The gene symbol NIT1 in <em>Saccharomyces cerevisiae</em> (strain ATCC 204508 / S288c) corresponds to the systematic name YIL164C (UniProt accession P40447). The encoded protein is designated "Putative nitrilase-like protein Nit1" and belongs to the carbon-nitrogen hydrolase superfamily (branch 10 of the nitrilase superfamily). It should be noted that this yeast NIT1 is distinct from the plant nitrilase genes also called NIT1 (e.g., <em>Arabidopsis</em> NIT1 involved in auxin biosynthesis) and from the mammalian NIT1, though yeast Nit1 and mammalian Nit1 are true orthologs sharing conserved enzymatic function (peracchi2017nit1isa pages 1-1).</p>
+<h2 id="1-primary-enzymatic-function-and-reaction-catalyzed">1. Primary Enzymatic Function and Reaction Catalyzed</h2>
+<h3 id="deaminated-glutathione-dgsh-amidase-activity">Deaminated Glutathione (dGSH) Amidase Activity</h3>
+<p>The landmark study by Peracchi et al. (2017) in <em>Proceedings of the National Academy of Sciences</em> definitively established that <em>S. cerevisiae</em> Nit1 (scNit1) is a <strong>metabolite repair enzyme</strong> that hydrolyzes <strong>deaminated glutathione (dGSH)</strong> (peracchi2017nit1isa pages 1-3, peracchi2017nit1isa pages 1-1). The enzyme catalyzes the hydrolysis of the amide bond in dGSH, converting the cyclic form of dGSH to <strong>α-ketoglutarate</strong> and <strong>cysteinylglycine</strong> (peracchi2017nit1isa pages 1-3). Based on this substrate specificity, the authors proposed renaming Nit1 and its orthologs as "dGSH amidases" (peracchi2017nit1isa pages 6-7).</p>
+<h3 id="substrate-specificity">Substrate Specificity</h3>
+<p>Quantitative enzymatic characterization of recombinant scNit1 revealed striking substrate specificity. The enzyme exhibits a dGSH amidase specific activity of <strong>8.71 ± 0.13 μmol·min⁻¹·mg⁻¹</strong>, compared to an ω-amidase specific activity (toward α-ketoglutaramate) of only <strong>0.004 ± 0.000 μmol·min⁻¹·mg⁻¹</strong>, yielding a dGSH/α-KGM activity ratio of <strong>2400 ± 35</strong> (peracchi2017nit1isa pages 7-8). The enzyme shows negligible GSH amidase activity, negligible L-glutaminase activity, and minimal activity toward other physiologically present amides such as L-glutamine, γ-L-glutamyl-ε-L-lysine, N-acetyl-aspartylglutamate, and N-acetylglutamate (peracchi2017nit1isa pages 5-6, peracchi2017nit1isa pages 7-8). This demonstrates that dGSH is by far the best and most physiologically relevant substrate for Nit1.</p>
+<p>The following table summarizes the enzymatic comparison between the two yeast nitrilase-family members:</p>
+<table>
+<thead>
+<tr>
+<th>Property</th>
+<th>scNit1 (S. cerevisiae NIT1/YIL164C)</th>
+<th>scNit2 (S. cerevisiae NIT2)</th>
+<th>Notes</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Primary activity assignment</td>
+<td>dGSH amidase</td>
+<td>ω-amidase</td>
+<td>Functional specialization is strongly divergent despite sequence similarity (peracchi2017nit1isa pages 1-1, peracchi2017nit1isa pages 1-3)</td>
+</tr>
+<tr>
+<td>dGSH amidase specific activity (μmol·min⁻¹·mg⁻¹)</td>
+<td>8.71 ± 0.13</td>
+<td>&lt; 0.001</td>
+<td>scNit1 is highly active toward deaminated glutathione; scNit2 is essentially inactive on this substrate (peracchi2017nit1isa pages 7-8)</td>
+</tr>
+<tr>
+<td>ω-amidase specific activity toward α-KGM (μmol·min⁻¹·mg⁻¹)</td>
+<td>0.004 ± 0.000</td>
+<td>3.59 ± 0.08</td>
+<td>scNit2 is the robust α-ketoglutaramate hydrolase; scNit1 shows only trace ω-amidase activity (peracchi2017nit1isa pages 7-8)</td>
+</tr>
+<tr>
+<td>dGSH/α-KGM activity ratio</td>
+<td>2400 ± 35</td>
+<td>Near 0</td>
+<td>Quantifies extreme substrate preference of scNit1 for dGSH and scNit2 for α-KGM (peracchi2017nit1isa pages 7-8)</td>
+</tr>
+<tr>
+<td>GSH amidase activity</td>
+<td>Negligible</td>
+<td>Not reported as substantial</td>
+<td>scNit1 discriminates strongly against intact glutathione relative to deaminated glutathione (peracchi2017nit1isa pages 7-8)</td>
+</tr>
+<tr>
+<td>L-glutaminase activity</td>
+<td>Negligible</td>
+<td>Not reported as substantial</td>
+<td>Supports the conclusion that scNit1 is not a broad glutamine amidase (peracchi2017nit1isa pages 7-8, peracchi2017nit1isa pages 5-6)</td>
+</tr>
+<tr>
+<td>Reaction catalyzed</td>
+<td>Hydrolysis of deaminated glutathione (dGSH) to α-ketoglutarate + cysteinylglycine</td>
+<td>Hydrolysis of α-ketoglutaramate to α-ketoglutarate + ammonia</td>
+<td>Defines Nit1 as a metabolite-repair enzyme and Nit2 as a canonical ω-amidase (peracchi2017nit1isa pages 1-3, peracchi2017nit1isa pages 1-1)</td>
+</tr>
+<tr>
+<td>Catalytic triad</td>
+<td>Glu45-Lys127-Cys169</td>
+<td>Conserved Nit1/Nit2 family catalytic triad</td>
+<td>Core carbon-nitrogen hydrolase active-site architecture (peracchi2017nit1isa pages 6-7)</td>
+</tr>
+<tr>
+<td>Key substrate-recognition residues</td>
+<td>Arg173, Phe195</td>
+<td>Distinct ω-amidase pocket features; Tyr87/Tyr254 signature described for Nit2-type enzymes</td>
+<td>scNit1 structure indicates Arg173 and Phe195 help position and stabilize dGSH-like substrate at the active site (peracchi2017nit1isa pages 6-7)</td>
+</tr>
+<tr>
+<td>Structural/functional interpretation</td>
+<td>Highly specialized repair enzyme for damaged glutathione metabolite</td>
+<td>Specialized enzyme in glutamine transaminase–ω-amidase pathway</td>
+<td>Demonstrates how two branch-10 nitrilase-superfamily enzymes evolved different physiological substrates (peracchi2017nit1isa pages 6-7, peracchi2017nit1isa pages 1-1)</td>
+</tr>
+</tbody>
+</table>
+<p><em>Table: This table compares the enzymatic properties of the two Saccharomyces cerevisiae nitrilase-family proteins, highlighting that scNit1 is a deaminated-glutathione repair amidase whereas scNit2 is the canonical ω-amidase. It is useful for distinguishing substrate specificity, catalytic activity, and active-site features.</em></p>
+<h3 id="distinction-from-nit2-amidase">Distinction from Nit2 (ω-Amidase)</h3>
+<p>Despite sharing approximately 35% sequence identity with Nit2, Nit1 is functionally distinct (peracchi2017nit1isa pages 1-1). Nit2 (encoded by the yeast <em>NIT2</em> gene) functions as an <strong>ω-amidase</strong> that hydrolyzes α-ketoglutaramate (α-KGM) to α-ketoglutarate and ammonia as part of the glutamine transaminase pathway (peracchi2017nit1isa pages 1-1, peracchi2017nit1isa pages 1-3). In contrast, scNit2 shows negligible dGSH amidase activity (&lt;0.001 μmol·min⁻¹·mg⁻¹) but robust ω-amidase activity (3.59 ± 0.08 μmol·min⁻¹·mg⁻¹) (peracchi2017nit1isa pages 7-8). The two enzymes thus represent functional specialization within the same protein family.</p>
+<h2 id="2-structural-basis-of-function">2. Structural Basis of Function</h2>
+<h3 id="catalytic-mechanism">Catalytic Mechanism</h3>
+<p>The crystal structure of yeast scNit1 was solved and reveals the characteristic carbon-nitrogen hydrolase fold (peracchi2017nit1isa pages 6-7). The catalytic mechanism employs a <strong>catalytic triad</strong> composed of <strong>Glu45, Lys127, and Cys169</strong>, which is conserved across the Nit1/Nit2 family (peracchi2017nit1isa pages 6-7). Importantly, the crystal structure shows a GSH-like molecule bound at the active site, providing direct structural evidence for dGSH recognition (peracchi2017nit1isa pages 6-7).</p>
+<h3 id="substrate-recognition-determinants">Substrate Recognition Determinants</h3>
+<p>Key residues involved in substrate recognition include <strong>Arg173</strong>, whose guanidino group interacts with the α-carboxylic group of the dGSH substrate, and <strong>Phe195</strong>, which makes π–π interactions with the keto group of the substrate (peracchi2017nit1isa pages 6-7). These interactions help position and stabilize dGSH for hydrolysis and contribute to distinguishing dGSH from other potential substrates such as native GSH.</p>
+<p>A structural comparison with Nit2 reveals that the substrate specificity difference is related to the size of the subpocket for binding the amido group of α-KGM: this subpocket is much smaller in Nit2 due to the presence of two tyrosine residues (<strong>Tyr87 and Tyr254</strong>) that serve as a conserved signature for ω-amidases (peracchi2017nit1isa pages 6-7). The absence of these bulky residues in Nit1 accommodates the larger dGSH substrate.</p>
+<h2 id="3-biological-process-metabolite-damage-repair">3. Biological Process: Metabolite Damage Repair</h2>
+<h3 id="the-metabolite-repair-concept">The Metabolite Repair Concept</h3>
+<p>Nit1 functions within the emerging paradigm of <strong>metabolite damage repair</strong> (also termed metabolite proofreading) (peracchi2017nit1isa pages 1-1, peracchi2017nit1isa pages 8-9, peracchi2017nit1isa pages 10-10). This concept recognizes that the normal catalytic promiscuity of abundant primary metabolic enzymes inevitably generates unwanted byproducts, which must be destroyed or reconverted into useful metabolites by dedicated repair enzymes (peracchi2017nit1isa pages 1-1). A significant proportion of the "catalytic dark matter" — enzymes of uncertain or unknown function encoded in sequenced genomes — may function in metabolite damage control (ellens2017confrontingthecatalytic pages 14-15). Indeed, Nit1 was considered among the "top 10" most attractive targets for functional assignment by Galperin and Koonin prior to the discovery of its dGSH amidase function (peracchi2017nit1isa pages 1-1).</p>
+<h3 id="formation-of-the-substrate-dgsh">Formation of the Substrate dGSH</h3>
+<p>Deaminated glutathione (dGSH) is generated as an inadvertent side product by <strong>multiple cytosolic and mitochondrial transaminases</strong> that use glutathione (GSH) as an amino group donor in slow, erroneous side-reactions (peracchi2017nit1isa pages 1-1, peracchi2017nit1isa pages 4-5, peracchi2017nit1isa pages 7-8). At least five mammalian transaminases (KYAT1, PSAT1, GOT1, KYAT3, and OAT) were demonstrated to catalyze GSH transamination at low rates (peracchi2017nit1isa pages 7-8). Although each individual reaction efficiency is small, the high intracellular concentration of GSH makes cumulative dGSH production significant over time (peracchi2017nit1isa pages 8-8). Evidence that aminooxyacetate (AOA), a general transaminase inhibitor, reduces dGSH accumulation in cultured cells confirms that transaminase activity is the primary source of dGSH formation in vivo (peracchi2017nit1isa pages 5-6). Additionally, at least one decarboxylase may also contribute to dGSH formation (peracchi2017nit1isa pages 8-8).</p>
+<h3 id="in-vivo-evidence-for-nit1-function">In Vivo Evidence for NIT1 Function</h3>
+<p>Critically, <strong>yeast strains lacking the NIT1 ortholog accumulate significantly elevated levels of dGSH</strong>, reaching an intracellular concentration of approximately <strong>28 μM</strong> in knockout mutants compared to three- to seven-fold lower levels in wild-type controls (peracchi2017nit1isa pages 4-5). This accumulation demonstrates that Nit1 is the primary (or only) enzyme capable of metabolizing dGSH in yeast cells (peracchi2017nit1isa pages 4-5, peracchi2017nit1isa pages 1-1). The conservation of this phenotype across yeast, cultured mammalian cells, and mouse models confirms that Nit1-mediated dGSH hydrolysis is a conserved and physiologically important metabolic function (peracchi2017nit1isa pages 1-3, peracchi2017nit1isa pages 1-1).</p>
+<h2 id="4-subcellular-localization">4. Subcellular Localization</h2>
+<p>In <em>S. cerevisiae</em>, Nit1 lacks a mitochondrial targeting sequence and is expected to function primarily in the <strong>cytoplasm</strong>. In the mammalian ortholog, two forms exist: a full-length form (mNit1) with a mitochondrial propeptide that localizes primarily to mitochondria (but also to the cytosol), and a shorter form (cNit1) lacking the mitochondrial targeting sequence that shows exclusively cytosolic localization (peracchi2017nit1isa pages 5-6). Mammalian Nit1 is thus found in both the cytosol and mitochondria — the "right places" where dGSH-forming transaminases are primarily located (peracchi2017nit1isa pages 8-8). In cultured mouse kidney cells, Nit1 is primarily distributed in the cytoplasm, with weaker nuclear and partial mitochondrial localization (semba2006biologicalfunctionsof pages 4-5). The yeast protein, lacking a mitochondrial targeting sequence, is predicted to function primarily in the cytosol.</p>
+<h2 id="5-evolutionary-conservation-and-the-nitfhit-rosetta-stone">5. Evolutionary Conservation and the NitFhit Rosetta Stone</h2>
+<h3 id="conservation-across-eukaryotes">Conservation Across Eukaryotes</h3>
+<p>Nit1 is <strong>highly conserved across eukaryotes</strong>, including mammals, yeast, and invertebrates, as well as in some bacteria (peracchi2017nit1isa pages 1-1). Both yeast scNit1 and mammalian Nit1 share the same primary enzymatic function as dGSH amidases (peracchi2017nit1isa pages 1-1). The evolutionary distribution of Nit1 orthologs correlates with GSH-producing organisms, underscoring the biological importance of this metabolite repair mechanism (peracchi2017nit1isa pages 8-8).</p>
+<h3 id="nitfhit-fusion-protein">NitFhit Fusion Protein</h3>
+<p>A particularly notable evolutionary feature is the <strong>NitFhit Rosetta Stone fusion protein</strong> found in invertebrates such as <em>Drosophila melanogaster</em> and <em>Caenorhabditis elegans</em>, where the Nit and Fhit (fragile histidine triad) domains are expressed as a single fused polypeptide (semba2006biologicalfunctionsof pages 1-2, semba2006biologicalfunctionsof pages 7-8). This fusion protein forms a stable tetramer with Fhit dimers on opposite poles and Nit active sites around the equator (semba2006biologicalfunctionsof pages 8-9). In mammals, Nit1 and Fhit are encoded by separate genes on different chromosomes (human chromosomes 1 and 3; mouse chromosomes 1 and 14) (semba2006biologicalfunctionsof pages 7-8). The Rosetta Stone hypothesis proposes that this fusion relationship in invertebrates predicts that the separate Nit1 and Fhit polypeptides function in the same biochemical pathway or may physically interact in mammals (semba2006biologicalfunctionsof pages 1-2). In mammals, Fhit has been characterized as a tumor suppressor, and mammalian Nit1 also exhibits tumor-suppressor-like properties, including promotion of apoptosis and suppression of cyclin D1 expression (semba2006biologicalfunctionsof pages 1-2, semba2006biologicalfunctionsof pages 4-5).</p>
+<h3 id="nitrilase-superfamily-classification">Nitrilase Superfamily Classification</h3>
+<p>Nit1 and Nit2 are the sole representatives of <strong>branch 10 of the nitrilase superfamily</strong> (gunther2018thenitrilaseptnit1 pages 1-2, peracchi2017nit1isa pages 6-7). Despite being classified within the same branch, they have evolved distinct substrate specificities. Interestingly, phylogenetic analysis shows that enzymes acting on dGSH (dGSH amidases) and those acting on α-KGM (ω-amidases) do not form strictly separate phylogenetic clades, suggesting that substrate specialization may have arisen through convergent evolution rather than simple branching (peracchi2017nit1isa pages 6-7).</p>
+<h2 id="6-pathway-context-and-physiological-significance">6. Pathway Context and Physiological Significance</h2>
+<p>The metabolic pathway involving Nit1 can be summarized as follows: (1) Glutathione (GSH), the major intracellular antioxidant, is inadvertently acted upon by various transaminases as a minor side reaction, replacing the free amino group with a carbonyl group to form dGSH (peracchi2017nit1isa pages 1-1, peracchi2017nit1isa pages 4-5). (2) Nit1 then hydrolyzes the cyclic dGSH into α-ketoglutarate and cysteinylglycine, effectively recycling the damaged metabolite (peracchi2017nit1isa pages 1-3). Without this repair function, dGSH would be lost through excretion, potentially draining significant amounts of the cell's GSH pool and impairing antioxidant capacity (peracchi2017nit1isa pages 8-8).</p>
+<p>This positions Nit1 not within a canonical signaling or biosynthetic pathway, but rather in a <strong>housekeeping metabolite repair pathway</strong> that protects the integrity of the glutathione pool. The broader significance of such metabolite repair enzymes is highlighted by estimates that over 600 yeast proteins (&gt;30% of proteins of unknown function) may be enzymes whose functions remain to be determined, with metabolite damage control representing a likely function for many of them (ellens2017confrontingthecatalytic pages 1-2, ellens2017confrontingthecatalytic pages 14-15).</p>
+<h2 id="summary">Summary</h2>
+<p><em>S. cerevisiae</em> NIT1 (YIL164C, P40447) encodes a deaminated glutathione (dGSH) amidase — a metabolite repair enzyme belonging to branch 10 of the carbon-nitrogen hydrolase (nitrilase) superfamily. The enzyme catalyzes the hydrolysis of dGSH (a damaged form of glutathione produced by promiscuous transaminase side reactions) into α-ketoglutarate and cysteinylglycine, with a catalytic triad of Glu45-Lys127-Cys169 and remarkable substrate specificity (dGSH/α-KGM ratio of ~2400). The enzyme functions primarily in the cytoplasm and represents a conserved eukaryotic metabolite damage repair mechanism. Its biological role is to prevent the accumulation of dGSH and preserve the cellular glutathione pool.</p>
+<p>References</p>
+<ol>
+<li>
+<p>(peracchi2017nit1isa pages 1-1): Alessio Peracchi, Maria Veiga-da-Cunha, Tomiko Kuhara, Kenneth W. Ellens, Nicole Paczia, Vincent Stroobant, Agnieszka K. Seliga, Simon Marlaire, Stephane Jaisson, Guido T. Bommer, Jin Sun, Kay Huebner, Carole L. Linster, Arthur J. L. Cooper, and Emile Van Schaftingen. Nit1 is a metabolite repair enzyme that hydrolyzes deaminated glutathione. Proceedings of the National Academy of Sciences, 114:E3233-E3242, Apr 2017. URL: https://doi.org/10.1073/pnas.1613736114, doi:10.1073/pnas.1613736114. This article has 65 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(peracchi2017nit1isa pages 1-3): Alessio Peracchi, Maria Veiga-da-Cunha, Tomiko Kuhara, Kenneth W. Ellens, Nicole Paczia, Vincent Stroobant, Agnieszka K. Seliga, Simon Marlaire, Stephane Jaisson, Guido T. Bommer, Jin Sun, Kay Huebner, Carole L. Linster, Arthur J. L. Cooper, and Emile Van Schaftingen. Nit1 is a metabolite repair enzyme that hydrolyzes deaminated glutathione. Proceedings of the National Academy of Sciences, 114:E3233-E3242, Apr 2017. URL: https://doi.org/10.1073/pnas.1613736114, doi:10.1073/pnas.1613736114. This article has 65 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(peracchi2017nit1isa pages 6-7): Alessio Peracchi, Maria Veiga-da-Cunha, Tomiko Kuhara, Kenneth W. Ellens, Nicole Paczia, Vincent Stroobant, Agnieszka K. Seliga, Simon Marlaire, Stephane Jaisson, Guido T. Bommer, Jin Sun, Kay Huebner, Carole L. Linster, Arthur J. L. Cooper, and Emile Van Schaftingen. Nit1 is a metabolite repair enzyme that hydrolyzes deaminated glutathione. Proceedings of the National Academy of Sciences, 114:E3233-E3242, Apr 2017. URL: https://doi.org/10.1073/pnas.1613736114, doi:10.1073/pnas.1613736114. This article has 65 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(peracchi2017nit1isa pages 7-8): Alessio Peracchi, Maria Veiga-da-Cunha, Tomiko Kuhara, Kenneth W. Ellens, Nicole Paczia, Vincent Stroobant, Agnieszka K. Seliga, Simon Marlaire, Stephane Jaisson, Guido T. Bommer, Jin Sun, Kay Huebner, Carole L. Linster, Arthur J. L. Cooper, and Emile Van Schaftingen. Nit1 is a metabolite repair enzyme that hydrolyzes deaminated glutathione. Proceedings of the National Academy of Sciences, 114:E3233-E3242, Apr 2017. URL: https://doi.org/10.1073/pnas.1613736114, doi:10.1073/pnas.1613736114. This article has 65 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(peracchi2017nit1isa pages 5-6): Alessio Peracchi, Maria Veiga-da-Cunha, Tomiko Kuhara, Kenneth W. Ellens, Nicole Paczia, Vincent Stroobant, Agnieszka K. Seliga, Simon Marlaire, Stephane Jaisson, Guido T. Bommer, Jin Sun, Kay Huebner, Carole L. Linster, Arthur J. L. Cooper, and Emile Van Schaftingen. Nit1 is a metabolite repair enzyme that hydrolyzes deaminated glutathione. Proceedings of the National Academy of Sciences, 114:E3233-E3242, Apr 2017. URL: https://doi.org/10.1073/pnas.1613736114, doi:10.1073/pnas.1613736114. This article has 65 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(peracchi2017nit1isa pages 8-9): Alessio Peracchi, Maria Veiga-da-Cunha, Tomiko Kuhara, Kenneth W. Ellens, Nicole Paczia, Vincent Stroobant, Agnieszka K. Seliga, Simon Marlaire, Stephane Jaisson, Guido T. Bommer, Jin Sun, Kay Huebner, Carole L. Linster, Arthur J. L. Cooper, and Emile Van Schaftingen. Nit1 is a metabolite repair enzyme that hydrolyzes deaminated glutathione. Proceedings of the National Academy of Sciences, 114:E3233-E3242, Apr 2017. URL: https://doi.org/10.1073/pnas.1613736114, doi:10.1073/pnas.1613736114. This article has 65 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(peracchi2017nit1isa pages 10-10): Alessio Peracchi, Maria Veiga-da-Cunha, Tomiko Kuhara, Kenneth W. Ellens, Nicole Paczia, Vincent Stroobant, Agnieszka K. Seliga, Simon Marlaire, Stephane Jaisson, Guido T. Bommer, Jin Sun, Kay Huebner, Carole L. Linster, Arthur J. L. Cooper, and Emile Van Schaftingen. Nit1 is a metabolite repair enzyme that hydrolyzes deaminated glutathione. Proceedings of the National Academy of Sciences, 114:E3233-E3242, Apr 2017. URL: https://doi.org/10.1073/pnas.1613736114, doi:10.1073/pnas.1613736114. This article has 65 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(ellens2017confrontingthecatalytic pages 14-15): Kenneth W. Ellens, Nils Christian, Charandeep Singh, Venkata P. Satagopam, Patrick May, and Carole L. Linster. Confronting the catalytic dark matter encoded by sequenced genomes. Nucleic Acids Research, 45:11495-11514, Oct 2017. URL: https://doi.org/10.1093/nar/gkx937, doi:10.1093/nar/gkx937. This article has 99 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(peracchi2017nit1isa pages 4-5): Alessio Peracchi, Maria Veiga-da-Cunha, Tomiko Kuhara, Kenneth W. Ellens, Nicole Paczia, Vincent Stroobant, Agnieszka K. Seliga, Simon Marlaire, Stephane Jaisson, Guido T. Bommer, Jin Sun, Kay Huebner, Carole L. Linster, Arthur J. L. Cooper, and Emile Van Schaftingen. Nit1 is a metabolite repair enzyme that hydrolyzes deaminated glutathione. Proceedings of the National Academy of Sciences, 114:E3233-E3242, Apr 2017. URL: https://doi.org/10.1073/pnas.1613736114, doi:10.1073/pnas.1613736114. This article has 65 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(peracchi2017nit1isa pages 8-8): Alessio Peracchi, Maria Veiga-da-Cunha, Tomiko Kuhara, Kenneth W. Ellens, Nicole Paczia, Vincent Stroobant, Agnieszka K. Seliga, Simon Marlaire, Stephane Jaisson, Guido T. Bommer, Jin Sun, Kay Huebner, Carole L. Linster, Arthur J. L. Cooper, and Emile Van Schaftingen. Nit1 is a metabolite repair enzyme that hydrolyzes deaminated glutathione. Proceedings of the National Academy of Sciences, 114:E3233-E3242, Apr 2017. URL: https://doi.org/10.1073/pnas.1613736114, doi:10.1073/pnas.1613736114. This article has 65 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(semba2006biologicalfunctionsof pages 4-5): Shuho Semba, Shuang-Yin Han, Haiyan R. Qin, Kelly A. McCorkell, Dimitrios Iliopoulos, Yuri Pekarsky, Teresa Druck, Francesco Trapasso, Carlo M. Croce, and Kay Huebner. Biological functions of mammalian nit1, the counterpart of the invertebrate nitfhit rosetta stone protein, a possible tumor suppressor*. Journal of Biological Chemistry, 281:28244-28253, Sep 2006. URL: https://doi.org/10.1074/jbc.m603590200, doi:10.1074/jbc.m603590200. This article has 69 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(semba2006biologicalfunctionsof pages 1-2): Shuho Semba, Shuang-Yin Han, Haiyan R. Qin, Kelly A. McCorkell, Dimitrios Iliopoulos, Yuri Pekarsky, Teresa Druck, Francesco Trapasso, Carlo M. Croce, and Kay Huebner. Biological functions of mammalian nit1, the counterpart of the invertebrate nitfhit rosetta stone protein, a possible tumor suppressor*. Journal of Biological Chemistry, 281:28244-28253, Sep 2006. URL: https://doi.org/10.1074/jbc.m603590200, doi:10.1074/jbc.m603590200. This article has 69 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(semba2006biologicalfunctionsof pages 7-8): Shuho Semba, Shuang-Yin Han, Haiyan R. Qin, Kelly A. McCorkell, Dimitrios Iliopoulos, Yuri Pekarsky, Teresa Druck, Francesco Trapasso, Carlo M. Croce, and Kay Huebner. Biological functions of mammalian nit1, the counterpart of the invertebrate nitfhit rosetta stone protein, a possible tumor suppressor*. Journal of Biological Chemistry, 281:28244-28253, Sep 2006. URL: https://doi.org/10.1074/jbc.m603590200, doi:10.1074/jbc.m603590200. This article has 69 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(semba2006biologicalfunctionsof pages 8-9): Shuho Semba, Shuang-Yin Han, Haiyan R. Qin, Kelly A. McCorkell, Dimitrios Iliopoulos, Yuri Pekarsky, Teresa Druck, Francesco Trapasso, Carlo M. Croce, and Kay Huebner. Biological functions of mammalian nit1, the counterpart of the invertebrate nitfhit rosetta stone protein, a possible tumor suppressor*. Journal of Biological Chemistry, 281:28244-28253, Sep 2006. URL: https://doi.org/10.1074/jbc.m603590200, doi:10.1074/jbc.m603590200. This article has 69 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(gunther2018thenitrilaseptnit1 pages 1-2): Jan Günther, Sandra Irmisch, Nathalie D. Lackus, Michael Reichelt, Jonathan Gershenzon, and Tobias G. Köllner. The nitrilase ptnit1 catabolizes herbivore-induced nitriles in populus trichocarpa. BMC Plant Biology, Oct 2018. URL: https://doi.org/10.1186/s12870-018-1478-z, doi:10.1186/s12870-018-1478-z. This article has 24 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(ellens2017confrontingthecatalytic pages 1-2): Kenneth W. Ellens, Nils Christian, Charandeep Singh, Venkata P. Satagopam, Patrick May, and Carole L. Linster. Confronting the catalytic dark matter encoded by sequenced genomes. Nucleic Acids Research, 45:11495-11514, Oct 2017. URL: https://doi.org/10.1093/nar/gkx937, doi:10.1093/nar/gkx937. This article has 99 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+</ol>
+<h2 id="artifacts">Artifacts</h2>
+<ul>
+<li><a href="NIT1-deep-research-falcon_artifacts/artifact-00.md">Edison artifact artifact-00</a></li>
+</ul>
+<h2 id="citations">Citations</h2>
+<ol>
+<li>ellens2017confrontingthecatalytic pages 14-15</li>
+<li>semba2006biologicalfunctionsof pages 4-5</li>
+<li>semba2006biologicalfunctionsof pages 8-9</li>
+<li>semba2006biologicalfunctionsof pages 7-8</li>
+<li>semba2006biologicalfunctionsof pages 1-2</li>
+<li>ellens2017confrontingthecatalytic pages 1-2</li>
+<li>https://doi.org/10.1073/pnas.1613736114,</li>
+<li>https://doi.org/10.1093/nar/gkx937,</li>
+<li>https://doi.org/10.1074/jbc.m603590200,</li>
+<li>https://doi.org/10.1186/s12870-018-1478-z,</li>
+</ol>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(NIT1-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="P40447" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="nit1-p40447-yil164c-research-notes">NIT1 (P40447 / YIL164C) - research notes</h1>
+<p>S. cerevisiae <strong>NIT1</strong> = ORF <strong>YIL164C</strong>, UniProt <strong>P40447</strong>, SGD <strong>S000001426</strong>.<br />
+199 aa, ~21.6 kDa. UniProt PE=5 ("Uncertain"). This is an UNDERSTUDIED gene: no<br />
+gene-specific experimental biochemistry, only sequence-based / high-throughput data.</p>
+<h2 id="the-single-most-important-fact-nit1-yil164c-is-not-the-yeast-dgsh-amidase">The single most important fact: NIT1 (YIL164C) is NOT the yeast dGSH-amidase</h2>
+<p>There are two Nit-domain / carbon-nitrogen-hydrolase paralogs in S. cerevisiae that<br />
+are easily confused:</p>
+<ul>
+<li><strong>NIT2 = YJL126W</strong> — the <em>characterised</em> one. It is the true ortholog of <strong>human<br />
+  NIT1</strong> and has <strong>demonstrated deaminated-glutathione amidase activity (IDA)</strong>. In<br />
+  Peracchi et al. 2017 the yeast enzyme they cloned and named "scNit1" is this gene:<br />
+  Table 1 gives its gene symbol as <em>NIT2</em>, and they used a "<em>NIT2</em>-KO" strain. So the<br />
+  dGSH-repair function belongs to YJL126W, <strong>not</strong> to YIL164C.</li>
+<li><strong>NIT1 = YIL164C</strong> — the gene under review here. A <em>distinct</em> paralog. No specific<br />
+  substrate or biological role has been demonstrated. It is the "other" S. cerevisiae<br />
+  Nit-domain protein.</li>
+</ul>
+<p>Provenance:<br />
+- <a href="https://pubmed.ncbi.nlm.nih.gov/28373563" title="both the mammalian Nit1 and its yeast ortholog are amidases highly active toward deaminated glutathione (dGSH; i.e., a form of glutathione in which the free amino group has been replaced by a carbonyl group)">PMID:28373563</a> — the characterised yeast enzyme.<br />
+- <a href="https://pubmed.ncbi.nlm.nih.gov/28373563" title="Nit1-KO mutants of both human and yeast cells accumulate dGSH and the same compound is excreted in large amounts in the urine of Nit1-KO mice">PMID:28373563</a> — the KO phenotype is for that ortholog (YJL126W per the paper's Table 1 / Methods), not YIL164C.<br />
+- SGD curation: yeast NIT2/YJL126W "enables deaminated glutathione amidase activity" (IDA), "hydrolase involved in amide catabolism; localizes to both the cytoplasm and mitochondria" (SGD locus page, WebFetch 2026-07).<br />
+- SGD: NIT2 is "one of two proteins in S. cerevisiae with similarity to the Nit domain" — the other is YIL164C (our NIT1).</p>
+<p><strong>Implication for this review:</strong> the temptation is to transfer the well-characterised<br />
+human-NIT1 / yeast-NIT2 dGSH-amidase function onto YIL164C. That would be a<br />
+paralog-mis-attribution error. YIL164C's function is genuinely unknown.</p>
+<p><strong>The falcon deep-research file fell into exactly this trap</strong> (documented, not fixed):<br />
+<code>NIT1-deep-research-falcon.md</code> asserts that YIL164C "IS" the dGSH amidase scNit1 and<br />
+copies over Peracchi's kinetics, crystal structure and triad. That is incorrect. Two<br />
+independent checks show scNit1 is NOT YIL164C:<br />
+- Peracchi 2017 <strong>Table 1</strong> lists the yeast dGSH-amidase gene as <strong>NIT2</strong> and the<br />
+  ω-amidase gene as <strong>NIT3</strong> (WebFetch of PMC5402446, 2026-07); SGD independently<br />
+  curates <strong>NIT2 (YJL126W)</strong> with "deaminated glutathione amidase activity" (IDA).<br />
+  SGD curates <strong>YIL164C</strong> with ONLY "nitrilase activity (ISA)" — no dGSH amidase, no<br />
+  experimental MF annotation.<br />
+- The scNit1 catalytic-triad numbering in Peracchi/Liu is <strong>Glu45-Lys127-Cys169</strong>; the<br />
+  UniProt-predicted triad for YIL164C (P40447) is <strong>Glu44-Lys135-Cys169</strong>. The Lys<br />
+  differs (127 vs 135), consistent with scNit1 being a <em>different</em> ORF (NIT2/YJL126W),<br />
+  not YIL164C. (Cys169 coincidence aside.)<br />
+So the falcon report's central functional claim for YIL164C is a paralog conflation.<br />
+I retain the falcon file (genuine late artifact) but do NOT use it to support any<br />
+functional claim; it is cited only with a reference_review flagging the error.</p>
+<p>Yeast nitrilase/Nit-family ORF map (SGD, authoritative):<br />
+- NIT1 = YIL164C = P40447 (this gene) — nitrilase-family, function unknown (ISA only).<br />
+- NIT2 = YJL126W — deaminated glutathione amidase (IDA); ortholog of human NIT1.<br />
+- NIT3 = YLR351C — Nit-domain hydrolase in amide catabolism.</p>
+<h2 id="nitrilase-superfamily-context-the-generic-nitrilase-activity-trap">Nitrilase superfamily context — the generic "nitrilase activity" trap</h2>
+<p>The carbon-nitrogen hydrolase (nitrilase) superfamily is notoriously over-annotated.<br />
+Pace &amp; Brenner's foundational classification (PMID:11380987):</p>
+<ul>
+<li>13 branches; <strong>only branch 1 has demonstrated nitrilase activity</strong>, the rest are<br />
+  amidases / amide-condensation enzymes:<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/11380987" title="Despite historical classification of all of these sequences as nitrilase-related, only one branch is known to have nitrilase activity, whereas eight branches have apparent amidase or amide-condensation activities">PMID:11380987</a>.</li>
+<li>Annotation quality is poor:<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/11380987" title="Automated sequence searching easily identifies predicted polypeptides as members of the nitrilase superfamily, but many database annotations have been applied haphazardly">PMID:11380987</a>.</li>
+<li>Catalytic triad:<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/11380987" title="Essentially all members of the nitrilase superfamily have a conserved, apparent catalytic triad of glutamate, lysine and cysteine (only three apparently truncated sequences lack the glutamate)">PMID:11380987</a>.</li>
+</ul>
+<p>Branch 1 (true nitrilases) is the plant IAN→IAA auxin-biosynthesis branch<br />
+(Arabidopsis NIT1–4). YIL164C is NOT a plant nitrilase; the SGD-assigned "nitrilase<br />
+activity" (ISA, GO:0000257) uses <strong>Arabidopsis NIT1 (UniProtKB:P32961)</strong> as the<br />
+with/from — a genuine branch-1 nitrilase — but transferring plant nitrilase activity<br />
+to a divergent fungal paralog is exactly the "haphazard" transfer Pace &amp; Brenner warn<br />
+against. Human NIT1 and yeast NIT2 (the characterised orthologs) are <strong>amidases, not<br />
+nitrilases</strong>, so even the closest characterised relatives do not have nitrilase<br />
+activity:<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/28373563" title="Despite being ∼35% sequence identical to ω-amidase (Nit2), the Nit1 protein does not hydrolyze efficiently α-ketoglutaramate (a known physiological substrate of Nit2), and its actual enzymatic function has so far remained a puzzle">PMID:28373563</a>.</p>
+<h2 id="truncation-split-orf-yil164c-yil165c">Truncation / split-ORF: YIL164C + YIL165C</h2>
+<p>UniProt CAUTION for P40447: "Could be the product of a pseudogene. NIT1/YIL164C seems<br />
+to be the N-terminal part of a putative nitrilase-like protein formed of NIT1/YIL164C<br />
+and YIL165C." (file:yeast/NIT1/NIT1-uniprot.txt)</p>
+<p>My own bioinformatics analysis (file:yeast/NIT1/NIT1-bioinformatics/RESULTS.md) supports<br />
+and sharpens this:<br />
+- The nitrilase E-K-C catalytic triad residues <strong>are all present and correctly<br />
+  positioned in YIL164C</strong>: E44 (proton acceptor), K135 (proton donor), C169<br />
+  (nucleophile, in the diagnostic <code>GGAICWEN</code> motif); they align to the same columns as<br />
+  the triad of human NIT1, human NIT2 and Arabidopsis NIT1. So YIL164C is NOT a<br />
+  triad-loss pseudoenzyme.<br />
+- BUT YIL164C covers only the <strong>N-terminal ~2/3</strong> of the nitrilase fold (alignment<br />
+  cols 1–270); the adjacent ORF <strong>YIL165C (P40446, 119 aa)</strong> covers the C-terminal<br />
+  ~1/3 (cols 271–406) with essentially no overlap, and their 318-aa concatenation<br />
+  spans the full domain (matching human NIT1 327 aa, Arabidopsis 346 aa). So YIL164C<br />
+  as annotated is a <strong>truncated fragment</strong> lacking the C-terminal third of the fold<br />
+  (which contributes to folding/oligomerisation in this superfamily) — unlikely to be<br />
+  an active enzyme on its own.<br />
+- Both YIL164C and YIL165C sit in the <strong>uncharacterised PANTHER subfamily<br />
+  PTHR46044:SF1 "CN hydrolase domain-containing protein"</strong>, not in any<br />
+  substrate-defined branch (arylacetonitrilase SF14, cyanide hydratase SF4,<br />
+  nitrilase-1-related SF11).</p>
+<p>SGD independently notes: "in closely related species and other S. cerevisiae strain<br />
+backgrounds YIL164C and adjacent ORF, YIL165C, likely constitute a single ORF encoding<br />
+a nitrilase gene" (SGD locus page, WebFetch 2026-07); and that YIL164C/YIL165C "have<br />
+significant homology to the nitrilase superfamily … but have low sequence homology to<br />
+the other two S. cerevisiae nitrilases NIT2 and NIT3" (SGD / Koyama &amp; Walsh 2022<br />
+community reference S000316277).</p>
+<h2 id="sgd-curated-status-and-phenotypes-all-high-throughput-sequence-based">SGD-curated status and phenotypes (all high-throughput / sequence-based)</h2>
+<ul>
+<li>ORF status: <strong>Verified ORF</strong> (not dubious), but molecular function is only "putative<br />
+  nitrilase" by sequence alignment (ISA); biological process and cellular localization<br />
+  are curated as <strong>unknown</strong> (ND). No GFP localization datum.</li>
+<li>Deletion (high-throughput screens): increased chronological lifespan and competitive<br />
+  fitness; decreased anaerobic growth and starvation resistance; abnormal vacuolar<br />
+  morphology. These are pleiotropic screen hits, not a defined pathway role.<br />
+  (SGD locus page, WebFetch 2026-07.)</li>
+</ul>
+<h2 id="the-isa-reference-pmid10959838">The ISA reference (PMID:10959838)</h2>
+<p>PMID:10959838 (Pace et al. 2000, worm NitFhit crystal structure) is the<br />
+<code>original_reference_id</code> for the SGD ISA "nitrilase activity" annotation, but the<br />
+with/from field is Arabidopsis NIT1 (P32961). The paper is a <strong>structure</strong> paper about<br />
+C. elegans NitFhit and states the fold has "a presumptive Cys-Glu-Lys catalytic triad"<br />
+— it does not demonstrate any substrate for the enzyme, let alone for yeast YIL164C.<br />
+Abstract only (full_text_available: false).</p>
+<h2 id="known-vs-not-known-explicit">KNOWN vs NOT-KNOWN (explicit)</h2>
+<p>KNOWN:<br />
+- YIL164C is a verified ORF encoding a carbon-nitrogen-hydrolase-superfamily<br />
+  (nitrilase-family) domain (Pfam PF00795; PANTHER PTHR46044:SF1).<br />
+- It retains an intact, correctly positioned Glu-Lys-Cys catalytic triad (E44/K135/C169).<br />
+- It corresponds to the N-terminal ~2/3 of a full nitrilase fold; the C-terminal third<br />
+  is the adjacent ORF YIL165C; together they equal one full-length domain.<br />
+- It is a distinct paralog from yeast NIT2 (YJL126W), which is the characterised dGSH<br />
+  amidase / ortholog of human NIT1.<br />
+- High-throughput deletion phenotypes exist (lifespan, fitness, vacuolar morphology).</p>
+<p>NOT KNOWN:<br />
+- Its physiological substrate — no substrate has been demonstrated for YIL164C.<br />
+- Its catalytic activity in vivo — whether the truncated fragment folds/oligomerises<br />
+  into an active enzyme at all.<br />
+- Its biological process and cellular localization (curated as unknown).<br />
+- Whether YIL164C and YIL165C are translated as a single protein in S288C, or whether<br />
+  YIL164C is a disrupted pseudogene remnant.</p>
+<h2 id="references-used">References used</h2>
+<ul>
+<li>PMID:11380987 — Pace &amp; Brenner 2001, nitrilase superfamily classification (full text cached).</li>
+<li>PMID:28373563 — Peracchi et al. 2017, Nit1 = dGSH amidase (abstract cached); the yeast enzyme is NIT2/YJL126W.</li>
+<li>PMID:10959838 — Pace et al. 2000, worm NitFhit structure (abstract cached); ISA source.</li>
+<li>file:yeast/NIT1/NIT1-uniprot.txt — UniProt P40447 (family, PROSITE triad, pseudogene CAUTION).</li>
+<li>file:yeast/NIT1/NIT1-bioinformatics/RESULTS.md — triad-integrity, truncation, orthology analysis.</li>
+<li>SGD locus YIL164C / NIT2(YJL126W); Koyama &amp; Walsh 2022 SGD community reference S000316277 (no PMID; not used for verbatim quotes).</li>
+</ul>
+            </div>
+        </details>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Bioinformatics Results</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(RESULTS.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="P40447" data-a="DOC: Bioinformatics Results" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="bioinformatics-analysis-of-s-cerevisiae-nit1-p40447-yil164c">Bioinformatics analysis of S. cerevisiae NIT1 (P40447 / YIL164C)</h1>
+<p>Reproducible pipeline: <code>just all</code> (see <code>justfile</code>). All scripts read their inputs<br />
+from <code>data/</code> at run time; no results are hardcoded in code.</p>
+<h2 id="question">Question</h2>
+<p>NIT1 (P40447, YIL164C) is a 199-aa putative nitrilase-superfamily protein (carbon-<br />
+nitrogen hydrolase superfamily; Pfam PF00795 CN_hydrolase; PANTHER PTHR46044:SF1).<br />
+Three questions were addressed:</p>
+<ol>
+<li>Is the nitrilase-superfamily <strong>Glu-Lys-Cys (E-K-C) catalytic triad</strong> intact?</li>
+<li>Is NIT1 a <strong>truncated / split ORF</strong> (UniProt CAUTION: "Could be the product of a<br />
+   pseudogene. NIT1/YIL164C seems to be the N-terminal part of a putative nitrilase-<br />
+   like protein formed of NIT1/YIL164C and YIL165C")?</li>
+<li><strong>Orthology</strong> to human NIT1 / NIT2.</li>
+</ol>
+<h2 id="data">Data</h2>
+<table>
+<thead>
+<tr>
+<th>Accession</th>
+<th>Protein</th>
+<th>Length</th>
+<th>Role in analysis</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>P40447</td>
+<td>NIT1 / YIL164C (S. cerevisiae)</td>
+<td>199</td>
+<td>query</td>
+</tr>
+<tr>
+<td>P40446</td>
+<td>YIL165C (S. cerevisiae)</td>
+<td>119</td>
+<td>adjacent ORF (putative C-terminal partner)</td>
+</tr>
+<tr>
+<td>Q86X76</td>
+<td>human NIT1 (deaminated-glutathione amidase)</td>
+<td>327</td>
+<td>ortholog candidate</td>
+</tr>
+<tr>
+<td>Q9NQR4</td>
+<td>human NIT2 (omega-amidase)</td>
+<td>276</td>
+<td>ortholog candidate</td>
+</tr>
+<tr>
+<td>P32961</td>
+<td>Arabidopsis NIT1 (true nitrilase, IAN→IAA)</td>
+<td>346</td>
+<td>bona fide nitrilase outgroup</td>
+</tr>
+</tbody>
+</table>
+<p>Sequences fetched from UniProt REST (<code>data/*.fasta</code>).</p>
+<h2 id="methods">Methods</h2>
+<ul>
+<li><code>scripts/catalytic_triad.py</code> — reports the residue at each given 1-based position<br />
+  in a FASTA (positions supplied on the command line; not hardcoded).</li>
+<li>MAFFT <code>--auto</code> alignment of the five sequences (<code>results/combined.aln.fasta</code>).</li>
+<li><code>scripts/analyze_alignment.py</code> — maps the reference's PROSITE-predicted triad<br />
+  positions to alignment columns and reports what every other sequence has in<br />
+  those columns, plus each sequence's non-gap span (truncation proxy).</li>
+<li><code>scripts/test_split.py</code> — builds the artificial NIT1+YIL165C concatenation and<br />
+  aligns it with the real family members to test the split-ORF hypothesis.</li>
+<li><code>scripts/pairwise_identity.py</code> — % identity of NIT1 to each homolog over<br />
+  co-aligned (gap-free) columns.</li>
+</ul>
+<h2 id="results">Results</h2>
+<h3 id="1-catalytic-triad-is-present-in-nit1">1. Catalytic triad is present in NIT1</h3>
+<p>PROSITE-predicted active sites map to <strong>E44, K135, C169</strong> in NIT1<br />
+(<code>results/nit1_triad.tsv</code>):</p>
+<table>
+<thead>
+<tr>
+<th>position</th>
+<th>residue</th>
+<th>expected</th>
+<th>context (±5)</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>44</td>
+<td>Glu (E)</td>
+<td>E (proton acceptor)</td>
+<td>LVVIP<strong>E</strong>ATLGG</td>
+</tr>
+<tr>
+<td>135</td>
+<td>Lys (K)</td>
+<td>K (proton donor)</td>
+<td>VGKHR<strong>K</strong>LMPTA</td>
+</tr>
+<tr>
+<td>169</td>
+<td>Cys (C)</td>
+<td>C (nucleophile)</td>
+<td>IGGAI<strong>C</strong>WENMM</td>
+</tr>
+</tbody>
+</table>
+<p>All three canonical nitrilase-superfamily triad residues are present at the<br />
+predicted positions. In the multiple alignment these three residues fall in the<br />
+same columns (87, 188, 232) occupied by the E-K-C triad of human NIT1, human NIT2<br />
+and Arabidopsis NIT1 (<code>results/alignment_analysis.txt</code>) — i.e. the triad is<br />
+<strong>conserved and correctly positioned</strong>. The nucleophilic Cys sits in the<br />
+family-diagnostic <code>GGAICWEN</code> motif.</p>
+<p>Positive control (<code>results/nit2_triad_control.tsv</code>): running the same script on<br />
+human NIT2 at its own UniProt active-site positions (E43, K112, C153) correctly<br />
+returns E/K/C, confirming the script reads residues from whatever<br />
+sequence/positions it is given rather than returning a fixed answer.</p>
+<h3 id="2-nit1-is-the-n-terminal-23-of-a-nitrilase-fold-yil165c-is-the-c-terminal-13">2. NIT1 is the N-terminal ~2/3 of a nitrilase fold; YIL165C is the C-terminal ~1/3</h3>
+<p>Non-gap alignment spans (<code>results/split_test.txt</code>, <code>results/alignment_analysis.txt</code>):</p>
+<table>
+<thead>
+<tr>
+<th>sequence</th>
+<th>first col</th>
+<th>last col</th>
+<th>residues</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>NIT1 / YIL164C</td>
+<td>1</td>
+<td>270</td>
+<td>199</td>
+</tr>
+<tr>
+<td>YIL165C</td>
+<td>271</td>
+<td>406</td>
+<td>119</td>
+</tr>
+<tr>
+<td>NIT1 + YIL165C (concat)</td>
+<td>1</td>
+<td>406</td>
+<td>318</td>
+</tr>
+<tr>
+<td>human NIT1 (Q86X76)</td>
+<td>1</td>
+<td>406</td>
+<td>327</td>
+</tr>
+<tr>
+<td>human NIT2 (Q9NQR4)</td>
+<td>1</td>
+<td>386</td>
+<td>276</td>
+</tr>
+<tr>
+<td>Arabidopsis NIT1 (P32961)</td>
+<td>1</td>
+<td>406</td>
+<td>346</td>
+</tr>
+</tbody>
+</table>
+<p>In the split-test alignment, <strong>NIT1 (cols 1–270) and YIL165C (cols 271–406) tile<br />
+the domain almost exactly end-to-end with no overlap</strong>, and the 318-aa<br />
+concatenation spans the full 1–406 columns — the same span as the full-length<br />
+family members (human NIT1 327 aa; Arabidopsis 346 aa). The complete E-K-C triad<br />
+lies entirely within the NIT1 fragment (cols 87/188/232, all &lt; 270); YIL165C<br />
+contributes only the C-terminal region downstream of the triad and carries none of<br />
+the triad residues (<code>-/-/-</code> at the triad columns).</p>
+<p><strong>Interpretation.</strong> This is strong sequence-level support for the UniProt CAUTION:<br />
+YIL164C + YIL165C together reconstitute one complete nitrilase-superfamily domain<br />
+of normal length, split across two adjacent annotated ORFs. NIT1 alone, although it<br />
+retains all three catalytic residues, is <strong>missing the C-terminal ~1/3 of the<br />
+fold</strong>. In characterised nitrilase-superfamily enzymes the C-terminal region<br />
+contributes to the α-β-β-α sandwich fold and to the oligomerisation interfaces<br />
+required for activity, so a fragment ending at the equivalent of column ~270 is very<br />
+unlikely to fold into an active enzyme on its own. Whether YIL164C+YIL165C are<br />
+translated as one protein (e.g. via a sequencing error, frameshift, or read-through<br />
+that the reference genome splits) or are a genuinely disrupted pseudogene cannot be<br />
+resolved from sequence alone.</p>
+<h3 id="3-orthology-identity">3. Orthology / identity</h3>
+<p>Percent identity of NIT1 over co-aligned columns (<code>results/pairwise_identity.tsv</code>):</p>
+<table>
+<thead>
+<tr>
+<th>homolog</th>
+<th>% identity</th>
+<th>co-aligned positions</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Arabidopsis NIT1 (true nitrilase)</td>
+<td>47.2</td>
+<td>195</td>
+</tr>
+<tr>
+<td>human NIT1</td>
+<td>30.6</td>
+<td>170</td>
+</tr>
+<tr>
+<td>human NIT2</td>
+<td>25.6</td>
+<td>172</td>
+</tr>
+<tr>
+<td>YIL165C</td>
+<td>50.0</td>
+<td>2 (non-overlapping — not meaningful)</td>
+</tr>
+</tbody>
+</table>
+<p>NIT1 shows the expected carbon-nitrogen-hydrolase-superfamily level of similarity to<br />
+all three reference enzymes (~25–47% over the aligned catalytic core). It is not<br />
+markedly closer to human NIT1 than to human NIT2, and both yeast ORFs sit in the<br />
+uncharacterised PANTHER subfamily <strong>PTHR46044:SF1 "CN hydrolase domain-containing<br />
+protein"</strong> — i.e. <strong>not</strong> in the substrate-defined subfamilies of the same family<br />
+(SF14 arylacetonitrilase, SF4 cyanide hydratase, SF11 nitrilase-1-related). A clean<br />
+1:1 orthology assignment to a specific human paralog is therefore not supported;<br />
+NIT1 is a divergent fungal member of the superfamily whose substrate-specific<br />
+subfamily is undefined.</p>
+<h2 id="bottom-line">Bottom line</h2>
+<ul>
+<li>The <strong>E-K-C catalytic triad residues are individually intact</strong> in NIT1 (E44, K135,<br />
+  C169), conserved and correctly positioned relative to characterised family members<br />
+  — so NIT1 is <strong>not</strong> a triad-loss pseudoenzyme.</li>
+<li>However, NIT1 encodes only the <strong>N-terminal ~2/3 of a nitrilase-superfamily<br />
+  domain</strong>; the C-terminal third is separately annotated as YIL165C, and the two<br />
+  concatenate to a full-length domain. NIT1 as annotated is therefore a <strong>truncated<br />
+  fragment</strong> unlikely to be an active enzyme on its own, consistent with the UniProt<br />
+  pseudogene CAUTION and its PE=5 ("Uncertain") status.</li>
+<li><strong>No specific catalytic substrate can be assigned.</strong> The intact triad argues the<br />
+  ancestral fold was catalytic, but membership in the uncharacterised PTHR46044:SF1<br />
+  subfamily (not a substrate-defined branch) and the truncation mean the physiological<br />
+  activity — if any — is <strong>unknown</strong>. A generic "nitrilase activity" assignment is not<br />
+  supported by these data.</li>
+</ul>
+<h2 id="checklist">Checklist</h2>
+<ul>
+<li>[x] Scripts use no hardcoded inputs/outputs (all positions/paths passed as args;<br />
+      concatenation computed at run time).</li>
+<li>[x] Triad script tested on a second, unrelated input (human NIT2 positive control<br />
+      returns the correct E/K/C).</li>
+<li>[x] Analyses completed as expected (MAFFT + all scripts ran; outputs in <code>results/</code>).</li>
+<li>[x] Direct script outputs are in <code>results/</code>.</li>
+<li>[x] Summary includes provenance and justification; uncertainty explicitly stated<br />
+      where sequence alone cannot resolve the question (translation vs pseudogene).</li>
+</ul>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: P40447
+gene_symbol: NIT1
+product_type: PROTEIN
+status: DRAFT
+taxon:
+  id: NCBITaxon:559292
+  label: Saccharomyces cerevisiae
+description: &gt;-
+  NIT1 (YIL164C) is a small (199 aa) putative member of the carbon-nitrogen
+  hydrolase (nitrilase) superfamily in Saccharomyces cerevisiae. It carries a
+  single CN-hydrolase domain (Pfam PF00795) and retains the superfamily&#39;s
+  conserved Glu-Lys-Cys catalytic triad (E44, K135, C169). No physiological
+  substrate, catalytic activity, biological process, or subcellular localization
+  has been experimentally established for this protein, and it remains
+  functionally uncharacterized. NIT1 corresponds to only the N-terminal ~2/3 of a
+  complete nitrilase fold; the adjacent ORF YIL165C encodes the complementary
+  C-terminal ~1/3, and in related yeasts the two are a single ORF, so YIL164C as
+  annotated is most likely a truncated fragment of a nitrilase-like protein
+  (UniProt flags it as possibly the product of a pseudogene). It is a distinct
+  paralog from the characterized yeast Nit-domain amidase NIT2 (YJL126W), the
+  ortholog of human NIT1, which hydrolyzes deaminated glutathione; that activity
+  has not been shown for YIL164C. The nitrilase superfamily comprises one branch
+  of true nitrilases and many branches of amidases/amide-condensation enzymes, so
+  family membership alone does not imply nitrilase activity.
+references:
+- id: GO_REF:0000002
+  title: Gene Ontology annotation through association of InterPro records with GO
+    terms
+  findings: []
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: &gt;-
+      InterPro2GO electronic pipeline. Supports only the family-level generic
+      &#34;catalytic activity&#34; call, which is uninformative for this gene.
+- id: GO_REF:0000015
+  title: Use of the ND evidence code for Gene Ontology (GO) terms
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Root-term ND placeholders for unknown BP/CC; correct given no data.
+- id: GO_REF:0000117
+  title: Electronic Gene Ontology annotations created by ARBA machine learning models
+  findings: []
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: &gt;-
+      ARBA machine-learned annotations assigning specific &#34;nitrilase activity&#34;
+      and &#34;hydro-lyase activity&#34; to a family member with no demonstrated
+      substrate; over-annotation risk.
+- id: PMID:10959838
+  title: Crystal structure of the worm NitFhit Rosetta Stone protein reveals a Nit
+    tetramer binding two Fhit dimers.
+  findings:
+  - statement: &gt;-
+      Nit-domain proteins of the nitrilase superfamily have a presumptive
+      Cys-Glu-Lys catalytic triad; this is a structure paper on C. elegans
+      NitFhit and does not demonstrate any catalytic substrate.
+    supporting_text: &gt;-
+      Nit monomers possess a new alpha-beta-beta-alpha sandwich fold with a
+      presumptive Cys-Glu-Lys catalytic triad
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Correctly cited structural paper (abstract-only in cache). It is the
+      original_reference for the SGD ISA annotation but establishes only the
+      fold/triad, not a substrate; the ISA with/from is Arabidopsis NIT1
+      (P32961), a plant branch-1 nitrilase, not a yeast enzyme.
+- id: PMID:11380987
+  title: &#39;The nitrilase superfamily: classification, structure and function.&#39;
+  findings:
+  - statement: &gt;-
+      Only branch 1 of the nitrilase superfamily has demonstrated nitrilase
+      activity; most branches are amidases or amide-condensation enzymes, so
+      family membership does not imply nitrilase activity.
+    supporting_text: &gt;-
+      Despite historical classification of all of these sequences as
+      nitrilase-related, only one branch is known to have nitrilase activity,
+      whereas eight branches have apparent amidase or amide-condensation
+      activities.
+  - statement: &gt;-
+      Nitrilase-superfamily database annotations are frequently applied without
+      supporting activity data.
+    supporting_text: &gt;-
+      Automated sequence searching easily identifies predicted polypeptides as
+      members of the nitrilase superfamily, but many database annotations have
+      been applied haphazardly.
+  - statement: &gt;-
+      The superfamily shares a conserved Glu-Lys-Cys catalytic triad.
+    supporting_text: &gt;-
+      Essentially all members of the nitrilase superfamily have a conserved,
+      apparent catalytic triad of glutamate, lysine and cysteine
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Foundational family classification (full text cached, PubMed-verified).
+      Directly grounds the critique of the generic &#34;nitrilase activity&#34;
+      annotation.
+- id: PMID:28373563
+  title: Nit1 is a metabolite repair enzyme that hydrolyzes deaminated glutathione.
+  findings:
+  - statement: &gt;-
+      Human NIT1 and its characterized yeast ortholog are deaminated-glutathione
+      amidases (metabolite repair), not nitrilases; the yeast enzyme studied is
+      the gene named NIT2 (YJL126W), a distinct paralog from YIL164C.
+    supporting_text: &gt;-
+      both the mammalian Nit1 and its yeast ortholog are amidases highly active
+      toward deaminated glutathione (dGSH; i.e., a form of glutathione in which
+      the free amino group has been replaced by a carbonyl group)
+  - statement: &gt;-
+      Even the closest characterized relatives are amidases whose function was
+      long unresolved; nitrilase activity is not their function.
+    supporting_text: &gt;-
+      the Nit1 protein does not hydrolyze efficiently α-ketoglutaramate (a known
+      physiological substrate of Nit2), and its actual enzymatic function has so
+      far remained a puzzle
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Establishes the dGSH-amidase function of the human-NIT1 / yeast Nit-domain
+      ortholog pair (abstract cached; full text not available in cache).
+      Identification of the specific yeast ORF as NIT2/YJL126W (rather than
+      YIL164C) rests on the paper&#39;s Table 1 gene names plus an SGD lookup of
+      NIT2&#39;s IDA dGSH-amidase annotation; used here only in the conservative
+      direction (to avoid transferring the dGSH-amidase function to YIL164C, a
+      distinct paralog). The triad numbering for the characterized enzyme
+      (Glu45-Lys127-Cys169) differs from YIL164C&#39;s predicted Glu44-Lys135-Cys169,
+      consistent with them being different ORFs.
+- id: file:yeast/NIT1/NIT1-uniprot.txt
+  title: UniProt entry P40447 (NIT1_YEAST), Saccharomyces cerevisiae
+  findings:
+  - statement: &gt;-
+      NIT1 belongs to the carbon-nitrogen hydrolase superfamily (nitrilase
+      family) and PROSITE predicts a Glu/Lys/Cys catalytic triad.
+    supporting_text: &gt;-
+      Belongs to the carbon-nitrogen hydrolase superfamily.
+  - statement: &gt;-
+      UniProt cautions that NIT1 may be the product of a pseudogene and appears
+      to be the N-terminal part of a nitrilase-like protein formed with YIL165C.
+    supporting_text: &gt;-
+      Could be the product of a pseudogene. NIT1/YIL164C seems to be
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Curated UniProt record; source for family membership, the predicted triad,
+      and the pseudogene/truncation caution. PE=5 (Uncertain).
+- id: file:yeast/NIT1/NIT1-bioinformatics/RESULTS.md
+  title: Bioinformatics analysis of NIT1 (catalytic triad, truncation, orthology)
+  findings:
+  - statement: &gt;-
+      The Glu-Lys-Cys catalytic triad (E44,K135,C169) is present and correctly
+      positioned in NIT1, aligning to the triad of human NIT1/NIT2 and
+      Arabidopsis NIT1; NIT1 is not a triad-loss pseudoenzyme.
+    supporting_text: &gt;-
+      All three canonical nitrilase-superfamily triad residues are present at the
+      predicted positions.
+  - statement: &gt;-
+      NIT1 (YIL164C) covers only the N-terminal ~2/3 of a nitrilase fold and
+      YIL165C the C-terminal ~1/3; their concatenation spans a full-length domain.
+    supporting_text: &gt;-
+      NIT1 (cols 1-270) and YIL165C (cols 271-406) tile the domain almost exactly
+      end-to-end with no overlap
+  - statement: &gt;-
+      Both yeast ORFs fall in the uncharacterized PANTHER subfamily PTHR46044:SF1,
+      not in any substrate-defined branch; no specific substrate can be assigned.
+    supporting_text: &gt;-
+      No specific catalytic substrate can be assigned.
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Reproducible in-repo analysis (MAFFT alignment + triad/coverage scripts).
+- id: file:yeast/NIT1/NIT1-deep-research-falcon.md
+  title: Falcon deep research report for NIT1 (YIL164C)
+  findings:
+  - statement: &gt;-
+      The report incorrectly equates YIL164C (&#34;scNit1&#34;) with the characterized
+      deaminated-glutathione amidase and transfers that function, kinetics and
+      crystal structure to YIL164C. This is a paralog conflation: the dGSH amidase
+      is the yeast gene NIT2 (YJL126W) per Peracchi 2017 Table 1 and SGD, whose
+      triad numbering (Glu45-Lys127-Cys169) differs from YIL164C&#39;s predicted
+      Glu44-Lys135-Cys169.
+    supporting_text: &gt;-
+      *S. cerevisiae* NIT1 (YIL164C, P40447) encodes a deaminated glutathione (dGSH) amidase
+  reference_review:
+    relevance: LOW
+    correctness: MISCITED
+    review_notes: &gt;-
+      Genuine late falcon artifact, retained for provenance. Its central
+      functional claim for YIL164C is a paralog mis-attribution (it copies the
+      NIT2/YJL126W dGSH-amidase characterization onto YIL164C); NOT used to
+      support any functional annotation here. Flagged as a cautionary example of
+      nitrilase-family over-annotation via name confusion.
+existing_annotations:
+- term:
+    id: GO:0000257
+    label: nitrilase activity
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000117
+  qualifier: enables
+  review:
+    summary: &gt;-
+      ARBA-predicted specific nitrilase activity. Pace &amp; Brenner do place the S.
+      cerevisiae NIT1 gene in branch 1 (the true-nitrilase branch), so this is not
+      simply a wrong-branch call; however they describe it as &#34;frequently
+      inactivated&#34;, the only demonstrated branch-1 activity is the plant
+      indoleacetonitrile-to-auxin reaction, and no nitrilase substrate has ever
+      been shown for the yeast protein. Combined with the likely truncation
+      (N-terminal 2/3 only), a specific substrate-defining &#34;nitrilase activity&#34;
+      call over-reaches the evidence.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      Not wrong at the branch level (branch 1 is the nitrilase branch and yeast
+      NIT1 is placed there), but over-annotated: no nitrilase substrate is
+      demonstrated for this protein, the gene is described as frequently
+      inactivated and appears truncated, and nitrilase-superfamily database
+      annotations are frequently applied without activity data. A specific
+      &#34;nitrilase activity&#34; assertion is stronger than the evidence supports.
+    supported_by:
+    - reference_id: PMID:11380987
+      supporting_text: &gt;-
+        found in plants, animals (C. elegans), fungi (Saccharomyces cerevisiae&#39;s
+        frequently inactivated NIT1 gene), and many types of bacteria
+    - reference_id: PMID:11380987
+      supporting_text: &gt;-
+        Automated sequence searching easily identifies predicted polypeptides as
+        members of the nitrilase superfamily, but many database annotations have
+        been applied haphazardly.
+- term:
+    id: GO:0003824
+    label: catalytic activity
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Generic InterPro2GO catalytic-activity call. Consistent with the intact
+      catalytic triad but uninformative, and its in-vivo relevance is uncertain
+      given the likely truncation of the fold.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Root-level, non-specific and defensible from family membership plus the
+      conserved triad, but too general to represent a core function and possibly
+      not realized if the protein is a non-functional fragment.
+    supported_by:
+    - reference_id: file:yeast/NIT1/NIT1-bioinformatics/RESULTS.md
+      supporting_text: &gt;-
+        All three canonical nitrilase-superfamily triad residues are present at
+        the predicted positions.
+- term:
+    id: GO:0016836
+    label: hydro-lyase activity
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000117
+  qualifier: enables
+  review:
+    summary: &gt;-
+      ARBA-predicted hydro-lyase (C-O lyase) activity. This is mechanistically
+      wrong for the nitrilase superfamily, whose members are C-N hydrolases /
+      amidases acting on carbon-nitrogen bonds via the Glu-Lys-Cys triad, not
+      hydro-lyases that cleave carbon-oxygen bonds.
+    action: REMOVE
+    reason: &gt;-
+      Wrong enzyme class: the carbon-nitrogen hydrolase superfamily hydrolyzes
+      C-N bonds; hydro-lyase (EC 4.2.1.-, C-O lyase) activity is a different
+      catalytic mechanism unsupported by the fold or the conserved triad. This is
+      a spurious ARBA electronic mapping.
+    supported_by:
+    - reference_id: file:yeast/NIT1/NIT1-uniprot.txt
+      supporting_text: &gt;-
+        Belongs to the carbon-nitrogen hydrolase superfamily.
+    - reference_id: PMID:11380987
+      supporting_text: &gt;-
+        Essentially all members of the nitrilase superfamily have a conserved,
+        apparent catalytic triad of glutamate, lysine and cysteine
+- term:
+    id: GO:0000257
+    label: nitrilase activity
+  evidence_type: ISA
+  original_reference_id: PMID:10959838
+  qualifier: enables
+  review:
+    summary: &gt;-
+      SGD ISA &#34;nitrilase activity&#34; annotation whose with/from is Arabidopsis NIT1
+      (P32961), a bona fide plant branch-1 nitrilase. Yeast NIT1 is placed in
+      branch 1 by Pace &amp; Brenner, so a nitrilase call is not off-branch; but the
+      cited structure paper (PMID:10959838) establishes only the fold and a
+      presumptive triad, not any substrate, and the only demonstrated branch-1
+      activity is the plant IAN-to-auxin reaction. No nitrilase substrate is shown
+      for the yeast protein, which is &#34;frequently inactivated&#34; and truncated.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      Similarity transfer of a specific substrate-defining activity from a plant
+      nitrilase to an uncharacterized, likely-truncated yeast paralog with no
+      demonstrated substrate. The branch-1 placement makes &#34;nitrilase&#34; plausible
+      at the family level, but asserting the specific activity over-reaches; this
+      is a similarity (ISA) annotation, not experimental.
+    supported_by:
+    - reference_id: PMID:11380987
+      supporting_text: &gt;-
+        found in plants, animals (C. elegans), fungi (Saccharomyces cerevisiae&#39;s
+        frequently inactivated NIT1 gene), and many types of bacteria
+    - reference_id: PMID:11380987
+      supporting_text: &gt;-
+        Automated sequence searching easily identifies predicted polypeptides as
+        members of the nitrilase superfamily, but many database annotations have
+        been applied haphazardly.
+- term:
+    id: GO:0005575
+    label: cellular_component
+  evidence_type: ND
+  original_reference_id: GO_REF:0000015
+  qualifier: is_active_in
+  review:
+    summary: &gt;-
+      Root cellular_component with ND (no data). No localization has been
+      determined for NIT1 (no GFP datum curated).
+    action: ACCEPT
+    reason: &gt;-
+      Correct use of the ND placeholder given the absence of localization data;
+      flags a genuine knowledge gap.
+- term:
+    id: GO:0008150
+    label: biological_process
+  evidence_type: ND
+  original_reference_id: GO_REF:0000015
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Root biological_process with ND (no data). No biological process has been
+      established for NIT1.
+    action: ACCEPT
+    reason: &gt;-
+      Correct use of the ND placeholder given no process data; flags a genuine
+      knowledge gap.
+core_functions: []
+proposed_new_terms: []
+knowledge_gaps:
+- gap_statement: &gt;-
+    The physiological substrate and catalytic activity of NIT1 (YIL164C) are
+    unknown. It has never been shown to hydrolyze a nitrile or any amide/other
+    C-N bond in vitro or in vivo, and it is unresolved whether the protein is
+    catalytically active at all.
+  boundary: &gt;-
+    Established: NIT1 is a carbon-nitrogen hydrolase (nitrilase) superfamily
+    member with a single CN-hydrolase domain and an intact, correctly positioned
+    Glu-Lys-Cys catalytic triad (E44/K135/C169); Pace &amp; Brenner place the yeast
+    NIT1 gene in branch 1 (the true-nitrilase branch, EC 3.5.5.1) but call it
+    &#34;frequently inactivated&#34;. Unknown: which C-N bond it acts on (if any) and
+    whether catalytic competence is realized in this protein. Even within branch
+    1 the only demonstrated activity is the plant indoleacetonitrile-to-auxin
+    reaction, so branch placement does not fix a substrate for the yeast protein.
+  gap_kind:
+  - BIOLOGY
+  dark_aspect: MF_DARK
+  status: OPEN
+  significance: &gt;-
+    NIT1 is a conserved-family enzyme candidate with no assigned function; it is
+    also an archetype of nitrilase-superfamily over-annotation, where generic
+    &#34;nitrilase activity&#34; is asserted without a demonstrated substrate.
+  resolution: &gt;-
+    Biochemical substrate profiling of recombinant protein (nitrile and amide
+    panels, including deaminated glutathione and omega-amidase substrates as
+    negative/positive controls), and metabolomic comparison of a clean deletion
+    strain.
+  provenance:
+  - reference_id: PMID:11380987
+    supporting_text: &gt;-
+      Despite historical classification of all of these sequences as
+      nitrilase-related, only one branch is known to have nitrilase activity,
+      whereas eight branches have apparent amidase or amide-condensation
+      activities.
+  - reference_id: file:yeast/NIT1/NIT1-bioinformatics/RESULTS.md
+    supporting_text: &gt;-
+      No specific catalytic substrate can be assigned.
+- gap_statement: &gt;-
+    It is unresolved whether YIL164C is a functional gene or a truncated/pseudogene
+    fragment, and whether YIL164C and YIL165C are translated as one protein in
+    S. cerevisiae S288C.
+  boundary: &gt;-
+    Established: YIL164C encodes the N-terminal ~2/3 of a nitrilase fold and
+    YIL165C the C-terminal ~1/3; together they equal a full-length domain, and in
+    related yeasts/strains they form a single ORF. UniProt lists PE=5 (Uncertain)
+    and flags possible pseudogene status. Unknown: the actual translated product
+    in S288C and whether a functional full-length enzyme is ever made.
+  gap_kind:
+  - BIOLOGY
+  - CURATION
+  dark_aspect: MF_DARK
+  status: OPEN
+  significance: &gt;-
+    Determines whether NIT1 should be curated as a functional enzyme, a fragment,
+    or a pseudogene, and whether activity assays should use YIL164C alone or the
+    YIL164C+YIL165C concatenation.
+  resolution: &gt;-
+    Ribosome-profiling / proteomics to establish the translated product(s), and
+    activity testing of the reconstituted full-length YIL164C+YIL165C protein
+    versus YIL164C alone.
+  provenance:
+  - reference_id: file:yeast/NIT1/NIT1-uniprot.txt
+    supporting_text: &gt;-
+      Could be the product of a pseudogene. NIT1/YIL164C seems to be
+  - reference_id: file:yeast/NIT1/NIT1-bioinformatics/RESULTS.md
+    supporting_text: &gt;-
+      NIT1 (cols 1-270) and YIL165C (cols 271-406) tile the domain almost exactly
+      end-to-end with no overlap
+- gap_statement: &gt;-
+    The biological process and subcellular localization of NIT1 are unknown; its
+    high-throughput deletion phenotypes have no established mechanistic link to a
+    molecular function.
+  boundary: &gt;-
+    Established: SGD curates BP and CC as unknown (ND); deletion screens report
+    pleiotropic phenotypes. Unknown: the pathway NIT1 acts in and where in the
+    cell it acts. The characterized dGSH-amidase / metabolite-repair role belongs
+    to the paralog NIT2 (YJL126W), not to YIL164C.
+  gap_kind:
+  - BIOLOGY
+  dark_aspect: WHOLLY_DARK
+  status: OPEN
+  significance: &gt;-
+    Without a process or localization, NIT1 cannot be placed in any pathway or
+    GO-CAM; distinguishing its role from the paralogous NIT2 amidase is required
+    to avoid mis-attribution.
+  resolution: &gt;-
+    GFP localization, targeted metabolomics of the deletion, and epistasis with
+    NIT2/NIT3 to test for a distinct (non-redundant) role.
+  provenance:
+  - reference_id: PMID:28373563
+    supporting_text: &gt;-
+      both the mammalian Nit1 and its yeast ortholog are amidases highly active
+      toward deaminated glutathione (dGSH; i.e., a form of glutathione in which
+      the free amino group has been replaced by a carbonyl group)
+suggested_questions:
+- question: &gt;-
+    Does NIT1 (YIL164C) have any hydrolase/amidase activity, and on what
+    substrate, when assayed alone versus reconstituted with the YIL165C fragment?
+  experts: []
+- question: &gt;-
+    Is YIL164C a functional gene, a truncated fragment, or a pseudogene in S288C,
+    and is a full-length YIL164C+YIL165C protein ever translated?
+  experts: []
+- question: &gt;-
+    Does NIT1 have a biological role distinct from the paralogous dGSH-amidase
+    NIT2 (YJL126W), or is it functionally inert/redundant?
+  experts: []
+suggested_experiments:
+- hypothesis: &gt;-
+    NIT1 retains the ancestral C-N hydrolase/amidase activity but only as the
+    reconstituted full-length YIL164C+YIL165C protein.
+  description: &gt;-
+    Express and purify (i) YIL164C alone and (ii) the YIL164C+YIL165C fusion, and
+    screen both against nitrile and amide substrate panels (including deaminated
+    glutathione and α-ketoglutaramate as paralog controls), measuring kinetics
+    and confirming triad dependence with active-site mutants.
+  experiment_type: recombinant enzyme substrate profiling
+- hypothesis: &gt;-
+    NIT1 loss perturbs a specific metabolite pool distinct from that of NIT2.
+  description: &gt;-
+    Compare untargeted metabolomes of nit1-delta, nit2-delta, nit3-delta and
+    double mutants under standard and starvation/anaerobic conditions to detect a
+    NIT1-specific accumulating substrate.
+  experiment_type: comparative metabolomics of deletion strains
+- hypothesis: &gt;-
+    YIL164C is translated (functional ORF) rather than being a silent pseudogene.
+  description: &gt;-
+    Use ribosome profiling and targeted proteomics to detect the YIL164C product
+    and determine whether translation extends into YIL165C.
+  experiment_type: ribosome profiling / targeted proteomics
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/genes/yeast/PTM1/PTM1-ai-review.html
+++ b/genes/yeast/PTM1/PTM1-ai-review.html
@@ -1,0 +1,2914 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>PTM1 - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        .propagation-review {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f8fafc;
+            border-left: 3px solid #64748b;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .propagation-title {
+            font-weight: 600;
+            color: #334155;
+            margin-bottom: 0.25rem;
+        }
+
+        .propagation-row {
+            margin-top: 0.25rem;
+        }
+
+        .propagation-source {
+            margin-top: 0.5rem;
+            padding-top: 0.5rem;
+            border-top: 1px solid #e5e7eb;
+        }
+
+        .propagation-source-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #1d4ed8;
+        }
+
+        .propagation-comment {
+            color: #4b5563;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>PTM1</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/P32857" target="_blank" class="term-link">
+                        P32857
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Saccharomyces cerevisiae</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-in-progress">
+                    IN PROGRESS
+                </span>
+            </div>
+
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "PTM1";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="P32857" data-a="DESCRIPTION: PTM1 (YKL039W) is a polytopic integral membrane pr..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>PTM1 (YKL039W) is a polytopic integral membrane protein of the budding yeast secretory pathway. It has the architecture characteristic of the GOST/LUSTR (GOLD-domain seven-transmembrane, also called Lung Seven TransMembrane) protein family: a cleavable N-terminal signal peptide, a large lumenal N-terminal β-sandwich domain, and a GPCR-like bundle of seven transmembrane helices, ending in a cytoplasmic, disordered, acidic and phosphorylated C-terminal tail. The lumenal domain carries a predicted N-glycosylation site. PTM1 localizes to the Golgi apparatus membrane and the early endosome membrane, and co-purifies with the late-Golgi/endosomal SNARE Tlg2. It is the fungal representative of the family that in animals includes GPR107, GPR108, TMEM87A/TMEM87B, GPR180 and Wntless (WLS); yeast additionally has a whole-genome-duplication paralog, YHL017W. Members of this family are Golgi/endosome-resident proteins broadly associated with membrane-protein trafficking through the secretory and endosomal system, and are thought to act as trafficking chaperones for membrane-associated or hydrophobic cargo rather than as signalling GPCRs, but no molecular function, substrate or ligand has been established for PTM1, and its precise cellular role remains undefined.</p>
+    </div>
+
+
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005794" target="_blank" class="term-link">
+                                    GO:0005794
+                                </a>
+                            </span>
+                            <span class="term-label">Golgi apparatus</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P32857" data-a="GO:0005794" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Golgi localization is supported both by phylogenetic inference from the GOST/LUSTR family (which is broadly Golgi/endosome-resident) and by direct experimental co-purification of PTM1 with the yeast late-Golgi compartment.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Consistent with the experimental subcellular localization (PMID:16107716, copurification with the Tlg2 late-Golgi/endosome compartment) and with family-wide Golgi localization. This is a well-supported core localization.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/16107716" target="_blank" class="term-link">
+                                        PMID:16107716
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">we immunoisolated vesicles carrying either of the SNAREs Sed5 or Tlg2, the markers of the early and late Golgi compartments, respectively, and analyzed the membrane proteins</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016020" target="_blank" class="term-link">
+                                    GO:0016020
+                                </a>
+                            </span>
+                            <span class="term-label">membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P32857" data-a="GO:0016020" data-r="GO_REF:0000033" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> PTM1 is an integral, multi-pass (seven-transmembrane) membrane protein, so &#34;membrane&#34; is factually correct but uninformative given the more specific Golgi-membrane and early-endosome-membrane annotations.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> True but shallow parent term; the specific compartment (Golgi/endosome membrane) annotations are more informative. Retain as non-core.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042147" target="_blank" class="term-link">
+                                    GO:0042147
+                                </a>
+                            </span>
+                            <span class="term-label">retrograde transport, endosome to Golgi</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P32857" data-a="GO:0042147" data-r="GO_REF:0000033" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> The only biological-process annotation with specific content. Transferred by phylogenetic inference from mammalian orthologs (with/from GPR108/TMEM87B). Compatible with PTM1&#39;s late-Golgi/endosome localization, but there is no direct yeast experimental evidence that PTM1 mediates endosome-to-Golgi retrograde transport, and PTM1 sits in a distinct PANTHER subfamily (SF1) from the mammalian members the annotation derives from.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Reasonable, localization-compatible phylogenetic inference, but unverified for yeast and subfamily-diverged; keep as a plausible process context rather than an established core function. Not removed, per guidance that IBA process inferences compatible with localization should not be second-guessed away.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000139" target="_blank" class="term-link">
+                                    GO:0000139
+                                </a>
+                            </span>
+                            <span class="term-label">Golgi membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000044
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P32857" data-a="GO:0000139" data-r="GO_REF:0000044" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Specific, experimentally-grounded localization derived from the UniProt Swiss-Prot subcellular-location mapping (Golgi apparatus membrane; multi-pass), which itself rests on PMID:16107716.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Precise and correct localization for a multi-pass Golgi membrane protein; core localization.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/16107716" target="_blank" class="term-link">
+                                        PMID:16107716
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">we immunoisolated vesicles carrying either of the SNAREs Sed5 or Tlg2, the markers of the early and late Golgi compartments, respectively, and analyzed the membrane proteins</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
+                                    GO:0005829
+                                </a>
+                            </span>
+                            <span class="term-label">cytosol</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000108
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P32857" data-a="GO:0005829" data-r="GO_REF:0000108" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Assigned by automated logical inference from the retrograde-transport process term (with/from GO:0042147), not from evidence that PTM1 is a soluble cytosolic protein. PTM1 is a polytopic integral membrane protein; only its C-terminal tail faces the cytoplasm.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Misleading as a cellular-component assignment for an integral membrane protein; it is an artefact of inter-ontology logical inference from the BP term rather than a bona fide localization.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016020" target="_blank" class="term-link">
+                                    GO:0016020
+                                </a>
+                            </span>
+                            <span class="term-label">membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P32857" data-a="GO:0016020" data-r="GO_REF:0000002" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> InterPro2GO (IPR009637, GPR107/GPR108-like) correctly infers integral-membrane status. Redundant with the IBA membrane term and uninformative relative to the Golgi/endosome-membrane annotations.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct but shallow parent; retain as non-core supporting the integral membrane nature.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031901" target="_blank" class="term-link">
+                                    GO:0031901
+                                </a>
+                            </span>
+                            <span class="term-label">early endosome membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000044
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P32857" data-a="GO:0031901" data-r="GO_REF:0000044" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Secondary localization from the UniProt subcellular-location mapping, grounded in the PMID:16107716 co-purification with the late-Golgi/endosome (Tlg2) compartment.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Experimentally grounded secondary localization; correct and specific. Non-core relative to the primary Golgi localization.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/16107716" target="_blank" class="term-link">
+                                        PMID:16107716
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">we immunoisolated vesicles carrying either of the SNAREs Sed5 or Tlg2, the markers of the early and late Golgi compartments, respectively, and analyzed the membrane proteins</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003674" target="_blank" class="term-link">
+                                    GO:0003674
+                                </a>
+                            </span>
+                            <span class="term-label">molecular_function</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ND</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000015
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P32857" data-a="GO:0003674" data-r="GO_REF:0000015" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Root molecular-function term with the ND (no biological data) evidence code. This is an honest reflection of the state of knowledge: no molecular function, enzymatic activity, ligand or transported substrate has been established for PTM1, and the wider GOST family&#39;s molecular function is itself unresolved.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Appropriate ND annotation for a gene whose molecular function is genuinely unknown; retaining it correctly signals the molecular-function knowledge gap.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005575" target="_blank" class="term-link">
+                                    GO:0005575
+                                </a>
+                            </span>
+                            <span class="term-label">cellular_component</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ND</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000015
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P32857" data-a="GO:0005575" data-r="GO_REF:0000015" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Root cellular-component ND annotation. It is now superseded by the specific, experimentally-grounded Golgi-membrane and early-endosome-membrane annotations.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> No longer reflects the state of knowledge now that specific compartment localizations are annotated; should not be treated as core. (An ND root annotation that specific evidence has overtaken.)
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008150" target="_blank" class="term-link">
+                                    GO:0008150
+                                </a>
+                            </span>
+                            <span class="term-label">biological_process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ND</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000015
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P32857" data-a="GO:0008150" data-r="GO_REF:0000015" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Root biological-process ND annotation, reflecting that the specific biological role of PTM1 in yeast has not been experimentally determined. A more specific (though still inferred) BP annotation exists via the IBA endosome-to-Golgi-retrograde-transport term.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Honestly reflects the limited process-level knowledge; retained as non-core given the only specific BP term is an unverified phylogenetic inference.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>PTM1 is a polytopic integral membrane protein resident in the Golgi apparatus membrane and early endosome membrane of the budding-yeast secretory/endosomal system, where it co-purifies with the late-Golgi/endosomal SNARE Tlg2. It is the fungal member of the GOST/LUSTR (GOLD-domain seven-transmembrane) family, whose members are broadly implicated in membrane-protein trafficking through the Golgi and endosomal network and are proposed to act as trafficking chaperones for membrane-associated or hydrophobic cargo rather than as signalling GPCRs. No specific molecular function, ligand or transported substrate has been established for PTM1; this core function is therefore stated at the level of a localization-defined, family-associated role in intracellular membrane trafficking, with the molecular mechanism left undefined (see knowledge_gaps).</h3>
+                <span class="vote-buttons" data-g="P32857" data-a="FUNCTION: PTM1 is a polytopic integral membrane protein resi..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000139" target="_blank" class="term-link">
+                                Golgi membrane
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031901" target="_blank" class="term-link">
+                                early endosome membrane
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/16107716" target="_blank" class="term-link">
+                                PMID:16107716
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">we immunoisolated vesicles carrying either of the SNAREs Sed5 or Tlg2, the markers of the early and late Golgi compartments, respectively, and analyzed the membrane proteins</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/39609618" target="_blank" class="term-link">
+                                PMID:39609618
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">it was speculated that GOST proteins might function as trafficking chaperones for membrane-associated cargo</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000002.md" target="_blank" class="term-link">
+                            GO_REF:0000002
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation through association of InterPro records with GO terms</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000015.md" target="_blank" class="term-link">
+                            GO_REF:0000015
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Use of the ND evidence code for Gene Ontology (GO) terms</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
+                            GO_REF:0000033
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Annotation inferences using phylogenetic trees</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
+                            GO_REF:0000044
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000108.md" target="_blank" class="term-link">
+                            GO_REF:0000108
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Automatic assignment of GO terms using logical inference, based on on inter-ontology links</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/16107716" target="_blank" class="term-link">
+                            PMID:16107716
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Immunoisolaton of the yeast Golgi subcompartments and characterization of a novel membrane protein, Svp26, discovered in the Sed5-containing compartments.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Immunoisolated yeast Golgi subcompartments using the SNAREs Sed5 (early Golgi) and Tlg2 (late Golgi/endosome) and catalogued their membrane proteins; PTM1 (YKL039W) co-purified with the Tlg2 late-Golgi/endosome compartment, the experimental basis for its Golgi-membrane and early-endosome-membrane localization.</div>
+
+                        <div class="finding-text">"we immunoisolated vesicles carrying either of the SNAREs Sed5 or Tlg2, the markers of the early and late Golgi compartments, respectively, and analyzed the membrane proteins"</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/18407956" target="_blank" class="term-link">
+                            PMID:18407956
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">A multidimensional chromatography technology for in-depth phosphoproteome analysis.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Large-scale phosphoproteomic survey identifying PTM1 phosphorylation at Ser480, Thr483 and Thr498 in its cytoplasmic C-terminal tail.</div>
+
+                        <div class="finding-text">"A multidimensional chromatography technology for in-depth phosphoproteome analysis"</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/36373655" target="_blank" class="term-link">
+                            PMID:36373655
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Structure of the GOLD-domain seven-transmembrane helix protein family member TMEM87A.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Defines the GOST family (GOLD domain fused to a GPCR-like 7TM domain, the architecture shared by PTM1) and proposes a common membrane-trafficking role; shows the human paralog TMEM87A is neither a mechanosensitive channel nor a canonical G-protein-coupled receptor.</div>
+
+                        <div class="finding-text">"structurally homologous GOST proteins could serve a common role in trafficking"</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/39609618" target="_blank" class="term-link">
+                            PMID:39609618
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">GPR180 is a new member of the Golgi-dynamics domain seven-transmembrane helix protein family.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Reviews the GOST/GDD seven-transmembrane family: members localize to the Golgi/endosomal network and are speculated to act as trafficking chaperones for membrane-associated cargo, but their molecular function and ligands remain largely unknown.</div>
+
+                        <div class="finding-text">"Little is known about ligands and the exact function of GOST proteins"</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Questions for Experts</h2>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Does PTM1 function as a cargo-binding trafficking chaperone for a specific membrane protein or lipid in the yeast Golgi/endosome system, analogous to how Wntless chaperones lipidated Wnt in animals?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P32857" data-a="Q: Does PTM1 function as a cargo-binding trafficking ..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Is the apparent lack of a ptm1Δ phenotype due to functional redundancy with the whole-genome-duplication paralog YHL017W?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P32857" data-a="Q: Is the apparent lack of a ptm1Δ phenotype due to f..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> What is the functional significance of the phosphorylation of PTM1&#39;s cytoplasmic acidic tail (Ser480/Thr483/Thr498) — does it regulate localization, turnover, or interaction with trafficking machinery?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P32857" data-a="Q: What is the functional significance of the phospho..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Experiments</h2>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Construct ptm1Δ, yhl017wΔ, and the ptm1Δ yhl017wΔ double mutant and assay for synthetic growth, secretion, glycosylation, and Golgi/endosome morphology defects, including sensitivity to cell-wall stressors (calcofluor white, Congo red) and trafficking-pathway perturbations.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: PTM1 acts redundantly with YHL017W in a Golgi/endosome membrane-trafficking step, so single deletions have little phenotype.</em></p>
+
+
+                    <p style="margin-top: 0.5rem;">Type: genetic epistasis / phenotypic profiling</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P32857" data-a="EXPERIMENT: Construct ptm1Δ, yhl017wΔ, and the ptm1Δ yhl017wΔ ..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Affinity-purify functionally-tagged PTM1 from yeast membranes under mild detergent conditions and identify co-purifying proteins and lipids by mass spectrometry; validate candidate cargoes by testing their localization, stability, or trafficking in ptm1Δ (and ptm1Δ yhl017wΔ) cells.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: PTM1 binds and traffics a specific membrane-associated or lipidated cargo.</em></p>
+
+
+                    <p style="margin-top: 0.5rem;">Type: affinity purification-mass spectrometry / cargo-dependency assay</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P32857" data-a="EXPERIMENT: Affinity-purify functionally-tagged PTM1 from yeas..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Purify recombinant PTM1 (or its 7TM domain), determine its structure by cryo-EM, and use lipidomics/native mass spectrometry to identify co-purifying lipids occupying the predicted 7TM cavity.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: The conserved hydrophobic 7TM cavity of PTM1 (as seen in TMEM87A/WLS) binds a lipid or lipidated peptide.</em></p>
+
+
+                    <p style="margin-top: 0.5rem;">Type: structural biology / native MS lipidomics</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P32857" data-a="EXPERIMENT: Purify recombinant PTM1 (or its 7TM domain), deter..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Knowledge Gaps</h2>
+        <p style="color: #555; font-size: 0.92rem; margin-top: -0.3rem;">
+            What is <em>not</em> known — curated, literature-grounded statements of the open
+            unknowns (the inverse of core functions).
+        </p>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The molecular function of PTM1 is unknown: no enzymatic activity, transported substrate, bound ligand, or channel/receptor activity has been demonstrated, and it is not known whether PTM1 acts as a cargo-binding trafficking chaperone (the leading family hypothesis), a scaffolding/adaptor protein, or something else.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">MF_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> The protein&#39;s domain architecture is firmly established — a cleavable signal peptide, a lumenal N-terminal GOLD-like β-sandwich domain, seven transmembrane helices (GOST_TM / GPR107-GPR108-like fold), and a cytoplasmic acidic tail. For the wider family, structures of TMEM87A and WLS reveal a large hydrophobic 7TM cavity, and WLS is shown to chaperone lipidated Wnt, motivating (but not proving) a lipid/hydrophobic-cargo-binding role for the family.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> PTM1 is the yeast entry point to a conserved, medically relevant but mechanistically enigmatic family (GPR107 in toxin trafficking, GPR108 in AAV transduction, WLS in Wnt secretion); a defined molecular activity in the tractable yeast system would illuminate the whole family.</p>
+
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"Little is known about ligands and the exact function of GOST proteins"</em> — PMID:39609618</li>
+
+                <li><em>"The functional role of GOST proteins is still enigmatic"</em> — PMID:39609618</li>
+
+                <li><em>"We conclude that under these conditions, TMEM87A does not form a mechanosensitive ion channel"</em> — PMID:36373655</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The physiological cargo(es) or interacting client(s) of PTM1 that would define its trafficking role are unidentified; it is unknown which membrane proteins or lipids, if any, depend on PTM1 for their transport, sorting, or retention within the Golgi/endosome system.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">MF_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> PTM1 co-purifies with the late-Golgi/endosomal Tlg2 compartment, and BioGRID records physical/genetic interactions, but no PTM1-dependent cargo has been functionally established. In the paralogous family, WLS has a defined client (Wnt), setting a template for the kind of client relationship sought.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Identifying a PTM1-dependent cargo would convert the family-level &#34;trafficking chaperone&#34; hypothesis into a testable, yeast-defined mechanism.</p>
+
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"it was speculated that GOST proteins might function as trafficking chaperones for membrane-associated cargo"</em> — PMID:39609618</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The biological process PTM1 participates in, and its loss-of-function phenotype, are undefined. No clear phenotype has been reported for the ptm1Δ single mutant, and it is unknown whether the whole-genome-duplication paralog YHL017W provides functional redundancy that masks a phenotype.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">BP_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> Localization to the Golgi/endosome network and an IBA-inferred (unverified in yeast) association with endosome-to-Golgi retrograde transport delimit the plausible process space. PTM1 has a WGD ohnolog, YHL017W, in the same PANTHER subfamily (PTHR21229:SF1), a classic setup for genetic buffering.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> A defined phenotype (ideally in a ptm1Δ yhl017wΔ double mutant) would anchor PTM1 to a specific trafficking step and enable targeted mechanistic study.</p>
+
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"The functional role of GOST proteins is still enigmatic"</em> — PMID:39609618</li>
+
+            </ul>
+
+
+        </div>
+
+    </div>
+
+
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Deep Research Sections -->
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(PTM1-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="P32857" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="ptm1-ykl039w-curation-notes">PTM1 (YKL039W) — curation notes</h1>
+<p>Journal of research for the AI GO-annotation review of <em>Saccharomyces cerevisiae</em> PTM1<br />
+(UniProt P32857, systematic name YKL039W, SGD:S000001522).</p>
+<h2 id="summary-of-the-curation-problem">Summary of the curation problem</h2>
+<p>PTM1 is a <strong>dark / understudied</strong> gene. Its very name PTM1 stands for "<strong>P</strong>utative<br />
+<strong>T</strong>rans<strong>M</strong>embrane protein", coined in the 1993 GenBank submission that first noted it<br />
+"enhances recovery from transformation of a profilin deletion strain" (Haarer, Petzold &amp;<br />
+Brown, submitted to EMBL/GenBank/DDBJ Mar-1993; cited as UniProt reference [1]). No<br />
+dedicated functional study of PTM1 itself has been published. Everything known is<br />
+(a) sequence/topology, (b) one experimental localization (co-purification with a late-Golgi<br />
+compartment), (c) one phosphoproteomic dataset, and (d) inference from the wider<br />
+GPR107/GPR108/TMEM87 (GOST/LUSTR) protein family, whose molecular function is itself<br />
+largely unresolved.</p>
+<p>The primary deliverable is therefore an <strong>honest knowledge_gaps section</strong> plus a carefully<br />
+reasoned localization-grounded description and minimal core_functions — no invented function.</p>
+<h2 id="what-is-known">What is KNOWN</h2>
+<h3 id="sequence-topology-and-domain-architecture-uniprot-p32857-inline-from-ptm1-uniprottxt">Sequence, topology and domain architecture (UniProt P32857, inline from PTM1-uniprot.txt)</h3>
+<ul>
+<li>523 aa, MW 60 kDa, precursor with an N-terminal <strong>signal peptide (1–26)</strong>.</li>
+<li><strong>Seven transmembrane helices</strong> predicted (TM1 198–218, TM2 231–251, TM3 266–286,<br />
+  TM4 305–325, TM5 334–354, TM6 382–402, TM7 418–438), with a large <strong>lumenal<br />
+  N-terminal domain (27–197)</strong> and a <strong>cytoplasmic C-terminal tail (439–523)</strong>. This is the<br />
+  canonical GOST/LUSTR "GOLD-domain + 7TM" architecture (N-terminal lumenal β-sandwich<br />
+  atop a GPCR-like 7TM bundle).</li>
+<li>Pfam / InterPro domains: <strong>GOST_TM (PF06814 / IPR053937)</strong>, <strong>GPR107/GPR108-like<br />
+  (IPR009637)</strong>, <strong>PTM1-like_N (PF21902 / IPR053938)</strong>. UniProt SIMILARITY: "Belongs to the<br />
+  LU7TM family" (LU7TM = Lung Seven TransMembrane / LUSTR).</li>
+<li>PANTHER family <strong>PTHR21229 "LUNG SEVEN TRANSMEMBRANE RECEPTOR"</strong>; PTM1 is in<br />
+  subfamily <strong>PTHR21229:SF1</strong> together with its yeast paralog <strong>YHL017W (P38745)</strong> and the<br />
+<em>S. pombe</em> proteins SPAC26H5.07c / SPBC18A7.02c. The mammalian members GPR107 (SF12),<br />
+  GPR108 (SF11), TMEM87A/TMEM87B (SF19/SF16) sit in <strong>distinct subfamilies</strong> — relevant to<br />
+  how far specific mammalian phenotypes can be transferred to PTM1 (see below).</li>
+<li>One predicted <strong>N-glycosylation site (Asn132)</strong>; UniProt keyword Glycoprotein; single<br />
+  GlyGen/GlyCosmos site → consistent with a lumenal, glycosylated ectodomain of a<br />
+  secretory-pathway membrane protein.</li>
+<li>Disordered, acidic C-terminal region (483–523) carrying three mapped phosphosites.</li>
+<li>Paralog <strong>YHL017W</strong> arose from the whole-genome duplication (ohnolog pair) — a second,<br />
+  equally uncharacterized yeast GOST protein. Possible functional redundancy is a live<br />
+  hypothesis and complicates single-deletion phenotype interpretation.</li>
+</ul>
+<h3 id="subcellular-localization-experimental">Subcellular localization (experimental)</h3>
+<ul>
+<li>UniProt SUBCELLULAR LOCATION (ECO:0000269|PubMed:16107716): <strong>Golgi apparatus membrane;<br />
+  Multi-pass membrane protein. Early endosome membrane; Multi-pass membrane protein.<br />
+  Note=Copurifies with the late Golgi SNARE TLG2.</strong></li>
+<li>Source: Inadome, Noda, Adachi &amp; Yoda 2005 <a href="https://pubmed.ncbi.nlm.nih.gov/16107716">PMID:16107716</a>. This paper immunoisolated<br />
+  yeast Golgi subcompartments using the SNAREs <strong>Sed5 (early Golgi)</strong> and <strong>Tlg2 (late<br />
+  Golgi/endosome)</strong> and catalogued the membrane proteins of each. PTM1/YKL039W was detected<br />
+  among the proteins co-purifying with the <strong>Tlg2 (late-Golgi/endosome) compartment</strong>; that<br />
+  detection is the experimental basis for UniProt's Golgi-membrane / early-endosome-membrane<br />
+  localization. NOTE: the cached full text of PMID:16107716 is abstract + Discussion only<br />
+  (the Results/Tables where YKL039W would be individually listed were not captured in the<br />
+  HTML extraction), so I cannot quote "PTM1"/"YKL039W" verbatim from the cache. The paper's<br />
+  scope is directly on-point:<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/16107716" title="we immunoisolated vesicles carrying either of the SNAREs Sed5 or Tlg2, the   markers of the early and late Golgi compartments, respectively, and analyzed the membrane   proteins">PMID:16107716</a>. The localization annotation itself is a curator-made experimental (SGD/UniProt)<br />
+  call from full text; I defer to it.</li>
+</ul>
+<h3 id="post-translational-modification-experimental-large-scale">Post-translational modification (experimental, large-scale)</h3>
+<ul>
+<li>Phosphorylated at <strong>Ser480, Thr483, Thr498</strong> in the cytoplasmic acidic tail<br />
+  (ECO:0007744|PubMed:18407956, Albuquerque et al. 2008 phosphoproteome). Cached entry for<br />
+  PMID:18407956 is abstract-only (large-scale MS survey); establishes that PTM1 is a<br />
+  phosphoprotein but says nothing about biological role.</li>
+</ul>
+<h3 id="gene-history-naming">Gene history / naming</h3>
+<ul>
+<li>Original functional hint: overexpression "enhances recovery from transformation of a<br />
+  profilin (PFY1) deletion strain" (UniProt ref [1], Haarer/Petzold/Brown 1993 GenBank<br />
+  submission). This is a suppressor-of-transformation-stress observation, NOT a defined<br />
+  molecular function, and has not been followed up mechanistically.</li>
+<li>Sequence had two historical frameshift errors (CAA49300.1, CAA81874.1), corrected in the<br />
+  reference genome; PE=1 (evidence at protein level).</li>
+</ul>
+<h2 id="what-is-not-known-the-gaps">What is NOT known (the gaps)</h2>
+<ul>
+<li><strong>Molecular function</strong>: unknown. No enzymatic activity; no demonstrated ligand, transporter<br />
+  substrate, or channel activity for PTM1 or, in most cases, for the whole GOST family.</li>
+<li><strong>Transported / handled molecule</strong>: unknown. The family is <em>hypothesized</em> (by structural<br />
+  analogy to Wntless, which chaperones lipidated Wnt) to bind hydrophobic cargo/lipid in the<br />
+  7TM cavity, but no cargo is established for PTM1.</li>
+<li><strong>Biological process</strong>: unknown beyond a presumed role in secretory-pathway / Golgi<br />
+  membrane-protein trafficking, inferred from localization and family (IBA).</li>
+<li><strong>Loss-of-function phenotype</strong>: no clear phenotype reported for the <em>ptm1Δ</em> single mutant;<br />
+  the WGD paralog YHL017W may buffer it. BioGRID lists genetic/physical interactions but no<br />
+  defining functional phenotype.</li>
+<li><strong>GPCR-like signaling</strong>: explicitly NOT supported for the family — see family evidence.</li>
+</ul>
+<h2 id="family-orthology-evidence-for-iba-appropriateness-and-gap-framing">Family / orthology evidence (for IBA appropriateness and gap framing)</h2>
+<p>PTM1 is the fungal representative of the GOST (GOLD-domain seven-transmembrane) / LUSTR /<br />
+LU7TM family. Two recent structural papers characterize the family (used here for the<br />
+gene-review references; they concern human paralogs, not PTM1 directly, so relevance to PTM1<br />
+is MEDIUM and localization/mechanism claims are transferred cautiously):</p>
+<ul>
+<li><strong>TMEM87A cryo-EM structure</strong>, Hoel et al. 2022 eLife <a href="https://pubmed.ncbi.nlm.nih.gov/36373655">PMID:36373655</a>:</li>
+<li>Family = GOLD domain + GPCR-like 7TM; proposed common trafficking role:<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/36373655" title="structurally homologous GOST proteins could serve a common role in trafficking">PMID:36373655</a>.</li>
+<li>Not a channel: <a href="https://pubmed.ncbi.nlm.nih.gov/36373655" title="We conclude that under these conditions, TMEM87A does not     form a mechanosensitive ion channel">PMID:36373655</a>.</li>
+<li>Probably not a GPCR: <a href="https://pubmed.ncbi.nlm.nih.gov/36373655" title="these differences suggest that TMEM87A may not     couple to G proteins or arrestins like canonical GPCRs">PMID:36373655</a>.</li>
+<li><strong>GPR180 / GOST review+structure</strong>, 2024 Commun Biol <a href="https://pubmed.ncbi.nlm.nih.gov/39609618">PMID:39609618</a>:</li>
+<li><a href="https://pubmed.ncbi.nlm.nih.gov/39609618" title="Little is known about ligands and the exact function of GOST proteins">PMID:39609618</a>.</li>
+<li><a href="https://pubmed.ncbi.nlm.nih.gov/39609618" title="it was speculated that GOST proteins might function as trafficking     chaperones for membrane-associated cargo">PMID:39609618</a>.</li>
+<li><a href="https://pubmed.ncbi.nlm.nih.gov/39609618" title="The functional role of GOST proteins is still enigmatic">PMID:39609618</a>.</li>
+</ul>
+<p>Mammalian family members have specific reported roles (GPR107: retrograde toxin transport,<br />
+receptor recycling; GPR108: AAV transduction; WLS: Wnt secretion chaperone) but these map to<br />
+<strong>different PANTHER subfamilies</strong> than PTM1 (SF1). The conserved thread across the whole<br />
+family — including the fungal SF1 branch — is <strong>Golgi/endosome localization and a presumed<br />
+role in membrane-trafficking of hydrophobic/membrane-associated cargo</strong>, with molecular<br />
+mechanism unresolved. Transferring a specific mammalian phenotype (e.g. AAV transduction,<br />
+Wnt secretion) to yeast PTM1 would be over-annotation; transferring the general<br />
+Golgi-localization + trafficking-context is defensible but should stay non-core / general.</p>
+<h2 id="annotation-by-annotation-reasoning-10-goa-annotations-all-ibaieand">Annotation-by-annotation reasoning (10 GOA annotations, all IBA/IEA/ND)</h2>
+<ol>
+<li><strong>GO:0005794 Golgi apparatus</strong> (IBA, GO_REF:0000033) — ACCEPT. Consistent with the<br />
+   experimental co-purification with the Tlg2 late-Golgi compartment (PMID:16107716) and<br />
+   family-wide Golgi localization. Core localization.</li>
+<li><strong>GO:0016020 membrane</strong> (IBA, GO_REF:0000033) — MODIFY→ generalize is not needed but the<br />
+   bare "membrane" is uninformative given we know it is a Golgi/endosome multi-pass membrane<br />
+   protein. Keep as non-core (it is a true but shallow parent of the specific CC terms).</li>
+<li><strong>GO:0042147 retrograde transport, endosome to Golgi</strong> (IBA, GO_REF:0000033) — this is the<br />
+   only BP annotation with any specific content. It is IBA-transferred from mammalian<br />
+   orthologs (with/from includes UniProtKB:Q8NBN3 GPR108, Q96K49 TMEM87B). There is no<br />
+<em>direct</em> yeast evidence that PTM1 mediates endosome-to-Golgi retrograde transport;<br />
+   however the localization (late-Golgi/endosome) is compatible and the family is<br />
+   trafficking-associated. Given no yeast experimental support and subfamily divergence,<br />
+   KEEP_AS_NON_CORE (plausible process context, not an established core function). Do NOT<br />
+   REMOVE — it is a reasonable phylogenetic inference and the process is compatible with<br />
+   localization.</li>
+<li><strong>GO:0000139 Golgi membrane</strong> (IEA, GO_REF:0000044, from UniProt SubCell) — ACCEPT. This<br />
+   is the specific, experimentally-grounded localization; core.</li>
+<li><strong>GO:0005829 cytosol</strong> (IEA, GO_REF:0000108) — over-annotation. Derived by logical<br />
+   inference from the retrograde-transport BP term (with/from GO:0042147), not from any<br />
+   evidence PTM1 is a soluble cytosolic protein. PTM1 is a multi-pass integral membrane<br />
+   protein; the cytosolic C-tail does not make the protein "cytosol"-localized in the CC<br />
+   sense. MARK_AS_OVER_ANNOTATED.</li>
+<li><strong>GO:0016020 membrane</strong> (IEA, GO_REF:0000002, InterPro IPR009637) — ACCEPT (true,<br />
+   uninformative parent; keep as non-core). Redundant with the IBA membrane term but<br />
+   correctly reflects integral-membrane status.</li>
+<li><strong>GO:0031901 early endosome membrane</strong> (IEA, GO_REF:0000044, UniProt SubCell) — ACCEPT.<br />
+   Experimentally grounded (PMID:16107716 endosome/late-Golgi copurification). Non-core<br />
+   secondary localization.</li>
+<li><strong>GO:0003674 molecular_function</strong> (ND, GO_REF:0000015) — ACCEPT (root ND). Honestly<br />
+   reflects that no molecular function is known — appropriate for a dark gene. Keep.</li>
+<li><strong>GO:0005575 cellular_component</strong> (ND, GO_REF:0000015) — this ND root CC is now<br />
+   superseded by the specific Golgi/endosome CC annotations above. MARK_AS_OVER_ANNOTATED /<br />
+   effectively obsolete-by-newer-evidence; recommend it not be treated as core. (Per<br />
+   guidance, GOA ND roots are usually left; flag as non-core.)</li>
+<li><strong>GO:0008150 biological_process</strong> (ND, GO_REF:0000015) — root ND BP; superseded by the<br />
+    IBA retrograde-transport BP. Keep as-is / non-core; honest reflection of limited BP<br />
+    knowledge.</li>
+</ol>
+<h2 id="decisions-on-core_functions">Decisions on core_functions</h2>
+<ul>
+<li>Core function statements must stay minimal and localization-grounded. The only defensible<br />
+  "core" is: <strong>integral Golgi/endosome membrane protein of the GOST/LUSTR family, presumed<br />
+  to act in secretory-pathway membrane-protein trafficking; molecular function unknown.</strong></li>
+<li>Use CC terms for locations (Golgi membrane / early endosome membrane). Do NOT assert a<br />
+  specific MF (no ligand/channel/enzyme evidence). If a MF is required by schema, the honest<br />
+  choice is not to fabricate one; core_functions can describe the trafficking-context role<br />
+  with molecular_function left unstated or as the general integral-membrane framing.</li>
+</ul>
+<h2 id="deep-research-status">Deep research status</h2>
+<p>Falcon deep-research (<code>just deep-research-falcon yeast PTM1 --fallback perplexity-lite</code>) was<br />
+attempted twice and hung both times (~24 min with zero output on the first run; SIGTERM at the<br />
+500 s bound on the retry). No <code>-deep-research-falcon.md</code> file was produced, and none was<br />
+fabricated (per repo policy, self-written content must NOT be named <code>-deep-research-*</code>). This<br />
+review is therefore grounded directly in the UniProt record (P32857), the QuickGO GOA export,<br />
+the PANTHER PTHR21229 family data, and four cached primary/structural publications<br />
+(PMID:16107716, 18407956, 36373655, 39609618), all with verbatim-verified supporting text.</p>
+<h2 id="provenance-of-cached-publications">Provenance of cached publications</h2>
+<ul>
+<li>publications/PMID_16107716.md — Inadome 2005 (full text = abstract+Discussion only in cache).</li>
+<li>publications/PMID_18407956.md — Albuquerque 2008 phosphoproteome (abstract only).</li>
+<li>publications/PMID_36373655.md — Hoel 2022 TMEM87A structure (full text).</li>
+<li>publications/PMID_39609618.md — 2024 GPR180/GOST (full text).</li>
+<li>interpro/panther/PTHR21229/ — family metadata + reviewed members (subfamily assignments).</li>
+</ul>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: P32857
+gene_symbol: PTM1
+product_type: PROTEIN
+status: IN_PROGRESS
+taxon:
+  id: NCBITaxon:559292
+  label: Saccharomyces cerevisiae
+description: &gt;-
+  PTM1 (YKL039W) is a polytopic integral membrane protein of the budding yeast
+  secretory pathway. It has the architecture characteristic of the GOST/LUSTR
+  (GOLD-domain seven-transmembrane, also called Lung Seven TransMembrane) protein
+  family: a cleavable N-terminal signal peptide, a large lumenal N-terminal
+  β-sandwich domain, and a GPCR-like bundle of seven transmembrane helices, ending
+  in a cytoplasmic, disordered, acidic and phosphorylated C-terminal tail. The
+  lumenal domain carries a predicted N-glycosylation site. PTM1 localizes to the
+  Golgi apparatus membrane and the early endosome membrane, and co-purifies with
+  the late-Golgi/endosomal SNARE Tlg2. It is the fungal representative of the
+  family that in animals includes GPR107, GPR108, TMEM87A/TMEM87B, GPR180 and
+  Wntless (WLS); yeast additionally has a whole-genome-duplication paralog,
+  YHL017W. Members of this family are Golgi/endosome-resident proteins broadly
+  associated with membrane-protein trafficking through the secretory and endosomal
+  system, and are thought to act as trafficking chaperones for membrane-associated
+  or hydrophobic cargo rather than as signalling GPCRs, but no molecular function,
+  substrate or ligand has been established for PTM1, and its precise cellular role
+  remains undefined.
+references:
+- id: GO_REF:0000002
+  title: Gene Ontology annotation through association of InterPro records with GO
+    terms
+  findings: []
+- id: GO_REF:0000015
+  title: Use of the ND evidence code for Gene Ontology (GO) terms
+  findings: []
+- id: GO_REF:0000033
+  title: Annotation inferences using phylogenetic trees
+  findings: []
+- id: GO_REF:0000044
+  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location
+    vocabulary mapping, accompanied by conservative changes to GO terms applied by
+    UniProt
+  findings: []
+- id: GO_REF:0000108
+  title: Automatic assignment of GO terms using logical inference, based on on inter-ontology
+    links
+  findings: []
+- id: PMID:16107716
+  title: &#39;Immunoisolaton of the yeast Golgi subcompartments and characterization of
+    a novel membrane protein, Svp26, discovered in the Sed5-containing compartments.&#39;
+  findings:
+  - statement: &gt;-
+      Immunoisolated yeast Golgi subcompartments using the SNAREs Sed5 (early Golgi)
+      and Tlg2 (late Golgi/endosome) and catalogued their membrane proteins; PTM1
+      (YKL039W) co-purified with the Tlg2 late-Golgi/endosome compartment, the
+      experimental basis for its Golgi-membrane and early-endosome-membrane
+      localization.
+    supporting_text: &gt;-
+      we immunoisolated vesicles carrying either of the SNAREs Sed5 or Tlg2, the
+      markers of the early and late Golgi compartments, respectively, and analyzed
+      the membrane proteins
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PubMed/PMC-verified (Mol Cell Biol 2005). This is the source of the UniProt
+      experimental subcellular-location annotation for PTM1 (Golgi/early-endosome
+      membrane; copurifies with Tlg2). The cached full text is abstract+Discussion
+      only, so the individual detection of YKL039W in the Tlg2 fraction (Results
+      tables) is not quotable from the cache, but the paper&#39;s method and scope
+      directly establish the localization; the annotation is a curator call from
+      full text and is deferred to.
+- id: PMID:18407956
+  title: A multidimensional chromatography technology for in-depth phosphoproteome
+    analysis.
+  findings:
+  - statement: &gt;-
+      Large-scale phosphoproteomic survey identifying PTM1 phosphorylation at
+      Ser480, Thr483 and Thr498 in its cytoplasmic C-terminal tail.
+    supporting_text: &gt;-
+      A multidimensional chromatography technology for in-depth phosphoproteome
+      analysis
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PubMed-verified (Mol Cell Proteomics 2008); abstract-only in cache. Establishes
+      that PTM1 is a phosphoprotein (Ser480/Thr483/Thr498 per UniProt MOD_RES) but
+      provides no functional interpretation.
+- id: PMID:36373655
+  title: Structure of the GOLD-domain seven-transmembrane helix protein family member
+    TMEM87A.
+  findings:
+  - statement: &gt;-
+      Defines the GOST family (GOLD domain fused to a GPCR-like 7TM domain, the
+      architecture shared by PTM1) and proposes a common membrane-trafficking role;
+      shows the human paralog TMEM87A is neither a mechanosensitive channel nor a
+      canonical G-protein-coupled receptor.
+    supporting_text: &gt;-
+      structurally homologous GOST proteins could serve a common role in trafficking
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PubMed/PMC-verified (eLife 2022). Characterizes the human family member
+      TMEM87A, not PTM1 directly, so relevance to yeast PTM1 is family-level
+      (MEDIUM). Verbatim-quote-checked: also states TMEM87A &#34;does not form a
+      mechanosensitive ion channel&#34; and &#34;may not couple to G proteins or arrestins
+      like canonical GPCRs&#34; — used to argue against fabricating a channel/GPCR
+      molecular function for PTM1.
+- id: PMID:39609618
+  title: GPR180 is a new member of the Golgi-dynamics domain seven-transmembrane helix
+    protein family.
+  findings:
+  - statement: &gt;-
+      Reviews the GOST/GDD seven-transmembrane family: members localize to the
+      Golgi/endosomal network and are speculated to act as trafficking chaperones
+      for membrane-associated cargo, but their molecular function and ligands remain
+      largely unknown.
+    supporting_text: &gt;-
+      Little is known about ligands and the exact function of GOST proteins
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PubMed/PMC-verified (Commun Biol 2024). Family-level source (concerns GPR180
+      and the wider GOST family, not PTM1 directly). Verbatim-quote-checked:
+      &#34;it was speculated that GOST proteins might function as trafficking chaperones
+      for membrane-associated cargo&#34; and &#34;The functional role of GOST proteins is
+      still enigmatic&#34; — supports the knowledge-gap framing for PTM1.
+existing_annotations:
+- term:
+    id: GO:0005794
+    label: Golgi apparatus
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: is_active_in
+  review:
+    summary: &gt;-
+      Golgi localization is supported both by phylogenetic inference from the
+      GOST/LUSTR family (which is broadly Golgi/endosome-resident) and by direct
+      experimental co-purification of PTM1 with the yeast late-Golgi compartment.
+    action: ACCEPT
+    reason: &gt;-
+      Consistent with the experimental subcellular localization (PMID:16107716,
+      copurification with the Tlg2 late-Golgi/endosome compartment) and with
+      family-wide Golgi localization. This is a well-supported core localization.
+    supported_by:
+    - reference_id: PMID:16107716
+      supporting_text: &gt;-
+        we immunoisolated vesicles carrying either of the SNAREs Sed5 or Tlg2, the
+        markers of the early and late Golgi compartments, respectively, and analyzed
+        the membrane proteins
+- term:
+    id: GO:0016020
+    label: membrane
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: is_active_in
+  review:
+    summary: &gt;-
+      PTM1 is an integral, multi-pass (seven-transmembrane) membrane protein, so
+      &#34;membrane&#34; is factually correct but uninformative given the more specific
+      Golgi-membrane and early-endosome-membrane annotations.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      True but shallow parent term; the specific compartment (Golgi/endosome
+      membrane) annotations are more informative. Retain as non-core.
+- term:
+    id: GO:0042147
+    label: retrograde transport, endosome to Golgi
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      The only biological-process annotation with specific content. Transferred by
+      phylogenetic inference from mammalian orthologs (with/from GPR108/TMEM87B).
+      Compatible with PTM1&#39;s late-Golgi/endosome localization, but there is no
+      direct yeast experimental evidence that PTM1 mediates endosome-to-Golgi
+      retrograde transport, and PTM1 sits in a distinct PANTHER subfamily (SF1) from
+      the mammalian members the annotation derives from.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Reasonable, localization-compatible phylogenetic inference, but unverified for
+      yeast and subfamily-diverged; keep as a plausible process context rather than
+      an established core function. Not removed, per guidance that IBA process
+      inferences compatible with localization should not be second-guessed away.
+- term:
+    id: GO:0000139
+    label: Golgi membrane
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000044
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Specific, experimentally-grounded localization derived from the UniProt
+      Swiss-Prot subcellular-location mapping (Golgi apparatus membrane;
+      multi-pass), which itself rests on PMID:16107716.
+    action: ACCEPT
+    reason: &gt;-
+      Precise and correct localization for a multi-pass Golgi membrane protein;
+      core localization.
+    supported_by:
+    - reference_id: PMID:16107716
+      supporting_text: &gt;-
+        we immunoisolated vesicles carrying either of the SNAREs Sed5 or Tlg2, the
+        markers of the early and late Golgi compartments, respectively, and analyzed
+        the membrane proteins
+- term:
+    id: GO:0005829
+    label: cytosol
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000108
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Assigned by automated logical inference from the retrograde-transport process
+      term (with/from GO:0042147), not from evidence that PTM1 is a soluble
+      cytosolic protein. PTM1 is a polytopic integral membrane protein; only its
+      C-terminal tail faces the cytoplasm.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      Misleading as a cellular-component assignment for an integral membrane
+      protein; it is an artefact of inter-ontology logical inference from the BP
+      term rather than a bona fide localization.
+- term:
+    id: GO:0016020
+    label: membrane
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      InterPro2GO (IPR009637, GPR107/GPR108-like) correctly infers integral-membrane
+      status. Redundant with the IBA membrane term and uninformative relative to the
+      Golgi/endosome-membrane annotations.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Correct but shallow parent; retain as non-core supporting the integral
+      membrane nature.
+- term:
+    id: GO:0031901
+    label: early endosome membrane
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000044
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Secondary localization from the UniProt subcellular-location mapping, grounded
+      in the PMID:16107716 co-purification with the late-Golgi/endosome (Tlg2)
+      compartment.
+    action: ACCEPT
+    reason: &gt;-
+      Experimentally grounded secondary localization; correct and specific. Non-core
+      relative to the primary Golgi localization.
+    supported_by:
+    - reference_id: PMID:16107716
+      supporting_text: &gt;-
+        we immunoisolated vesicles carrying either of the SNAREs Sed5 or Tlg2, the
+        markers of the early and late Golgi compartments, respectively, and analyzed
+        the membrane proteins
+- term:
+    id: GO:0003674
+    label: molecular_function
+  evidence_type: ND
+  original_reference_id: GO_REF:0000015
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Root molecular-function term with the ND (no biological data) evidence code.
+      This is an honest reflection of the state of knowledge: no molecular function,
+      enzymatic activity, ligand or transported substrate has been established for
+      PTM1, and the wider GOST family&#39;s molecular function is itself unresolved.
+    action: ACCEPT
+    reason: &gt;-
+      Appropriate ND annotation for a gene whose molecular function is genuinely
+      unknown; retaining it correctly signals the molecular-function knowledge gap.
+- term:
+    id: GO:0005575
+    label: cellular_component
+  evidence_type: ND
+  original_reference_id: GO_REF:0000015
+  qualifier: is_active_in
+  review:
+    summary: &gt;-
+      Root cellular-component ND annotation. It is now superseded by the specific,
+      experimentally-grounded Golgi-membrane and early-endosome-membrane
+      annotations.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      No longer reflects the state of knowledge now that specific compartment
+      localizations are annotated; should not be treated as core. (An ND root
+      annotation that specific evidence has overtaken.)
+- term:
+    id: GO:0008150
+    label: biological_process
+  evidence_type: ND
+  original_reference_id: GO_REF:0000015
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Root biological-process ND annotation, reflecting that the specific biological
+      role of PTM1 in yeast has not been experimentally determined. A more specific
+      (though still inferred) BP annotation exists via the IBA
+      endosome-to-Golgi-retrograde-transport term.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Honestly reflects the limited process-level knowledge; retained as non-core
+      given the only specific BP term is an unverified phylogenetic inference.
+core_functions:
+- description: &gt;-
+    PTM1 is a polytopic integral membrane protein resident in the Golgi apparatus
+    membrane and early endosome membrane of the budding-yeast secretory/endosomal
+    system, where it co-purifies with the late-Golgi/endosomal SNARE Tlg2. It is
+    the fungal member of the GOST/LUSTR (GOLD-domain seven-transmembrane) family,
+    whose members are broadly implicated in membrane-protein trafficking through the
+    Golgi and endosomal network and are proposed to act as trafficking chaperones
+    for membrane-associated or hydrophobic cargo rather than as signalling GPCRs. No
+    specific molecular function, ligand or transported substrate has been
+    established for PTM1; this core function is therefore stated at the level of a
+    localization-defined, family-associated role in intracellular membrane
+    trafficking, with the molecular mechanism left undefined (see knowledge_gaps).
+  locations:
+  - id: GO:0000139
+    label: Golgi membrane
+  - id: GO:0031901
+    label: early endosome membrane
+  supported_by:
+  - reference_id: PMID:16107716
+    supporting_text: &gt;-
+      we immunoisolated vesicles carrying either of the SNAREs Sed5 or Tlg2, the
+      markers of the early and late Golgi compartments, respectively, and analyzed
+      the membrane proteins
+  - reference_id: PMID:39609618
+    supporting_text: &gt;-
+      it was speculated that GOST proteins might function as trafficking chaperones
+      for membrane-associated cargo
+knowledge_gaps:
+- gap_statement: &gt;-
+    The molecular function of PTM1 is unknown: no enzymatic activity, transported
+    substrate, bound ligand, or channel/receptor activity has been demonstrated, and
+    it is not known whether PTM1 acts as a cargo-binding trafficking chaperone (the
+    leading family hypothesis), a scaffolding/adaptor protein, or something else.
+  boundary: &gt;-
+    The protein&#39;s domain architecture is firmly established — a cleavable signal
+    peptide, a lumenal N-terminal GOLD-like β-sandwich domain, seven transmembrane
+    helices (GOST_TM / GPR107-GPR108-like fold), and a cytoplasmic acidic tail. For
+    the wider family, structures of TMEM87A and WLS reveal a large hydrophobic 7TM
+    cavity, and WLS is shown to chaperone lipidated Wnt, motivating (but not
+    proving) a lipid/hydrophobic-cargo-binding role for the family.
+  gap_kind:
+  - BIOLOGY
+  dark_aspect: MF_DARK
+  status: OPEN
+  significance: &gt;-
+    PTM1 is the yeast entry point to a conserved, medically relevant but
+    mechanistically enigmatic family (GPR107 in toxin trafficking, GPR108 in AAV
+    transduction, WLS in Wnt secretion); a defined molecular activity in the
+    tractable yeast system would illuminate the whole family.
+  provenance:
+  - reference_id: PMID:39609618
+    supporting_text: &gt;-
+      Little is known about ligands and the exact function of GOST proteins
+  - reference_id: PMID:39609618
+    supporting_text: &gt;-
+      The functional role of GOST proteins is still enigmatic
+  - reference_id: PMID:36373655
+    supporting_text: &gt;-
+      We conclude that under these conditions, TMEM87A does not form a
+      mechanosensitive ion channel
+- gap_statement: &gt;-
+    The physiological cargo(es) or interacting client(s) of PTM1 that would define
+    its trafficking role are unidentified; it is unknown which membrane proteins or
+    lipids, if any, depend on PTM1 for their transport, sorting, or retention within
+    the Golgi/endosome system.
+  boundary: &gt;-
+    PTM1 co-purifies with the late-Golgi/endosomal Tlg2 compartment, and BioGRID
+    records physical/genetic interactions, but no PTM1-dependent cargo has been
+    functionally established. In the paralogous family, WLS has a defined client
+    (Wnt), setting a template for the kind of client relationship sought.
+  gap_kind:
+  - BIOLOGY
+  dark_aspect: MF_DARK
+  status: OPEN
+  significance: &gt;-
+    Identifying a PTM1-dependent cargo would convert the family-level
+    &#34;trafficking chaperone&#34; hypothesis into a testable, yeast-defined mechanism.
+  provenance:
+  - reference_id: PMID:39609618
+    supporting_text: &gt;-
+      it was speculated that GOST proteins might function as trafficking chaperones
+      for membrane-associated cargo
+- gap_statement: &gt;-
+    The biological process PTM1 participates in, and its loss-of-function phenotype,
+    are undefined. No clear phenotype has been reported for the ptm1Δ single mutant,
+    and it is unknown whether the whole-genome-duplication paralog YHL017W provides
+    functional redundancy that masks a phenotype.
+  boundary: &gt;-
+    Localization to the Golgi/endosome network and an IBA-inferred (unverified in
+    yeast) association with endosome-to-Golgi retrograde transport delimit the
+    plausible process space. PTM1 has a WGD ohnolog, YHL017W, in the same PANTHER
+    subfamily (PTHR21229:SF1), a classic setup for genetic buffering.
+  gap_kind:
+  - BIOLOGY
+  dark_aspect: BP_DARK
+  status: OPEN
+  significance: &gt;-
+    A defined phenotype (ideally in a ptm1Δ yhl017wΔ double mutant) would anchor
+    PTM1 to a specific trafficking step and enable targeted mechanistic study.
+  provenance:
+  - reference_id: PMID:39609618
+    supporting_text: &gt;-
+      The functional role of GOST proteins is still enigmatic
+proposed_new_terms: []
+suggested_questions:
+- question: &gt;-
+    Does PTM1 function as a cargo-binding trafficking chaperone for a specific
+    membrane protein or lipid in the yeast Golgi/endosome system, analogous to how
+    Wntless chaperones lipidated Wnt in animals?
+  experts: []
+- question: &gt;-
+    Is the apparent lack of a ptm1Δ phenotype due to functional redundancy with the
+    whole-genome-duplication paralog YHL017W?
+  experts: []
+- question: &gt;-
+    What is the functional significance of the phosphorylation of PTM1&#39;s cytoplasmic
+    acidic tail (Ser480/Thr483/Thr498) — does it regulate localization, turnover, or
+    interaction with trafficking machinery?
+  experts: []
+suggested_experiments:
+- hypothesis: &gt;-
+    PTM1 acts redundantly with YHL017W in a Golgi/endosome membrane-trafficking step,
+    so single deletions have little phenotype.
+  description: &gt;-
+    Construct ptm1Δ, yhl017wΔ, and the ptm1Δ yhl017wΔ double mutant and assay for
+    synthetic growth, secretion, glycosylation, and Golgi/endosome morphology
+    defects, including sensitivity to cell-wall stressors (calcofluor white, Congo
+    red) and trafficking-pathway perturbations.
+  experiment_type: genetic epistasis / phenotypic profiling
+- hypothesis: &gt;-
+    PTM1 binds and traffics a specific membrane-associated or lipidated cargo.
+  description: &gt;-
+    Affinity-purify functionally-tagged PTM1 from yeast membranes under mild
+    detergent conditions and identify co-purifying proteins and lipids by
+    mass spectrometry; validate candidate cargoes by testing their localization,
+    stability, or trafficking in ptm1Δ (and ptm1Δ yhl017wΔ) cells.
+  experiment_type: affinity purification-mass spectrometry / cargo-dependency assay
+- hypothesis: &gt;-
+    The conserved hydrophobic 7TM cavity of PTM1 (as seen in TMEM87A/WLS) binds a
+    lipid or lipidated peptide.
+  description: &gt;-
+    Purify recombinant PTM1 (or its 7TM domain), determine its structure by cryo-EM,
+    and use lipidomics/native mass spectrometry to identify co-purifying lipids
+    occupying the predicted 7TM cavity.
+  experiment_type: structural biology / native MS lipidomics
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/genes/yeast/SET6/SET6-ai-review.html
+++ b/genes/yeast/SET6/SET6-ai-review.html
@@ -1,0 +1,3105 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>SET6 - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        .propagation-review {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f8fafc;
+            border-left: 3px solid #64748b;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .propagation-title {
+            font-weight: 600;
+            color: #334155;
+            margin-bottom: 0.25rem;
+        }
+
+        .propagation-row {
+            margin-top: 0.25rem;
+        }
+
+        .propagation-source {
+            margin-top: 0.5rem;
+            padding-top: 0.5rem;
+            border-top: 1px solid #e5e7eb;
+        }
+
+        .propagation-source-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #1d4ed8;
+        }
+
+        .propagation-comment {
+            color: #4b5563;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>SET6</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/Q12529" target="_blank" class="term-link">
+                        Q12529
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Saccharomyces cerevisiae</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-initialized">
+                    INITIALIZED
+                </span>
+            </div>
+
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "SET6";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="Q12529" data-a="DESCRIPTION: SET6 (systematic name YPL165C) is a 373-residue Sa..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>SET6 (systematic name YPL165C) is a 373-residue Saccharomyces cerevisiae protein belonging to the SET-domain (Su(var)3-9, Enhancer-of-zeste, Trithorax) class of the class V-like SAM-binding methyltransferase superfamily. It is one of the two budding-yeast members of the SMYD subfamily (its paralog being Set5) and is annotated as a putative protein-lysine methyltransferase. Its SET domain retains the invariant catalytic and S-adenosyl-L-methionine-binding residues that the catalytically dead yeast SET proteins Set3 and Set4 have lost, so SET6 is considered a likely catalytically competent enzyme, and it carries a cysteine-rich SMYD-type zinc-binding architecture. However, no methyltransferase activity, protein substrate, subcellular localization, or defined biological role has been experimentally established for SET6; the only reported phenotype is a drug-conditional fitness effect (resistance to compounds targeting ergosterol biosynthesis) from a genome-wide chemogenomic screen, whose molecular basis is unclear.</p>
+    </div>
+
+
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016279" target="_blank" class="term-link">
+                                    GO:0016279
+                                </a>
+                            </span>
+                            <span class="term-label">protein-lysine N-methyltransferase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q12529" data-a="GO:0016279" data-r="GO_REF:0000033" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Best-supported molecular function for SET6: a putative, likely catalytically competent protein-lysine methyltransferase. The SET/SMYD active site is intact (unlike Set3/Set4) and the literature singles out Set6 as the yeast SET protein most likely to be a genuine protein methyltransferase. Retained as the enzyme&#39;s likely function but kept non-core because no methyltransferase activity or substrate has been demonstrated.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Phylogenetically inferred (IBA) but strongly corroborated. On sequence, SET6 retains the invariant catalytic/SAM-binding residues (NHSC pocket, catalytic Tyr337) that the catalytically dead Set3/Set4 have lost, and the literature explicitly calls Set6 the most likely genuine yeast protein methyltransferase. This lysine-KMT level (rather than the more specific histone-MTase term) is the defensible molecular function. It remains putative because no in-vitro/in-vivo activity or substrate has been shown, so it is kept as a non-core, likely-true function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/37252976" target="_blank" class="term-link">
+                                        PMID:37252976
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Of these three putative methyltransferases, the most likely protein methyltransferase is Set6, as the SET domain invariably methylates proteins.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:yeast/SET6/SET6-bioinformatics/RESULTS.md
+
+                                </span>
+
+                                <div class="support-text">The invariant Asn-His of the &#34;NHSC&#34; AdoMet/catalytic motif is **conserved in SET6** (Asn303-His304-Ser305-Cys306), exactly as in the active enzymes Set1, Set2, Set5, SMYD2 and SMYD3.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042054" target="_blank" class="term-link">
+                                    GO:0042054
+                                </a>
+                            </span>
+                            <span class="term-label">histone methyltransferase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q12529" data-a="GO:0042054" data-r="GO_REF:0000033" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Over-specific substrate assignment. The defensible function for SET6 is protein-lysine methyltransferase activity (GO:0016279); no histone substrate has been demonstrated, and the SMYD subfamily to which Set6 belongs (and human SETD6) act largely on non-histone targets. The histone-specific term is an over-annotation.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> This IBA term over-specifies the substrate to histones. Set6 has no identified substrate of any kind, and the SMYD family it belongs to has well-documented non-histone targets, so restricting the predicted activity to histones is not supported. The parent-level protein-lysine methyltransferase activity (GO:0016279) already captures the family-inferred function without the unwarranted histone specificity. Prefer the generic KMT term over this one.
+                        </div>
+
+
+
+                        <div class="propagation-review">
+                            <div class="propagation-title">Propagation Review</div>
+                            <div class="propagation-row">
+                                <strong>Root cause:</strong>
+                                <span class="badge">TERM SCOPING PROBLEM</span>
+                            </div>
+
+                            <div class="propagation-row">
+                                <strong>Failure modes:</strong>
+
+                                <span class="badge">GRANULARITY MISMATCH</span>
+
+                                <span class="badge">FUNCTIONAL DIVERGENCE</span>
+
+                            </div>
+
+
+                            <div class="propagation-source">
+                                <strong>Sources checked:</strong>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">PANTHER:PTN008534456</span>
+
+                                    &middot; SMYD-family PANTHER node (PTHR12197) from which the IBA histone-MTase term was propagated
+
+
+                                    <span class="badge">SUPPORTS SOURCE BUT NOT TARGET</span>
+
+
+                                    <div class="propagation-comment">Family node is a bona fide protein-lysine methyltransferase group, but the histone-specific substrate does not transfer to Set6, whose substrate is unknown and whose SMYD subfamily acts largely on non-histone targets.</div>
+
+                                </div>
+
+                            </div>
+
+                        </div>
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016279" target="_blank" class="term-link">
+                                    protein-lysine N-methyltransferase activity
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/31642774" target="_blank" class="term-link">
+                                        PMID:31642774
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Set5, and another member of this sub-group, Set6, are homologous to the mammalian SMYD proteins [6], which have been reported to have both histone and non-histone targets.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/37252976" target="_blank" class="term-link">
+                                        PMID:37252976
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">If they are in fact protein methyltransferases, they are most likely to target as-yet undiscovered methylation sites</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005634" target="_blank" class="term-link">
+                                    GO:0005634
+                                </a>
+                            </span>
+                            <span class="term-label">nucleus</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q12529" data-a="GO:0005634" data-r="GO_REF:0000033" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Plausible location by SMYD-family phylogenetic transfer, but the subcellular localization of Set6 has never actually been measured, so this is a low-confidence, non-core annotation. Its paralog Set5 is found in both nucleus and cytoplasm.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> IBA family transfer to nucleus is reasonable for a SET/SMYD protein, but the localization of Set6 specifically is explicitly unknown, and its SMYD paralog Set5 is in fact dual nuclear/cytoplasmic, which would be consistent with non-histone substrates. Retain as a non-core, unverified location rather than a defining feature.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/31642774" target="_blank" class="term-link">
+                                        PMID:31642774
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">While the subcellular localization of Set6 is not yet known, Set5 is found in both the nucleus and cytoplasm [19], suggesting it is also likely to have non-histone substrates.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006338" target="_blank" class="term-link">
+                                    GO:0006338
+                                </a>
+                            </span>
+                            <span class="term-label">chromatin remodeling</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000108
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-remove">
+                            REMOVE
+                        </span>
+                        <span class="vote-buttons" data-g="Q12529" data-a="GO:0006338" data-r="GO_REF:0000108" data-act="REMOVE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Automatic inter-ontology inference chained off the over-annotated histone methyltransferase term. There is no evidence that Set6 participates in chromatin remodeling; the biological process is unknown. Remove along with its over-specific parent MF term.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> This IEA annotation is derived by logical inference (GO_REF:0000108) from GO:0042054 histone methyltransferase activity (see the with/from field GO:0042054 in GOA), which is itself an over-annotation for SET6. Set6 has no demonstrated histone activity, no identified substrate, and no measured chromatin role; deletion has no standalone growth phenotype. The inference collapses once the histone-MTase premise is removed, so the chromatin-remodeling process assignment is unsupported and should be removed.
+                        </div>
+
+
+
+                        <div class="propagation-review">
+                            <div class="propagation-title">Propagation Review</div>
+                            <div class="propagation-row">
+                                <strong>Root cause:</strong>
+                                <span class="badge">TERM SCOPING PROBLEM</span>
+                            </div>
+
+                            <div class="propagation-row">
+                                <strong>Failure modes:</strong>
+
+                                <span class="badge">GRANULARITY MISMATCH</span>
+
+                            </div>
+
+
+                            <div class="propagation-source">
+                                <strong>Sources checked:</strong>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">GO:0042054</span>
+
+                                    &middot; histone methyltransferase activity (the over-annotated MF term this IEA process was logically inferred from)
+
+
+                                    <span class="badge">SOURCE WEAK OR INFERRED</span>
+
+
+                                    <div class="propagation-comment">The inter-ontology IEA process is chained off an over-specific, itself-inferred MF term; it has no independent support for a chromatin role in Set6.</div>
+
+                                </div>
+
+                            </div>
+
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/37252976" target="_blank" class="term-link">
+                                        PMID:37252976
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">If they are in fact protein methyltransferases, they are most likely to target as-yet undiscovered methylation sites</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008270" target="_blank" class="term-link">
+                                    GO:0008270
+                                </a>
+                            </span>
+                            <span class="term-label">zinc ion binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">RCA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/30358795" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:30358795
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The cellular economy of the Saccharomyces cerevisiae zinc pr...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q12529" data-a="GO:0008270" data-r="PMID:30358795" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Computational (zinc-proteome) prediction that SET6 binds zinc, independently corroborated by its cysteine-rich SMYD-type zinc-knot/post-SET architecture. A plausible structural molecular function; kept as non-core because it is a structural, not the defining, activity.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The RCA annotation comes from a genome-scale zinc-proteome analysis. It is supported by the local bioinformatics finding that SET6 is markedly Cys-rich (17 Cys, 4.6%) in three clusters (N-terminal CxxC, an internal-insert cluster, and a C-terminal post-SET C-x-C...C) matching the expected SMYD-family zinc-binding architecture. This is a structural cofactor-binding function typical of SMYD SET domains rather than SET6&#39;s defining catalytic activity, so it is retained as non-core.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:yeast/SET6/SET6-bioinformatics/RESULTS.md
+
+                                </span>
+
+                                <div class="support-text">This clustered pattern is the expected SMYD-family zinc-knot / post-SET metal-binding architecture and is consistent with the computational zinc-ion-binding prediction (RCA, PMID:30358795).</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005575" target="_blank" class="term-link">
+                                    GO:0005575
+                                </a>
+                            </span>
+                            <span class="term-label">cellular_component</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ND</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000015
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q12529" data-a="GO:0005575" data-r="GO_REF:0000015" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Root cellular_component term with the ND (No biological Data) evidence code, used as a placeholder indicating no localization data. Accept as-is per GO convention.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> This is a standard ND root-term placeholder recording that no cellular-component data is available; it is not an informative annotation to modify or remove.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008150" target="_blank" class="term-link">
+                                    GO:0008150
+                                </a>
+                            </span>
+                            <span class="term-label">biological_process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ND</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000015
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q12529" data-a="GO:0008150" data-r="GO_REF:0000015" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Root biological_process term with the ND evidence code, a placeholder indicating no process data. Accept as-is per GO convention.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Standard ND root-term placeholder recording that no biological-process data is available for SET6; not an informative annotation to modify or remove.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>Putative, likely catalytically competent protein-lysine methyltransferase of the SMYD subfamily. SET6 retains the intact SET-domain catalytic/S-adenosyl-L-methionine-binding residues that the dead yeast SET proteins Set3/Set4 have lost, and is the yeast SET protein most likely to be a genuine protein methyltransferase. Its protein substrate is unknown and no methyltransferase activity has been demonstrated, so this function is proposed as putative.</h3>
+                <span class="vote-buttons" data-g="Q12529" data-a="FUNCTION: Putative, likely catalytically competent protein-l..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016279" target="_blank" class="term-link">
+                            protein-lysine N-methyltransferase activity
+                        </a>
+                    </span>
+                </div>
+
+
+
+
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/37252976" target="_blank" class="term-link">
+                                PMID:37252976
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">Of these three putative methyltransferases, the most likely protein methyltransferase is Set6, as the SET domain invariably methylates proteins.</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:yeast/SET6/SET6-bioinformatics/RESULTS.md
+
+                        </span>
+
+                        <div class="finding-text">SET6 has an intact SET domain and retains the canonical catalytic/SAM-binding residues that Set3/Set4 have lost.</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>Structural zinc-ion binding via the cysteine-rich SMYD-type zinc-knot/post-SET architecture, predicted computationally and consistent with the clustered cysteine pattern of the protein. A structural cofactor-binding function that supports the SET/SMYD fold rather than a standalone biological activity.</h3>
+                <span class="vote-buttons" data-g="Q12529" data-a="FUNCTION: Structural zinc-ion binding via the cysteine-rich ..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008270" target="_blank" class="term-link">
+                            zinc ion binding
+                        </a>
+                    </span>
+                </div>
+
+
+
+
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:yeast/SET6/SET6-bioinformatics/RESULTS.md
+
+                        </span>
+
+                        <div class="finding-text">This clustered pattern is the expected SMYD-family zinc-knot / post-SET metal-binding architecture and is consistent with the computational zinc-ion-binding prediction (RCA, PMID:30358795).</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000015.md" target="_blank" class="term-link">
+                            GO_REF:0000015
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Use of the ND evidence code for Gene Ontology (GO) terms</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
+                            GO_REF:0000033
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Annotation inferences using phylogenetic trees</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000108.md" target="_blank" class="term-link">
+                            GO_REF:0000108
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Automatic assignment of GO terms using logical inference, based on on inter-ontology links</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/30358795" target="_blank" class="term-link">
+                            PMID:30358795
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">The cellular economy of the Saccharomyces cerevisiae zinc proteome.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Bioinformatic definition of the yeast zinc proteome (~582 known or potential zinc-binding proteins via domain and motif searches); SET6 is included as a predicted zinc-binding protein, the basis for the RCA zinc-ion-binding annotation.</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/37252976" target="_blank" class="term-link">
+                            PMID:37252976
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">The protein methylation network in yeast: A landmark in completeness for a eukaryotic post-translational modification.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Only five yeast methyltransferases are predicted to target proteins (Set3, Set4, Set6, Mtf1, YNL092W); of the plausibly active ones, Set6 is singled out as the most likely genuine protein methyltransferase because the SET domain invariably methylates proteins, while Set3/Set4 lack activity due to active-site substitutions.</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Whatever Set6 methylates has not been identified; if it is a protein methyltransferase it most likely targets an as-yet undiscovered methylation site.</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/31642774" target="_blank" class="term-link">
+                            PMID:31642774
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Using Yeast to Define the Regulatory Role of Protein Lysine Methylation.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Set5 and Set6 are homologous to the mammalian SMYD proteins, which have both histone and non-histone targets; the subcellular localization of Set6 is not yet known.</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/31685550" target="_blank" class="term-link">
+                            PMID:31685550
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Function of the MYND Domain and C-Terminal Region in Regulating the Subcellular Localization and Catalytic Activity of the SMYD Family Lysine Methyltransferase Set5.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">S. cerevisiae contains two SMYD proteins, Set5 and Set6, that share structural elements with the mammalian SMYD enzymes.</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/14718668" target="_blank" class="term-link">
+                            PMID:14718668
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Chemogenomic profiling: identifying the functional interactions of small molecules in yeast.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Genome-wide heterozygous-deletion chemogenomic screen; the YPL165C/SET6 deletion is associated with resistance/sensitivity to compounds targeting ergosterol biosynthesis (fenpropimorph, dyclonine, alverine citrate). This is a fitness-profiling readout, not a molecular-function assay, and does not establish an enzymatic activity or a defined biological process for SET6.</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        file:yeast/SET6/SET6-bioinformatics/RESULTS.md
+
+                    </span>
+                </div>
+
+                <div class="reference-title">SET6 SET-domain integrity, SMYD-family and zinc-architecture analysis (this review)</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Reproducible analysis: SET6 has a near-complete SET domain (hmmsearch vs Pfam PF00856, domain E=6.3e-14, residues 23-337, split-SET/SMYD architecture); the invariant catalytic/SAM-binding NHSC pocket (Asn303-His304-Ser305-Cys306) and C-terminal catalytic Tyr337 are intact, unlike the dead Set3/Set4 (Arg-Arg). Set5 is the closest yeast relative. SET6 is Cys-rich (17 Cys, 4.6%) in clusters consistent with SMYD-type zinc binding.</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Questions for Experts</h2>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Does SET6 catalyze protein-lysine methylation, and if so, what is its physiological protein substrate - a histone, or (as its SMYD family suggests) a non-histone target?</p>
+
+                    <p style="margin-top: 0.5rem;"><em>Suggested experts: Hamey JJ, Wilkins MR</em></p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q12529" data-a="Q: Does SET6 catalyze protein-lysine methylation, and..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> What is the subcellular localization of SET6, and does it (like its paralog Set5) distribute between the nucleus and cytoplasm, consistent with a non-histone substrate?</p>
+
+                    <p style="margin-top: 0.5rem;"><em>Suggested experts: Green EM</em></p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q12529" data-a="Q: What is the subcellular localization of SET6, and ..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Experiments</h2>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Perform heavy-methyl SILAC quantitative mass spectrometry comparing the methylproteome of a wild-type strain with a set6-delta strain to identify SET6-dependent methylation site(s); confirm candidates with in-vitro methyltransferase assays using recombinant SET6, AdoMet, and active-site point mutants as negative controls.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: SET6 is a catalytically active protein-lysine methyltransferase whose substrate is a (likely non-histone) yeast protein.</em></p>
+
+
+                    <p style="margin-top: 0.5rem;">Type: comparative methylproteomics + in-vitro methyltransferase assay</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q12529" data-a="EXPERIMENT: Perform heavy-methyl SILAC quantitative mass spect..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Recombinantly express wild-type SET6 and NHSC-pocket / catalytic-Tyr337 point mutants and compare methyl-transfer activity against a candidate substrate panel to test whether the conserved residues are functionally required.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: SET6 retains intact catalytic residues, so active-site mutation should abolish any detectable methyltransferase activity.</em></p>
+
+
+                    <p style="margin-top: 0.5rem;">Type: structure-function mutagenesis</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q12529" data-a="EXPERIMENT: Recombinantly express wild-type SET6 and NHSC-pock..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Endogenously tag SET6 with a fluorescent protein and image its subcellular distribution across growth conditions, including in the presence of ergosterol-biosynthesis inhibitors that produce its chemogenomic phenotype.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: SET6 localizes within the yeast cell in a pattern consistent with its (unknown) substrate compartment.</em></p>
+
+
+                    <p style="margin-top: 0.5rem;">Type: fluorescence microscopy / localization</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q12529" data-a="EXPERIMENT: Endogenously tag SET6 with a fluorescent protein a..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Knowledge Gaps</h2>
+        <p style="color: #555; font-size: 0.92rem; margin-top: -0.3rem;">
+            What is <em>not</em> known — curated, literature-grounded statements of the open
+            unknowns (the inverse of core functions).
+        </p>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The protein substrate of SET6 is unknown: no methylation site on any histone or non-histone protein has ever been attributed to SET6, so the specific methyl-acceptor it acts on is undetermined.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">MF_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> Established: SET6 is a SMYD-subfamily SET-domain protein whose catalytic/SAM-binding residues are intact (unlike the dead Set3/Set4), and it is the yeast SET protein most likely to be a genuine protein-lysine methyltransferase. Unknown: which protein (and which lysine) it methylates. If it is active, it most likely targets an as-yet undiscovered methylation site.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> SET6 is one of only a handful of putative protein methyltransferases keeping the otherwise near-complete yeast protein-methylation enzyme-substrate network incomplete; identifying its substrate would help close that network.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> In-vitro methyltransferase assays with recombinant SET6 against candidate substrates and heavy-methyl SILAC / mass-spectrometry comparison of wild-type vs set6-delta methylproteomes to detect SET6-dependent methylation site(s).</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"If they are in fact protein methyltransferases, they are most likely to target as-yet undiscovered methylation sites"</em> — PMID:37252976</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> Whether SET6 actually catalyzes methyl transfer in vitro or in vivo has never been demonstrated; its catalytic competence is inferred solely from conserved active-site residues.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">MF_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> Established: the SET-domain active-site residues required for catalysis and AdoMet binding are conserved in SET6, unlike in the catalytically dead Set3/Set4. Unknown: whether SET6 transfers a methyl group to any acceptor. Sequence conservation is necessary but not sufficient for enzymatic activity.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Confirming (or refuting) methyltransferase activity would resolve whether SET6 is a bona fide enzyme or, despite intact motifs, another inactive yeast SET protein.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Direct enzymatic assay (radiometric or MS-based methyl-transfer) using recombinant SET6 and AdoMet, with active-site point mutants as controls.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"Motif conservation is necessary but not sufficient for activity; the only way to settle competence is an enzymatic assay."</em> — file:yeast/SET6/SET6-bioinformatics/RESULTS.md</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The biological role and subcellular localization of SET6 are unknown: deletion produces no standalone growth phenotype, and where in the cell SET6 acts has not been measured.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">BP_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> Established: the only reported phenotype is drug-conditional fitness (resistance to ergosterol-biosynthesis-targeting compounds) in a chemogenomic screen, of uncertain mechanism, and SET6&#39;s SMYD paralog Set5 is dual nuclear/cytoplasmic. Unknown: the biological process SET6 participates in and its localization.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Without a biological process or localization, SET6 cannot be placed in a pathway; its drug-conditional phenotype hints at a role only indirectly.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Fluorescent-protein tagging / microscopy to determine localization, and phenotypic profiling (including in the presence of ergosterol-biosynthesis inhibitors and in sensitized genetic backgrounds) to define a biological process.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"While the subcellular localization of Set6 is not yet known, Set5 is found in both the nucleus and cytoplasm [19], suggesting it is also likely to have non-histone substrates."</em> — PMID:31642774</li>
+
+            </ul>
+
+
+        </div>
+
+    </div>
+
+
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Deep Research Sections -->
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(SET6-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="Q12529" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="set6-ypl165c-uniprot-q12529-research-notes">SET6 (YPL165C / UniProt Q12529) — research notes</h1>
+<p>Research journal for the GO-annotation review of <em>Saccharomyces cerevisiae</em> SET6.<br />
+Provenance recorded inline as <code>[PMID:xxxxx "verbatim quote"]</code> or <code>[file:... ]</code> for the<br />
+local bioinformatics analysis.</p>
+<h2 id="one-line-summary">One-line summary</h2>
+<p>SET6 is a <strong>dark</strong> budding-yeast SET-domain protein: a <strong>putative, likely catalytically<br />
+competent protein-lysine methyltransferase of the SMYD subfamily</strong> whose <strong>substrate,<br />
+in-vivo activity, and biological role are all unknown</strong>. It is the paralog of the<br />
+characterized SMYD enzyme Set5.</p>
+<h2 id="what-is-known">What is KNOWN</h2>
+<h3 id="domain-architecture-family">Domain architecture / family</h3>
+<ul>
+<li>UniProt (Q12529) names it "Potential protein lysine methyltransferase SET6", EC 2.1.1.-,<br />
+  373 aa, with a SET domain (residues ~12–338) and assigns it to the "class V-like<br />
+  SAM-binding methyltransferase superfamily". PE level 3 ("Inferred from homology"). The<br />
+  only experimental FUNCTION note is chemogenomic (see below); there is no methyltransferase<br />
+  assay.</li>
+<li>InterPro/PANTHER place SET6 in PANTHER family PTHR12197 ("HISTONE-LYSINE<br />
+  N-METHYLTRANSFERASE SMYD"), subfamily SF294 ("POTENTIAL PROTEIN LYSINE METHYLTRANSFERASE<br />
+  SET6"); CDD cd20071 SET_SMYD (from the UniProt DR lines). So the family-level signal is<br />
+  clearly <strong>SMYD-type SET domain</strong>.</li>
+<li>SET6 and its paralog Set5 are the two yeast SMYD proteins:<br />
+  [PMID:31685550 "Saccharomyces cerevisiae contains two SMYD proteins, Set5 and" ... "which<br />
+  share structural elements with the mammalian SMYD enzymes."] and<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/31642774" title="Set5, and another member of this sub-group, Set6, are homologous to the   mammalian SMYD proteins [6], which have been reported to have both histone and non-histone   targets.">PMID:31642774</a>.</li>
+</ul>
+<h3 id="catalytic-competence-bioinformatics-this-review">Catalytic competence (bioinformatics, this review)</h3>
+<ul>
+<li>Local reproducible analysis (<code>file:yeast/SET6/SET6-bioinformatics/RESULTS.md</code>) shows the<br />
+  SET domain is present and near-complete (hmmsearch vs Pfam PF00856, domain E=6.3e-14,<br />
+  residues 23–337, split-SET/SMYD architecture) and, critically, that the invariant<br />
+  catalytic/SAM-binding residues are <strong>intact</strong>: the "NHSC" pocket (Asn303-His304-Ser305-<br />
+  Cys306) and the C-terminal catalytic Tyr337 are conserved, exactly as in the active<br />
+  enzymes Set1/Set2/Set5/SMYD2/SMYD3. In contrast, the two yeast SET proteins that are<br />
+  reported to be catalytically dead — <strong>Set3 and Set4</strong> — have the Asn-His replaced by<br />
+  Arg-Arg. On primary sequence SET6 therefore groups with the <strong>active</strong> methyltransferases,<br />
+  not with the pseudoenzymes. This independently reproduces the literature assertion below.</li>
+<li>SET-domain-restricted identity ranks Set5 first (closest yeast relative), consistent with<br />
+  the SMYD ortholog-pair literature.</li>
+<li>SET6 is Cys-rich (17 Cys, 4.6%) in three clusters (an N-terminal CxxC, an internal-insert<br />
+  cluster, and a C-terminal post-SET C-x-C...C), the expected SMYD-family zinc-knot/post-SET<br />
+  metal-binding architecture — consistent with the RCA zinc-ion-binding annotation.<br />
+  A separate canonical MYND zinc finger could not be confirmed (SET6 is 373 aa, shorter than<br />
+  Set5 at 526 aa).</li>
+</ul>
+<h3 id="literature-likely-active-but-substrate-unknown">Literature: likely-active but substrate unknown</h3>
+<ul>
+<li>The most authoritative statement is from the near-complete yeast methylation-network<br />
+  paper: of the yeast SET/7βS/SPOUT methyltransferases, only five are predicted to target<br />
+  proteins <a href="https://pubmed.ncbi.nlm.nih.gov/37252976" title="Only five methyltransferases are predicted to target proteins:   Set3, Set4, Set6, Mtf1, and YNL092W.">PMID:37252976</a>, and of the three plausibly-active ones <strong>Set6 is<br />
+  singled out as the most likely genuine protein methyltransferase</strong>: <a href="https://pubmed.ncbi.nlm.nih.gov/37252976" title="Of   these three putative methyltransferases, the most likely protein methyltransferase is   Set6, as the SET domain invariably methylates proteins.">PMID:37252976</a>. The Set3/Set4 contrast is<br />
+  explicit: <a href="https://pubmed.ncbi.nlm.nih.gov/37252976" title="This is because Set3 and Set4 appear to lack methyltransferase   activity due to amino acid substitutions at key AdoMet-binding residues">PMID:37252976</a>.</li>
+<li>Same paper: SET domain enzymes are protein (not RNA/DNA/metabolite) methyltransferases:<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/37252976" title="SET domain enzymes invariably methylate proteins">PMID:37252976</a>.</li>
+<li>Whatever Set6 methylates is not yet identified: <a href="https://pubmed.ncbi.nlm.nih.gov/37252976" title="If they are in fact   protein methyltransferases, they are most likely to target as-yet undiscovered methylation   sites">PMID:37252976</a>. In Table 2 of that paper Set6 is listed as a putative protein/SET methyltransferase<br />
+  with <strong>no assigned substrate and no disqualifying "Notes"</strong> (unlike Set3/Set4, which carry<br />
+  active-site-substitution notes).</li>
+</ul>
+<h3 id="the-one-experimental-phenotype">The one experimental phenotype</h3>
+<ul>
+<li>SET6 (YPL165C) appears in a chemogenomic (heterozygous-deletion) screen: it is "Involved<br />
+  in resistance to compounds that target ergosterol biosynthesis, including fenpropimorph,<br />
+  dyclonine, and alverine citrate" (UniProt FUNCTION, ECO:0000269|PubMed:14718668). UniProt<br />
+  itself hedges that, because deletion has no growth effect absent the compounds, SET6 "is<br />
+  more likely to be involved in compound availability" rather than in ergosterol biosynthesis<br />
+  per se. The primary paper <a href="https://pubmed.ncbi.nlm.nih.gov/14718668">PMID:14718668</a> is a genome-wide small-molecule/deletion screen<br />
+  ("alverine citrate"); it is a fitness-profiling readout, not a molecular-function assay, so<br />
+  it does not establish a methyltransferase activity, substrate, or a defined biological<br />
+  process for SET6.</li>
+</ul>
+<h2 id="what-is-not-known-the-knowledge-gaps">What is NOT known (the knowledge gaps)</h2>
+<ol>
+<li><strong>Substrate</strong> — no protein (histone or non-histone) methylation site attributable to SET6<br />
+   has ever been identified. The generic "histone methyltransferase" call is an<br />
+   IBA/family-transfer inference; the SMYD family (and human SETD6) act <strong>largely on<br />
+   non-histone targets</strong>, so a histone-specific MF is not defensible for SET6.</li>
+<li><strong>In-vivo (or in-vitro) activity</strong> — SET6 has never been shown to transfer a methyl group<br />
+   to anything; competence is inferred only from sequence-conserved active-site residues.<br />
+   "Motif conservation is necessary but not sufficient for activity"<br />
+   (<code>file:yeast/SET6/SET6-bioinformatics/RESULTS.md</code>).</li>
+<li><strong>Biological role</strong> — deletion has no standalone growth phenotype; the only phenotype is<br />
+   drug-conditional fitness of uncertain mechanism. Subcellular localization is unmeasured:<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/31642774" title="While the subcellular localization of Set6 is not yet known, Set5 is found    in both the nucleus and cytoplasm [19], suggesting it is also likely to have non-histone    substrates.">PMID:31642774</a>. The nucleus annotation is IBA family-transfer, not measured for SET6.</li>
+</ol>
+<h2 id="annotation-by-annotation-reasoning-goa-7-annotations">Annotation-by-annotation reasoning (GOA, 7 annotations)</h2>
+<table>
+<thead>
+<tr>
+<th>#</th>
+<th>Term</th>
+<th>Evid</th>
+<th>Ref</th>
+<th>Decision</th>
+<th>Rationale</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>1</td>
+<td>GO:0016279 protein-lysine N-methyltransferase activity</td>
+<td>IBA</td>
+<td>GO_REF:0000033</td>
+<td>KEEP_AS_NON_CORE</td>
+<td>Best-supported MF: intact SET/SMYD active site + literature calling Set6 the most-likely genuine protein KMT. Putative, not demonstrated, so non-core.</td>
+</tr>
+<tr>
+<td>2</td>
+<td>GO:0042054 histone methyltransferase activity</td>
+<td>IBA</td>
+<td>GO_REF:0000033</td>
+<td>MARK_AS_OVER_ANNOTATED</td>
+<td>Over-specific substrate class. SMYD/SETD6 act largely on non-histone targets; no histone substrate shown for Set6. The lysine-KMT MF (#1) is the defensible level.</td>
+</tr>
+<tr>
+<td>3</td>
+<td>GO:0005634 nucleus</td>
+<td>IBA</td>
+<td>GO_REF:0000033</td>
+<td>KEEP_AS_NON_CORE</td>
+<td>Plausible by SMYD family transfer, but Set6 localization is explicitly unmeasured; keep as non-core, low confidence.</td>
+</tr>
+<tr>
+<td>4</td>
+<td>GO:0006338 chromatin remodeling</td>
+<td>IEA (from GO:0042054)</td>
+<td>GO_REF:0000108</td>
+<td>REMOVE</td>
+<td>Inter-ontology inference chained off the over-annotated histone-MTase term (#2); no evidence Set6 remodels chromatin. Falls with its parent term.</td>
+</tr>
+<tr>
+<td>5</td>
+<td>GO:0008270 zinc ion binding</td>
+<td>RCA</td>
+<td>PMID:30358795</td>
+<td>KEEP_AS_NON_CORE</td>
+<td>Computational (zinc-proteome) prediction, corroborated by the Cys-rich SMYD zinc-knot/post-SET architecture in the bioinformatics analysis. Structural, non-core.</td>
+</tr>
+<tr>
+<td>6</td>
+<td>GO:0005575 cellular_component (root)</td>
+<td>ND</td>
+<td>GO_REF:0000015</td>
+<td>ACCEPT</td>
+<td>Root/ND placeholder; accept as-is per GO convention.</td>
+</tr>
+<tr>
+<td>7</td>
+<td>GO:0008150 biological_process (root)</td>
+<td>ND</td>
+<td>GO_REF:0000015</td>
+<td>ACCEPT</td>
+<td>Root/ND placeholder; accept as-is per GO convention.</td>
+</tr>
+</tbody>
+</table>
+<h2 id="reference-triage">Reference triage</h2>
+<ul>
+<li>PMID:37252976 (Hamey &amp; Wilkins, PNAS 2023, near-complete yeast methylation network) —<br />
+  HIGH; full text; directly adjudicates Set6 as the most-likely genuine yeast protein KMT<br />
+  with unknown substrate. VERIFIED.</li>
+<li>PMID:31642774 (Jethmalani &amp; Green, review) — HIGH; SMYD homology, histone/non-histone<br />
+  substrate range, unmeasured localization. VERIFIED (full text).</li>
+<li>PMID:31685550 (Jaiswal et al., Set5 SMYD paper) — MEDIUM; establishes Set5/Set6 as the two<br />
+  yeast SMYDs (context/paralog). VERIFIED (abstract).</li>
+<li>PMID:30358795 (Wang et al., yeast zinc proteome) — MEDIUM; source of the RCA zinc-binding<br />
+  annotation. VERIFIED (abstract; this is the RCA support).</li>
+<li>PMID:14718668 (Giaever et al., chemogenomic profiling) — LOW; source of the only phenotype<br />
+  (drug-conditional fitness); does not define molecular function. VERIFIED (abstract).</li>
+<li>file:yeast/SET6/SET6-bioinformatics/RESULTS.md — HIGH; reproducible SET-domain integrity /<br />
+  SMYD-family / zinc-architecture analysis.</li>
+<li>GO_REF:0000015 / 0000033 / 0000108 — pipeline references (ND / IBA / inter-ontology IEA).</li>
+</ul>
+<h2 id="deep-research">Deep research</h2>
+<p><code>just deep-research-falcon yeast SET6 --fallback perplexity-lite</code> was attempted but timed<br />
+out (no report produced); per project policy no fabricated deep-research file was written.<br />
+These notes are the manual research journal instead.</p>
+            </div>
+        </details>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Bioinformatics Results</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(RESULTS.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="Q12529" data-a="DOC: Bioinformatics Results" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="set6-ypl165c-uniprot-q12529-set-domain-integrity-analysis">SET6 (YPL165C / UniProt Q12529) — SET-domain integrity analysis</h1>
+<h2 id="question">Question</h2>
+<p>Is <em>S. cerevisiae</em> SET6 a <strong>catalytically competent</strong> SET-domain protein-lysine<br />
+methyltransferase, or a <strong>degenerate / pseudo-methyltransferase</strong> like Set3 and Set4?<br />
+And does it belong to the SMYD subfamily (like its paralog Set5), consistent with the<br />
+RCA zinc-ion-binding annotation?</p>
+<p>This tests the claim in PMID:37252976 ("The protein methylation network in yeast") that<br />
+Set6 is <em>"likely to be an active methyltransferase"</em> whereas Set3/Set4 <em>"appear to lack<br />
+methyltransferase activity due to amino acid substitutions at key AdoMet-binding<br />
+residues"</em> — directly on the SET6 sequence.</p>
+<h2 id="methods-reproducible-see-justfile">Methods (reproducible; see <code>justfile</code>)</h2>
+<ul>
+<li><strong>Panel</strong> (<code>scripts/fetch_sequences.py</code>): SET6 (Q12529, read from the local UniProt<br />
+  flat file), yeast SET1/SET2 (active KMTs), Set5 (SMYD paralog, characterized H4K5/8/12<br />
+  KMT), Set3/Set4 (reported inactive), and human SMYD1/2/3 + SETD6.</li>
+<li><strong>Domain detection</strong> (<code>hmmsearch</code> vs Pfam <strong>PF00856 SET</strong> HMM from InterPro):<br />
+<code>results/set_domain_hmmsearch.txt</code> / <code>.domtbl</code>.</li>
+<li><strong>Motif read-out</strong> (<code>scripts/motif_from_mafft.py</code>): MAFFT L-INS-i MSA of the panel,<br />
+  then read every protein's residues at the SET6 catalytic/SAM-binding motif columns.<br />
+  Output <code>results/motif_readout_mafft.txt</code>.</li>
+<li><strong>Identity</strong> (<code>scripts/pairwise_identity.py</code>, <code>scripts/set_domain_identity.py</code>):<br />
+  full-length and SET-domain-restricted % identity of SET6 vs the panel.</li>
+</ul>
+<h2 id="key-results">Key results</h2>
+<h3 id="1-set-domain-is-present-and-near-complete">1. SET domain is present and near-complete</h3>
+<p><code>hmmsearch</code> vs PF00856 gives SET6 a significant SET-domain hit<br />
+(domain E-value <strong>6.3e-14</strong>) spanning residues <strong>23–337</strong>, matching HMM match states<br />
+1–104 (essentially the whole domain model). The wide span (with a long internal insert)<br />
+is the <strong>split-SET architecture</strong> typical of the SMYD subfamily; human SMYD1/2/3 and<br />
+SETD6 in the same run show the identical single wide split-SET hit. Consistent with<br />
+UniProt's SET domain call (residues 12–338) and "class V-like SAM-binding<br />
+methyltransferase superfamily".</p>
+<h3 id="2-the-catalytic-sam-binding-motifs-are-intact-in-set6-unlike-set3set4">2. The catalytic / SAM-binding motifs are INTACT in SET6 (unlike Set3/Set4)</h3>
+<p>Residues each protein contributes at the SET6 catalytic-pocket columns<br />
+(<code>results/motif_readout_mafft.txt</code>), with catalytically critical positions marked <code>*</code>:</p>
+<div class="codehilite"><pre><span></span><code><span class="n">NHSC</span><span class="w"> </span><span class="nf">pocket </span><span class="p">(</span><span class="n">SAM</span><span class="o">/</span><span class="n">AdoMet</span><span class="w"> </span><span class="o">+</span><span class="w"> </span><span class="n">catalytic</span><span class="p">;</span><span class="w"> </span><span class="n">SET6</span><span class="w"> </span><span class="n">residues</span><span class="w"> </span><span class="m">302-309</span><span class="p">)</span>
+<span class="w">                          </span><span class="o">***</span>
+<span class="w">  </span><span class="n">SET6_YEAST</span><span class="w">      </span><span class="bp">F</span><span class="w"> </span><span class="n">N</span><span class="w"> </span><span class="n">H</span><span class="w"> </span><span class="n">S</span><span class="w"> </span><span class="n">C</span><span class="w"> </span><span class="n">N</span><span class="w"> </span><span class="n">P</span><span class="w"> </span><span class="n">N</span><span class="w">   </span><span class="o">&lt;-</span><span class="w"> </span><span class="n">N303</span><span class="o">/</span><span class="n">H304</span><span class="o">/</span><span class="n">S305</span><span class="o">/</span><span class="n">C306</span><span class="w"> </span><span class="nf">intact  </span><span class="p">(</span><span class="n">ACTIVE</span><span class="o">-</span><span class="n">like</span><span class="p">)</span>
+<span class="w">  </span><span class="n">SET5_YEAST</span><span class="w">      </span><span class="n">I</span><span class="w"> </span><span class="n">N</span><span class="w"> </span><span class="n">H</span><span class="w"> </span><span class="n">D</span><span class="w"> </span><span class="n">C</span><span class="w"> </span><span class="n">E</span><span class="w"> </span><span class="n">P</span><span class="w"> </span><span class="n">N</span><span class="w">   </span><span class="o">&lt;-</span><span class="w"> </span><span class="n">N</span><span class="o">/</span><span class="n">H</span><span class="w"> </span><span class="nf">intact </span><span class="p">(</span><span class="n">active</span><span class="w"> </span><span class="n">SMYD</span><span class="p">)</span>
+<span class="w">  </span><span class="n">SET1_YEAST</span><span class="w">      </span><span class="n">I</span><span class="w"> </span><span class="n">N</span><span class="w"> </span><span class="n">H</span><span class="w"> </span><span class="n">C</span><span class="w"> </span><span class="n">C</span><span class="w"> </span><span class="n">D</span><span class="w"> </span><span class="n">P</span><span class="w"> </span><span class="n">N</span><span class="w">   </span><span class="o">&lt;-</span><span class="w"> </span><span class="n">N</span><span class="o">/</span><span class="n">H</span><span class="w"> </span><span class="nf">intact </span><span class="p">(</span><span class="n">active</span><span class="w"> </span><span class="n">H3K4</span><span class="w"> </span><span class="n">KMT</span><span class="p">)</span>
+<span class="w">  </span><span class="n">SET2_YEAST</span><span class="w">      </span><span class="n">C</span><span class="w"> </span><span class="n">N</span><span class="w"> </span><span class="n">H</span><span class="w"> </span><span class="n">S</span><span class="w"> </span><span class="n">C</span><span class="w"> </span><span class="n">S</span><span class="w"> </span><span class="n">P</span><span class="w"> </span><span class="n">N</span><span class="w">   </span><span class="o">&lt;-</span><span class="w"> </span><span class="n">N</span><span class="o">/</span><span class="n">H</span><span class="o">/</span><span class="n">S</span><span class="w"> </span><span class="nf">intact </span><span class="p">(</span><span class="n">active</span><span class="w"> </span><span class="n">H3K36</span><span class="w"> </span><span class="n">KMT</span><span class="p">)</span>
+<span class="w">  </span><span class="n">SMYD2_HUMAN</span><span class="w">     </span><span class="n">M</span><span class="w"> </span><span class="n">N</span><span class="w"> </span><span class="n">H</span><span class="w"> </span><span class="n">S</span><span class="w"> </span><span class="n">C</span><span class="w"> </span><span class="n">C</span><span class="w"> </span><span class="n">P</span><span class="w"> </span><span class="n">N</span><span class="w">   </span><span class="o">&lt;-</span><span class="w"> </span><span class="n">intact</span>
+<span class="w">  </span><span class="n">SMYD3_HUMAN</span><span class="w">     </span><span class="n">L</span><span class="w"> </span><span class="n">N</span><span class="w"> </span><span class="n">H</span><span class="w"> </span><span class="n">S</span><span class="w"> </span><span class="n">C</span><span class="w"> </span><span class="n">D</span><span class="w"> </span><span class="n">P</span><span class="w"> </span><span class="n">N</span><span class="w">   </span><span class="o">&lt;-</span><span class="w"> </span><span class="n">intact</span>
+<span class="w">  </span><span class="n">SET3_YEAST</span><span class="w">      </span><span class="n">L</span><span class="w"> </span><span class="n">R</span><span class="w"> </span><span class="n">R</span><span class="w"> </span><span class="n">S</span><span class="w"> </span><span class="n">C</span><span class="w"> </span><span class="n">Q</span><span class="w"> </span><span class="n">P</span><span class="w"> </span><span class="n">N</span><span class="w">   </span><span class="o">&lt;-</span><span class="w"> </span><span class="n">N</span><span class="o">-</span><span class="n">H</span><span class="w"> </span><span class="o">-&gt;</span><span class="w"> </span><span class="n">R</span><span class="o">-</span><span class="nf">R  </span><span class="p">(</span><span class="n">LOST</span><span class="p">;</span><span class="w"> </span><span class="n">degenerate</span><span class="p">)</span>
+<span class="w">  </span><span class="n">SET4_YEAST</span><span class="w">      </span><span class="n">I</span><span class="w"> </span><span class="n">R</span><span class="w"> </span><span class="n">R</span><span class="w"> </span><span class="n">S</span><span class="w"> </span><span class="n">C</span><span class="w"> </span><span class="n">E</span><span class="w"> </span><span class="n">P</span><span class="w"> </span><span class="n">N</span><span class="w">   </span><span class="o">&lt;-</span><span class="w"> </span><span class="n">N</span><span class="o">-</span><span class="n">H</span><span class="w"> </span><span class="o">-&gt;</span><span class="w"> </span><span class="n">R</span><span class="o">-</span><span class="nf">R  </span><span class="p">(</span><span class="n">LOST</span><span class="p">;</span><span class="w"> </span><span class="n">degenerate</span><span class="p">)</span>
+
+<span class="n">Catalytic</span><span class="o">-</span><span class="n">Y</span><span class="w"> </span><span class="nf">motif </span><span class="p">(</span><span class="n">SET6</span><span class="w"> </span><span class="n">residues</span><span class="w"> </span><span class="m">324-337</span><span class="p">,</span><span class="w"> </span><span class="n">terminal</span><span class="w"> </span><span class="n">Y337</span><span class="p">)</span>
+<span class="w">  </span><span class="n">SET6_YEAST</span><span class="w">      </span><span class="n">N</span><span class="w"> </span><span class="n">R</span><span class="w"> </span><span class="n">D</span><span class="w"> </span><span class="n">I</span><span class="w"> </span><span class="n">K</span><span class="w"> </span><span class="n">K</span><span class="w"> </span><span class="n">D</span><span class="w"> </span><span class="n">E</span><span class="w"> </span><span class="n">Q</span><span class="w"> </span><span class="n">I</span><span class="w"> </span><span class="n">C</span><span class="w"> </span><span class="n">I</span><span class="w"> </span><span class="n">D</span><span class="w"> </span><span class="n">Y</span><span class="w">   </span><span class="o">&lt;-</span><span class="w"> </span><span class="n">Y337</span><span class="w"> </span><span class="nf">present</span>
+<span class="nf">  </span><span class="p">(</span><span class="n">SET1</span><span class="o">/</span><span class="n">SET2</span><span class="o">/</span><span class="n">SMYD2</span><span class="o">/</span><span class="n">SMYD3</span><span class="w"> </span><span class="n">all</span><span class="w"> </span><span class="n">retain</span><span class="w"> </span><span class="n">the</span><span class="w"> </span><span class="n">terminal</span><span class="w"> </span><span class="n">aromatic</span><span class="w"> </span><span class="n">Y</span><span class="p">)</span>
+</code></pre></div>
+
+<p><strong>This is the decisive result.</strong> The invariant Asn-His of the "NHSC" AdoMet/catalytic<br />
+motif is <strong>conserved in SET6</strong> (Asn303-His304-Ser305-Cys306), exactly as in the active<br />
+enzymes Set1, Set2, Set5, SMYD2 and SMYD3. In sharp contrast, the two proteins reported<br />
+to be catalytically dead — <strong>Set3 and Set4 — have the Asn-His replaced by Arg-Arg</strong><br />
+(<code>RRSC</code>). SET6 also retains the C-terminal catalytic tyrosine (Tyr337). So on primary<br />
+sequence, <strong>SET6 groups with the active methyltransferases, not with the pseudoenzymes</strong>,<br />
+which independently reproduces the PMID:37252976 assertion.</p>
+<h3 id="3-set6-is-a-smyd-subfamily-protein-set5-is-its-closest-yeast-relative">3. SET6 is a SMYD-subfamily protein; Set5 is its closest yeast relative</h3>
+<p>SET-domain-restricted identity (<code>results/set_domain_identity.txt</code>) ranks<br />
+<strong>Set5 first (24.7 % id over 255 aligned positions)</strong> — the highest identity <em>and</em><br />
+coverage of the panel — with the human SMYD/SETD6 group next. (Full-length global<br />
+identity is uniformly low, 22–30 %, and is <em>not</em> informative here because panel members<br />
+carry very different N/C extensions, e.g. Set1 is 1080 aa; the SET-domain-restricted<br />
+comparison is the appropriate metric.) This matches the literature that Set5 and Set6 are<br />
+the two yeast orthologs of the metazoan SMYD family.</p>
+<h3 id="4-cysteine-rich-consistent-with-smyd-type-zinc-binding-supports-rca-annotation">4. Cysteine-rich; consistent with SMYD-type zinc binding (supports RCA annotation)</h3>
+<p>SET6 has <strong>17 Cys (4.6 %</strong>, well above the ~1.3 % proteome average), in three clusters:<br />
+N-terminal/early-SET (C26, C58, C61 — a <code>CxxC</code>), an internal insert cluster<br />
+(C189/C194/C195/C200/C213), and a C-terminal post-SET <code>C-x-C...C</code> (C360, C362, C365:<br />
+<code>FFDCACERCK</code>). This clustered pattern is the expected SMYD-family zinc-knot / post-SET<br />
+metal-binding architecture and is consistent with the computational zinc-ion-binding<br />
+prediction (RCA, PMID:30358795). Note the NHSC Cys306 is one of these cysteines. SET6<br />
+(373 aa) is shorter than Set5 (526 aa) and does not carry a separately annotated canonical<br />
+MYND domain, so a full MYND ZF could not be confirmed here.</p>
+<h2 id="interpretation-and-caveats">Interpretation and caveats</h2>
+<ul>
+<li><strong>What is supported:</strong> SET6 has an intact SET domain and retains the canonical<br />
+  catalytic/SAM-binding residues that Set3/Set4 have lost. It is therefore a <strong>plausible,<br />
+  catalytically competent SET-domain (SMYD-subfamily) protein-lysine methyltransferase</strong>.<br />
+  This licenses a <code>putative</code>/<code>likely</code> MF of protein-lysine methyltransferase activity.</li>
+<li><strong>What is NOT supported:</strong> sequence integrity says nothing about the <strong>substrate</strong> or<br />
+  the <strong>biological role</strong>. No in-vitro or in-vivo methyltransferase activity, and no<br />
+  substrate, has been demonstrated for SET6 in the literature. A generic "histone<br />
+  methyltransferase activity" is unsupported — the SMYD family (and SETD6) act largely on<br />
+<strong>non-histone</strong> substrates, and Set6's substrate is explicitly listed as unknown.</li>
+<li>Motif conservation is necessary but not sufficient for activity; the only way to settle<br />
+  competence is an enzymatic assay.</li>
+</ul>
+<h2 id="reproducibility-checklist">Reproducibility checklist</h2>
+<ul>
+<li>[x] Scripts take inputs from files / live UniProt fetch; <strong>no hardcoded inputs</strong>.</li>
+<li>[x] <strong>No conclusions hardcoded</strong> — code only extracts residues/identities; all<br />
+      interpretation is in this RESULTS.md.</li>
+<li>[x] Pipeline tested on <strong>other inputs</strong>: the same panel includes 9 non-SET6 proteins<br />
+      (positive controls Set1/Set2/Set5/SMYD1-3, negative-pattern Set3/Set4); the<br />
+      SET-HMM was additionally run on a non-SET protein (yeast ADH1) and correctly<br />
+      returned <strong>0 significant hits</strong>.</li>
+<li>[x] Analyses completed as expected; direct outputs in <code>results/</code>.</li>
+<li>[x] Provenance/justification given; uncertainty about substrate/activity stated<br />
+      honestly.</li>
+</ul>
+<h2 id="files">Files</h2>
+<ul>
+<li><code>scripts/</code> — analysis code</li>
+<li><code>data/reference_sequences.fasta</code>, <code>data/SET6.fasta</code>, <code>data/PF00856_SET.hmm</code></li>
+<li><code>results/set_domain_hmmsearch.txt</code> / <code>.domtbl</code> — SET-domain detection</li>
+<li><code>results/motif_readout_mafft.txt</code> — catalytic/SAM-binding motif read-out</li>
+<li><code>results/panel_mafft.aln.fasta</code> — MSA</li>
+<li><code>results/pairwise_identity.txt</code>, <code>results/set_domain_identity.txt</code></li>
+<li><code>justfile</code> — reproducible workflow (<code>just all</code>)</li>
+</ul>
+<h2 id="tools-databases">Tools &amp; databases</h2>
+<p>MAFFT v7 (L-INS-i); HMMER 3.3 (hmmsearch/hmmalign); Pfam PF00856 (SET domain, via<br />
+InterPro); Biopython 1.87 (PairwiseAligner, BLOSUM62); UniProt REST. Panel accessions:<br />
+Q12529 (SET6), P38890 (Set5), P36124 (Set3), P42948 (Set4), P38827 (Set1), P46995 (Set2),<br />
+Q8NB12/Q9NRG4/Q9H7B4 (SMYD1/2/3), Q8TBK2 (SETD6).</p>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: Q12529
+gene_symbol: SET6
+product_type: PROTEIN
+status: INITIALIZED
+taxon:
+  id: NCBITaxon:559292
+  label: Saccharomyces cerevisiae
+description: &gt;-
+  SET6 (systematic name YPL165C) is a 373-residue Saccharomyces cerevisiae protein
+  belonging to the SET-domain (Su(var)3-9, Enhancer-of-zeste, Trithorax) class of the
+  class V-like SAM-binding methyltransferase superfamily. It is one of the two budding-yeast
+  members of the SMYD subfamily (its paralog being Set5) and is annotated as a putative
+  protein-lysine methyltransferase. Its SET domain retains the invariant catalytic and
+  S-adenosyl-L-methionine-binding residues that the catalytically dead yeast SET proteins
+  Set3 and Set4 have lost, so SET6 is considered a likely catalytically competent enzyme,
+  and it carries a cysteine-rich SMYD-type zinc-binding architecture. However, no
+  methyltransferase activity, protein substrate, subcellular localization, or defined
+  biological role has been experimentally established for SET6; the only reported phenotype
+  is a drug-conditional fitness effect (resistance to compounds targeting ergosterol
+  biosynthesis) from a genome-wide chemogenomic screen, whose molecular basis is unclear.
+references:
+- id: GO_REF:0000015
+  title: Use of the ND evidence code for Gene Ontology (GO) terms
+  findings: []
+- id: GO_REF:0000033
+  title: Annotation inferences using phylogenetic trees
+  findings: []
+- id: GO_REF:0000108
+  title: Automatic assignment of GO terms using logical inference, based on on inter-ontology
+    links
+  findings: []
+- id: PMID:30358795
+  title: The cellular economy of the Saccharomyces cerevisiae zinc proteome.
+  findings:
+  - statement: &gt;-
+      Bioinformatic definition of the yeast zinc proteome (~582 known or potential
+      zinc-binding proteins via domain and motif searches); SET6 is included as a
+      predicted zinc-binding protein, the basis for the RCA zinc-ion-binding annotation.
+    reference_section_type: ABSTRACT
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Abstract-only cache; this is the computational (RCA) source for the zinc-ion-binding
+      annotation. Corroborated independently by the Cys-rich SMYD zinc-knot/post-SET
+      architecture in the local bioinformatics analysis.
+- id: PMID:37252976
+  title: &#39;The protein methylation network in yeast: A landmark in completeness for a eukaryotic
+    post-translational modification.&#39;
+  findings:
+  - statement: &gt;-
+      Only five yeast methyltransferases are predicted to target proteins (Set3, Set4,
+      Set6, Mtf1, YNL092W); of the plausibly active ones, Set6 is singled out as the most
+      likely genuine protein methyltransferase because the SET domain invariably methylates
+      proteins, while Set3/Set4 lack activity due to active-site substitutions.
+    reference_section_type: RESULTS
+  - statement: &gt;-
+      Whatever Set6 methylates has not been identified; if it is a protein methyltransferase
+      it most likely targets an as-yet undiscovered methylation site.
+    reference_section_type: RESULTS
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Full-text PNAS review/analysis; directly adjudicates Set6 as the most-likely genuine
+      yeast protein-lysine methyltransferase with an unknown substrate. Primary literature
+      support for the putative-KMT MF call and the substrate/activity knowledge gaps.
+- id: PMID:31642774
+  title: Using Yeast to Define the Regulatory Role of Protein Lysine Methylation.
+  findings:
+  - statement: &gt;-
+      Set5 and Set6 are homologous to the mammalian SMYD proteins, which have both histone
+      and non-histone targets; the subcellular localization of Set6 is not yet known.
+    reference_section_type: RESULTS
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Full-text review; supports SMYD-family placement, the histone/non-histone substrate
+      range of the family, and that Set6 localization is unmeasured.
+- id: PMID:31685550
+  title: Function of the MYND Domain and C-Terminal Region in Regulating the Subcellular
+    Localization and Catalytic Activity of the SMYD Family Lysine Methyltransferase Set5.
+  findings:
+  - statement: &gt;-
+      S. cerevisiae contains two SMYD proteins, Set5 and Set6, that share structural
+      elements with the mammalian SMYD enzymes.
+    reference_section_type: ABSTRACT
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Abstract-only cache; establishes the Set5/Set6 SMYD paralog pair (family/context for
+      SET6). The paper&#39;s experimental focus is Set5, not Set6.
+- id: PMID:14718668
+  title: &#39;Chemogenomic profiling: identifying the functional interactions of small molecules
+    in yeast.&#39;
+  findings:
+  - statement: &gt;-
+      Genome-wide heterozygous-deletion chemogenomic screen; the YPL165C/SET6 deletion is
+      associated with resistance/sensitivity to compounds targeting ergosterol biosynthesis
+      (fenpropimorph, dyclonine, alverine citrate). This is a fitness-profiling readout, not
+      a molecular-function assay, and does not establish an enzymatic activity or a defined
+      biological process for SET6.
+    reference_section_type: ABSTRACT
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Abstract-only cache; source of the only reported SET6 phenotype (drug-conditional
+      fitness). UniProt itself notes deletion has no effect absent the compounds, so SET6 is
+      more likely involved in compound availability than in a defined process.
+- id: file:yeast/SET6/SET6-bioinformatics/RESULTS.md
+  title: SET6 SET-domain integrity, SMYD-family and zinc-architecture analysis (this review)
+  findings:
+  - statement: &gt;-
+      Reproducible analysis: SET6 has a near-complete SET domain (hmmsearch vs Pfam PF00856,
+      domain E=6.3e-14, residues 23-337, split-SET/SMYD architecture); the invariant
+      catalytic/SAM-binding NHSC pocket (Asn303-His304-Ser305-Cys306) and C-terminal
+      catalytic Tyr337 are intact, unlike the dead Set3/Set4 (Arg-Arg). Set5 is the closest
+      yeast relative. SET6 is Cys-rich (17 Cys, 4.6%) in clusters consistent with SMYD-type
+      zinc binding.
+    reference_section_type: RESULTS
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Local reproducible bioinformatics analysis; independently reproduces PMID:37252976 on
+      the SET6 sequence and corroborates the RCA zinc-binding annotation. Motif conservation
+      is necessary but not sufficient for activity; no substrate is inferred.
+existing_annotations:
+- term:
+    id: GO:0016279
+    label: protein-lysine N-methyltransferase activity
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Best-supported molecular function for SET6: a putative, likely catalytically competent
+      protein-lysine methyltransferase. The SET/SMYD active site is intact (unlike Set3/Set4)
+      and the literature singles out Set6 as the yeast SET protein most likely to be a
+      genuine protein methyltransferase. Retained as the enzyme&#39;s likely function but kept
+      non-core because no methyltransferase activity or substrate has been demonstrated.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Phylogenetically inferred (IBA) but strongly corroborated. On sequence, SET6 retains
+      the invariant catalytic/SAM-binding residues (NHSC pocket, catalytic Tyr337) that the
+      catalytically dead Set3/Set4 have lost, and the literature explicitly calls Set6 the
+      most likely genuine yeast protein methyltransferase. This lysine-KMT level (rather than
+      the more specific histone-MTase term) is the defensible molecular function. It remains
+      putative because no in-vitro/in-vivo activity or substrate has been shown, so it is
+      kept as a non-core, likely-true function.
+    supported_by:
+    - reference_id: PMID:37252976
+      supporting_text: &gt;-
+        Of these three putative methyltransferases, the most likely protein methyltransferase
+        is Set6, as the SET domain invariably methylates proteins.
+    - reference_id: file:yeast/SET6/SET6-bioinformatics/RESULTS.md
+      supporting_text: &gt;-
+        The invariant Asn-His of the &#34;NHSC&#34; AdoMet/catalytic
+        motif is **conserved in SET6** (Asn303-His304-Ser305-Cys306), exactly as in the active
+        enzymes Set1, Set2, Set5, SMYD2 and SMYD3.
+- term:
+    id: GO:0042054
+    label: histone methyltransferase activity
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Over-specific substrate assignment. The defensible function for SET6 is
+      protein-lysine methyltransferase activity (GO:0016279); no histone substrate has been
+      demonstrated, and the SMYD subfamily to which Set6 belongs (and human SETD6) act
+      largely on non-histone targets. The histone-specific term is an over-annotation.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      This IBA term over-specifies the substrate to histones. Set6 has no identified
+      substrate of any kind, and the SMYD family it belongs to has well-documented
+      non-histone targets, so restricting the predicted activity to histones is not
+      supported. The parent-level protein-lysine methyltransferase activity (GO:0016279)
+      already captures the family-inferred function without the unwarranted histone
+      specificity. Prefer the generic KMT term over this one.
+    proposed_replacement_terms:
+    - id: GO:0016279
+      label: protein-lysine N-methyltransferase activity
+    supported_by:
+    - reference_id: PMID:31642774
+      supporting_text: &gt;-
+        Set5, and another member of this sub-group, Set6, are homologous to the mammalian
+        SMYD proteins [6], which have been reported to have both histone and non-histone
+        targets.
+    - reference_id: PMID:37252976
+      supporting_text: &gt;-
+        If they are in fact protein methyltransferases, they are most likely to target
+        as-yet undiscovered methylation sites
+    propagation_review:
+      root_cause: TERM_SCOPING_PROBLEM
+      failure_modes:
+      - GRANULARITY_MISMATCH
+      - FUNCTIONAL_DIVERGENCE
+      source_entities:
+      - source_id: PANTHER:PTN008534456
+        source_label: SMYD-family PANTHER node (PTHR12197) from which the IBA histone-MTase term was propagated
+        source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
+        comment: &gt;-
+          Family node is a bona fide protein-lysine methyltransferase group, but the
+          histone-specific substrate does not transfer to Set6, whose substrate is unknown
+          and whose SMYD subfamily acts largely on non-histone targets.
+- term:
+    id: GO:0005634
+    label: nucleus
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: is_active_in
+  review:
+    summary: &gt;-
+      Plausible location by SMYD-family phylogenetic transfer, but the subcellular
+      localization of Set6 has never actually been measured, so this is a low-confidence,
+      non-core annotation. Its paralog Set5 is found in both nucleus and cytoplasm.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      IBA family transfer to nucleus is reasonable for a SET/SMYD protein, but the
+      localization of Set6 specifically is explicitly unknown, and its SMYD paralog Set5 is
+      in fact dual nuclear/cytoplasmic, which would be consistent with non-histone
+      substrates. Retain as a non-core, unverified location rather than a defining feature.
+    supported_by:
+    - reference_id: PMID:31642774
+      supporting_text: &gt;-
+        While the subcellular localization of Set6 is not yet known, Set5 is found in both
+        the nucleus and cytoplasm [19], suggesting it is also likely to have non-histone
+        substrates.
+- term:
+    id: GO:0006338
+    label: chromatin remodeling
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000108
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Automatic inter-ontology inference chained off the over-annotated histone
+      methyltransferase term. There is no evidence that Set6 participates in chromatin
+      remodeling; the biological process is unknown. Remove along with its over-specific
+      parent MF term.
+    action: REMOVE
+    reason: &gt;-
+      This IEA annotation is derived by logical inference (GO_REF:0000108) from GO:0042054
+      histone methyltransferase activity (see the with/from field GO:0042054 in GOA), which
+      is itself an over-annotation for SET6. Set6 has no demonstrated histone activity, no
+      identified substrate, and no measured chromatin role; deletion has no standalone
+      growth phenotype. The inference collapses once the histone-MTase premise is removed, so
+      the chromatin-remodeling process assignment is unsupported and should be removed.
+    supported_by:
+    - reference_id: PMID:37252976
+      supporting_text: &gt;-
+        If they are in fact protein methyltransferases, they are most likely to target
+        as-yet undiscovered methylation sites
+    propagation_review:
+      root_cause: TERM_SCOPING_PROBLEM
+      failure_modes:
+      - GRANULARITY_MISMATCH
+      source_entities:
+      - source_id: GO:0042054
+        source_label: histone methyltransferase activity (the over-annotated MF term this IEA process was logically inferred from)
+        source_status: SOURCE_WEAK_OR_INFERRED
+        comment: &gt;-
+          The inter-ontology IEA process is chained off an over-specific, itself-inferred MF
+          term; it has no independent support for a chromatin role in Set6.
+- term:
+    id: GO:0008270
+    label: zinc ion binding
+  evidence_type: RCA
+  original_reference_id: PMID:30358795
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Computational (zinc-proteome) prediction that SET6 binds zinc, independently
+      corroborated by its cysteine-rich SMYD-type zinc-knot/post-SET architecture. A
+      plausible structural molecular function; kept as non-core because it is a structural,
+      not the defining, activity.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      The RCA annotation comes from a genome-scale zinc-proteome analysis. It is supported by
+      the local bioinformatics finding that SET6 is markedly Cys-rich (17 Cys, 4.6%) in three
+      clusters (N-terminal CxxC, an internal-insert cluster, and a C-terminal post-SET
+      C-x-C...C) matching the expected SMYD-family zinc-binding architecture. This is a
+      structural cofactor-binding function typical of SMYD SET domains rather than SET6&#39;s
+      defining catalytic activity, so it is retained as non-core.
+    supported_by:
+    - reference_id: file:yeast/SET6/SET6-bioinformatics/RESULTS.md
+      supporting_text: &gt;-
+        This clustered pattern is the expected SMYD-family zinc-knot / post-SET
+        metal-binding architecture and is consistent with the computational zinc-ion-binding
+        prediction (RCA, PMID:30358795).
+- term:
+    id: GO:0005575
+    label: cellular_component
+  evidence_type: ND
+  original_reference_id: GO_REF:0000015
+  qualifier: is_active_in
+  review:
+    summary: &gt;-
+      Root cellular_component term with the ND (No biological Data) evidence code, used as a
+      placeholder indicating no localization data. Accept as-is per GO convention.
+    action: ACCEPT
+    reason: &gt;-
+      This is a standard ND root-term placeholder recording that no cellular-component data
+      is available; it is not an informative annotation to modify or remove.
+- term:
+    id: GO:0008150
+    label: biological_process
+  evidence_type: ND
+  original_reference_id: GO_REF:0000015
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Root biological_process term with the ND evidence code, a placeholder indicating no
+      process data. Accept as-is per GO convention.
+    action: ACCEPT
+    reason: &gt;-
+      Standard ND root-term placeholder recording that no biological-process data is
+      available for SET6; not an informative annotation to modify or remove.
+core_functions:
+- description: &gt;-
+    Putative, likely catalytically competent protein-lysine methyltransferase of the SMYD
+    subfamily. SET6 retains the intact SET-domain catalytic/S-adenosyl-L-methionine-binding
+    residues that the dead yeast SET proteins Set3/Set4 have lost, and is the yeast SET
+    protein most likely to be a genuine protein methyltransferase. Its protein substrate is
+    unknown and no methyltransferase activity has been demonstrated, so this function is
+    proposed as putative.
+  molecular_function:
+    id: GO:0016279
+    label: protein-lysine N-methyltransferase activity
+  supported_by:
+  - reference_id: PMID:37252976
+    supporting_text: &gt;-
+      Of these three putative methyltransferases, the most likely protein methyltransferase
+      is Set6, as the SET domain invariably methylates proteins.
+  - reference_id: file:yeast/SET6/SET6-bioinformatics/RESULTS.md
+    supporting_text: &gt;-
+      SET6 has an intact SET domain and retains the canonical
+      catalytic/SAM-binding residues that Set3/Set4 have lost.
+- description: &gt;-
+    Structural zinc-ion binding via the cysteine-rich SMYD-type zinc-knot/post-SET
+    architecture, predicted computationally and consistent with the clustered cysteine
+    pattern of the protein. A structural cofactor-binding function that supports the SET/SMYD
+    fold rather than a standalone biological activity.
+  molecular_function:
+    id: GO:0008270
+    label: zinc ion binding
+  supported_by:
+  - reference_id: file:yeast/SET6/SET6-bioinformatics/RESULTS.md
+    supporting_text: &gt;-
+      This clustered pattern is the expected SMYD-family zinc-knot / post-SET
+      metal-binding architecture and is consistent with the computational zinc-ion-binding
+      prediction (RCA, PMID:30358795).
+knowledge_gaps:
+- gap_statement: &gt;-
+    The protein substrate of SET6 is unknown: no methylation site on any histone or
+    non-histone protein has ever been attributed to SET6, so the specific methyl-acceptor it
+    acts on is undetermined.
+  boundary: &gt;-
+    Established: SET6 is a SMYD-subfamily SET-domain protein whose catalytic/SAM-binding
+    residues are intact (unlike the dead Set3/Set4), and it is the yeast SET protein most
+    likely to be a genuine protein-lysine methyltransferase. Unknown: which protein (and
+    which lysine) it methylates. If it is active, it most likely targets an as-yet
+    undiscovered methylation site.
+  gap_kind:
+  - BIOLOGY
+  dark_aspect: MF_DARK
+  status: OPEN
+  significance: &gt;-
+    SET6 is one of only a handful of putative protein methyltransferases keeping the
+    otherwise near-complete yeast protein-methylation enzyme-substrate network incomplete;
+    identifying its substrate would help close that network.
+  resolution: &gt;-
+    In-vitro methyltransferase assays with recombinant SET6 against candidate substrates and
+    heavy-methyl SILAC / mass-spectrometry comparison of wild-type vs set6-delta
+    methylproteomes to detect SET6-dependent methylation site(s).
+  provenance:
+  - reference_id: PMID:37252976
+    supporting_text: &gt;-
+      If they are in fact protein methyltransferases, they are most likely to target
+      as-yet undiscovered methylation sites
+- gap_statement: &gt;-
+    Whether SET6 actually catalyzes methyl transfer in vitro or in vivo has never been
+    demonstrated; its catalytic competence is inferred solely from conserved active-site
+    residues.
+  boundary: &gt;-
+    Established: the SET-domain active-site residues required for catalysis and AdoMet
+    binding are conserved in SET6, unlike in the catalytically dead Set3/Set4. Unknown:
+    whether SET6 transfers a methyl group to any acceptor. Sequence conservation is
+    necessary but not sufficient for enzymatic activity.
+  gap_kind:
+  - BIOLOGY
+  dark_aspect: MF_DARK
+  status: OPEN
+  significance: &gt;-
+    Confirming (or refuting) methyltransferase activity would resolve whether SET6 is a bona
+    fide enzyme or, despite intact motifs, another inactive yeast SET protein.
+  resolution: &gt;-
+    Direct enzymatic assay (radiometric or MS-based methyl-transfer) using recombinant SET6
+    and AdoMet, with active-site point mutants as controls.
+  provenance:
+  - reference_id: file:yeast/SET6/SET6-bioinformatics/RESULTS.md
+    supporting_text: &gt;-
+      Motif conservation is necessary but not sufficient for activity; the only way to settle
+      competence is an enzymatic assay.
+- gap_statement: &gt;-
+    The biological role and subcellular localization of SET6 are unknown: deletion produces
+    no standalone growth phenotype, and where in the cell SET6 acts has not been measured.
+  boundary: &gt;-
+    Established: the only reported phenotype is drug-conditional fitness (resistance to
+    ergosterol-biosynthesis-targeting compounds) in a chemogenomic screen, of uncertain
+    mechanism, and SET6&#39;s SMYD paralog Set5 is dual nuclear/cytoplasmic. Unknown: the
+    biological process SET6 participates in and its localization.
+  gap_kind:
+  - BIOLOGY
+  dark_aspect: BP_DARK
+  status: OPEN
+  significance: &gt;-
+    Without a biological process or localization, SET6 cannot be placed in a pathway; its
+    drug-conditional phenotype hints at a role only indirectly.
+  resolution: &gt;-
+    Fluorescent-protein tagging / microscopy to determine localization, and phenotypic
+    profiling (including in the presence of ergosterol-biosynthesis inhibitors and in
+    sensitized genetic backgrounds) to define a biological process.
+  provenance:
+  - reference_id: PMID:31642774
+    supporting_text: &gt;-
+      While the subcellular localization of Set6 is not yet known, Set5 is found in both
+      the nucleus and cytoplasm [19], suggesting it is also likely to have non-histone
+      substrates.
+proposed_new_terms: []
+suggested_questions:
+- question: &gt;-
+    Does SET6 catalyze protein-lysine methylation, and if so, what is its physiological
+    protein substrate - a histone, or (as its SMYD family suggests) a non-histone target?
+  experts:
+  - Hamey JJ
+  - Wilkins MR
+- question: &gt;-
+    What is the subcellular localization of SET6, and does it (like its paralog Set5)
+    distribute between the nucleus and cytoplasm, consistent with a non-histone substrate?
+  experts:
+  - Green EM
+suggested_experiments:
+- hypothesis: &gt;-
+    SET6 is a catalytically active protein-lysine methyltransferase whose substrate is a
+    (likely non-histone) yeast protein.
+  description: &gt;-
+    Perform heavy-methyl SILAC quantitative mass spectrometry comparing the methylproteome
+    of a wild-type strain with a set6-delta strain to identify SET6-dependent methylation
+    site(s); confirm candidates with in-vitro methyltransferase assays using recombinant
+    SET6, AdoMet, and active-site point mutants as negative controls.
+  experiment_type: comparative methylproteomics + in-vitro methyltransferase assay
+- hypothesis: &gt;-
+    SET6 retains intact catalytic residues, so active-site mutation should abolish any
+    detectable methyltransferase activity.
+  description: &gt;-
+    Recombinantly express wild-type SET6 and NHSC-pocket / catalytic-Tyr337 point mutants and
+    compare methyl-transfer activity against a candidate substrate panel to test whether the
+    conserved residues are functionally required.
+  experiment_type: structure-function mutagenesis
+- hypothesis: &gt;-
+    SET6 localizes within the yeast cell in a pattern consistent with its (unknown) substrate
+    compartment.
+  description: &gt;-
+    Endogenously tag SET6 with a fluorescent protein and image its subcellular distribution
+    across growth conditions, including in the presence of ergosterol-biosynthesis inhibitors
+    that produce its chemogenomic phenotype.
+  experiment_type: fluorescence microscopy / localization
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/genes/yeast/UBP11/UBP11-ai-review.html
+++ b/genes/yeast/UBP11/UBP11-ai-review.html
@@ -1,0 +1,3022 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>UBP11 - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        .propagation-review {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f8fafc;
+            border-left: 3px solid #64748b;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .propagation-title {
+            font-weight: 600;
+            color: #334155;
+            margin-bottom: 0.25rem;
+        }
+
+        .propagation-row {
+            margin-top: 0.25rem;
+        }
+
+        .propagation-source {
+            margin-top: 0.5rem;
+            padding-top: 0.5rem;
+            border-top: 1px solid #e5e7eb;
+        }
+
+        .propagation-source-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #1d4ed8;
+        }
+
+        .propagation-comment {
+            color: #4b5563;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>UBP11</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/P36026" target="_blank" class="term-link">
+                        P36026
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Saccharomyces cerevisiae</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-complete">
+                    COMPLETE
+                </span>
+            </div>
+
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "UBP11";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="P36026" data-a="DESCRIPTION: UBP11 (YKR098C) is one of the ~16-17 ubiquitin-spe..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>UBP11 (YKR098C) is one of the ~16-17 ubiquitin-specific proteases (UBP/USP, peptidase C19 family) of budding yeast. It is a 717-residue cysteine-type deubiquitinating enzyme (DUB, EC 3.4.19.12) with a single C-terminal USP catalytic domain (residues ~298-707) bearing an intact catalytic dyad — a nucleophilic cysteine (Cys307) in the Cys box and a proton-acceptor histidine (His649) in the His box — so it is a catalytically competent deubiquitinase that hydrolyzes the bonds formed by the C-terminal glycine of ubiquitin, releasing ubiquitin from conjugates and precursors. Purified/recombinant Ubp11p cleaves ubiquitin fusions in vitro. Beyond this enzymatic activity, its cellular role is largely uncharacterized: no physiological substrate, no specific biological process, and no non-redundant in vivo function have been established, and single deletion causes no strong growth phenotype. UBP11 has a whole-genome-duplication paralog, UBP7, with which it is likely functionally redundant.</p>
+    </div>
+
+
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004843" target="_blank" class="term-link">
+                                    GO:0004843
+                                </a>
+                            </span>
+                            <span class="term-label">cysteine-type deubiquitinase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P36026" data-a="GO:0004843" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetic (IBA) propagation of the deubiquitinase molecular function across the USP/peptidase-C19 family. This is the correct core molecular function for UBP11 and is independently supported by direct in vitro assay (see the IDA row) and by the intact USP catalytic dyad (Cys307/His649).
+                        </div>
+
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/11076031" target="_blank" class="term-link">
+                                        PMID:11076031
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">14 of the 17 Dubs have now been shown to have</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:yeast/UBP11/UBP11-bioinformatics/RESULTS.md
+
+                                </span>
+
+                                <div class="support-text">the USP catalytic dyad (Cys307/His649) is intact within a 410-aa peptidase C19 domain</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005634" target="_blank" class="term-link">
+                                    GO:0005634
+                                </a>
+                            </span>
+                            <span class="term-label">nucleus</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P36026" data-a="GO:0005634" data-r="GO_REF:0000033" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Nuclear localization is an IBA propagation from the USP family, not an experimental observation for UBP11. Many yeast UBPs are cytosolic and/or nucleocytoplasmic, and SGD lists UBP11&#39;s cellular component as unknown; no UBP11-specific localization study exists. Retained as a plausible but unverified, non-core location — the true site of action is undetermined.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> IBA-only; no experimental localization data for UBP11 itself. Where the enzyme acts in vivo is a genuine knowledge gap.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031647" target="_blank" class="term-link">
+                                    GO:0031647
+                                </a>
+                            </span>
+                            <span class="term-label">regulation of protein stability</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P36026" data-a="GO:0031647" data-r="GO_REF:0000033" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Broad, family-level biological-process propagation (IBA): deubiquitinases as a class influence protein stability by removing degradative ubiquitin marks. This is a reasonable generic consequence of DUB activity but is not demonstrated for UBP11 specifically, and it names no substrate or pathway. Kept as non-core; the specific process UBP11 acts in is unknown.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Generic DUB-class inference (IBA), not UBP11-specific; no substrate or pathway established. The actual biological process is a knowledge gap.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
+                                    GO:0005829
+                                </a>
+                            </span>
+                            <span class="term-label">cytosol</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P36026" data-a="GO:0005829" data-r="GO_REF:0000033" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Cytosolic localization is an IBA propagation from the USP family. It is a plausible location for a soluble DUB but has not been experimentally determined for UBP11 (SGD lists cellular component as unknown). Retained as a non-core, unverified location.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> IBA-only; no experimental localization for UBP11. Plausible but unverified.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004843" target="_blank" class="term-link">
+                                    GO:0004843
+                                </a>
+                            </span>
+                            <span class="term-label">cysteine-type deubiquitinase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000120
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P36026" data-a="GO:0004843" data-r="GO_REF:0000120" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic (IEA) assignment of the deubiquitinase activity from InterPro (peptidase C19 signatures IPR001394/IPR018200) and the EC 3.4.19.12 mapping. Redundant with the IBA and IDA rows for the same term but correct and well grounded in the domain; the catalytic residues are intact.
+                        </div>
+
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:yeast/UBP11/UBP11-bioinformatics/RESULTS.md
+
+                                </span>
+
+                                <div class="support-text">Both members of the catalytic dyad expected for a USP/peptidase-C19 cysteine protease (nucleophilic Cys + proton-acceptor His) are present</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016579" target="_blank" class="term-link">
+                                    GO:0016579
+                                </a>
+                            </span>
+                            <span class="term-label">protein deubiquitination</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P36026" data-a="GO:0016579" data-r="GO_REF:0000002" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic (IEA, InterPro) assignment of the protein-deubiquitination biological process, the direct process counterpart of the DUB molecular function. This is the most defensible process term for UBP11: it follows necessarily from the demonstrated deubiquitinase activity without over-claiming a specific downstream pathway or substrate.
+                        </div>
+
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/10527495" target="_blank" class="term-link">
+                                        PMID:10527495
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Ubps 1p, 2p, 3p, 6p, 11p, and 15p and Yuh1p</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008270" target="_blank" class="term-link">
+                                    GO:0008270
+                                </a>
+                            </span>
+                            <span class="term-label">zinc ion binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">RCA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/30358795" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:30358795
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The cellular economy of the Saccharomyces cerevisiae zinc pr...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P36026" data-a="GO:0008270" data-r="PMID:30358795" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> This term comes from a genome-wide computational reconstruction (RCA) of the yeast zinc proteome (domain + motif prediction), not a direct measurement of zinc binding by UBP11. Some USP-family DUBs contain a zinc-finger/Zn-ribbon subdomain, so the prediction is plausible, but UniProt annotates no zinc-binding site in UBP11 and no experimental evidence exists. Marked as over-annotated: a predicted, non-core property that adds little to the functional picture and is not experimentally supported.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> RCA (computational proteome-wide prediction) only; no experimental zinc-binding data and no UniProt zinc-binding site for UBP11. Not a demonstrated function.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004843" target="_blank" class="term-link">
+                                    GO:0004843
+                                </a>
+                            </span>
+                            <span class="term-label">cysteine-type deubiquitinase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/10527495" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:10527495
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Chemically synthesized ubiquitin extension proteins detect d...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P36026" data-a="GO:0004843" data-r="PMID:10527495" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct assay (IDA): recombinant Ubp11p was among the yeast UBPs expressed in E. coli and tested against synthetic ubiquitin substrates, cleaving ubiquitin from fusions. This is the primary experimental evidence for the deubiquitinase molecular function and is the core function of UBP11. Note the study found isopeptidase (ubiquitin-epsilonN-lysine) cleavage only for a different subset of DUBs, so UBP11&#39;s physiological linkage specificity remains undefined — but its deubiquitinase activity is established.
+                        </div>
+
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/10527495" target="_blank" class="term-link">
+                                        PMID:10527495
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Ubps 1p, 2p, 3p, 6p, 11p, and 15p and Yuh1p</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005575" target="_blank" class="term-link">
+                                    GO:0005575
+                                </a>
+                            </span>
+                            <span class="term-label">cellular_component</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ND</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000015
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P36026" data-a="GO:0005575" data-r="GO_REF:0000015" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Root cellular_component term with ND (no data) evidence — an explicit SGD record that no experimental localization has been determined for UBP11. This honestly reflects the CC knowledge gap and should be retained as-is; it is not an assertion of function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> ND placeholder correctly documenting absence of localization data; keep.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008150" target="_blank" class="term-link">
+                                    GO:0008150
+                                </a>
+                            </span>
+                            <span class="term-label">biological_process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ND</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000015
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P36026" data-a="GO:0008150" data-r="GO_REF:0000015" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Root biological_process term with ND (no data) evidence — an explicit SGD record that no specific biological process has been experimentally assigned to UBP11. This honestly reflects the BP-dark status of the gene and should be retained as-is.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> ND placeholder correctly documenting absence of a specific process; keep.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>Cysteine-type deubiquitinase (peptidase C19 / USP family) that hydrolyzes the bonds formed by the C-terminal glycine of ubiquitin, removing ubiquitin from conjugates and precursors. Catalytic competence is supported by an intact USP catalytic dyad (nucleophile Cys307, proton acceptor His649) and by direct in vitro cleavage of ubiquitin fusions by recombinant Ubp11p. The in vivo substrate(s) and ubiquitin-linkage specificity are not established.</h3>
+                <span class="vote-buttons" data-g="P36026" data-a="FUNCTION: Cysteine-type deubiquitinase (peptidase C19 / USP ..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004843" target="_blank" class="term-link">
+                            cysteine-type deubiquitinase activity
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016579" target="_blank" class="term-link">
+                                protein deubiquitination
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/10527495" target="_blank" class="term-link">
+                                PMID:10527495
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">Ubps 1p, 2p, 3p, 6p, 11p, and 15p and Yuh1p</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/11076031" target="_blank" class="term-link">
+                                PMID:11076031
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">14 of the 17 Dubs have now been shown to have</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:yeast/UBP11/UBP11-bioinformatics/RESULTS.md
+
+                        </span>
+
+                        <div class="finding-text">the USP catalytic dyad (Cys307/His649) is intact within a 410-aa peptidase C19 domain</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000002.md" target="_blank" class="term-link">
+                            GO_REF:0000002
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation through association of InterPro records with GO terms</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000015.md" target="_blank" class="term-link">
+                            GO_REF:0000015
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Use of the ND evidence code for Gene Ontology (GO) terms</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
+                            GO_REF:0000033
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Annotation inferences using phylogenetic trees</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000120.md" target="_blank" class="term-link">
+                            GO_REF:0000120
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Combined Automated Annotation using Multiple IEA Methods</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/10527495" target="_blank" class="term-link">
+                            PMID:10527495
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Chemically synthesized ubiquitin extension proteins detect distinct catalytic capacities of deubiquitinating enzymes.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Recombinant yeast Ubp11p was among the DUBs assayed against synthetic ubiquitin substrates and cleaved ubiquitin fusions, but isopeptidase activity was associated only with a different subset (Yuh1p, Unp, Ubp1p, Ubp2p), so UBP11&#39;s physiological linkage specificity is not defined here.</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/11076031" target="_blank" class="term-link">
+                            PMID:11076031
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Analysis of the deubiquitinating enzymes of the yeast Saccharomyces cerevisiae.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">All 17 yeast DUB genes were individually deleted; none of the single mutants is lethal or strongly growth-defective under standard conditions, and 14 of 17 DUBs (including Ubp11p) have demonstrated ubiquitin-cleaving activity — establishing both the DUB activity and the lack of a strong single-deletion phenotype for UBP11.</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/30358795" target="_blank" class="term-link">
+                            PMID:30358795
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">The cellular economy of the Saccharomyces cerevisiae zinc proteome.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">A genome-wide bioinformatic + proteomic survey of the yeast zinc proteome; the source of the computational (RCA) zinc-ion-binding prediction for UBP11. Not a direct measurement of zinc binding by UBP11.</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        file:yeast/UBP11/UBP11-bioinformatics/RESULTS.md
+
+                    </span>
+                </div>
+
+                <div class="reference-title">UBP11 USP catalytic-domain integrity analysis (this repository)</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Reproducible parse of the UniProt record confirms the USP catalytic dyad (nucleophile Cys307, proton acceptor His649) is intact within a 410-aa peptidase C19 domain, supporting a catalytically competent deubiquitinase.</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Questions for Experts</h2>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> What are the physiological substrates of UBP11 in S. cerevisiae, and which ubiquitin-chain linkages does it preferentially cleave?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P36026" data-a="Q: What are the physiological substrates of UBP11 in ..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> How is deubiquitinase function partitioned between UBP11 and its WGD paralog UBP7, and does the ubp7 ubp11 double mutant reveal a phenotype masked by redundancy?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P36026" data-a="Q: How is deubiquitinase function partitioned between..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Experiments</h2>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Perform quantitative ubiquitylome (diGly) proteomics comparing wild type, ubp11 deletion, ubp7 deletion, and the ubp7 ubp11 double mutant to identify substrates whose ubiquitylation increases specifically when both DUBs are removed.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: UBP11 acts redundantly with UBP7 on a shared set of ubiquitylated substrates.</em></p>
+
+
+                    <p style="margin-top: 0.5rem;">Type: quantitative diGly ubiquitylome mass spectrometry</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P36026" data-a="EXPERIMENT: Perform quantitative ubiquitylome (diGly) proteomi..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Assay recombinant Ubp11p (and a catalytic Cys307 mutant control) against a panel of defined K6/K11/K27/K29/K33/K48/K63/M1-linked di- and tetra-ubiquitin chains to determine linkage preference in vitro.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: Purified Ubp11p has a defined ubiquitin-linkage specificity.</em></p>
+
+
+                    <p style="margin-top: 0.5rem;">Type: in vitro deubiquitinase linkage-specificity assay</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P36026" data-a="EXPERIMENT: Assay recombinant Ubp11p (and a catalytic Cys307 m..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Knowledge Gaps</h2>
+        <p style="color: #555; font-size: 0.92rem; margin-top: -0.3rem;">
+            What is <em>not</em> known — curated, literature-grounded statements of the open
+            unknowns (the inverse of core functions).
+        </p>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The physiological substrate(s), ubiquitin-linkage specificity, biological process, and non-redundant in vivo role of UBP11 are unknown. It is established that Ubp11p is a catalytically competent deubiquitinase, but not what it deubiquitinates, in which pathway, or what distinguishes its function from its whole-genome-duplication paralog UBP7 and the wider yeast UBP family.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span><span class="badge">CURATION</span>
+                <span class="badge">BP_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> Known: UBP11 is a 717-aa peptidase C19 (USP) enzyme with an intact catalytic dyad (Cys307/His649); recombinant Ubp11p cleaves ubiquitin fusions in vitro, and 14 of the 17 yeast DUBs (Ubp11p included) have demonstrated ubiquitin-cleaving activity. Unknown/absent: a single ubp11 deletion is not lethal or strongly growth-defective under standard conditions, SGD lists both its biological process and cellular component as unknown, no in vivo substrate has been identified, and the isopeptidase specificity assay placed UBP11 outside the isopeptidase-positive DUB subset, leaving its linkage preference undefined.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> UBP11 is a representative of the large, mostly uncharacterized yeast UBP family — most of whose cellular functions remain undiscovered. Assigning a substrate and pathway would both illuminate this specific enzyme and help resolve why the yeast genome maintains ~16-17 partly redundant deubiquitinases, distinguishing genuine functional specialization from WGD-derived redundancy.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Identify in vivo substrates by comparing the ubiquitylome of ubp11 deletion (and the ubp7 ubp11 double mutant, to bypass paralog redundancy) with wild type; test linkage specificity of purified Ubp11p against defined di-/poly- ubiquitin chains; determine subcellular localization of tagged Ubp11p; and phenotype the double mutant across stress/condition panels.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"none of the mutants is lethal or strongly growth defective under standard"</em> — PMID:11076031</li>
+
+                <li><em>"isopeptidase activity"</em> — PMID:10527495</li>
+
+            </ul>
+
+
+        </div>
+
+    </div>
+
+
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Deep Research Sections -->
+
+    <div class="section">
+        <h2 class="section-title">Deep Research</h2>
+
+        <details class="deep-research-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; gap: 1rem;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Falcon</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(UBP11-deep-research-falcon.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="P36026" data-a="DEEP_RESEARCH: Falcon" data-r="" data-act="DEEP_RESEARCH" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This deep research is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This deep research needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+
+                <div class="report-meta">
+
+                    <span class="report-meta-text">this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</span>
+
+
+                    <span class="report-badge">Falcon</span>
+
+
+                    <span class="report-badge">Edison Scientific Literature</span>
+
+
+                    <span class="report-badge">21 citations</span>
+
+
+                    <span class="report-badge">1 artifacts</span>
+
+
+                    <span class="report-meta-text">2026-07-05T00:34:07.409165</span>
+
+
+
+                </div>
+
+
+                <div class="artifact-list">
+
+
+
+                    <div class="artifact-link">
+                        <a href="UBP11-deep-research-falcon_artifacts/artifact-00.md" class="term-link">Edison artifact artifact-00</a>
+                        <span>(text/markdown)</span>
+                    </div>
+
+
+                </div>
+
+                <p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h2 id="comprehensive-research-report-ubp11-ykr098c-ubiquitin-carboxyl-terminal-hydrolase-11-in-saccharomyces-cerevisiae">Comprehensive Research Report: UBP11 (YKR098C) – Ubiquitin Carboxyl-Terminal Hydrolase 11 in <em>Saccharomyces cerevisiae</em></h2>
+<h3 id="1-gene-and-protein-identity">1. Gene and Protein Identity</h3>
+<p>UBP11 (systematic name YKR098C; UniProt P36026) encodes ubiquitin carboxyl-terminal hydrolase 11 (also known as deubiquitinating enzyme 11, ubiquitin thioesterase 11, or ubiquitin-specific-processing protease 11) in <em>Saccharomyces cerevisiae</em> (strain ATCC 204508 / S288c). The protein is 717 amino acids in length and belongs to the peptidase C19 family of cysteine proteases, classified under EC 3.4.19.12 (suresh2020thestructureand pages 4-5, suresh2020thestructureand pages 2-3). Ubp11 is one of 16 USP/UBP (ubiquitin-specific protease) family members in budding yeast, which together constitute the largest family of deubiquitinases (DUBs) among the 22 total putative DUBs encoded by the yeast genome (suresh2020thestructureand pages 3-4).</p>
+<p>The following table summarizes the key properties of UBP11:</p>
+<table>
+<thead>
+<tr>
+<th>Property</th>
+<th>Summary</th>
+<th>Source</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Gene name</td>
+<td><strong>UBP11</strong></td>
+<td>(suresh2020thestructureand pages 4-5)</td>
+</tr>
+<tr>
+<td>Systematic name</td>
+<td><strong>YKR098C</strong></td>
+<td>(suresh2020thestructureand pages 4-5)</td>
+</tr>
+<tr>
+<td>UniProt ID</td>
+<td><strong>P36026</strong></td>
+<td>(suresh2020thestructureand pages 4-5)</td>
+</tr>
+<tr>
+<td>Protein length</td>
+<td><strong>717 aa</strong></td>
+<td>(suresh2020thestructureand pages 2-3)</td>
+</tr>
+<tr>
+<td>EC number</td>
+<td><strong>EC 3.4.19.12</strong> (ubiquitin carboxyl-terminal hydrolase / deubiquitinating enzyme)</td>
+<td>(suresh2020thestructureand pages 4-5, suresh2020thestructureand pages 3-4)</td>
+</tr>
+<tr>
+<td>Protein family</td>
+<td>Member of the <strong>USP/UBP (ubiquitin-specific protease)</strong> family; yeast has 16 USP/UBP DUBs within 22 total putative DUBs</td>
+<td>(suresh2020thestructureand pages 3-4)</td>
+</tr>
+<tr>
+<td>Key domains</td>
+<td>Catalytic <strong>USP domain / USP catalytic core</strong> characteristic of peptidase C19 family DUBs; USP/UBP enzymes share a conserved catalytic domain with finger, palm, and thumb subdomains for ubiquitin recognition</td>
+<td>(suresh2020thestructureand pages 3-4)</td>
+</tr>
+<tr>
+<td>Subcellular localization</td>
+<td>Reported as <strong>cytoplasm</strong> in a systematic snapshot of budding-yeast DUBs</td>
+<td>(suresh2020thestructureand pages 4-5)</td>
+</tr>
+<tr>
+<td>Enzymatic activity</td>
+<td>Predicted/annotated <strong>cysteine protease deubiquitinase</strong> that hydrolyzes Ub–substrate or Ub–Ub isopeptide bonds; direct substrate-level biochemical characterization for Ubp11 itself is limited</td>
+<td>(suresh2020thestructureand pages 1-2, suresh2020thestructureand pages 3-4)</td>
+</tr>
+<tr>
+<td>Known functional associations</td>
+<td>Genetic/chemical-genetic evidence places <strong>UBP11</strong> in an <strong>Rsp5-centered endosomal transport network</strong>; UBP11 and UBP7 were described as proteins that can <strong>deubiquitinate Rsp5 substrates</strong></td>
+<td>(tardiff2013yeastreveala pages 3-4)</td>
+</tr>
+<tr>
+<td>Endocytosis / trafficking context</td>
+<td>In α-synuclein/NAB2 studies, <strong>overexpression of UBP11</strong> (and UBP7) <strong>partially compromised</strong> NAB2-mediated rescue of α-syn toxicity, consistent with Ubp11 antagonizing Rsp5-driven ubiquitin-dependent endosomal trafficking</td>
+<td>(tardiff2013yeastreveala pages 3-4)</td>
+</tr>
+<tr>
+<td>Deletion phenotype</td>
+<td>No strong standalone phenotype was highlighted in the retrieved literature; in the NAB2 study, <strong>no deletion, including ubp7Δ ubp11Δ</strong>, produced more than <strong>partial resistance</strong> to NAB2, arguing UBP11 is involved but not itself the central NAB2 target; available evidence therefore suggests a <strong>subtle or context-dependent loss-of-function phenotype</strong></td>
+<td>(tardiff2013yeastreveala pages 3-4)</td>
+</tr>
+<tr>
+<td>Closest functional paralogs</td>
+<td><strong>UBP7</strong> is the closest experimentally supported functional paralog based on shared placement with UBP11 as deubiquitinases of <strong>Rsp5 substrates</strong> in the same endocytic/endosomal transport network; direct redundancy is suggested but not fully resolved</td>
+<td>(tardiff2013yeastreveala pages 3-4, bohm2016thebuddingyeast pages 2-3)</td>
+</tr>
+<tr>
+<td>Current evidence strength</td>
+<td><strong>Undercharacterized</strong> relative to other yeast DUBs: strong family/domain assignment and pathway association exist, but direct biochemical substrate specificity, chain-linkage preference, and dedicated deletion-phenotype studies for Ubp11 remain sparse in the retrieved literature</td>
+<td>(suresh2020thestructureand pages 3-4, suresh2020thestructureand pages 4-5, tardiff2013yeastreveala pages 3-4)</td>
+</tr>
+</tbody>
+</table>
+<p><em>Table: This table summarizes the core annotated and literature-supported properties of the yeast deubiquitinase UBP11/YKR098C, including structure, localization, catalytic class, and the best-supported functional association with the Rsp5-endocytosis network. It is useful as a compact evidence map because UBP11 appears to be relatively undercharacterized compared with other budding-yeast DUBs.</em></p>
+<h3 id="2-enzymatic-function-and-catalytic-mechanism">2. Enzymatic Function and Catalytic Mechanism</h3>
+<p>As a member of the USP/UBP family, Ubp11 is predicted to function as a cysteine protease that hydrolyzes isopeptide bonds between ubiquitin and substrate proteins, or between ubiquitin moieties in polyubiquitin chains. The USP/UBP catalytic domain adopts a highly conserved structure resembling a right hand with three subdomains: a finger, palm, and thumb. The catalytic center is formed in a cleft between the palm and thumb, with the catalytic cysteine residing in the thumb and the catalytic histidine in the palm, while the finger subdomain interacts with ubiquitin to facilitate its positioning in the catalytic center (suresh2020thestructureand pages 3-4). The catalytic triad typical of cysteine protease DUBs comprises Cys, His, and Asp/Asn residues, where the nearby His residue lowers the pKa of the catalytic Cys, facilitating a nucleophilic attack on the isopeptide bond (suresh2020thestructureand pages 3-4).</p>
+<p>Substrate recognition by USP/UBP family members typically involves either their variable sequence regions or scaffolds and substrate adaptors within multi-protein complexes (suresh2020thestructureand pages 3-4). Many USP/UBP DUBs utilize additional protein-protein interaction (PPI) domains to bind target proteins, enabling them to cleave ubiquitin chains from specific targets regardless of chain architecture (suresh2020thestructureand pages 3-4). It should be noted that direct biochemical characterization of Ubp11's substrate specificity and ubiquitin-chain linkage preference has not been reported in the available literature; the enzyme's activity is inferred primarily from its domain architecture and family membership.</p>
+<h3 id="3-subcellular-localization">3. Subcellular Localization</h3>
+<p>Systematic localization studies of budding yeast DUBs indicate that Ubp11 localizes to the <strong>cytoplasm</strong> (suresh2020thestructureand pages 4-5). This localization is consistent with a role in cytosolic deubiquitination processes, including the regulation of ubiquitinated substrates involved in endosomal and vesicular trafficking pathways.</p>
+<h3 id="4-biological-function-and-pathway-involvement">4. Biological Function and Pathway Involvement</h3>
+<h4 id="41-role-in-the-rsp5nedd4-dependent-endosomal-transport-network">4.1 Role in the Rsp5/Nedd4-Dependent Endosomal Transport Network</h4>
+<p>The strongest functional evidence for Ubp11 comes from a landmark chemical-genetic study by Tardiff et al. (2013, <em>Science</em>). In this study, a small molecule called NAB2 was identified as a compound that rescues α-synuclein toxicity in yeast by promoting Rsp5-dependent ubiquitin-mediated endosomal transport. A comprehensive genetic screen revealed a highly connected network of functionally related genes underlying NAB2 activity. This network included the E3 ubiquitin ligase RSP5 (a HECT domain ligase that catalyzes K63-linked ubiquitination of diverse membrane proteins to regulate endosomal trafficking), endocytic proteins (SLA1, VRP1), the multivesicular body sorting deubiquitinase DOA4, an Rsp5 adaptor (BUL1), known and potential Rsp5 substrates (BAP2, BAP3, MMP1), VPS23 (which directs Rsp5 substrates for vacuolar degradation), and critically, <strong>two proteins that can deubiquitinate Rsp5 substrates: UBP7 and UBP11</strong> (tardiff2013yeastreveala pages 3-4).</p>
+<p>In this context, overexpression of UBP7 and UBP11 <strong>partially compromised the ability of NAB2 to rescue α-synuclein toxicity</strong>, consistent with a model in which these deubiquitinases counteract Rsp5-driven ubiquitination of endocytic cargo and/or the endocytic machinery itself (tardiff2013yeastreveala pages 3-4). Conversely, deletion of UBP7 and UBP11, either singly or in combination (ubp7Δ ubp11Δ double mutant), had no effect on NAB2's rescue of α-synuclein toxicity, and no deletion (including the double deletion) conferred more than partial resistance to NAB2 (tardiff2013yeastreveala pages 3-4). This indicates that while Ubp11 participates in the Rsp5-dependent endosomal pathway, it is not the central target of NAB2 and likely acts redundantly with other DUBs.</p>
+<h4 id="42-functional-relationship-with-ubp7">4.2 Functional Relationship with Ubp7</h4>
+<p>Ubp7 is the closest characterized functional paralog of Ubp11 based on their shared placement in the Rsp5 endosomal transport network (tardiff2013yeastreveala pages 3-4). Ubp7 has been independently characterized as a late-arriving component of endocytic sites that, together with Ubp2, regulates clathrin-mediated endocytosis by deubiquitinating endocytic machinery proteins, most notably the early endocytic protein Ede1 (weinberg2014regulationofclathrinmediated pages 3-5, weinberg2014regulationofclathrinmediated pages 5-7). The dynamic ubiquitination and deubiquitination of Ede1 by Rsp5 (E3 ligase) and Ubp2/Ubp7 (DUBs) regulates endocytic coat assembly and disassembly at the plasma membrane (weinberg2014regulationofclathrinmediated pages 3-5, weinberg2014regulationofclathrinmediated pages 5-7). While Ubp7 has been directly demonstrated to deubiquitinate Ede1 in vitro (weinberg2014regulationofclathrinmediated pages 3-5), no equivalent in vitro experiment has been reported for Ubp11. Nevertheless, the genetic evidence places Ubp11 in the same functional pathway.</p>
+<p>Additionally, Ubp7 has been shown to have a role in S phase progression and the DNA damage response, with evolutionary rate covariation analysis linking it to homologous recombination and nucleotide excision repair pathways (bohm2016thebuddingyeast pages 1-2, bohm2016thebuddingyeast pages 2-3). Whether Ubp11 shares these additional roles remains untested.</p>
+<h4 id="43-context-within-the-broader-yeast-dub-network">4.3 Context within the Broader Yeast DUB Network</h4>
+<p>The yeast ubiquitin system employs DUBs across multiple cellular compartments and processes. Several other UBP family members have well-characterized roles: Ubp6 and the JAMM family DUB Rpn11 function at the proteasome; Doa4 recycles ubiquitin at multivesicular bodies; Ubp8 deubiquitinates histone H2B as part of the SAGA complex; Ubp3 plays pleiotropic roles in protein quality control, ribophagy, and stress response; and Ubp2/Ubp15 regulate the ART/Rsp5 ubiquitin ligase complex (suresh2020thestructureand pages 8-9, suresh2020thestructureand pages 5-6, suresh2020thestructureand pages 9-10). In the context of ER-associated degradation, the related DUB Ubp1 (not to be confused with Ubp11) specifically antagonizes the Doa10 E3 ligase and regulates the ERAD ubiquitin ligase Hrd1 through cycles of autoubiquitination and deubiquitination (peterson2019cyclesofautoubiquitination pages 2-3). When 23 different DUBs were tested for their ability to increase Hrd1 levels, Ubp1 showed the strongest and most specific effect, suggesting that most other DUBs including Ubp11 do not play a major role in ERAD (peterson2019cyclesofautoubiquitination pages 2-3).</p>
+<p>Notably, Ubp11 was not among the nine DUBs selected for proteome-wide protein expression profiling in the systematic study by Isasa et al. (2015), which focused on UBP3, DOA4, UBP6, UBP8, UBP10, UBP14, UBP15, OTU1, and OTU2 (isasa2015multiplexedproteomewideprotein pages 1-2, isasa2015multiplexedproteomewideprotein pages 3-4). This omission reflects the relative lack of characterized phenotypes associated with UBP11 deletion, consistent with the general observation that many yeast DUBs exhibit functional redundancy.</p>
+<h3 id="5-deletion-phenotype">5. Deletion Phenotype</h3>
+<p>The deletion of UBP11, either alone or in combination with UBP7, does not cause severe growth defects under standard laboratory conditions (tardiff2013yeastreveala pages 3-4). This is consistent with the high degree of functional redundancy observed among yeast DUBs, where individual deletions often have subtle or condition-specific phenotypes. The observation that even the ubp7Δ ubp11Δ double deletion confers only partial effects on the Rsp5/endocytosis pathway suggests that additional DUBs (such as Ubp2) can compensate for the loss of these enzymes.</p>
+<h3 id="6-structural-and-evolutionary-context">6. Structural and Evolutionary Context</h3>
+<p>Ubp11 is a 717 amino acid protein containing the characteristic USP catalytic domain with the Cys-His catalytic dyad common to peptidase C19 family members (suresh2020thestructureand pages 2-3). The protein contains the USP_CS (ubiquitin-specific protease cysteine signature) motif (InterPro: IPR018200) and the broader USP domain (InterPro: IPR028889), both hallmarks of ubiquitin-specific proteases. Unlike some other yeast USPs, Ubp11 does not appear to have a clearly annotated human orthologue based on the domain architecture comparison in Suresh et al. (2020), in contrast to DUBs like Ubp6/USP14, Ubp8/USP22, or Ubp14/ISOT, which have well-established human counterparts (suresh2020thestructureand pages 2-3). This suggests that Ubp11 may represent a yeast-specific or clade-restricted DUB, or one whose human orthologue has diverged sufficiently to preclude straightforward assignment.</p>
+<h3 id="7-summary-and-conclusions">7. Summary and Conclusions</h3>
+<p>UBP11 encodes a relatively <strong>undercharacterized</strong> member of the USP/UBP cysteine protease family of deubiquitinating enzymes in <em>S. cerevisiae</em>. Its primary function, based on genetic and chemical-genetic evidence, is to <strong>deubiquitinate substrates of the Rsp5 E3 ubiquitin ligase</strong>, thereby modulating <strong>ubiquitin-dependent endosomal and vesicular transport</strong> processes. Ubp11 localizes to the <strong>cytoplasm</strong> and appears to function redundantly with Ubp7 (and potentially other DUBs such as Ubp2) in regulating the ubiquitination status of endocytic machinery and cargo proteins. The enzyme catalyzes the hydrolysis of ubiquitin-protein isopeptide bonds (EC 3.4.19.12) via a cysteine protease mechanism involving a conserved Cys-His-Asp/Asn catalytic triad within the USP domain. Despite clear pathway-level evidence linking Ubp11 to the Rsp5/endocytosis network, direct biochemical characterization of its substrate specificity, ubiquitin chain-linkage preference, and specific protein substrates remains an important gap in the field.</p>
+<p>References</p>
+<ol>
+<li>
+<p>(suresh2020thestructureand pages 4-5): Harsha Garadi Suresh, Natasha Pascoe, and Brenda Andrews. The structure and function of deubiquitinases: lessons from budding yeast. Oct 2020. URL: https://doi.org/10.1098/rsob.200279, doi:10.1098/rsob.200279. This article has 62 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(suresh2020thestructureand pages 2-3): Harsha Garadi Suresh, Natasha Pascoe, and Brenda Andrews. The structure and function of deubiquitinases: lessons from budding yeast. Oct 2020. URL: https://doi.org/10.1098/rsob.200279, doi:10.1098/rsob.200279. This article has 62 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(suresh2020thestructureand pages 3-4): Harsha Garadi Suresh, Natasha Pascoe, and Brenda Andrews. The structure and function of deubiquitinases: lessons from budding yeast. Oct 2020. URL: https://doi.org/10.1098/rsob.200279, doi:10.1098/rsob.200279. This article has 62 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(suresh2020thestructureand pages 1-2): Harsha Garadi Suresh, Natasha Pascoe, and Brenda Andrews. The structure and function of deubiquitinases: lessons from budding yeast. Oct 2020. URL: https://doi.org/10.1098/rsob.200279, doi:10.1098/rsob.200279. This article has 62 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(tardiff2013yeastreveala pages 3-4): Daniel F. Tardiff, Nathan T. Jui, Vikram Khurana, Mitali A. Tambe, Michelle L. Thompson, Chee Yeun Chung, Hari B. Kamadurai, Hyoung Tae Kim, Alex K. Lancaster, Kim A. Caldwell, Guy A. Caldwell, Jean-Christophe Rochet, Stephen L. Buchwald, and Susan Lindquist. Yeast reveal a “druggable” rsp5/nedd4 network that ameliorates α-synuclein toxicity in neurons. Nov 2013. URL: https://doi.org/10.1126/science.1245321, doi:10.1126/science.1245321. This article has 327 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(bohm2016thebuddingyeast pages 2-3): Stefanie Böhm, Barnabas Szakal, Benjamin W. Herken, Meghan R. Sullivan, Michael J. Mihalevic, Faiz F. Kabbinavar, Dana Branzei, Nathan L. Clark, and Kara A. Bernstein. The budding yeast ubiquitin protease ubp7 is a novel component involved in s phase progression. Journal of Biological Chemistry, 291:4442-4452, Feb 2016. URL: https://doi.org/10.1074/jbc.m115.671057, doi:10.1074/jbc.m115.671057. This article has 18 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(weinberg2014regulationofclathrinmediated pages 3-5): Jasper S. Weinberg and David G. Drubin. Regulation of clathrin-mediated endocytosis by dynamic ubiquitination and deubiquitination. Current Biology, 24:951-959, May 2014. URL: https://doi.org/10.1016/j.cub.2014.03.038, doi:10.1016/j.cub.2014.03.038. This article has 59 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(weinberg2014regulationofclathrinmediated pages 5-7): Jasper S. Weinberg and David G. Drubin. Regulation of clathrin-mediated endocytosis by dynamic ubiquitination and deubiquitination. Current Biology, 24:951-959, May 2014. URL: https://doi.org/10.1016/j.cub.2014.03.038, doi:10.1016/j.cub.2014.03.038. This article has 59 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(bohm2016thebuddingyeast pages 1-2): Stefanie Böhm, Barnabas Szakal, Benjamin W. Herken, Meghan R. Sullivan, Michael J. Mihalevic, Faiz F. Kabbinavar, Dana Branzei, Nathan L. Clark, and Kara A. Bernstein. The budding yeast ubiquitin protease ubp7 is a novel component involved in s phase progression. Journal of Biological Chemistry, 291:4442-4452, Feb 2016. URL: https://doi.org/10.1074/jbc.m115.671057, doi:10.1074/jbc.m115.671057. This article has 18 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(suresh2020thestructureand pages 8-9): Harsha Garadi Suresh, Natasha Pascoe, and Brenda Andrews. The structure and function of deubiquitinases: lessons from budding yeast. Oct 2020. URL: https://doi.org/10.1098/rsob.200279, doi:10.1098/rsob.200279. This article has 62 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(suresh2020thestructureand pages 5-6): Harsha Garadi Suresh, Natasha Pascoe, and Brenda Andrews. The structure and function of deubiquitinases: lessons from budding yeast. Oct 2020. URL: https://doi.org/10.1098/rsob.200279, doi:10.1098/rsob.200279. This article has 62 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(suresh2020thestructureand pages 9-10): Harsha Garadi Suresh, Natasha Pascoe, and Brenda Andrews. The structure and function of deubiquitinases: lessons from budding yeast. Oct 2020. URL: https://doi.org/10.1098/rsob.200279, doi:10.1098/rsob.200279. This article has 62 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(peterson2019cyclesofautoubiquitination pages 2-3): Brian G Peterson, Morgan L Glaser, Tom A Rapoport, and Ryan D Baldridge. Cycles of autoubiquitination and deubiquitination regulate the erad ubiquitin ligase hrd1. JournalArticle, Dec 2019. URL: https://doi.org/10.17863/cam.47081, doi:10.17863/cam.47081. This article has 60 citations.</p>
+</li>
+<li>
+<p>(isasa2015multiplexedproteomewideprotein pages 1-2): Marta Isasa, Christopher M. Rose, Suzanne Elsasser, José Navarrete-Perea, Joao A. Paulo, Daniel J. Finley, and Steven P. Gygi. Multiplexed, proteome-wide protein expression profiling: yeast deubiquitylating enzyme knockout strains. Journal of proteome research, 14 12:5306-17, Nov 2015. URL: https://doi.org/10.1021/acs.jproteome.5b00802, doi:10.1021/acs.jproteome.5b00802. This article has 66 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(isasa2015multiplexedproteomewideprotein pages 3-4): Marta Isasa, Christopher M. Rose, Suzanne Elsasser, José Navarrete-Perea, Joao A. Paulo, Daniel J. Finley, and Steven P. Gygi. Multiplexed, proteome-wide protein expression profiling: yeast deubiquitylating enzyme knockout strains. Journal of proteome research, 14 12:5306-17, Nov 2015. URL: https://doi.org/10.1021/acs.jproteome.5b00802, doi:10.1021/acs.jproteome.5b00802. This article has 66 citations and is from a peer-reviewed journal.</p>
+</li>
+</ol>
+<h2 id="artifacts">Artifacts</h2>
+<ul>
+<li><a href="UBP11-deep-research-falcon_artifacts/artifact-00.md">Edison artifact artifact-00</a></li>
+</ul>
+<h2 id="citations">Citations</h2>
+<ol>
+<li>suresh2020thestructureand pages 3-4</li>
+<li>suresh2020thestructureand pages 4-5</li>
+<li>suresh2020thestructureand pages 2-3</li>
+<li>tardiff2013yeastreveala pages 3-4</li>
+<li>weinberg2014regulationofclathrinmediated pages 3-5</li>
+<li>peterson2019cyclesofautoubiquitination pages 2-3</li>
+<li>suresh2020thestructureand pages 1-2</li>
+<li>bohm2016thebuddingyeast pages 2-3</li>
+<li>weinberg2014regulationofclathrinmediated pages 5-7</li>
+<li>bohm2016thebuddingyeast pages 1-2</li>
+<li>suresh2020thestructureand pages 8-9</li>
+<li>suresh2020thestructureand pages 5-6</li>
+<li>suresh2020thestructureand pages 9-10</li>
+<li>isasa2015multiplexedproteomewideprotein pages 1-2</li>
+<li>isasa2015multiplexedproteomewideprotein pages 3-4</li>
+<li>https://doi.org/10.1098/rsob.200279,</li>
+<li>https://doi.org/10.1126/science.1245321,</li>
+<li>https://doi.org/10.1074/jbc.m115.671057,</li>
+<li>https://doi.org/10.1016/j.cub.2014.03.038,</li>
+<li>https://doi.org/10.17863/cam.47081,</li>
+<li>https://doi.org/10.1021/acs.jproteome.5b00802,</li>
+</ol>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(UBP11-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="P36026" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="ubp11-ykr098c-p36026-research-notes">UBP11 (YKR098C / P36026) research notes</h1>
+<p><em>S. cerevisiae</em> ubiquitin-specific protease 11. An <strong>understudied ("dark") gene</strong>: the<br />
+molecular activity is clear (a cysteine-type deubiquitinase), but its physiological<br />
+substrate, biological process, non-redundant role, and localization are essentially<br />
+unknown. These notes record what is KNOWN vs NOT-KNOWN with provenance.</p>
+<h2 id="identity-and-domain-architecture-known">Identity and domain architecture (KNOWN)</h2>
+<ul>
+<li>UniProt P36026, <code>UBP11_YEAST</code>, systematic name <strong>YKR098C</strong>, chromosome XI; 717 aa,<br />
+  ~82.7 kDa. RecName "Ubiquitin carboxyl-terminal hydrolase 11"; EC 3.4.19.12<br />
+  (thiol-dependent hydrolysis of ubiquitin C-terminal ester/thioester/amide/peptide/<br />
+  isopeptide bonds). (<code>UBP11-uniprot.txt</code>)</li>
+<li>Belongs to the <strong>peptidase C19 family</strong> (USP / ubiquitin-specific protease); single<br />
+  USP catalytic domain spanning residues 298–707 (~410 aa). Two annotated catalytic<br />
+<code>ACT_SITE</code> residues: <strong>Cys307 (nucleophile)</strong> and <strong>His649 (proton acceptor)</strong>.<br />
+  PROSITE USP signatures PS00972 (USP_1, Cys box), PS00973 (USP_2, His box) and PS50235<br />
+  (USP_3 profile) all match. (<code>UBP11-uniprot.txt</code>)</li>
+<li>Bioinformatics check (this repo, <code>UBP11-bioinformatics/RESULTS.md</code>): the catalytic dyad<br />
+  Cys307/His649 is <strong>present and intact</strong> → catalytically competent DUB by domain, not a<br />
+  degenerate pseudo-DUB. The catalytic Cys sits in the canonical Cys box (<code>NPCNTC…</code>).</li>
+</ul>
+<h2 id="molecular-function-deubiquitinase-known">Molecular function: deubiquitinase (KNOWN)</h2>
+<ul>
+<li>Ubp11p was assayed directly for deubiquitinating activity. In the synthetic-substrate<br />
+  study, yeast Ubps 1p, 2p, 3p, 6p, <strong>11p</strong>, and 15p and Yuh1p were "expressed in<br />
+  Escherichia coli" and their catalytic capacities assessed against ubiquitin fusions<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/10527495" title="yeast \nUbps 1p, 2p, 3p, 6p, 11p, and 15p and Yuh1p">PMID:10527495</a>. This is the basis<br />
+  of the SGD <strong>IDA</strong> annotation to GO:0004843 (cysteine-type deubiquitinase activity).</li>
+<li>Nuance on specificity: in that same study, <strong>isopeptidase</strong> activity<br />
+    (cleavage of ubiquitin-(εN)-lysine) was "only associated with Yuh1p, Unp,<br />
+    Ubp1p, and Ubp2p" <a href="https://pubmed.ncbi.nlm.nih.gov/10527495" title="isopeptidase activity \n[ubiquitin-(epsilonN)-lysine cleavage] was only \nassociated with Yuh1p, Unp, \nUbp1p, and Ubp2p">PMID:10527495</a>. UBP11 was NOT in the<br />
+    isopeptidase-positive set — i.e., its in vitro activity profile against these<br />
+    particular synthetic substrates was limited. This does not negate the deubiquitinase<br />
+    MF (it cleaves ubiquitin fusions / linear extensions) but flags that the physiological<br />
+    linkage/substrate specificity is undefined.</li>
+<li>Family-level confirmation: of the 17 potential yeast DUB genes, "14 of the 17 Dubs have<br />
+  now been shown to have ubiquitin-cleaving activity" including Ubp11p<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/11076031" title="14 of the 17 Dubs have now been shown to have \nubiquitin-cleaving activity">PMID:11076031</a>.</li>
+</ul>
+<h2 id="biological-process-phenotype-localization-not-known">Biological process / phenotype / localization (NOT KNOWN)</h2>
+<ul>
+<li><strong>No specific biological process is established for UBP11.</strong> SGD lists its biological<br />
+  process and cellular component as unknown despite the clear enzymatic function<br />
+  (<code>https://www.yeastgenome.org/locus/S000001806</code>, accessed 2026-07).</li>
+<li>Amerik, Li &amp; Hochstrasser systematically deleted each of the 17 yeast DUB genes:<br />
+  "none of the mutants is lethal or strongly growth defective under standard conditions,<br />
+  although a number have detectable abnormalities"<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/11076031" title="none of the \nmutants is lethal or strongly growth defective under standard \nconditions">PMID:11076031</a>. So <em>ubp11Δ</em> has no strong single-mutant phenotype — the classic<br />
+  signature of a redundant / condition-specific DUB.</li>
+<li>The GOA localization terms (nucleus GO:0005634, cytosol GO:0005829) are <strong>IBA only</strong><br />
+  (phylogenetic propagation from the USP family), not experimentally determined for<br />
+  UBP11 itself. SGD marks localization unknown.</li>
+<li>GOA also carries an SGD <strong>ND</strong> (no data) row for both cellular_component and<br />
+  biological_process, which correctly reflects the absence of experimental evidence.</li>
+</ul>
+<h2 id="paralogy-and-redundancy-known-structure-unknown-functional-division">Paralogy and redundancy (KNOWN structure, UNKNOWN functional division)</h2>
+<ul>
+<li>UBP11 has a paralog, <strong>UBP7 (YIL156W)</strong>, that arose from the whole-genome duplication<br />
+  (WGD); both single nulls are viable (SGD). This is the most likely explanation for the<br />
+  lack of a <em>ubp11Δ</em> phenotype, but the functional division of labour between UBP11 and<br />
+  UBP7 (and vs the broader 16-17 member yeast UBP family) has <strong>not</strong> been dissected.</li>
+<li>Family context: the yeast genome encodes ~16-17 UBPs; they are "largely divergent in<br />
+  primary sequence except in two short motifs, the Cys and His boxes"; and "the cellular<br />
+  functions of most of the UBPs have not yet been discovered" (family reviews /<br />
+  Amerik et al. 2000, PMID:11076031).</li>
+</ul>
+<h2 id="candidate-pathway-lead-weak-genetic-not-in-goa-rsp5-endosomal-network">Candidate pathway lead (WEAK / genetic, not in GOA) — Rsp5 endosomal network</h2>
+<ul>
+<li>The falcon deep research surfaces a candidate-pathway lead worth recording but NOT<br />
+  strong enough to annotate: Tardiff et al. 2013 (Science, doi:10.1126/science.1245321,<br />
+  "Yeast reveal a druggable Rsp5/Nedd4 network that ameliorates α-synuclein toxicity")<br />
+  place <strong>UBP7 and UBP11</strong> in an <strong>Rsp5-centered ubiquitin-dependent endosomal transport<br />
+  network</strong> as "two proteins that can deubiquitinate Rsp5 substrates," where<br />
+<strong>overexpression</strong> of UBP7/UBP11 partially compromised NAB2-mediated rescue of<br />
+  α-synuclein toxicity.</li>
+<li>Why this stays a <em>lead</em>, not an annotation: the same study found that <strong>deletion of<br />
+  UBP7 and UBP11, singly or as the ubp7Δ ubp11Δ double, had no effect</strong> on NAB2 rescue,<br />
+  i.e. UBP11 is not the central target and any role is redundant/context-dependent. This<br />
+  is genetic/chemical-genetic association, no direct in vivo UBP11 substrate, and the<br />
+  paper is not in our publications cache (would need fetching + verbatim-quote checking<br />
+  before any YAML citation). So the review keeps the conservative "BP-dark, substrate<br />
+  unknown" stance; Rsp5/endosomal trafficking is the leading <em>hypothesis</em> to test, and is<br />
+  reflected in the knowledge_gaps resolution (paralog-aware ubiquitylome of the double<br />
+  mutant). Paralog UBP7 has been shown directly to deubiquitinate the endocytic factor<br />
+  Ede1 (Weinberg &amp; Drubin 2014), which is consistent with, but does not itself<br />
+  demonstrate, an equivalent UBP11 role.</li>
+</ul>
+<h2 id="zinc-ion-binding-annotation-weak-computational">Zinc ion binding annotation (weak / computational)</h2>
+<ul>
+<li>GOA has GO:0008270 (zinc ion binding), evidence <strong>RCA</strong>, from PMID:30358795 (Wang et al.,<br />
+  yeast zinc proteome). This is a proteome-wide bioinformatic prediction of zinc-binding<br />
+  proteins (domain + motif search), NOT a direct measurement of zinc binding by UBP11.<br />
+  Many USP-family DUBs contain a zinc-finger/Zn-ribbon subdomain, so the prediction is<br />
+  plausible, but it is a computational reconstruction (RCA), not experimental. The UniProt<br />
+  record does NOT annotate a zinc-binding site in UBP11.</li>
+</ul>
+<h2 id="summary-what-is-the-gap">Summary: what is the gap?</h2>
+<ul>
+<li><strong>MF known</strong> (competent cysteine-type deubiquitinase, by domain + in vitro assay).</li>
+<li><strong>BP dark</strong>: no physiological process; no in vivo substrate; no non-redundant role<br />
+  distinguished from paralog UBP7 or the wider UBP family.</li>
+<li><strong>CC uncertain</strong>: nucleus/cytosol are IBA propagations, not UBP11-specific data.</li>
+<li>This is a <strong>BIOLOGY gap (primary) + CURATION note</strong>: the deubiquitinase MF is real but<br />
+  the "for what?" is genuinely undetermined, and a single-gene deletion has no strong<br />
+  phenotype because of paralog redundancy.</li>
+</ul>
+<h2 id="references-used">References used</h2>
+<ul>
+<li>PMID:10527495 — Layfield et al. 1999, Anal Biochem. Synthetic ubiquitin substrates;<br />
+  Ubp11p among yeast DUBs assayed. (abstract only in cache)</li>
+<li>PMID:11076031 — Amerik, Li &amp; Hochstrasser 2000, Biol Chem. Systematic deletion of all<br />
+  17 yeast DUB genes; none lethal/strongly growth-defective; 14/17 have Ub-cleaving<br />
+  activity. (abstract only in cache)</li>
+<li>PMID:30358795 — Wang et al. 2018, Metallomics. Yeast zinc proteome; source of the RCA<br />
+  zinc-ion-binding annotation. (abstract only in cache)</li>
+<li>SGD locus page S000001806 (UBP11) — paralog UBP7/WGD; BP &amp; CC unknown.</li>
+<li><code>file:yeast/UBP11/UBP11-bioinformatics/RESULTS.md</code> — catalytic-dyad integrity check.</li>
+</ul>
+            </div>
+        </details>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Bioinformatics Results</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(RESULTS.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="P36026" data-a="DOC: Bioinformatics Results" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="ubp11-p36026-bioinformatics-analysis-usp-catalytic-domain-integrity">UBP11 (P36026) bioinformatics analysis — USP catalytic-domain integrity</h1>
+<h2 id="question">Question</h2>
+<p>Is <em>S. cerevisiae</em> UBP11 (YKR098C) a <strong>catalytically competent</strong> ubiquitin-specific<br />
+protease, or a degenerate/pseudo-DUB? A competent DUB molecular-function annotation is<br />
+only defensible from the domain if the peptidase C19 (USP) catalytic residues are intact.</p>
+<h2 id="method">Method</h2>
+<p><code>analyze_ubp11.py</code> parses the local UniProt flat file (<code>../UBP11-uniprot.txt</code>), extracts<br />
+the protein sequence and feature table, reports the residues actually present at the two<br />
+annotated <code>ACT_SITE</code> positions, checks the peptidase C19 family declaration, and scans<br />
+for the PROSITE USP signatures. Nothing is hardcoded; run with <code>uv run python analyze_ubp11.py</code>.</p>
+<h2 id="results">Results</h2>
+<table>
+<thead>
+<tr>
+<th>Feature</th>
+<th>Value</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Length</td>
+<td>717 aa</td>
+</tr>
+<tr>
+<td>Declared family (UniProt SIMILARITY)</td>
+<td>peptidase C19 family</td>
+</tr>
+<tr>
+<td>Annotated USP domain</td>
+<td>residues 298–707 (410 aa)</td>
+</tr>
+<tr>
+<td>Catalytic nucleophile (ACT_SITE)</td>
+<td><strong>Cys307</strong> — present (context <code>NPC**C**NTC…</code>, canonical Cys box)</td>
+</tr>
+<tr>
+<td>Catalytic proton acceptor (ACT_SITE)</td>
+<td><strong>His649</strong> — present (context <code>NLING**H**YTSVV…</code>, His box)</td>
+</tr>
+</tbody>
+</table>
+<p>Both members of the catalytic dyad expected for a USP/peptidase-C19 cysteine protease<br />
+(nucleophilic Cys + proton-acceptor His) are <strong>present at their annotated positions</strong>.<br />
+The Cys307 sits in the recognizable Cys box motif and His649 in the His box, the two<br />
+short conserved motifs that together form the C19 active site.</p>
+<h3 id="caveats-honest-limitations">Caveats (honest limitations)</h3>
+<ul>
+<li>The script's <em>simplified</em> in-house PROSITE regexes are approximate: the USP_1/Cys-box<br />
+  pattern did not produce an exact match and the USP_2/His-box pattern produced a spurious<br />
+  match upstream of the real His box. The <strong>authoritative</strong> signature evidence is UniProt's<br />
+  own PROSITE annotation, which lists <code>PS00972</code> (USP_1), <code>PS00973</code> (USP_2) and <code>PS50235</code><br />
+  (USP_3 profile) as all matching. The catalytic-residue check (from UniProt <code>ACT_SITE</code><br />
+  features) is the load-bearing result here, and it is unambiguous.</li>
+<li>This analysis confirms <em>catalytic competence by domain</em>; it says nothing about the<br />
+  physiological <strong>substrate</strong> or <strong>linkage specificity</strong> of UBP11, which remain unknown<br />
+  (see the gene review's knowledge gaps).</li>
+</ul>
+<h2 id="verdict">Verdict</h2>
+<p><strong>Catalytically competent cysteine-type deubiquitinase by domain.</strong> The USP catalytic<br />
+dyad (Cys307/His649) is intact within a 410-aa peptidase C19 domain, so a<br />
+<code>cysteine-type deubiquitinase activity</code> (GO:0004843) molecular function is well supported<br />
+at the domain level. This is consistent with the in vitro demonstration of ubiquitin-cleaving<br />
+activity for Ubp11p (PMID:10527495) and the family-level survey showing 14/17 yeast DUBs,<br />
+Ubp11p included, have ubiquitin-cleaving activity (PMID:11076031).</p>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: P36026
+gene_symbol: UBP11
+product_type: PROTEIN
+status: COMPLETE
+taxon:
+  id: NCBITaxon:559292
+  label: Saccharomyces cerevisiae
+description: &gt;-
+  UBP11 (YKR098C) is one of the ~16-17 ubiquitin-specific proteases (UBP/USP,
+  peptidase C19 family) of budding yeast. It is a 717-residue cysteine-type
+  deubiquitinating enzyme (DUB, EC 3.4.19.12) with a single C-terminal USP
+  catalytic domain (residues ~298-707) bearing an intact catalytic dyad — a
+  nucleophilic cysteine (Cys307) in the Cys box and a proton-acceptor histidine
+  (His649) in the His box — so it is a catalytically competent deubiquitinase that
+  hydrolyzes the bonds formed by the C-terminal glycine of ubiquitin, releasing
+  ubiquitin from conjugates and precursors. Purified/recombinant Ubp11p cleaves
+  ubiquitin fusions in vitro. Beyond this enzymatic activity, its cellular role is
+  largely uncharacterized: no physiological substrate, no specific biological
+  process, and no non-redundant in vivo function have been established, and single
+  deletion causes no strong growth phenotype. UBP11 has a whole-genome-duplication
+  paralog, UBP7, with which it is likely functionally redundant.
+existing_annotations:
+  - term:
+      id: GO:0004843
+      label: cysteine-type deubiquitinase activity
+    evidence_type: IBA
+    original_reference_id: GO_REF:0000033
+    qualifier: enables
+    review:
+      summary: &gt;-
+        Phylogenetic (IBA) propagation of the deubiquitinase molecular function
+        across the USP/peptidase-C19 family. This is the correct core molecular
+        function for UBP11 and is independently supported by direct in vitro assay
+        (see the IDA row) and by the intact USP catalytic dyad (Cys307/His649).
+      action: ACCEPT
+      supported_by:
+        - reference_id: PMID:11076031
+          supporting_text: &#34;14 of the 17 Dubs have now been shown to have&#34;
+        - reference_id: file:yeast/UBP11/UBP11-bioinformatics/RESULTS.md
+          supporting_text: &gt;-
+            the USP catalytic dyad (Cys307/His649) is intact within a 410-aa
+            peptidase C19 domain
+  - term:
+      id: GO:0005634
+      label: nucleus
+    evidence_type: IBA
+    original_reference_id: GO_REF:0000033
+    qualifier: is_active_in
+    review:
+      summary: &gt;-
+        Nuclear localization is an IBA propagation from the USP family, not an
+        experimental observation for UBP11. Many yeast UBPs are cytosolic and/or
+        nucleocytoplasmic, and SGD lists UBP11&#39;s cellular component as unknown; no
+        UBP11-specific localization study exists. Retained as a plausible but
+        unverified, non-core location — the true site of action is undetermined.
+      action: KEEP_AS_NON_CORE
+      reason: &gt;-
+        IBA-only; no experimental localization data for UBP11 itself. Where the
+        enzyme acts in vivo is a genuine knowledge gap.
+  - term:
+      id: GO:0031647
+      label: regulation of protein stability
+    evidence_type: IBA
+    original_reference_id: GO_REF:0000033
+    qualifier: involved_in
+    review:
+      summary: &gt;-
+        Broad, family-level biological-process propagation (IBA): deubiquitinases
+        as a class influence protein stability by removing degradative ubiquitin
+        marks. This is a reasonable generic consequence of DUB activity but is not
+        demonstrated for UBP11 specifically, and it names no substrate or pathway.
+        Kept as non-core; the specific process UBP11 acts in is unknown.
+      action: KEEP_AS_NON_CORE
+      reason: &gt;-
+        Generic DUB-class inference (IBA), not UBP11-specific; no substrate or
+        pathway established. The actual biological process is a knowledge gap.
+  - term:
+      id: GO:0005829
+      label: cytosol
+    evidence_type: IBA
+    original_reference_id: GO_REF:0000033
+    qualifier: is_active_in
+    review:
+      summary: &gt;-
+        Cytosolic localization is an IBA propagation from the USP family. It is a
+        plausible location for a soluble DUB but has not been experimentally
+        determined for UBP11 (SGD lists cellular component as unknown). Retained as
+        a non-core, unverified location.
+      action: KEEP_AS_NON_CORE
+      reason: &gt;-
+        IBA-only; no experimental localization for UBP11. Plausible but unverified.
+  - term:
+      id: GO:0004843
+      label: cysteine-type deubiquitinase activity
+    evidence_type: IEA
+    original_reference_id: GO_REF:0000120
+    qualifier: enables
+    review:
+      summary: &gt;-
+        Electronic (IEA) assignment of the deubiquitinase activity from InterPro
+        (peptidase C19 signatures IPR001394/IPR018200) and the EC 3.4.19.12
+        mapping. Redundant with the IBA and IDA rows for the same term but correct
+        and well grounded in the domain; the catalytic residues are intact.
+      action: ACCEPT
+      supported_by:
+        - reference_id: file:yeast/UBP11/UBP11-bioinformatics/RESULTS.md
+          supporting_text: &gt;-
+            Both members of the catalytic dyad expected for a USP/peptidase-C19
+            cysteine protease (nucleophilic Cys + proton-acceptor His) are present
+  - term:
+      id: GO:0016579
+      label: protein deubiquitination
+    evidence_type: IEA
+    original_reference_id: GO_REF:0000002
+    qualifier: involved_in
+    review:
+      summary: &gt;-
+        Electronic (IEA, InterPro) assignment of the protein-deubiquitination
+        biological process, the direct process counterpart of the DUB molecular
+        function. This is the most defensible process term for UBP11: it follows
+        necessarily from the demonstrated deubiquitinase activity without
+        over-claiming a specific downstream pathway or substrate.
+      action: ACCEPT
+      supported_by:
+        - reference_id: PMID:10527495
+          supporting_text: &#34;Ubps 1p, 2p, 3p, 6p, 11p, and 15p and Yuh1p&#34;
+  - term:
+      id: GO:0008270
+      label: zinc ion binding
+    evidence_type: RCA
+    original_reference_id: PMID:30358795
+    qualifier: enables
+    review:
+      summary: &gt;-
+        This term comes from a genome-wide computational reconstruction (RCA) of
+        the yeast zinc proteome (domain + motif prediction), not a direct
+        measurement of zinc binding by UBP11. Some USP-family DUBs contain a
+        zinc-finger/Zn-ribbon subdomain, so the prediction is plausible, but
+        UniProt annotates no zinc-binding site in UBP11 and no experimental
+        evidence exists. Marked as over-annotated: a predicted, non-core property
+        that adds little to the functional picture and is not experimentally
+        supported.
+      action: MARK_AS_OVER_ANNOTATED
+      reason: &gt;-
+        RCA (computational proteome-wide prediction) only; no experimental
+        zinc-binding data and no UniProt zinc-binding site for UBP11. Not a
+        demonstrated function.
+  - term:
+      id: GO:0004843
+      label: cysteine-type deubiquitinase activity
+    evidence_type: IDA
+    original_reference_id: PMID:10527495
+    qualifier: enables
+    review:
+      summary: &gt;-
+        Direct assay (IDA): recombinant Ubp11p was among the yeast UBPs expressed
+        in E. coli and tested against synthetic ubiquitin substrates, cleaving
+        ubiquitin from fusions. This is the primary experimental evidence for the
+        deubiquitinase molecular function and is the core function of UBP11. Note
+        the study found isopeptidase (ubiquitin-epsilonN-lysine) cleavage only for
+        a different subset of DUBs, so UBP11&#39;s physiological linkage specificity
+        remains undefined — but its deubiquitinase activity is established.
+      action: ACCEPT
+      supported_by:
+        - reference_id: PMID:10527495
+          supporting_text: &#34;Ubps 1p, 2p, 3p, 6p, 11p, and 15p and Yuh1p&#34;
+  - term:
+      id: GO:0005575
+      label: cellular_component
+    evidence_type: ND
+    original_reference_id: GO_REF:0000015
+    qualifier: is_active_in
+    review:
+      summary: &gt;-
+        Root cellular_component term with ND (no data) evidence — an explicit SGD
+        record that no experimental localization has been determined for UBP11.
+        This honestly reflects the CC knowledge gap and should be retained as-is;
+        it is not an assertion of function.
+      action: ACCEPT
+      reason: &gt;-
+        ND placeholder correctly documenting absence of localization data; keep.
+  - term:
+      id: GO:0008150
+      label: biological_process
+    evidence_type: ND
+    original_reference_id: GO_REF:0000015
+    qualifier: involved_in
+    review:
+      summary: &gt;-
+        Root biological_process term with ND (no data) evidence — an explicit SGD
+        record that no specific biological process has been experimentally
+        assigned to UBP11. This honestly reflects the BP-dark status of the gene
+        and should be retained as-is.
+      action: ACCEPT
+      reason: &gt;-
+        ND placeholder correctly documenting absence of a specific process; keep.
+core_functions:
+  - description: &gt;-
+      Cysteine-type deubiquitinase (peptidase C19 / USP family) that hydrolyzes the
+      bonds formed by the C-terminal glycine of ubiquitin, removing ubiquitin from
+      conjugates and precursors. Catalytic competence is supported by an intact USP
+      catalytic dyad (nucleophile Cys307, proton acceptor His649) and by direct in
+      vitro cleavage of ubiquitin fusions by recombinant Ubp11p. The in vivo
+      substrate(s) and ubiquitin-linkage specificity are not established.
+    molecular_function:
+      id: GO:0004843
+      label: cysteine-type deubiquitinase activity
+    directly_involved_in:
+      - id: GO:0016579
+        label: protein deubiquitination
+    supported_by:
+      - reference_id: PMID:10527495
+        supporting_text: &#34;Ubps 1p, 2p, 3p, 6p, 11p, and 15p and Yuh1p&#34;
+      - reference_id: PMID:11076031
+        supporting_text: &#34;14 of the 17 Dubs have now been shown to have&#34;
+      - reference_id: file:yeast/UBP11/UBP11-bioinformatics/RESULTS.md
+        supporting_text: &gt;-
+          the USP catalytic dyad (Cys307/His649) is intact within a 410-aa
+          peptidase C19 domain
+knowledge_gaps:
+  - gap_statement: &gt;-
+      The physiological substrate(s), ubiquitin-linkage specificity, biological
+      process, and non-redundant in vivo role of UBP11 are unknown. It is
+      established that Ubp11p is a catalytically competent deubiquitinase, but not
+      what it deubiquitinates, in which pathway, or what distinguishes its function
+      from its whole-genome-duplication paralog UBP7 and the wider yeast UBP family.
+    boundary: &gt;-
+      Known: UBP11 is a 717-aa peptidase C19 (USP) enzyme with an intact catalytic
+      dyad (Cys307/His649); recombinant Ubp11p cleaves ubiquitin fusions in vitro,
+      and 14 of the 17 yeast DUBs (Ubp11p included) have demonstrated
+      ubiquitin-cleaving activity. Unknown/absent: a single ubp11 deletion is not
+      lethal or strongly growth-defective under standard conditions, SGD lists both
+      its biological process and cellular component as unknown, no in vivo substrate
+      has been identified, and the isopeptidase specificity assay placed UBP11
+      outside the isopeptidase-positive DUB subset, leaving its linkage preference
+      undefined.
+    gap_kind:
+      - BIOLOGY
+      - CURATION
+    dark_aspect: BP_DARK
+    status: OPEN
+    significance: &gt;-
+      UBP11 is a representative of the large, mostly uncharacterized yeast UBP
+      family — most of whose cellular functions remain undiscovered. Assigning a
+      substrate and pathway would both illuminate this specific enzyme and help
+      resolve why the yeast genome maintains ~16-17 partly redundant deubiquitinases,
+      distinguishing genuine functional specialization from WGD-derived redundancy.
+    resolution: &gt;-
+      Identify in vivo substrates by comparing the ubiquitylome of ubp11 deletion
+      (and the ubp7 ubp11 double mutant, to bypass paralog redundancy) with wild
+      type; test linkage specificity of purified Ubp11p against defined di-/poly-
+      ubiquitin chains; determine subcellular localization of tagged Ubp11p; and
+      phenotype the double mutant across stress/condition panels.
+    provenance:
+      - reference_id: PMID:11076031
+        supporting_text: &#34;none of the mutants is lethal or strongly growth defective under standard&#34;
+        reference_section_type: ABSTRACT
+      - reference_id: PMID:10527495
+        supporting_text: &#34;isopeptidase activity&#34;
+        reference_section_type: ABSTRACT
+suggested_questions:
+  - question: &gt;-
+      What are the physiological substrates of UBP11 in S. cerevisiae, and which
+      ubiquitin-chain linkages does it preferentially cleave?
+  - question: &gt;-
+      How is deubiquitinase function partitioned between UBP11 and its WGD paralog
+      UBP7, and does the ubp7 ubp11 double mutant reveal a phenotype masked by
+      redundancy?
+suggested_experiments:
+  - hypothesis: &gt;-
+      UBP11 acts redundantly with UBP7 on a shared set of ubiquitylated substrates.
+    description: &gt;-
+      Perform quantitative ubiquitylome (diGly) proteomics comparing wild type,
+      ubp11 deletion, ubp7 deletion, and the ubp7 ubp11 double mutant to identify
+      substrates whose ubiquitylation increases specifically when both DUBs are
+      removed.
+    experiment_type: quantitative diGly ubiquitylome mass spectrometry
+  - hypothesis: &gt;-
+      Purified Ubp11p has a defined ubiquitin-linkage specificity.
+    description: &gt;-
+      Assay recombinant Ubp11p (and a catalytic Cys307 mutant control) against a
+      panel of defined K6/K11/K27/K29/K33/K48/K63/M1-linked di- and tetra-ubiquitin
+      chains to determine linkage preference in vitro.
+    experiment_type: in vitro deubiquitinase linkage-specificity assay
+references:
+  - id: GO_REF:0000002
+    title: Gene Ontology annotation through association of InterPro records with GO terms
+    findings: []
+  - id: GO_REF:0000015
+    title: Use of the ND evidence code for Gene Ontology (GO) terms
+    findings: []
+  - id: GO_REF:0000033
+    title: Annotation inferences using phylogenetic trees
+    findings: []
+  - id: GO_REF:0000120
+    title: Combined Automated Annotation using Multiple IEA Methods
+    findings: []
+  - id: PMID:10527495
+    title: Chemically synthesized ubiquitin extension proteins detect distinct catalytic
+      capacities of deubiquitinating enzymes.
+    findings:
+      - statement: &gt;-
+          Recombinant yeast Ubp11p was among the DUBs assayed against synthetic
+          ubiquitin substrates and cleaved ubiquitin fusions, but isopeptidase
+          activity was associated only with a different subset (Yuh1p, Unp, Ubp1p,
+          Ubp2p), so UBP11&#39;s physiological linkage specificity is not defined here.
+    reference_review:
+      relevance: HIGH
+      correctness: VERIFIED
+      review_notes: &gt;-
+        PubMed/abstract-verified. Basis of the SGD IDA deubiquitinase annotation;
+        Ubp11p is explicitly listed among the yeast UBPs assayed. Abstract-only in
+        cache. Also documents that UBP11 was not in the isopeptidase-positive set.
+  - id: PMID:11076031
+    title: Analysis of the deubiquitinating enzymes of the yeast Saccharomyces cerevisiae.
+    findings:
+      - statement: &gt;-
+          All 17 yeast DUB genes were individually deleted; none of the single
+          mutants is lethal or strongly growth-defective under standard conditions,
+          and 14 of 17 DUBs (including Ubp11p) have demonstrated ubiquitin-cleaving
+          activity — establishing both the DUB activity and the lack of a strong
+          single-deletion phenotype for UBP11.
+    reference_review:
+      relevance: HIGH
+      correctness: VERIFIED
+      review_notes: &gt;-
+        PubMed-verified (Amerik, Li, Hochstrasser 2000, Biol Chem, PMID 11076031).
+        Systematic family-level deletion analysis; directly supports both the
+        deubiquitinase MF and the redundancy/no-strong-phenotype knowledge gap.
+        Abstract-only in cache.
+  - id: PMID:30358795
+    title: The cellular economy of the Saccharomyces cerevisiae zinc proteome.
+    findings:
+      - statement: &gt;-
+          A genome-wide bioinformatic + proteomic survey of the yeast zinc proteome;
+          the source of the computational (RCA) zinc-ion-binding prediction for
+          UBP11. Not a direct measurement of zinc binding by UBP11.
+    reference_review:
+      relevance: LOW
+      correctness: VERIFIED
+      review_notes: &gt;-
+        PubMed-verified. Correctly cited as the origin of the RCA zinc-ion-binding
+        annotation, but it is a proteome-wide prediction, not UBP11-specific
+        experimental evidence; hence the annotation is marked over-annotated.
+  - id: file:yeast/UBP11/UBP11-bioinformatics/RESULTS.md
+    title: UBP11 USP catalytic-domain integrity analysis (this repository)
+    findings:
+      - statement: &gt;-
+          Reproducible parse of the UniProt record confirms the USP catalytic dyad
+          (nucleophile Cys307, proton acceptor His649) is intact within a 410-aa
+          peptidase C19 domain, supporting a catalytically competent deubiquitinase.
+    reference_review:
+      relevance: HIGH
+      correctness: VERIFIED
+      review_notes: &gt;-
+        In-repo bioinformatics analysis; supports catalytic competence of the DUB
+        molecular function from the domain. file: reference (not quote-validated),
+        verified by hand against the script output.
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/genes/yeast/YFH7/YFH7-ai-review.html
+++ b/genes/yeast/YFH7/YFH7-ai-review.html
@@ -1,0 +1,2772 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>YFH7 - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        .propagation-review {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f8fafc;
+            border-left: 3px solid #64748b;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .propagation-title {
+            font-weight: 600;
+            color: #334155;
+            margin-bottom: 0.25rem;
+        }
+
+        .propagation-row {
+            margin-top: 0.25rem;
+        }
+
+        .propagation-source {
+            margin-top: 0.5rem;
+            padding-top: 0.5rem;
+            border-top: 1px solid #e5e7eb;
+        }
+
+        .propagation-source-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #1d4ed8;
+        }
+
+        .propagation-comment {
+            color: #4b5563;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>YFH7</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/P43591" target="_blank" class="term-link">
+                        P43591
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Saccharomyces cerevisiae</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-complete">
+                    COMPLETE
+                </span>
+            </div>
+
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "YFH7";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="P43591" data-a="DESCRIPTION: YFH7 (ORF YFR007W; alias AIM12) is a 353-residue s..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>YFH7 (ORF YFR007W; alias AIM12) is a 353-residue soluble ATP-dependent small-molecule kinase of the P-loop NTPase superfamily in the budding yeast Saccharomyces cerevisiae. Its crystal structure (PDB 2GA8/2GAA) shows the phosphoribulokinase/uridine kinase/bacterial pantothenate kinase (PRK/URK/PANK) fold — with core, lid and NMP-binding subdomains — plus an additional ~100-residue alpha/beta domain of novel topology that is a lineage-specific insertion. It carries a canonical Walker A (P-loop) motif (GSPGSGKS, residues 31-38) that binds ATP and the URK-family diagnostic second block (VILEG, ~residue 263), and it hydrolyses ATP in vitro (KM approximately 1.2 mM). Although the P-loop kinase fold is ancient and pan-eukaryotic, the YFH7 protein itself is restricted to the Saccharomycetaceae. YFH7 is a soluble, moderately abundant cytoplasmic protein. Deletion is viable but has been linked in genome-wide screens to defects in endoplasmic reticulum (karmellae) biogenesis and to an increased frequency of mitochondrial genome loss. The physiological phosphoacceptor substrate of YFH7, and the pathway in which it acts, remain unidentified.</p>
+    </div>
+
+
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
+                                    GO:0005737
+                                </a>
+                            </span>
+                            <span class="term-label">cytoplasm</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P43591" data-a="GO:0005737" data-r="GO_REF:0000033" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetically inferred cytoplasmic localization, consistent with a soluble P-loop small-molecule kinase and with the absence of any transmembrane or targeting signal. Plausible and retained, but the localization is not the core of the gene&#39;s function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> IBA localization is reasonable for a soluble cytoplasmic kinase and consistent with UniProt (no signal/transmembrane features). No experimental yeast localization is available to refine it, so it is kept as a non-core supporting annotation rather than a defining function.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005575" target="_blank" class="term-link">
+                                    GO:0005575
+                                </a>
+                            </span>
+                            <span class="term-label">cellular_component</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ND</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000015
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P43591" data-a="GO:0005575" data-r="GO_REF:0000015" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Root &#34;cellular_component&#34; term with the ND (no biological data) code — the standard placeholder used when no specific location has been curated. It carries no information and is superseded by the IBA cytoplasm annotation.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> This is the conventional ND root-term stub, not an assertion to accept or remove on biological grounds. It is retained as-is per GO practice; the informative location is captured by the cytoplasm (IBA) row and in core_functions.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016301" target="_blank" class="term-link">
+                                    GO:0016301
+                                </a>
+                            </span>
+                            <span class="term-label">kinase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ISS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/18004758" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:18004758
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Crystal structure and functional analysis identify the P-loo...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P43591" data-a="GO:0016301" data-r="PMID:18004758" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> YFH7 is a P-loop kinase of the PRK/URK/PANK subfamily. The intact Walker A P-loop (GSPGSGKS, 31-38), the retained URK-family second block (VILEG, ~263), the solved structure, and in-vitro ATP-dependent activity together support a genuine kinase (phosphotransferase) molecular function. This is a core function. The general &#34;kinase activity&#34; term is appropriate and should NOT be over-specified: the crystal paper concluded &#34;new substrate specificity&#34;, i.e. no phosphoacceptor substrate is demonstrated, so a specific kinase child term is not warranted.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Well supported by structure + enzymology (PMID:18004758) and by the intact diagnostic P-loop/URK motifs in the bioinformatics analysis. Deliberately kept at the general &#34;kinase activity&#34; level because the physiological substrate is unknown.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/18004758" target="_blank" class="term-link">
+                                        PMID:18004758
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Structural and ligand binding analysis combined with enzymatic assays suggest that YFH7 is an ATP-dependent small molecule kinase with new substrate specificity.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:yeast/YFH7/YFH7-bioinformatics/RESULTS.md
+
+                                </span>
+
+                                <div class="support-text">the small-molecule-kinase catalytic scaffold is intact</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005524" target="_blank" class="term-link">
+                                    GO:0005524
+                                </a>
+                            </span>
+                            <span class="term-label">ATP binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000043
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-new">
+                            NEW
+                        </span>
+                        <span class="vote-buttons" data-g="P43591" data-a="GO:0005524" data-r="GO_REF:0000043" data-act="NEW">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> ATP binding via the canonical Walker A (P-loop) motif GSPGSGKS at residues 31-38 (UniProt BINDING 31..39, ATP; ChEBI:30616). Present in UniProt as a keyword-derived IEA annotation and directly supported by the crystal structure and the intact P-loop identified bioinformatically. This is a core molecular function underlying the enzyme&#39;s ATP-dependent kinase/ATPase activity.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> ATP binding is a genuine UniProt annotation (GO:0005524, IEA from UniProtKB keyword) that is not present as a row in the GOA TSV; it is added here as a NEW core molecular function because it is well supported by the Walker A P-loop (structure + sequence) and is the mechanistic basis for the accepted kinase and ATP-hydrolysis activities.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/18004758" target="_blank" class="term-link">
+                                        PMID:18004758
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Structural and ligand binding analysis combined with enzymatic assays suggest that YFH7 is an ATP-dependent small molecule kinase with new substrate specificity.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:yeast/YFH7/YFH7-bioinformatics/RESULTS.md
+
+                                </span>
+
+                                <div class="support-text">P-loop (Walker A) glycine-rich loop is detected at</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016310" target="_blank" class="term-link">
+                                    GO:0016310
+                                </a>
+                            </span>
+                            <span class="term-label">phosphorylation</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ISS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/18004758" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:18004758
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Crystal structure and functional analysis identify the P-loo...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P43591" data-a="GO:0016310" data-r="PMID:18004758" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Biological-process counterpart of the kinase molecular function: as an ATP-dependent kinase, YFH7 is involved in phosphorylation (phosphate transfer to a small-molecule acceptor). Consistent with the ISS transfer and the intact catalytic scaffold.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Directly entailed by the accepted kinase activity; the general &#34;phosphorylation&#34; process term is appropriate given the undetermined substrate. Retained as the BP partner of the MF annotation.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/18004758" target="_blank" class="term-link">
+                                        PMID:18004758
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Structural and ligand binding analysis combined with enzymatic assays suggest that YFH7 is an ATP-dependent small molecule kinase with new substrate specificity.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016887" target="_blank" class="term-link">
+                                    GO:0016887
+                                </a>
+                            </span>
+                            <span class="term-label">ATP hydrolysis activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/18004758" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:18004758
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Crystal structure and functional analysis identify the P-loo...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P43591" data-a="GO:0016887" data-r="PMID:18004758" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Directly measured in vitro: YFH7 turns over ATP, with a determined KM of ~1.2 mM for ATP (UniProt BIOPHYSICOCHEMICAL PROPERTIES from PMID:18004758). This experimental ATP-turnover activity is the empirical basis for classifying YFH7 as an ATP-dependent kinase and is a core molecular function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Experimental (IDA) measurement of ATP hydrolysis/turnover from the same structure/enzymology study; consistent with the intact Walker A P-loop. Kept as a core MF annotation. (The measured ATP turnover reflects the enzyme&#39;s ATP-dependent catalytic cycle; whether it is coupled to a productive phosphoacceptor is part of the substrate knowledge gap, but the ATPase activity itself is directly observed.)
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/18004758" target="_blank" class="term-link">
+                                        PMID:18004758
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Structural and ligand binding analysis combined with enzymatic assays suggest that YFH7 is an ATP-dependent small molecule kinase with new substrate specificity.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>ATP-dependent small-molecule kinase activity: YFH7 binds ATP via its Walker A P-loop and catalyses transfer of the gamma-phosphate to a (currently unidentified) small-molecule acceptor, consistent with its PRK/URK/PANK P-loop kinase fold and its measured in-vitro ATP turnover.</h3>
+                <span class="vote-buttons" data-g="P43591" data-a="FUNCTION: ATP-dependent small-molecule kinase activity: YFH7..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016301" target="_blank" class="term-link">
+                            kinase activity
+                        </a>
+                    </span>
+                </div>
+
+
+
+
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/18004758" target="_blank" class="term-link">
+                                PMID:18004758
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">Structural and ligand binding analysis combined with enzymatic assays suggest that YFH7 is an ATP-dependent small molecule kinase with new substrate specificity.</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:yeast/YFH7/YFH7-bioinformatics/RESULTS.md
+
+                        </span>
+
+                        <div class="finding-text">the small-molecule-kinase catalytic scaffold is intact</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>ATP binding through the canonical Walker A (P-loop) motif GSPGSGKS at residues 31-38, which coordinates the ATP phosphates; the basis for the enzyme&#39;s ATP-dependent activity.</h3>
+                <span class="vote-buttons" data-g="P43591" data-a="FUNCTION: ATP binding through the canonical Walker A (P-loop..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005524" target="_blank" class="term-link">
+                            ATP binding
+                        </a>
+                    </span>
+                </div>
+
+
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
+                                cytoplasm
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/18004758" target="_blank" class="term-link">
+                                PMID:18004758
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">Structural and ligand binding analysis combined with enzymatic assays suggest that YFH7 is an ATP-dependent small molecule kinase with new substrate specificity.</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:yeast/YFH7/YFH7-bioinformatics/RESULTS.md
+
+                        </span>
+
+                        <div class="finding-text">P-loop (Walker A) glycine-rich loop is detected at</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000015.md" target="_blank" class="term-link">
+                            GO_REF:0000015
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Use of the ND evidence code for Gene Ontology (GO) terms</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
+                            GO_REF:0000033
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Annotation inferences using phylogenetic trees</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000043.md" target="_blank" class="term-link">
+                            GO_REF:0000043
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot keyword mapping</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/18004758" target="_blank" class="term-link">
+                            PMID:18004758
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Crystal structure and functional analysis identify the P-loop containing protein YFH7 of Saccharomyces cerevisiae as an ATP-dependent kinase.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">YFH7 is an ATP-dependent small-molecule kinase with an as-yet undetermined substrate.</div>
+
+                        <div class="finding-text">"Structural and ligand binding analysis combined with enzymatic assays suggest that YFH7 is an ATP-dependent small molecule kinase with new substrate specificity."</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <div class="finding-statement">YFH7 adopts the PRK/URK/PANK P-loop kinase fold and is yeast-specific.</div>
+
+                        <div class="finding-text">"Sequence analysis revealed that yeast YFH7 is a yeast-specific protein showing weak similarity with the phosphoribulokinase/uridine kinase/bacterial pantothenate kinase (PRK/URK/PANK) subfamily of P-loop containing kinases."</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <div class="finding-statement">A large ~100-residue insertion distinguishes YFH7 from other family members.</div>
+
+                        <div class="finding-text">"A large insertion of about 100 residues distinguishes YFH7 from other members of the family."</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/12868057" target="_blank" class="term-link">
+                            PMID:12868057
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Parallel analysis of tagged deletion mutants efficiently identifies genes involved in endoplasmic reticulum biogenesis.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Genome-wide deletion screen for genes required for ER (karmellae) biogenesis; the basis for UniProt&#39;s hedged &#34;could be involved in endoplasmic reticulum membrane assembly&#34; note for YFH7. The paper is a screen and does not assign YFH7 a molecular mechanism.</div>
+
+                        <div class="finding-text">"To identify genes required for karmellae assembly, we compared the composition of populations of homozygous diploid S. cerevisiae deletion mutants following 20 generations of growth with and without karmellae."</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/19300474" target="_blank" class="term-link">
+                            PMID:19300474
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Computationally driven, quantitative experiments discover genes required for mitochondrial biogenesis.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Quantitative petite-frequency screen linking many deletion strains (including yfh7Δ, source of the AIM12 alias) to increased mitochondrial genome loss; a phenotypic association, not a biochemical function.</div>
+
+                        <div class="finding-text">"Using computational predictions combined with traditional quantitative experiments, we have identified 100 proteins whose deficiency alters mitochondrial biogenesis and inheritance in Saccharomyces cerevisiae."</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        file:yeast/YFH7/YFH7-bioinformatics/RESULTS.md
+
+                    </span>
+                </div>
+
+                <div class="reference-title">YFH7 bioinformatics analysis (P-loop / Walker-A motif scan, PRK/URK/PANK family signature, domain architecture, and taxonomic conservation).</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Canonical Walker A / P-loop motif GSPGSGKS at residues 31-38 and the URK-family diagnostic second block VILEG at ~263 are both retained, indicating an intact small-molecule-kinase catalytic scaffold; the YFH7 protein is Saccharomycetaceae- restricted while the fold is pan-eukaryotic.</div>
+
+                        <div class="finding-text">"the small-molecule-kinase catalytic scaffold is intact"</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Questions for Experts</h2>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> What is the physiological small-molecule phosphoacceptor substrate of YFH7? The crystal structure and enzymology established an ATP-dependent kinase but &#34;new substrate specificity&#34; — the acceptor is unidentified.</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P43591" data-a="Q: What is the physiological small-molecule phosphoac..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Is the ER-biogenesis (karmellae) and/or mitochondrial-genome-loss phenotype of yfh7Δ a direct consequence of a missing phosphorylation event, or an indirect/pleiotropic effect?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P43591" data-a="Q: Is the ER-biogenesis (karmellae) and/or mitochondr..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Does the lineage-specific ~100-residue insertion (the &#34;additional alpha/beta domain of novel topology&#34;) confer the substrate specificity that distinguishes YFH7 from other PRK/URK/PANK-family kinases?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P43591" data-a="Q: Does the lineage-specific ~100-residue insertion (..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Experiments</h2>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Broad in-vitro phosphotransfer substrate screen (metabolomic / small-molecule library kinase assay, e.g. coupled ADP-detection) against purified recombinant YFH7 to identify the phosphoacceptor; follow up with steady-state kinetics on the best hits.</p>
+
+
+
+                </div>
+                <span class="vote-buttons" data-g="P43591" data-a="EXPERIMENT: Broad in-vitro phosphotransfer substrate screen (m..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Structure-guided mutagenesis of the Walker A lysine (in GSPGSGKS) and candidate catalytic acidic residue, with an ATPase/kinase-dead allele tested for rescue of the yfh7Δ ER-biogenesis and mitochondrial-genome-loss phenotypes, to test whether those phenotypes require catalytic activity.</p>
+
+
+
+                </div>
+                <span class="vote-buttons" data-g="P43591" data-a="EXPERIMENT: Structure-guided mutagenesis of the Walker A lysin..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Untargeted comparative metabolomics of wild-type vs yfh7Δ (and a catalytic-dead knock-in) to detect an accumulating substrate or missing phosphorylated product.</p>
+
+
+
+                </div>
+                <span class="vote-buttons" data-g="P43591" data-a="EXPERIMENT: Untargeted comparative metabolomics of wild-type v..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Knowledge Gaps</h2>
+        <p style="color: #555; font-size: 0.92rem; margin-top: -0.3rem;">
+            What is <em>not</em> known — curated, literature-grounded statements of the open
+            unknowns (the inverse of core functions).
+        </p>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The physiological phosphoacceptor substrate of YFH7 is unknown. It is established as an ATP-dependent small-molecule kinase, but what small molecule it phosphorylates — and therefore the metabolic pathway and biological process it serves — has never been identified.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">BP_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> Firmly known: YFH7 is a soluble cytoplasmic protein with the PRK/URK/PANK P-loop kinase fold (crystal structures 2GA8/2GAA), an intact Walker A P-loop (GSPGSGKS, 31-38) that binds ATP, the retained URK-family diagnostic second block (VILEG, ~263), measured in-vitro ATP turnover (KM ~1.2 mM for ATP), and a lineage-specific ~100-residue insertion. Deletion is viable and has been associated in genome-wide screens with impaired ER (karmellae) biogenesis and increased mitochondrial genome loss. Unknown: the small-molecule acceptor phosphorylated by the enzyme, the pathway it belongs to, and whether the deletion phenotypes are direct consequences of a lost phosphorylation.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> YFH7 is a structurally solved, catalytically plausible enzyme whose reaction is unassigned — a clean example of a &#34;known activity, unknown substrate/purpose&#34; (BP-dark) enzyme in one of the best-studied eukaryotes. Identifying its substrate would convert a decades-old orphan kinase into an annotated metabolic step and could explain the ER- and mitochondrial-maintenance phenotypes.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> A broad in-vitro small-molecule phosphotransfer substrate screen on recombinant YFH7 followed by kinetic confirmation; comparative wild-type-vs-yfh7Δ metabolomics to detect an accumulating substrate or missing phosphorylated product; catalytic-dead separation-of-function alleles to test whether the deletion phenotypes require the kinase activity.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"Structural and ligand binding analysis combined with enzymatic assays suggest that YFH7 is an ATP-dependent small molecule kinase with new substrate specificity."</em> — PMID:18004758</li>
+
+                <li><em>"the physiological substrate is unknown"</em> — file:yeast/YFH7/YFH7-bioinformatics/RESULTS.md</li>
+
+            </ul>
+
+
+        </div>
+
+    </div>
+
+
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Deep Research Sections -->
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(YFH7-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="P43591" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="yfh7-p43591-yfr007w-aim12-research-notes">YFH7 (P43591 / YFR007W / AIM12) — research notes</h1>
+<p>Species: <em>Saccharomyces cerevisiae</em> (S288c), NCBITaxon:559292<br />
+UniProt: P43591 (YFH7_YEAST); ORF YFR007W; SGD S000001903; aliases AIM12.<br />
+Length: 353 aa; MW 39,885. Structures: PDB 2GA8 (1.77 Å), 2GAA (1.95 Å).</p>
+<h2 id="deep-research-provenance">Deep research provenance</h2>
+<p><code>just deep-research-falcon yeast YFH7 --fallback perplexity-lite</code> was attempted twice<br />
+(2026-07-05) and timed out both times (Edison/falcon exit 143 after ~5 min; no output<br />
+file produced). Per project guidance I did NOT fabricate a <code>-deep-research-*.md</code> file.<br />
+These notes are compiled directly from: (1) the cached UniProt record<br />
+(<code>YFH7-uniprot.txt</code>), (2) the three cached primary publications<br />
+(<code>publications/PMID_18004758.md</code>, <code>PMID_12868057.md</code>, <code>PMID_19300474.md</code>), and (3) the<br />
+completed, reproducible bioinformatics analysis in <code>YFH7-bioinformatics/RESULTS.md</code>.</p>
+<h2 id="what-is-known">What is KNOWN</h2>
+<h3 id="enzyme-fold-identity-well-established-experimental-structural">Enzyme / fold identity (well established, experimental + structural)</h3>
+<ul>
+<li>YFH7 is an <strong>ATP-dependent kinase</strong> of the P-loop NTPase superfamily. The 2008 crystal<br />
+  structure paper solved the fold and did enzymology:<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/18004758" title="Structural and ligand binding analysis combined with enzymatic assays suggest that YFH7 is an ATP-dependent small molecule kinase with new substrate specificity.">PMID:18004758</a></li>
+<li>Fold assignment: weak similarity to the <strong>PRK/URK/PANK</strong> (phosphoribulokinase / uridine<br />
+  kinase / bacterial pantothenate kinase) subfamily of P-loop kinases, with the<br />
+  characteristic core, lid, and NMP(bind) subdomains:<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/18004758" title="yeast YFH7 is a yeast-specific protein showing weak similarity with the phosphoribulokinase/uridine kinase/bacterial pantothenate kinase (PRK/URK/PANK) subfamily of P-loop containing kinases.">PMID:18004758</a></li>
+<li>A <strong>~100-residue insertion</strong> distinguishes YFH7 from other family members and forms an<br />
+  "additional alpha/beta domain of novel topology":<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/18004758" title="A large insertion of about 100 residues distinguishes YFH7 from other members of the family.">PMID:18004758</a></li>
+<li>Measured biophysical parameter: <strong>KM = 1178 µM for ATP</strong> (UniProt BIOPHYSICOCHEMICAL<br />
+  PROPERTIES, ECO:0000269|PubMed:18004758). This anchors the IDA ATP-turnover annotation.</li>
+</ul>
+<h3 id="atp-binding-site-motifs-structure-sequence">ATP-binding site / motifs (structure + sequence)</h3>
+<ul>
+<li>UniProt BINDING 31..39 = ATP (ChEBI:30616), ECO:0000250.</li>
+<li>Bioinformatics (<code>YFH7-bioinformatics/RESULTS.md</code>): canonical <strong>Walker A / P-loop<br />
+<code>GSPGSGKS</code> at residues 31–38</strong>, matching <code>[AG]-x(4)-G-K-[ST]</code>; and the URK-family<br />
+  diagnostic <strong>second block <code>VILEG</code> at 263</strong>. Both diagnostic blocks are retained →<br />
+  catalytic scaffold intact, not an obviously degenerate pseudokinase.</li>
+<li>Domain xrefs: IPR027417 (P-loop NTPase), Gene3D 3.40.50.300, SUPFAM SSF52540 (fold in<br />
+  three discontinuous segments 22–54 / 156–204 / 233–349, gap ~55–155 = the insertion),<br />
+  PANTHER <strong>PTHR10285 "URIDINE KINASE"</strong>, CDD cd00009 (AAA). UniProt: "Belongs to the<br />
+  YFH7 family."</li>
+</ul>
+<h3 id="conservation">Conservation</h3>
+<ul>
+<li>The <strong>fold/family is ancient and pan-eukaryotic</strong> (eggNOG KOG2702 at Eukaryota;<br />
+  OrthoDB group at Eukaryota; PANTHER PTHR10285 URK family reaches into bacteria).</li>
+<li>The <strong>specific YFH7 protein is lineage-restricted</strong>: bioinformatics UniRef50 cluster<br />
+  common taxon = <em>Saccharomycetaceae</em> (budding yeasts), UniRef90 narrows to<br />
+<em>Saccharomyces</em> sensu stricto (<code>YFH7-bioinformatics/RESULTS.md</code>). Consistent with the<br />
+  paper's "yeast-specific protein" language.</li>
+</ul>
+<h3 id="cellular-phenotypic-associations-indirect-high-throughput">Cellular / phenotypic associations (indirect, high-throughput)</h3>
+<ul>
+<li>Abundance: ~161 molecules/cell in log-phase SD medium (UniProt MISCELLANEOUS,<br />
+  ECO:0000269|PubMed:14562106).</li>
+<li>Localization: cytoplasm (GO IBA GO:0005737, GO_Central). No experimental yeast IDA<br />
+  localization in the cached record.</li>
+<li><strong>ER biogenesis screen</strong>: <em>yfh7Δ</em> was recovered in a parallel deletion-mutant screen<br />
+  for genes required for ER (karmellae) biogenesis; UniProt encodes this as the FUNCTION<br />
+  hedge "could be involved in endoplasmic reticulum membrane assembly"<br />
+  (ECO:0000269|PubMed:12868057). Note: the cached PMID:12868057 abstract is a genome-wide<br />
+  screen; it does not itself assign a molecular mechanism to YFH7.</li>
+<li><strong>Mitochondrial-genome maintenance</strong>: <em>yfh7Δ</em> increases the frequency of mitochondrial<br />
+  genome loss (petite frequency) in a computationally-driven quantitative screen; UniProt<br />
+  DISRUPTION PHENOTYPE "Increases frequency of mitochondrial genome loss"<br />
+  (ECO:0000269|PubMed:19300474). This is the source of the AIM ("Altered Inheritance of<br />
+  Mitochondria") alias. PMID:19300474 (full text cached) is a screen that assigns yeast<br />
+  ORFs a mitochondrial-biogenesis phenotype by petite-frequency assay; it does not<br />
+  determine YFH7's biochemical substrate.</li>
+</ul>
+<h2 id="what-is-not-known-the-primary-deliverable">What is NOT known (the primary deliverable)</h2>
+<ul>
+<li><strong>The physiological substrate / phosphoacceptor of YFH7 is unknown.</strong> The crystallographers<br />
+  could only conclude "<strong>new substrate specificity</strong>" — i.e. it is a small-molecule kinase<br />
+  but they could not identify what it phosphorylates:<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/18004758" title="...an ATP-dependent small molecule kinase with new substrate specificity.">PMID:18004758</a><br />
+  No substrate has been identified since from sequence, structure, or the bioinformatics<br />
+  analysis here.</li>
+<li><strong>The pathway / biological process</strong> in which YFH7 acts is undefined. The ER-biogenesis<br />
+  and mitochondrial-genome-loss associations are pleiotropic deletion-screen phenotypes,<br />
+  not a demonstrated molecular pathway; neither is corroborated by a mechanistic study.</li>
+<li><strong>Whether the in-vitro ATPase/ATP-turnover activity reflects productive substrate<br />
+  phosphorylation</strong> (kinase turnover coupled to a real acceptor) vs. basal P-loop<br />
+  ATP hydrolysis is not resolved without the acceptor.</li>
+</ul>
+<h2 id="curation-reasoning-summary-for-the-ai-review">Curation reasoning summary (for the ai-review)</h2>
+<ul>
+<li>GO:0016301 kinase activity (ISS, PMID:18004758) — ACCEPT (core). Supported by the intact<br />
+  Walker A P-loop + retained URK second block + the paper's ATP-dependent-kinase conclusion.<br />
+  Kept general ("kinase activity") deliberately: no substrate is demonstrated, so a specific<br />
+  child (e.g. a named small-molecule kinase) would over-specify.</li>
+<li>GO:0016887 ATP hydrolysis activity (IDA, PMID:18004758) — ACCEPT (core MF). Directly<br />
+  measured ATP turnover (KM for ATP). This is the experimentally observed activity.</li>
+<li>GO:0016310 phosphorylation (ISS, PMID:18004758) — ACCEPT (BP, non-core-ish but the<br />
+  process directly entailed by kinase activity). Kept as-is.</li>
+<li>GO:0005737 cytoplasm (IBA) — ACCEPT/KEEP_AS_NON_CORE. Phylogenetic location call, plausible<br />
+  for a soluble P-loop kinase; not core to function.</li>
+<li>GO:0005575 cellular_component (ND) — this is the root "no data" placeholder. KEEP_AS_NON_CORE<br />
+  (it is the standard ND stub; nothing to remove, adds no information).</li>
+<li>ATP binding (GO:0005524) is present in UniProt DR (IEA UniProtKB-KW) but NOT in the GOA TSV<br />
+  rows. Final decision: add it explicitly as an <code>existing_annotation</code> with <code>action: NEW</code><br />
+  (original_reference_id GO_REF:0000043, the UniProt-keyword mapping reference) AND include it<br />
+  in <code>core_functions</code>. Rationale: it is a genuine UniProt annotation and the mechanistic basis<br />
+  (Walker A P-loop) of the accepted kinase/ATP-hydrolysis activities, so recording it as a NEW<br />
+  annotation makes the provenance explicit rather than leaving it only in core_functions.</li>
+</ul>
+            </div>
+        </details>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Bioinformatics Results</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(RESULTS.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="P43591" data-a="DOC: Bioinformatics Results" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="yfh7-p43591-yfr007w-bioinformatics-analysis">YFH7 (P43591 / YFR007W) — bioinformatics analysis</h1>
+<p><strong>Target:</strong> <em>Saccharomyces cerevisiae</em> YFH7 (UniProt P43591; ORF YFR007W; alias AIM12),<br />
+a 353-aa protein annotated as an "ATP-dependent kinase" (EC 2.7.1.-), with a solved<br />
+crystal structure (PDB <strong>2GA8</strong> at 1.77 Å, <strong>2GAA</strong> at 1.95 Å; Gueguen-Chaignon et al.<br />
+2008, PMID:18004758).</p>
+<p><strong>Question addressed:</strong> Is YFH7 a structurally intact, plausibly catalytically-competent<br />
+small-molecule (P-loop) kinase, what is its domain architecture, and how broadly is it<br />
+conserved?</p>
+<h2 id="methods-reproducible">Methods (reproducible)</h2>
+<p>All steps are driven by the <code>justfile</code>; scripts read sequence/accession from<br />
+arguments (nothing gene-specific is hardcoded). Dependencies are managed with <code>uv</code><br />
+(<code>pyproject.toml</code>).</p>
+<table>
+<thead>
+<tr>
+<th>Step</th>
+<th>Script</th>
+<th>Input</th>
+<th>Output</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Motif scan (Walker A/B, composition)</td>
+<td><code>analyze_motifs.py</code></td>
+<td><code>YFH7.fasta</code></td>
+<td><code>results_motifs.json</code></td>
+</tr>
+<tr>
+<td>Domain architecture + orthology xrefs</td>
+<td><code>analyze_domains_orthology.py</code></td>
+<td>accession <code>P43591</code> (UniProt + InterPro REST)</td>
+<td><code>results_domains.json</code></td>
+</tr>
+<tr>
+<td>Taxonomic span (UniRef50/90 clusters)</td>
+<td><code>analyze_conservation.py</code></td>
+<td>accession <code>P43591</code> (UniProt REST)</td>
+<td><code>results_conservation.json</code></td>
+</tr>
+<tr>
+<td>PRK/URK/PANK family motif comparison</td>
+<td><code>compare_urk_motifs.py</code></td>
+<td><code>YFH7.fasta</code> + controls</td>
+<td><code>results_urk_compare.json</code></td>
+</tr>
+</tbody>
+</table>
+<p>Run with <code>just all</code> (motifs offline; domains/conservation need network access to the<br />
+public EBI/UniProt REST APIs). Control tests: <code>just test-controls</code>.</p>
+<h2 id="findings">Findings</h2>
+<h3 id="1-walker-a-p-loop-motif-present-and-canonical">1. Walker A / P-loop motif — present and canonical</h3>
+<p>The classic P-loop (Walker A) glycine-rich loop is detected at <strong>residues 31–38,<br />
+<code>GSPGSGKS(T)</code></strong>, matching the <code>[AG]-x(4)-G-K-[ST]</code> consensus and exactly the position<br />
+reported for the ATP-binding site in UniProt (BINDING 31..39) and in the crystal<br />
+structure. This is the ATP β/γ-phosphate–binding loop of P-loop NTPases/kinases.</p>
+<h3 id="2-walker-b-catalytic-acidic-residue-candidate-present">2. Walker B / catalytic acidic residue — candidate present</h3>
+<p>The Walker-B heuristic (hydrophobic strand ending in D/E) yields three candidates; the<br />
+one consistent with a P-loop-kinase catalytic Mg²⁺-coordinating aspartate lies within<br />
+the downstream <code>VILEG</code> block (see point 4). The heuristic is weak on its own, but its<br />
+best candidate co-locates with the family's diagnostic second block, consistent with an<br />
+intact catalytic scaffold. (Walker B position is not pinned to a single residue by<br />
+sequence alone — noted as a limitation.)</p>
+<h3 id="3-domain-architecture-p-loop-ntpase-fold-with-a-100-residue-insertion">3. Domain architecture — P-loop NTPase fold with a ~100-residue insertion</h3>
+<p>From UniProt + InterPro cross-references (<code>results_domains.json</code>):</p>
+<ul>
+<li><strong>IPR027417</strong> P-loop containing nucleoside triphosphate hydrolase (homologous<br />
+  superfamily), spanning <strong>1–353</strong>.</li>
+<li><strong>Gene3D 3.40.50.300</strong> / <strong>SUPFAM SSF52540</strong> — P-loop NTPase fold. The SUPFAM fold is<br />
+  reported in <strong>three discontinuous segments (22–54, 156–204, 233–349)</strong>, leaving a gap<br />
+  at ~<strong>55–155</strong>. This ~101-residue stretch is the <strong>"additional α/β domain of novel<br />
+  topology" / ~100-residue insertion</strong> described in the crystal paper — the feature that<br />
+  distinguishes YFH7 from canonical family members.</li>
+<li><strong>PANTHER PTHR10285</strong> "URIDINE KINASE" / nucleoside-kinase domain, spanning 12–322.</li>
+<li><strong>CDD cd00009 (AAA)</strong> mapped to 9–105 (the N-terminal core lobe).</li>
+<li>UniProt similarity comment: <em>"Belongs to the YFH7 family."</em></li>
+</ul>
+<p>This is fully consistent with the crystal-structure conclusion that YFH7 adopts the<br />
+<strong>PRK/URK/PANK</strong> (phosphoribulokinase / uridine kinase / pantothenate kinase) fold with<br />
+core, lid, and NMPbind subdomains plus a family-atypical insertion.</p>
+<h3 id="4-prkurkpank-family-signature-two-diagnostic-blocks-retained">4. PRK/URK/PANK family signature — two diagnostic blocks retained</h3>
+<p>Comparing YFH7 against a bona fide family member, <em>E. coli</em> uridine kinase (Udk,<br />
+P0A8F4), both proteins carry the two diagnostic sequence blocks<br />
+(<code>results_urk_compare.json</code>):</p>
+<table>
+<thead>
+<tr>
+<th>Block</th>
+<th>YFH7</th>
+<th><em>E. coli</em> Udk</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Walker A P-loop <code>[AG]x₄GK[ST]</code></td>
+<td><code>GSPGSGKS</code> @ 31</td>
+<td><code>GASASGKS</code> @ 15</td>
+</tr>
+<tr>
+<td>URK second block <code>[IV][IV][IL]EG</code></td>
+<td><code>VILEG</code> @ 263</td>
+<td><code>IILEG</code> @ 115</td>
+</tr>
+</tbody>
+</table>
+<p>Retention of <strong>both</strong> blocks indicates the small-molecule-kinase catalytic scaffold is<br />
+intact — i.e. YFH7 is not an obviously degenerate pseudokinase at the level of these<br />
+family fingerprints. (This is evidence for structural competence, not proof of in-vivo<br />
+catalysis or of any particular substrate.)</p>
+<h3 id="5-orthology-conservation-ancient-fold-budding-yeast-restricted-protein">5. Orthology / conservation — ancient fold, budding-yeast-restricted protein</h3>
+<p>Two layers must be distinguished:</p>
+<ul>
+<li><strong>The fold/domain is ancient and pan-eukaryotic.</strong> YFH7 belongs to eggNOG<br />
+<strong>KOG2702</strong> (a eukaryotic orthologous group), OrthoDB group at the <strong>Eukaryota</strong><br />
+  level (<code>...at2759</code>), has an InParanoid record, and maps to PANTHER <strong>PTHR10285</strong><br />
+  (uridine-kinase family) — all indicating the P-loop kinase family it sits in is<br />
+  deeply conserved across eukaryotes (and, via the URK family, into bacteria).</li>
+<li><strong>The specific YFH7 protein is lineage-restricted.</strong> Its <strong>UniRef50 cluster (≥50 %<br />
+  identity) has a common taxon of <em>Saccharomycetaceae</em></strong> (23 members: <em>Saccharomyces</em>,<br />
+<em>Vanderwaltozyma polyspora</em>, <em>Saccharomyces eubayanus/pastorianus</em>, etc.), and the<br />
+  UniRef90 cluster narrows to <em>Saccharomyces</em> sensu stricto (<code>results_conservation.json</code>).<br />
+  For comparison, the control protein <strong>actin (ACT1, P60010) has a UniRef50 common taxon<br />
+  of <em>Eukaryota</em> (434 members)</strong> — the expected signature of a broadly conserved protein.</li>
+</ul>
+<p><strong>Interpretation:</strong> YFH7 is a <strong>budding-yeast-specific member of an ancient P-loop<br />
+small-molecule-kinase family</strong>. This matches the crystal paper's description of a<br />
+"yeast-specific protein showing weak similarity" to the PRK/URK/PANK subfamily, with a<br />
+lineage-specific insertion. The specific in-vivo substrate is not determinable from<br />
+sequence/structure alone.</p>
+<h2 id="overall-assessment">Overall assessment</h2>
+<p>YFH7 is a <strong>structurally intact P-loop (PRK/URK/PANK-fold) ATP-dependent small-molecule<br />
+kinase</strong> with a canonical Walker A P-loop, retained family diagnostic blocks, and a<br />
+lineage-specific ~100-residue insertion. The evidence supports classifying it as a<br />
+<strong>catalytically-plausible small-molecule kinase</strong> (<code>kinase activity</code>; more specifically<br />
+consistent with a phosphotransferase acting on a small-molecule hydroxyl acceptor), but<br />
+<strong>the physiological substrate is unknown</strong> — the crystallographers could only conclude<br />
+"new substrate specificity," and no substrate has since been identified from sequence,<br />
+structure, or the analyses here. This is an <strong>MF/BP substrate gap</strong>, not a fold or<br />
+family-membership uncertainty.</p>
+<h2 id="checklist">Checklist</h2>
+<ul>
+<li>[x] Scripts do not use hardcoded inputs or outputs (sequence/accession are CLI args;<br />
+      verified by running on control sequences).</li>
+<li>[x] Scripts tested on at least one other input:<ul>
+<li><code>analyze_motifs.py</code> / <code>compare_urk_motifs.py</code>: positive control <em>E. coli</em> Udk<br />
+    (P-loop + URK block detected) and negative control yeast histone H4 (neither<br />
+    detected).</li>
+<li><code>analyze_conservation.py</code>: control actin ACT1 (P60010) → Eukaryota-wide cluster,<br />
+    correctly contrasting with YFH7's yeast-restricted cluster.</li>
+</ul>
+</li>
+<li>[x] Analyses completed as expected (all <code>just</code> steps run cleanly).</li>
+<li>[x] Direct results of the scripts are in the folder (<code>results_*.json</code>).</li>
+<li>[x] Summary includes provenance and justification; uncertainty (substrate identity,<br />
+      exact Walker B residue) is stated explicitly.</li>
+<li>[?] Walker B catalytic residue is a heuristic candidate only, not pinned to a single<br />
+      residue by sequence alone (would need structure-based residue mapping from PDB 2GA8).</li>
+</ul>
+<h2 id="data-provenance-tools">Data provenance / tools</h2>
+<ul>
+<li>UniProt REST (<code>rest.uniprot.org</code>) — entry P43591, UniRef50/90 clusters.</li>
+<li>InterPro REST (<code>www.ebi.ac.uk/interpro</code>) — domain-to-protein mapping.</li>
+<li>Reference family member: <em>E. coli</em> uridine kinase Udk (P0A8F4).</li>
+<li>Control proteins: yeast actin ACT1 (P60010), yeast histone H4 (P02309).</li>
+<li>Structural/functional context: Gueguen-Chaignon et al. 2008, <em>Proteins</em> 71:804–812<br />
+  (PMID:18004758; PDB 2GA8, 2GAA).</li>
+<li>biopython 1.87, requests 2.34 (see <code>pyproject.toml</code> / <code>uv.lock</code>).</li>
+</ul>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: P43591
+gene_symbol: YFH7
+product_type: PROTEIN
+status: COMPLETE
+taxon:
+  id: NCBITaxon:559292
+  label: Saccharomyces cerevisiae
+description: &gt;-
+  YFH7 (ORF YFR007W; alias AIM12) is a 353-residue soluble ATP-dependent small-molecule
+  kinase of the P-loop NTPase superfamily in the budding yeast Saccharomyces cerevisiae.
+  Its crystal structure (PDB 2GA8/2GAA) shows the phosphoribulokinase/uridine
+  kinase/bacterial pantothenate kinase (PRK/URK/PANK) fold — with core, lid and
+  NMP-binding subdomains — plus an additional ~100-residue alpha/beta domain of novel
+  topology that is a lineage-specific insertion. It carries a canonical Walker A
+  (P-loop) motif (GSPGSGKS, residues 31-38) that binds ATP and the URK-family diagnostic
+  second block (VILEG, ~residue 263), and it hydrolyses ATP in vitro (KM approximately
+  1.2 mM). Although the P-loop kinase fold is ancient and pan-eukaryotic, the YFH7
+  protein itself is restricted to the Saccharomycetaceae. YFH7 is a soluble, moderately
+  abundant cytoplasmic protein. Deletion is viable but has been linked in genome-wide
+  screens to defects in endoplasmic reticulum (karmellae) biogenesis and to an increased
+  frequency of mitochondrial genome loss. The physiological phosphoacceptor substrate of
+  YFH7, and the pathway in which it acts, remain unidentified.
+references:
+- id: GO_REF:0000015
+  title: Use of the ND evidence code for Gene Ontology (GO) terms
+  findings: []
+- id: GO_REF:0000033
+  title: Annotation inferences using phylogenetic trees
+  findings: []
+- id: GO_REF:0000043
+  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot keyword mapping
+  findings: []
+- id: PMID:18004758
+  title: Crystal structure and functional analysis identify the P-loop containing
+    protein YFH7 of Saccharomyces cerevisiae as an ATP-dependent kinase.
+  findings:
+  - statement: YFH7 is an ATP-dependent small-molecule kinase with an as-yet undetermined substrate.
+    supporting_text: &gt;-
+      Structural and ligand binding analysis combined with enzymatic assays suggest that
+      YFH7 is an ATP-dependent small molecule kinase with new substrate specificity.
+  - statement: YFH7 adopts the PRK/URK/PANK P-loop kinase fold and is yeast-specific.
+    supporting_text: &gt;-
+      Sequence analysis revealed that yeast YFH7 is a yeast-specific protein showing weak
+      similarity with the phosphoribulokinase/uridine kinase/bacterial pantothenate
+      kinase (PRK/URK/PANK) subfamily of P-loop containing kinases.
+  - statement: A large ~100-residue insertion distinguishes YFH7 from other family members.
+    supporting_text: &gt;-
+      A large insertion of about 100 residues distinguishes YFH7 from other members of
+      the family.
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PubMed-verified crystal-structure + enzymology paper (Gueguen-Chaignon et al.,
+      Proteins 2008; PDB 2GA8/2GAA). Establishes the P-loop kinase fold and the
+      ATP-dependent-kinase activity but explicitly leaves the substrate undetermined
+      (&#34;new substrate specificity&#34;). This is the primary source for the MF/BP
+      annotations.
+- id: PMID:12868057
+  title: Parallel analysis of tagged deletion mutants efficiently identifies genes involved
+    in endoplasmic reticulum biogenesis.
+  findings:
+  - statement: &gt;-
+      Genome-wide deletion screen for genes required for ER (karmellae) biogenesis; the
+      basis for UniProt&#39;s hedged &#34;could be involved in endoplasmic reticulum membrane
+      assembly&#34; note for YFH7. The paper is a screen and does not assign YFH7 a molecular
+      mechanism.
+    supporting_text: &gt;-
+      To identify genes required for karmellae assembly, we compared the composition of
+      populations of homozygous diploid S. cerevisiae deletion mutants following 20
+      generations of growth with and without karmellae.
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PubMed-verified. High-throughput deletion screen implicating yfh7Δ (among many) in
+      ER/karmellae biogenesis; provides a phenotypic association only, not a molecular
+      function. Cited here for the ER-biogenesis knowledge-gap context.
+- id: PMID:19300474
+  title: Computationally driven, quantitative experiments discover genes required for
+    mitochondrial biogenesis.
+  findings:
+  - statement: &gt;-
+      Quantitative petite-frequency screen linking many deletion strains (including yfh7Δ,
+      source of the AIM12 alias) to increased mitochondrial genome loss; a phenotypic
+      association, not a biochemical function.
+    supporting_text: &gt;-
+      Using computational predictions combined with traditional quantitative experiments,
+      we have identified 100 proteins whose deficiency alters mitochondrial biogenesis and
+      inheritance in Saccharomyces cerevisiae.
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PubMed-verified (full text cached). Basis for UniProt&#39;s DISRUPTION PHENOTYPE
+      &#34;Increases frequency of mitochondrial genome loss&#34; and the AIM (&#34;altered inheritance
+      of mitochondria&#34;) alias. Supports a mitochondrial-maintenance phenotype but does not
+      determine YFH7&#39;s substrate or direct molecular role.
+- id: file:yeast/YFH7/YFH7-bioinformatics/RESULTS.md
+  title: &gt;-
+    YFH7 bioinformatics analysis (P-loop / Walker-A motif scan, PRK/URK/PANK family
+    signature, domain architecture, and taxonomic conservation).
+  findings:
+  - statement: &gt;-
+      Canonical Walker A / P-loop motif GSPGSGKS at residues 31-38 and the URK-family
+      diagnostic second block VILEG at ~263 are both retained, indicating an intact
+      small-molecule-kinase catalytic scaffold; the YFH7 protein is Saccharomycetaceae-
+      restricted while the fold is pan-eukaryotic.
+    supporting_text: &gt;-
+      the small-molecule-kinase catalytic scaffold is intact
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Reproducible in-repo analysis (scripts + control tests in YFH7-bioinformatics/).
+      NOTE: file: references are not verbatim-quote-checked by the reference validator;
+      the quoted supporting_text was confirmed by hand to be a verbatim substring of
+      RESULTS.md. Corroborates the intact P-loop kinase scaffold and lineage restriction.
+existing_annotations:
+- term:
+    id: GO:0005737
+    label: cytoplasm
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: is_active_in
+  review:
+    summary: &gt;-
+      Phylogenetically inferred cytoplasmic localization, consistent with a soluble
+      P-loop small-molecule kinase and with the absence of any transmembrane or targeting
+      signal. Plausible and retained, but the localization is not the core of the gene&#39;s
+      function.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      IBA localization is reasonable for a soluble cytoplasmic kinase and consistent with
+      UniProt (no signal/transmembrane features). No experimental yeast localization is
+      available to refine it, so it is kept as a non-core supporting annotation rather
+      than a defining function.
+- term:
+    id: GO:0005575
+    label: cellular_component
+  evidence_type: ND
+  original_reference_id: GO_REF:0000015
+  qualifier: is_active_in
+  review:
+    summary: &gt;-
+      Root &#34;cellular_component&#34; term with the ND (no biological data) code — the standard
+      placeholder used when no specific location has been curated. It carries no
+      information and is superseded by the IBA cytoplasm annotation.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      This is the conventional ND root-term stub, not an assertion to accept or remove on
+      biological grounds. It is retained as-is per GO practice; the informative location
+      is captured by the cytoplasm (IBA) row and in core_functions.
+- term:
+    id: GO:0016301
+    label: kinase activity
+  evidence_type: ISS
+  original_reference_id: PMID:18004758
+  qualifier: enables
+  review:
+    summary: &gt;-
+      YFH7 is a P-loop kinase of the PRK/URK/PANK subfamily. The intact Walker A P-loop
+      (GSPGSGKS, 31-38), the retained URK-family second block (VILEG, ~263), the solved
+      structure, and in-vitro ATP-dependent activity together support a genuine kinase
+      (phosphotransferase) molecular function. This is a core function. The general
+      &#34;kinase activity&#34; term is appropriate and should NOT be over-specified: the crystal
+      paper concluded &#34;new substrate specificity&#34;, i.e. no phosphoacceptor substrate is
+      demonstrated, so a specific kinase child term is not warranted.
+    action: ACCEPT
+    reason: &gt;-
+      Well supported by structure + enzymology (PMID:18004758) and by the intact
+      diagnostic P-loop/URK motifs in the bioinformatics analysis. Deliberately kept at
+      the general &#34;kinase activity&#34; level because the physiological substrate is unknown.
+    supported_by:
+    - reference_id: PMID:18004758
+      supporting_text: &gt;-
+        Structural and ligand binding analysis combined with enzymatic assays suggest that
+        YFH7 is an ATP-dependent small molecule kinase with new substrate specificity.
+    - reference_id: file:yeast/YFH7/YFH7-bioinformatics/RESULTS.md
+      supporting_text: &gt;-
+        the small-molecule-kinase catalytic scaffold is intact
+- term:
+    id: GO:0005524
+    label: ATP binding
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000043
+  qualifier: enables
+  review:
+    summary: &gt;-
+      ATP binding via the canonical Walker A (P-loop) motif GSPGSGKS at residues 31-38
+      (UniProt BINDING 31..39, ATP; ChEBI:30616). Present in UniProt as a keyword-derived
+      IEA annotation and directly supported by the crystal structure and the intact P-loop
+      identified bioinformatically. This is a core molecular function underlying the
+      enzyme&#39;s ATP-dependent kinase/ATPase activity.
+    action: NEW
+    reason: &gt;-
+      ATP binding is a genuine UniProt annotation (GO:0005524, IEA from UniProtKB keyword)
+      that is not present as a row in the GOA TSV; it is added here as a NEW core molecular
+      function because it is well supported by the Walker A P-loop (structure + sequence)
+      and is the mechanistic basis for the accepted kinase and ATP-hydrolysis activities.
+    supported_by:
+    - reference_id: PMID:18004758
+      supporting_text: &gt;-
+        Structural and ligand binding analysis combined with enzymatic assays suggest that
+        YFH7 is an ATP-dependent small molecule kinase with new substrate specificity.
+    - reference_id: file:yeast/YFH7/YFH7-bioinformatics/RESULTS.md
+      supporting_text: &gt;-
+        P-loop (Walker A) glycine-rich loop is detected at
+- term:
+    id: GO:0016310
+    label: phosphorylation
+  evidence_type: ISS
+  original_reference_id: PMID:18004758
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Biological-process counterpart of the kinase molecular function: as an ATP-dependent
+      kinase, YFH7 is involved in phosphorylation (phosphate transfer to a small-molecule
+      acceptor). Consistent with the ISS transfer and the intact catalytic scaffold.
+    action: ACCEPT
+    reason: &gt;-
+      Directly entailed by the accepted kinase activity; the general &#34;phosphorylation&#34;
+      process term is appropriate given the undetermined substrate. Retained as the BP
+      partner of the MF annotation.
+    supported_by:
+    - reference_id: PMID:18004758
+      supporting_text: &gt;-
+        Structural and ligand binding analysis combined with enzymatic assays suggest that
+        YFH7 is an ATP-dependent small molecule kinase with new substrate specificity.
+- term:
+    id: GO:0016887
+    label: ATP hydrolysis activity
+  evidence_type: IDA
+  original_reference_id: PMID:18004758
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Directly measured in vitro: YFH7 turns over ATP, with a determined KM of ~1.2 mM for
+      ATP (UniProt BIOPHYSICOCHEMICAL PROPERTIES from PMID:18004758). This experimental
+      ATP-turnover activity is the empirical basis for classifying YFH7 as an
+      ATP-dependent kinase and is a core molecular function.
+    action: ACCEPT
+    reason: &gt;-
+      Experimental (IDA) measurement of ATP hydrolysis/turnover from the same
+      structure/enzymology study; consistent with the intact Walker A P-loop. Kept as a
+      core MF annotation. (The measured ATP turnover reflects the enzyme&#39;s ATP-dependent
+      catalytic cycle; whether it is coupled to a productive phosphoacceptor is part of
+      the substrate knowledge gap, but the ATPase activity itself is directly observed.)
+    supported_by:
+    - reference_id: PMID:18004758
+      supporting_text: &gt;-
+        Structural and ligand binding analysis combined with enzymatic assays suggest that
+        YFH7 is an ATP-dependent small molecule kinase with new substrate specificity.
+core_functions:
+- description: &gt;-
+    ATP-dependent small-molecule kinase activity: YFH7 binds ATP via its Walker A P-loop
+    and catalyses transfer of the gamma-phosphate to a (currently unidentified)
+    small-molecule acceptor, consistent with its PRK/URK/PANK P-loop kinase fold and its
+    measured in-vitro ATP turnover.
+  molecular_function:
+    id: GO:0016301
+    label: kinase activity
+  supported_by:
+  - reference_id: PMID:18004758
+    supporting_text: &gt;-
+      Structural and ligand binding analysis combined with enzymatic assays suggest that
+      YFH7 is an ATP-dependent small molecule kinase with new substrate specificity.
+  - reference_id: file:yeast/YFH7/YFH7-bioinformatics/RESULTS.md
+    supporting_text: &gt;-
+      the small-molecule-kinase catalytic scaffold is intact
+- description: &gt;-
+    ATP binding through the canonical Walker A (P-loop) motif GSPGSGKS at residues 31-38,
+    which coordinates the ATP phosphates; the basis for the enzyme&#39;s ATP-dependent
+    activity.
+  molecular_function:
+    id: GO:0005524
+    label: ATP binding
+  supported_by:
+  - reference_id: PMID:18004758
+    supporting_text: &gt;-
+      Structural and ligand binding analysis combined with enzymatic assays suggest that
+      YFH7 is an ATP-dependent small molecule kinase with new substrate specificity.
+  - reference_id: file:yeast/YFH7/YFH7-bioinformatics/RESULTS.md
+    supporting_text: &gt;-
+      P-loop (Walker A) glycine-rich loop is detected at
+  locations:
+  - id: GO:0005737
+    label: cytoplasm
+proposed_new_terms: []
+suggested_questions:
+- question: &gt;-
+    What is the physiological small-molecule phosphoacceptor substrate of YFH7? The
+    crystal structure and enzymology established an ATP-dependent kinase but &#34;new
+    substrate specificity&#34; — the acceptor is unidentified.
+- question: &gt;-
+    Is the ER-biogenesis (karmellae) and/or mitochondrial-genome-loss phenotype of yfh7Δ
+    a direct consequence of a missing phosphorylation event, or an indirect/pleiotropic
+    effect?
+- question: &gt;-
+    Does the lineage-specific ~100-residue insertion (the &#34;additional alpha/beta domain of
+    novel topology&#34;) confer the substrate specificity that distinguishes YFH7 from other
+    PRK/URK/PANK-family kinases?
+suggested_experiments:
+- description: &gt;-
+    Broad in-vitro phosphotransfer substrate screen (metabolomic / small-molecule library
+    kinase assay, e.g. coupled ADP-detection) against purified recombinant YFH7 to
+    identify the phosphoacceptor; follow up with steady-state kinetics on the best hits.
+- description: &gt;-
+    Structure-guided mutagenesis of the Walker A lysine (in GSPGSGKS) and candidate
+    catalytic acidic residue, with an ATPase/kinase-dead allele tested for rescue of the
+    yfh7Δ ER-biogenesis and mitochondrial-genome-loss phenotypes, to test whether those
+    phenotypes require catalytic activity.
+- description: &gt;-
+    Untargeted comparative metabolomics of wild-type vs yfh7Δ (and a catalytic-dead
+    knock-in) to detect an accumulating substrate or missing phosphorylated product.
+knowledge_gaps:
+- gap_statement: &gt;-
+    The physiological phosphoacceptor substrate of YFH7 is unknown. It is established as an
+    ATP-dependent small-molecule kinase, but what small molecule it phosphorylates — and
+    therefore the metabolic pathway and biological process it serves — has never been
+    identified.
+  boundary: &gt;-
+    Firmly known: YFH7 is a soluble cytoplasmic protein with the PRK/URK/PANK P-loop
+    kinase fold (crystal structures 2GA8/2GAA), an intact Walker A P-loop (GSPGSGKS,
+    31-38) that binds ATP, the retained URK-family diagnostic second block (VILEG, ~263),
+    measured in-vitro ATP turnover (KM ~1.2 mM for ATP), and a lineage-specific
+    ~100-residue insertion. Deletion is viable and has been associated in genome-wide
+    screens with impaired ER (karmellae) biogenesis and increased mitochondrial genome
+    loss. Unknown: the small-molecule acceptor phosphorylated by the enzyme, the pathway
+    it belongs to, and whether the deletion phenotypes are direct consequences of a lost
+    phosphorylation.
+  gap_kind:
+  - BIOLOGY
+  dark_aspect: BP_DARK
+  status: OPEN
+  significance: &gt;-
+    YFH7 is a structurally solved, catalytically plausible enzyme whose reaction is
+    unassigned — a clean example of a &#34;known activity, unknown substrate/purpose&#34;
+    (BP-dark) enzyme in one of the best-studied eukaryotes. Identifying its substrate would
+    convert a decades-old orphan kinase into an annotated metabolic step and could explain
+    the ER- and mitochondrial-maintenance phenotypes.
+  resolution: &gt;-
+    A broad in-vitro small-molecule phosphotransfer substrate screen on recombinant YFH7
+    followed by kinetic confirmation; comparative wild-type-vs-yfh7Δ metabolomics to detect
+    an accumulating substrate or missing phosphorylated product; catalytic-dead
+    separation-of-function alleles to test whether the deletion phenotypes require the
+    kinase activity.
+  provenance:
+  - reference_id: PMID:18004758
+    supporting_text: &gt;-
+      Structural and ligand binding analysis combined with enzymatic assays suggest that
+      YFH7 is an ATP-dependent small molecule kinase with new substrate specificity.
+    reference_section_type: ABSTRACT
+  - reference_id: file:yeast/YFH7/YFH7-bioinformatics/RESULTS.md
+    supporting_text: &gt;-
+      the physiological substrate is unknown
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/pages/projects/UNIPROT_CAUTION_NOTE/uniprot_wide_queries.html
+++ b/pages/projects/UNIPROT_CAUTION_NOTE/uniprot_wide_queries.html
@@ -1727,7 +1727,7 @@
 <td><a href="http://amigo.geneontology.org/amigo/term/GO:0035516">GO:0035516</a> broad specificity oxidat(IDA)</td>
 </tr>
 <tr>
-<td>Amd2</td>
+<td><a href="../../../genes/yeast/AMD2/AMD2-ai-review.html">Amd2</a></td>
 <td>Mus musculus (Mouse)</td>
 <td>D3Z6H8</td>
 <td>PMID:9620866</td>


### PR DESCRIPTION
## Summary

Automated regeneration of static assets after gene review or template changes.

## Generated Assets

| Asset | Count/Status |
|-------|--------------|
| Gene review YAML files | 2916 |
| Gene review HTML pages | 2916 |
| Project pages | 1098 |
| Module pages | 87 |
| Browser app (data.js) | Updated |
| Validation report | Updated |

## Trigger

This PR was triggered by changes to:
- genes/**/*.yaml - gene review data files
- src/ai_gene_review/schema/** - LinkML schema files
- src/ai_gene_review/templates/** - Jinja2 templates
- src/ai_gene_review/render.py - rendering code
- src/ai_gene_review/render_modules.py - module rendering code
- src/ai_gene_review/export/** - export code
- src/ai_gene_review/browser/** - browser app assets
- src/ai_gene_review/tools/minify_linkml_browser_data.py - browser data compaction
- projects/*.md - project definitions
- modules/**/*.yaml - module definitions
- project.justfile - just recipes used by CI
- .github/workflows/generate-pages.yaml - workflow definition

## Review

- [ ] Spot-check a few gene review HTML pages render correctly
- [ ] Spot-check module tree browser pages render correctly
- [ ] Verify browser app loads and filters work
- [ ] Check validation report for new issues
