### PR TITLE
Add AI review for S. cerevisiae JIP4

### DIFF
--- a/genes/yeast/JIP4/JIP4-ai-review.yaml
+++ b/genes/yeast/JIP4/JIP4-ai-review.yaml
@@ -1,0 +1,395 @@
+id: Q03361
+gene_symbol: JIP4
+product_type: PROTEIN
+status: DRAFT
+taxon:
+  id: NCBITaxon:559292
+  label: Saccharomyces cerevisiae
+description: >-
+  JIP4 (systematic name YDR475C; "Jumonji-interacting protein 4") is a large
+  (876-residue) intrinsically disordered protein of Saccharomyces cerevisiae whose
+  molecular function has not been experimentally determined. Its sequence is dominated
+  by disorder and low-complexity composition, including several arginine/serine (RS)
+  and basic/acidic repetitive tracts, and on the basis of this compositional similarity
+  it is placed in the serine/arginine repetitive matrix protein family (PANTHER
+  PTHR23148), whose metazoan members (SRRM1/SRm160) are nuclear SR-related splicing
+  coactivators; JIP4 itself lacks the folded PWI nucleic-acid-binding domain that
+  defines those splicing proteins, and no splicing or RNA-related activity has been
+  demonstrated for it in yeast. JIP4 is a phosphoprotein, with multiple serine
+  residues phosphorylated in vivo (including cyclin-dependent-kinase-1-dependent sites)
+  as detected by large-scale phosphoproteomics. The gene is non-essential; deletion is
+  viable, and it has a paralog, YOR019W, arising from the whole-genome duplication that
+  is likewise uncharacterized.
+references:
+- id: file:yeast/JIP4/JIP4-uniprot.txt
+  title: UniProtKB entry Q03361 (JIP4_YEAST), including PANTHER family assignment and sequence features
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: >-
+      Cached UniProt record for JIP4/YDR475C. Source for the domain/composition analysis
+      (intrinsic disorder, RS/low-complexity tracts, absence of a PWI/RRM domain), the
+      PANTHER PTHR23148 family assignment, and the phosphosite features.
+- id: GO_REF:0000015
+  title: Use of the ND evidence code for Gene Ontology (GO) terms
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: >-
+      GO_REF documenting the ND (No biological Data available) evidence code. Correctly
+      applied by SGD to the three root-term annotations for this uncharacterized gene.
+- id: GO_REF:0000033
+  title: Annotation inferences using phylogenetic trees
+  findings: []
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: >-
+      Standard GO_REF for phylogenetically inferred (IBA) annotations from GO_Central.
+      Correctly identifies the method; the biological transfer of the specific SRRM1
+      splicing function to yeast JIP4 is questionable (see per-annotation reasons), but
+      the reference itself is valid.
+- id: file:yeast/JIP4/JIP4-deep-research-falcon.md
+  title: Falcon (Edison) deep-research report on S. cerevisiae JIP4/YDR475C
+  findings: []
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: >-
+      Automated Edison deep-research report (20 citations). Reconfirms merged-ORF status,
+      non-essentiality, the YOR019W paralog, and the Ser/Arg repetitive matrix domain,
+      and treats a splicing/RNA-processing role as a low-to-moderate-confidence,
+      domain-based inference only. Adds a naming-origin hypothesis that JIP4 is a
+      Gis1-associated factor. NOTE: its "165 aa" size claim is inconsistent with the
+      authoritative UniProt length (876 aa) and is not used.
+- id: PMID:19779198
+  title: Global analysis of Cdk1 substrate phosphorylation sites provides insights into evolution.
+  findings: []
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: >-
+      Large-scale identification of Cdk1 substrate phosphorylation sites in S.
+      cerevisiae; JIP4 (Ser-48, Ser-51, Ser-510, Ser-552, Ser-775) is one of many
+      phosphoproteins cataloged. Supports that JIP4 is an in vivo phosphoprotein and a
+      likely Cdk1 substrate, but does not assign a molecular function. Verified via
+      UniProt MOD_RES cross-references to this PMID.
+- id: PMID:18407956
+  title: A multidimensional chromatography technology for in-depth phosphoproteome analysis.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: >-
+      Methods-focused large-scale phosphoproteome study; JIP4 (Ser-48, Ser-360,
+      Ser-552) appears as a mapped phosphoprotein. Corroborates the phosphoprotein
+      status only. Verified via UniProt MOD_RES cross-references.
+- id: PMID:15665377
+  title: Quantitative phosphoproteomics applied to the yeast pheromone signaling pathway.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: >-
+      Pheromone-signaling phosphoproteome study; JIP4 Ser-577 detected as a
+      phosphosite. Corroborates phosphoprotein status. Verified via UniProt MOD_RES
+      cross-reference.
+existing_annotations:
+- term:
+    id: GO:0005681
+    label: spliceosomal complex
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: part_of
+  review:
+    summary: >-
+      Homology-only (IBA) inference propagated from the metazoan SRRM1/SRm160 orthologs
+      in PANTHER family PTHR23148. There is no experimental evidence that yeast JIP4 is
+      a spliceosome component, and this transfer is biologically questionable.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: >-
+      This annotation rests solely on JIP4's placement in the serine/arginine
+      repetitive matrix family (with/from human SRRM1 Q8IYB3, mouse Srrm1 MGI:1858303),
+      a placement driven by shared RS/low-complexity composition rather than a
+      conserved folded domain. JIP4 lacks the PWI nucleic-acid-binding domain that
+      defines the SRm160/SRRM1 splicing coactivators (UniProt annotates only disorder
+      and compositional bias, no PWI or RRM). The S. cerevisiae spliceosome has been
+      exhaustively purified and characterized, and JIP4 has never been reported as a
+      spliceosome subunit; the known yeast counterparts of the human SR-related
+      nuclear-matrix splicing proteins are other proteins (e.g. Cwc21/YDR482C). The
+      annotation is therefore retained but flagged as a likely over-annotation of an
+      uncharacterized gene rather than as core function.
+    propagation_review:
+      root_cause: PROPAGATION_BAD
+      failure_modes:
+      - FUNCTIONAL_DIVERGENCE
+      - PSEUDO_OR_SUBACTIVITY_LOSS
+      - COMPARTMENT_OR_COMPLEX_MISMATCH
+      source_entities:
+      - source_id: UniProtKB:Q8IYB3
+        source_label: SRRM1 (human)
+        source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
+        comment: >-
+          Human SRRM1/SRm160 is a bona fide PWI-domain spliceosome/EJC coactivator; the
+          spliceosome-membership term is sound for the source but should not transfer to
+          the PWI-less, uncharacterized yeast protein.
+      - source_id: MGI:MGI:1858303
+        source_label: Srrm1 (mouse)
+        source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
+      - source_id: PANTHER:PTN000567596
+        source_label: PTHR23148:SF0 ancestral node
+        source_status: SOURCE_WEAK_OR_INFERRED
+        comment: >-
+          Family placement is composition-driven (RS/low-complexity) rather than
+          domain-conserved.
+    supported_by:
+    - reference_id: file:yeast/JIP4/JIP4-uniprot.txt
+      supporting_text: "PANTHER; PTHR23148; SERINE/ARGININE REGULATED NUCLEAR MATRIX PROTEIN; 1."
+- term:
+    id: GO:0048024
+    label: regulation of mRNA splicing, via spliceosome
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: involved_in
+  review:
+    summary: >-
+      Homology-only (IBA) inference of a splicing-regulation role from metazoan/
+      Drosophila SRRM1-family members. Not supported by any experimental evidence in
+      yeast and biologically doubtful given the absence of the defining PWI domain.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: >-
+      As for the spliceosomal-complex annotation, this biological-process term is
+      transferred from SRRM1/SRm160 orthologs (with/from FB:FBgn0036340 and PANTHER
+      PTN000567596) purely on family membership. JIP4 has no demonstrated RNA-binding
+      or splicing activity, lacks the PWI domain, and does not appear in yeast
+      spliceosome or splicing-regulator datasets. Budding yeast introns are few and
+      simple with no minor (U12) spliceosome and no metazoan-style exon-junction
+      splicing coactivation, so the specific SRm160 splicing-activation role has no
+      clear yeast equivalent. Retained but flagged as a likely over-annotation rather
+      than established or core function.
+    propagation_review:
+      root_cause: PROPAGATION_BAD
+      failure_modes:
+      - FUNCTIONAL_DIVERGENCE
+      - PSEUDO_OR_SUBACTIVITY_LOSS
+      - LINEAGE_OR_TAXON_MISMATCH
+      source_entities:
+      - source_id: FB:FBgn0036340
+        source_label: Drosophila SRRM1-family member
+        source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
+      - source_id: PANTHER:PTN000567596
+        source_label: PTHR23148:SF0 ancestral node
+        source_status: SOURCE_WEAK_OR_INFERRED
+        comment: >-
+          Metazoan-style ESE-dependent splicing activation has no clear equivalent in
+          intron-poor budding yeast, which lacks a minor spliceosome.
+    supported_by:
+    - reference_id: file:yeast/JIP4/JIP4-uniprot.txt
+      supporting_text: "PANTHER; PTHR23148; SERINE/ARGININE REGULATED NUCLEAR MATRIX PROTEIN; 1."
+- term:
+    id: GO:0003674
+    label: molecular_function
+  evidence_type: ND
+  original_reference_id: GO_REF:0000015
+  qualifier: enables
+  review:
+    summary: >-
+      Root molecular_function term with the ND (No biological Data available) evidence
+      code, correctly recording that no molecular function has been determined for JIP4.
+    action: ACCEPT
+    reason: >-
+      The ND annotation to the MF root is an honest placeholder for an uncharacterized
+      gene. No experimentally supported molecular activity exists for JIP4, and no
+      folded catalytic or binding domain is identifiable in its sequence, so retaining
+      the ND root annotation accurately conveys the molecular-function-dark status. It
+      does not represent a core function.
+- term:
+    id: GO:0005575
+    label: cellular_component
+  evidence_type: ND
+  original_reference_id: GO_REF:0000015
+  qualifier: is_active_in
+  review:
+    summary: >-
+      Root cellular_component term with ND evidence, recording that JIP4's subcellular
+      localization has not been experimentally established.
+    action: ACCEPT
+    reason: >-
+      No experimental localization data are available for JIP4 (UniProt records no
+      subcellular-location annotation). While the RS-rich, disordered composition is
+      suggestive of a possible nuclear/RNA-associated localization, this is not
+      established, so the ND root annotation is an appropriate honest placeholder.
+- term:
+    id: GO:0008150
+    label: biological_process
+  evidence_type: ND
+  original_reference_id: GO_REF:0000015
+  qualifier: involved_in
+  review:
+    summary: >-
+      Root biological_process term with ND evidence, recording that no biological
+      process/pathway has been assigned to JIP4.
+    action: ACCEPT
+    reason: >-
+      JIP4 is non-essential (deletion viable) with no defined loss-of-function
+      phenotype beyond viability and no assigned pathway. The ND root annotation
+      correctly captures the biological-process-dark status of this gene.
+core_functions:
+- description: >-
+    No core molecular function can be assigned to JIP4 with confidence. It is an
+    intrinsically disordered, RS/low-complexity protein classified by composition in
+    the serine/arginine repetitive matrix (SRRM1/SRm160) family, and it is an in vivo
+    phosphoprotein (including Cdk1-dependent sites), but neither its molecular activity
+    nor its biological role has been experimentally established, and it lacks the folded
+    PWI domain that carries the splicing function of its metazoan family members. The
+    family-based splicing/spliceosome inferences are homology-only and are treated as
+    unverified rather than as core function.
+  supported_by:
+  - reference_id: file:yeast/JIP4/JIP4-uniprot.txt
+    supporting_text: "RecName: Full=Uncharacterized protein JIP4;"
+knowledge_gaps:
+- gap_statement: >-
+    The molecular function of JIP4 is entirely unknown. No biochemical activity has been
+    demonstrated, and its highly disordered sequence contains no recognizable folded
+    catalytic or nucleic-acid-binding domain (no PWI, no RRM), so even the family-based
+    "RNA binding" inference is unverified.
+  boundary: >-
+    It is firmly established that JIP4 is expressed as a protein (evidence at protein
+    level) and is phosphorylated in vivo at multiple serines. It is assigned by
+    low-complexity composition to the serine/arginine repetitive matrix family
+    (PTHR23148) whose metazoan members are SR-related splicing coactivators. What is
+    missing is any direct biochemical or genetic evidence of an activity for the yeast
+    protein.
+  gap_kind:
+  - BIOLOGY
+  dark_aspect: WHOLLY_DARK
+  status: OPEN
+  significance: >-
+    JIP4 is a conserved-family member left functionally dark in one of the best-studied
+    eukaryotes; assigning its activity would test whether the metazoan SRRM1 splicing
+    function is ancestral or a lineage-specific innovation, and would remove a genuine
+    hole in the yeast proteome annotation.
+  resolution: >-
+    Direct biochemical assays (RNA/DNA-binding, association with spliceosomal or mRNP
+    complexes by affinity purification-mass spectrometry), determination of subcellular
+    localization, and phenotyping of jip4 deletion (including the jip4 yor019w double
+    mutant) under diverse conditions would define or exclude an activity.
+  provenance:
+  - reference_id: file:yeast/JIP4/JIP4-uniprot.txt
+    supporting_text: "RecName: Full=Uncharacterized protein JIP4;"
+- gap_statement: >-
+    It is unknown whether the metazoan SRRM1/SRm160 splicing function transfers to yeast
+    JIP4 at all: whether JIP4 binds RNA, associates with the spliceosome, or regulates
+    mRNA splicing has never been tested experimentally, and the current spliceosome/
+    splicing GO annotations are homology-only (IBA) inferences.
+  boundary: >-
+    The S. cerevisiae spliceosome and its regulators are extensively characterized, and
+    JIP4 has not been identified as a component in those studies; the established yeast
+    counterparts of human SR-related nuclear-matrix splicing proteins are other genes.
+    JIP4 lacks the PWI domain that mediates the SRm160/SRRM1 splicing coactivator
+    function.
+  gap_kind:
+  - BIOLOGY
+  dark_aspect: MF_DARK
+  status: OPEN
+  significance: >-
+    Resolving this would either validate or correct the IBA-propagated splicing
+    annotations, clarifying whether a divergent, PWI-less SR-repetitive-matrix protein
+    retains any role in yeast RNA processing.
+  resolution: >-
+    Test for RNA binding and for physical/functional association with the spliceosome
+    (co-purification, CLIP-type RNA interaction mapping, splicing-reporter assays in
+    jip4 mutants), and compare against known yeast SR-related splicing factors.
+  provenance:
+  - reference_id: file:yeast/JIP4/JIP4-uniprot.txt
+    supporting_text: "DR   GO; GO:0005681; C:spliceosomal complex; IBA:GO_Central."
+- gap_statement: >-
+    The subcellular localization of JIP4 has not been experimentally determined, and its
+    biological process/pathway and loss-of-function phenotype (beyond viability of the
+    deletion) are unknown, including its functional relationship to the whole-genome-
+    duplication paralog YOR019W.
+  boundary: >-
+    JIP4 is non-essential; the jip4 deletion is viable and the yor019w deletion is
+    viable. JIP4 appears in high-throughput interactome and phosphoproteome datasets but
+    with no curated functional interpretation, and no dedicated study of the yeast
+    protein has been reported.
+  gap_kind:
+  - BIOLOGY
+  dark_aspect: BP_DARK
+  status: OPEN
+  significance: >-
+    A defined localization, phenotype, and paralog relationship would place JIP4 in a
+    cellular process and indicate whether functional redundancy with YOR019W is masking
+    its role.
+  resolution: >-
+    Endogenous fluorescent tagging for localization, condition-dependent phenotyping of
+    jip4 single and jip4 yor019w double deletions, and interpretation of its physical
+    interactors, together with functional analysis of its Cdk1-dependent phosphosites.
+  provenance:
+  - reference_id: file:yeast/JIP4/JIP4-uniprot.txt
+    supporting_text: "KW   Phosphoprotein; Reference proteome."
+- gap_statement: >-
+    The molecular basis of the "Jumonji-interacting protein" name is not established: it
+    is unclear whether JIP4 physically or functionally associates with the JmjC-domain
+    transcription factor Gis1 (or another Jumonji-family protein), and if so what that
+    interaction does, so any link to the Rim15/TOR/Sch9 nutrient-signaling and
+    calorie-restriction pathway is hypothetical.
+  boundary: >-
+    The name implies identification of JIP4 as a Gis1-associated factor, and Gis1 is a
+    well-characterized JmjC zinc-finger transcription factor downstream of Rim15/TOR/Sch9.
+    What is missing is any confirmed, mechanistically characterized JIP4-Gis1 (or
+    JIP4-Jumonji) interaction and its functional consequence.
+  gap_kind:
+  - BIOLOGY
+  dark_aspect: MF_DARK
+  status: OPEN
+  significance: >-
+    Confirming or refuting a JIP4-Gis1 association would either connect this dark gene to a
+    defined nutrient-signaling/chromatin transcription pathway or remove a misleading
+    name-based assumption.
+  resolution: >-
+    Co-immunoprecipitation/affinity purification to test a direct JIP4-Gis1 interaction,
+    and epistasis/phenotyping of jip4 in Rim15/TOR/Sch9-pathway and calorie-restriction
+    assays.
+  provenance:
+  - reference_id: file:yeast/JIP4/JIP4-deep-research-falcon.md
+    supporting_text: >-
+      Gis1 is a Jumonji-domain zinc-finger transcription factor acting downstream of
+      **Rim15/TOR/Sch9** nutrient signaling
+suggested_questions:
+- question: >-
+    Does JIP4 physically associate with the JmjC transcription factor Gis1 (as its name
+    implies) or with another Jumonji-family protein, and does it function in the
+    Rim15/TOR/Sch9 nutrient-signaling / calorie-restriction pathway?
+- question: >-
+    Does JIP4 bind RNA and/or associate with the spliceosome or other mRNP complexes in
+    yeast, or has the ancestral SRRM1-type splicing function been lost in this
+    PWI-less, RS-rich protein?
+- question: >-
+    Where does JIP4 localize in the cell, and does its RS/low-complexity composition
+    drive nuclear or condensate localization?
+- question: >-
+    What is the functional relationship between JIP4 and its whole-genome-duplication
+    paralog YOR019W, and does the double deletion reveal a phenotype masked by
+    redundancy?
+- question: >-
+    What is the functional consequence of the Cdk1-dependent phosphorylation of JIP4,
+    and is JIP4 a cell-cycle-regulated protein?
+suggested_experiments:
+- hypothesis: >-
+    JIP4 retains an ancestral RNA-processing/spliceosome-associated role inferred from
+    its SRRM1-family membership.
+  description: >-
+    Affinity-purify epitope-tagged JIP4 from yeast and identify co-purifying proteins
+    and RNAs by mass spectrometry and RNA sequencing; test for direct RNA binding in
+    vitro; assay splicing of intron-containing reporters in jip4 (and jip4 yor019w)
+    mutants.
+- hypothesis: >-
+    JIP4 has a non-redundant cellular role revealed only in combination with its
+    paralog YOR019W or under specific stress conditions.
+  description: >-
+    Construct jip4, yor019w, and jip4 yor019w deletion strains and phenotype them across
+    stress, cell-cycle, and iron-availability conditions; determine JIP4 subcellular
+    localization by endogenous fluorescent tagging.

--- a/genes/yeast/JIP4/JIP4-deep-research-falcon.md
+++ b/genes/yeast/JIP4/JIP4-deep-research-falcon.md
@@ -1,0 +1,280 @@
+---
+provider: falcon
+model: Edison Scientific Literature
+cached: false
+start_time: '2026-07-05T01:59:38.456579'
+end_time: '2026-07-05T02:22:24.962662'
+duration_seconds: 1366.51
+template_file: templates/gene_research_go_focused.md
+template_variables:
+  organism: yeast
+  gene_id: JIP4
+  gene_symbol: JIP4
+  uniprot_accession: Q03361
+  protein_description: 'RecName: Full=Uncharacterized protein JIP4; AltName: Full=Jumonji-interacting
+    protein 4;'
+  gene_info: Name=JIP4; OrderedLocusNames=YDR475C; ORFNames=YDR474C;
+  organism_full: Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).
+  protein_family: Not specified in UniProt
+  protein_domains: Ser/Arg_repetitive_matrix. (IPR052225)
+provider_config:
+  timeout: null
+  max_retries: 3
+  parameters:
+    allowed_domains: []
+    temperature: 0.1
+    max_embedded_images: 8
+citation_count: 20
+artifact_count: 1
+artifact_sources:
+  edison_answer_artifacts: 1
+artifacts:
+- filename: artifact-00.md
+  path: JIP4-deep-research-falcon_artifacts/artifact-00.md
+  media_type: text/markdown
+  source: edison_answer_artifacts
+  data_storage_id: null
+  description: Edison artifact artifact-00
+---
+
+## Question
+
+# Gene Research for Functional Annotation
+
+## ⚠️ CRITICAL: Gene/Protein Identification Context
+
+**BEFORE YOU BEGIN RESEARCH:** You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.
+
+### Target Gene/Protein Identity (from UniProt):
+- **UniProt Accession:** Q03361
+- **Protein Description:** RecName: Full=Uncharacterized protein JIP4; AltName: Full=Jumonji-interacting protein 4;
+- **Gene Information:** Name=JIP4; OrderedLocusNames=YDR475C; ORFNames=YDR474C;
+- **Organism (full):** Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).
+- **Protein Family:** Not specified in UniProt
+- **Key Domains:** Ser/Arg_repetitive_matrix. (IPR052225)
+
+### MANDATORY VERIFICATION STEPS:
+
+1. **Check if the gene symbol "JIP4" matches the protein description above**
+2. **Verify the organism is correct:** Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).
+3. **Check if protein family/domains align with what you find in literature**
+4. **If you find literature for a DIFFERENT gene with the same or similar symbol, STOP**
+
+### If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:
+
+**DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.** Instead:
+- State clearly: "The gene symbol 'JIP4' is ambiguous or literature is limited for this specific protein"
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")
+- Describe the protein based ONLY on the UniProt information provided above
+- Suggest that the protein function can be inferred from domain/family information
+
+### Research Target:
+
+Please provide a comprehensive research report on the gene **JIP4** (gene ID: JIP4, UniProt: Q03361) in yeast.
+
+The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.
+
+You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.
+
+We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.
+
+We are interested in where in or outside the cell the gene product carries out its function.
+
+We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.
+
+Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.
+
+## Output
+
+Question: You are an expert researcher providing comprehensive, well-cited information.
+
+Provide detailed information focusing on:
+1. Key concepts and definitions with current understanding
+2. Recent developments and latest research (prioritize 2023-2024 sources)
+3. Current applications and real-world implementations
+4. Expert opinions and analysis from authoritative sources
+5. Relevant statistics and data from recent studies
+
+Format as a comprehensive research report with proper citations. Include URLs and publication dates where available.
+Always prioritize recent, authoritative sources and provide specific citations for all major claims.
+
+# Gene Research for Functional Annotation
+
+## ⚠️ CRITICAL: Gene/Protein Identification Context
+
+**BEFORE YOU BEGIN RESEARCH:** You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.
+
+### Target Gene/Protein Identity (from UniProt):
+- **UniProt Accession:** Q03361
+- **Protein Description:** RecName: Full=Uncharacterized protein JIP4; AltName: Full=Jumonji-interacting protein 4;
+- **Gene Information:** Name=JIP4; OrderedLocusNames=YDR475C; ORFNames=YDR474C;
+- **Organism (full):** Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).
+- **Protein Family:** Not specified in UniProt
+- **Key Domains:** Ser/Arg_repetitive_matrix. (IPR052225)
+
+### MANDATORY VERIFICATION STEPS:
+
+1. **Check if the gene symbol "JIP4" matches the protein description above**
+2. **Verify the organism is correct:** Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).
+3. **Check if protein family/domains align with what you find in literature**
+4. **If you find literature for a DIFFERENT gene with the same or similar symbol, STOP**
+
+### If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:
+
+**DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.** Instead:
+- State clearly: "The gene symbol 'JIP4' is ambiguous or literature is limited for this specific protein"
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")
+- Describe the protein based ONLY on the UniProt information provided above
+- Suggest that the protein function can be inferred from domain/family information
+
+### Research Target:
+
+Please provide a comprehensive research report on the gene **JIP4** (gene ID: JIP4, UniProt: Q03361) in yeast.
+
+The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.
+
+You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.
+
+We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.
+
+We are interested in where in or outside the cell the gene product carries out its function.
+
+We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.
+
+Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.
+
+## Research Report: JIP4/YDR475C in *Saccharomyces cerevisiae*
+
+### Important Note on Gene Symbol Ambiguity
+
+The gene symbol "JIP4" in *Saccharomyces cerevisiae* must not be confused with mammalian JIP4 (also known as SPAG9/JIP4), which is a JNK-interacting protein involved in MAP kinase signaling. The yeast JIP4 (UniProt: Q03361, systematic name YDR475C) is an uncharacterized protein named for its interaction with the Jumonji-domain transcription factor Gis1. Direct literature on yeast JIP4 is extremely sparse, and the functional characterization below relies on a combination of genomic annotation, domain analysis, and contextual evidence from studies of its interaction partner Gis1.
+
+### 1. Gene Structure and Annotation History
+
+JIP4 is encoded by the locus YDR475C on the right arm of chromosome IV in the *S. cerevisiae* reference strain S288c. A key feature of this gene is its unusual annotation history: it was originally annotated as two separate open reading frames, YDR474C and YDR475C, which were subsequently merged into a single gene (acton2017genotypespecificphenotypicbehaviour pages 88-90). This merger was first identified during a comprehensive re-analysis of the *S. cerevisiae* genome through comparative genomics with other hemiascomycetous yeast species. Blandin et al. (2000) reported that YDR475C received a C-terminal extension and YDR474C received an N-terminal extension, such that the two neighboring genes fused into a single coding sequence spanning coordinates 1,407,454–1,410,082, encoding a protein of approximately 165 amino acids in the merged model (blandin2000genomicexplorationof pages 5-6). This gene fusion was identified through sequence homology with orthologous genes in *Saccharomyces bayanus*, *Saccharomyces servazzii*, and *Kluyveromyces lactis*, where a single continuous ORF was present. The yeast gene YOR019W was identified as a paralog of this merged locus (blandin2000genomicexplorationof pages 5-6).
+
+The summary table below compiles the key verified properties of JIP4:
+
+| Property | Summary |
+|---|---|
+| Gene name | **JIP4** |
+| Systematic name / ORF history | **YDR475C**; previously annotated as two separate ORFs, **YDR474C** and **YDR475C**, later merged into a single gene model (blandin2000genomicexplorationof pages 5-6, acton2017genotypespecificphenotypicbehaviour pages 88-90) |
+| UniProt accession | **Q03361** |
+| Protein description | Uncharacterized protein JIP4; Jumonji-interacting protein 4 |
+| Organism | *Saccharomyces cerevisiae* strain ATCC 204508 / S288c |
+| Chromosomal location | Chromosome IV right arm; merged locus reported at coordinates **1,407,454–1,410,082** in the genome re-analysis (blandin2000genomicexplorationof pages 5-6) |
+| Protein size | **165 aa** for the merged gene model/extension reported in genomic re-annotation (blandin2000genomicexplorationof pages 5-6) |
+| Domain | **IPR052225 Ser/Arg repetitive matrix**; this domain class is associated with SRRM-family/splicing-related proteins (birney1993analysisofthe pages 10-11, ilik2020sonandsrrm2 pages 1-2, ilik2020sonandsrrm2 pages 3-5) |
+| Paralog | **YOR019W** (reported as paralog in the fusion/extension analysis) (blandin2000genomicexplorationof pages 5-6) |
+| Essentiality | **Non-essential**; present in deletion-collection based summaries as a protein of unknown function rather than an essential gene (acton2017genotypespecificphenotypicbehaviour pages 88-90) |
+| Current annotation status | **Protein of unknown function / uncharacterized**; deletion-collection summary explicitly notes it as such (acton2017genotypespecificphenotypicbehaviour pages 88-90) |
+| Known interaction partner | **Gis1** inferred from the name “Jumonji-interacting protein 4”; the name indicates identification as a Gis1-associated factor, although direct mechanistic characterization remains limited (acton2017genotypespecificphenotypicbehaviour pages 88-90, wei2008lifespanextension pages 1-2) |
+| Relevant pathway context of partner | Gis1 is a Jumonji-domain zinc-finger transcription factor acting downstream of **Rim15/TOR/Sch9** nutrient signaling and calorie-restriction responses (wei2008lifespanextension pages 1-2, wei2008lifespanextension pages 7-9, wei2008lifespanextension pages 4-5, cameroni2007structuralandfunctional pages 103-109, cameroni2007structuralandfunctional pages 99-103) |
+| Functional inference | Because JIP4 is uncharacterized but contains a **Ser/Arg repetitive matrix** domain, the strongest evidence-based inference is a possible role in **RNA processing/splicing-related protein interactions** and/or **nuclear gene regulation**, rather than an enzymatic role (birney1993analysisofthe pages 10-11, ilik2020sonandsrrm2 pages 1-2, ilik2020sonandsrrm2 pages 3-5) |
+| Confidence assessment | **Low to moderate** for specific function; **high** for merged-gene status and uncharacterized annotation, but functional assignment remains inferential due to sparse direct literature (blandin2000genomicexplorationof pages 5-6, acton2017genotypespecificphenotypicbehaviour pages 88-90) |
+
+
+*Table: This table compiles the key verified properties of the yeast JIP4/YDR475C protein, emphasizing what is established from genome annotation and what remains inferential. It is useful for separating firm facts, such as the merged ORF status and non-essentiality, from tentative functional predictions based on domain architecture and naming.*
+
+### 2. Protein Function: Current Status as Uncharacterized
+
+JIP4 remains classified as a "protein of unknown function" in the *Saccharomyces* Genome Database (SGD) (acton2017genotypespecificphenotypicbehaviour pages 88-90). No enzymatic activity, substrate specificity, or defined biochemical role has been experimentally determined. The protein does not appear to be an enzyme, transporter, or signaling kinase/phosphatase based on its domain architecture. The gene is non-essential, as deletion strains are viable and were included in the systematic yeast deletion collection without notable growth defects under standard conditions (acton2017genotypespecificphenotypicbehaviour pages 88-90).
+
+### 3. Naming Context: Interaction with the Jumonji Domain Protein Gis1
+
+The name "JIP4" (Jumonji-Interacting Protein 4) indicates that this protein was identified as one of several proteins that interact with Gis1, a key yeast transcription factor containing Jumonji (JmjN and JmjC) domains. This naming derives from the study by Tronnersjö et al. (2007; Molecular Genetics and Genomics, 277:57–70), who characterized the JmjN and JmjC domains of the yeast zinc finger protein Gis1 and identified 19 proteins involved in transcription, SUMOylation, and DNA repair that interact with these domains. Although this primary reference was unobtainable for direct examination, its citation record establishes JIP4 as a Gis1-interacting protein.
+
+Gis1 itself is a well-characterized transcription factor belonging to the JMJD2/KDM4 subfamily of Jumonji-domain containing proteins. It possesses histone demethylase activity and functions as a key downstream effector in the TORC1/Sch9/Rim15 nutrient-sensing pathway (wei2008lifespanextension pages 1-2, wei2008lifespanextension pages 7-9). Gis1 recognizes PDS (Post-Diauxic Shift) elements in gene promoters and activates stress-response genes during nutrient limitation and caloric restriction, thereby mediating lifespan extension (wei2008lifespanextension pages 4-5, cameroni2007structuralandfunctional pages 103-109, cameroni2007structuralandfunctional pages 99-103). It works cooperatively with the Msn2/Msn4 transcription factors downstream of Rim15, with over 60% of Rim15-dependent genes also requiring Gis1 for their regulation during rapamycin (TORC1 inhibitor) treatment (cameroni2007structuralandfunctional pages 103-109).
+
+The proteome-wide identification of Gis1 interaction partners via mass spectrometry has revealed 147 unique Gis1-interacting proteins, including proteins involved in heterocyclic compound binding, metabolic pathways (glycolysis, TCA cycle, fatty acid metabolism), ubiquitin-like protein conjugation, and acetylation (konduri2020hemeametabolic pages 10-12, konduri2020hemeametabolic pages 7-10). Some of these interactions are mediated through the JmjN/C domain, while others are mediated through the C-terminal zinc finger domain of Gis1 (konduri2020hemeametabolic pages 18-19). The Gis1 interaction network is modulated by heme availability, with distinct protein partners associating under heme-sufficient versus heme-deficient conditions (konduri2020hemeametabolic pages 7-10). JIP4's position within this interaction network has not been further resolved with respect to which Gis1 domain mediates the contact or under which metabolic conditions the interaction is most prominent.
+
+### 4. Domain Architecture and Functional Inference
+
+The presence of a Ser/Arg repetitive matrix domain (InterPro: IPR052225) in JIP4 is the strongest bioinformatic clue to its potential function. This domain family is best characterized in the context of mammalian SRRM (Serine/Arginine Repetitive Matrix) proteins, particularly SRRM1 and SRRM2, which are key components of the pre-mRNA splicing machinery and play structural roles in nuclear speckles (ilik2020sonandsrrm2 pages 1-2, ilik2020sonandsrrm2 pages 3-5).
+
+In metazoan systems, SRRM2, together with the protein SON, forms the essential scaffold of nuclear speckles—biomolecular condensates enriched in splicing factors and involved in RNA processing (ilik2020sonandsrrm2 pages 1-2, ilık2020sonandsrrm2 pages 1-2). SRRM2 is a spliceosome-associated protein that joins at the Bact stage of spliceosome assembly and supports the activated conformation of the PRP8 switch-loop (ilik2020sonandsrrm2 pages 3-5). Its intrinsically disordered regions (IDRs), enriched in serine and arginine residues, are critical for nuclear speckle integrity, as their deletion leads to near-complete dissolution of these condensates (ilik2020sonandsrrm2 pages 1-2, ilık2020sonandsrrm2 pages 1-2).
+
+The yeast ortholog of SRRM2 is Cwc21p (also known as Cwf21p in *S. pombe*), which directly interacts with the spliceosomal proteins Prp8p and Snu114p (ilik2020sonandsrrm2 pages 3-5, ilik2020sonandsrrm2 pages 21-22). Notably, *S. cerevisiae* does not possess classical nuclear speckles as found in metazoan cells, although the spliceosomal functions of Cwc21/SRRM2 are conserved.
+
+Serine/arginine-rich (SR) domains are characteristic of splicing factors and are found exclusively in known or suspected splicing and spliceosome-associated proteins (birney1993analysisofthe pages 10-11). These RS-rich regions mediate protein-protein interactions that are critical for spliceosome assembly and splice site recognition. Given that JIP4 contains such a domain, a reasonable inference is that JIP4 may participate in RNA processing or splicing-related protein interactions. However, it must be emphasized that JIP4 is distinct from Cwc21p (the established yeast SRRM2 ortholog) and no direct evidence connects JIP4 to the spliceosome.
+
+### 5. Subcellular Localization
+
+No published subcellular localization data specific to JIP4 were identified in the literature surveyed. The protein was not highlighted in major proteome-wide GFP localization studies, which may reflect very low protein abundance or technical challenges with the C-terminal GFP tag for this particular protein. Given its Ser/Arg repetitive matrix domain and its interaction with the nuclear transcription factor Gis1, a nuclear localization would be a reasonable prediction, but this remains unconfirmed experimentally.
+
+### 6. Biological Pathways and Broader Context
+
+Through its interaction with Gis1, JIP4 is potentially linked to the nutrient-sensing and stress-response signaling network in yeast. Gis1 operates downstream of the TORC1/Sch9 and Ras/PKA pathways, where it is activated by the kinase Rim15 to drive transcription of stress-response and post-diauxic shift genes (wei2008lifespanextension pages 1-2, wei2008lifespanextension pages 7-9, wei2008lifespanextension pages 4-5). Gis1 is also subject to regulation by protein phosphatase 2A (PP2A), with the Igo1/2 endosulfines modulating PP2A-mediated dephosphorylation of Gis1 at Ser425 (severine2013yeastendosulfinescontrol pages 3-4). Furthermore, heme acts as a metabolic sensor that directly regulates Gis1's histone demethylase activity and transcriptional functions (konduri2020hemeametabolic pages 10-12, konduri2020hemeametabolic pages 7-10).
+
+Whether JIP4 modulates any of these Gis1-dependent activities remains unknown. Possible roles include: (i) serving as a cofactor or adaptor protein for Gis1's transcriptional or demethylase functions; (ii) mediating interactions between Gis1 and the RNA processing machinery via its SR-rich domain; or (iii) facilitating the coupling of transcription with mRNA splicing/processing at Gis1-target loci. These possibilities remain speculative in the absence of direct experimental evidence.
+
+### 7. Paralog YOR019W
+
+The paralog YOR019W was identified during the genomic re-annotation that merged YDR474C and YDR475C (blandin2000genomicexplorationof pages 5-6). YOR019W itself has not been extensively characterized, and the functional relationship between these paralogs remains unexplored. The existence of a paralog suggests that JIP4's function, while dispensable for viability, may be partially redundant with YOR019W, potentially masking phenotypic consequences of single-gene deletion.
+
+### 8. Conclusions and Research Gaps
+
+JIP4/YDR475C remains one of the uncharacterized proteins in the *S. cerevisiae* genome. The primary evidence supporting its functional annotation consists of: (1) its identification as a Gis1-interacting protein, linking it to nutrient sensing and transcriptional regulation; (2) the presence of a Ser/Arg repetitive matrix domain (IPR052225), suggesting a role in RNA processing or splicing-related protein-protein interactions; and (3) its non-essential status and existence of paralog YOR019W. A definitive functional assignment would require targeted experimental studies, including protein interaction mapping under defined metabolic conditions, phenotypic analysis of double-deletion mutants (with the paralog YOR019W), and determination of subcellular localization and RNA-binding properties. The integration of its SR-domain architecture with its interaction with a chromatin-modifying transcription factor raises the intriguing possibility that JIP4 may serve as a molecular link between transcriptional regulation and RNA processing at specific gene loci, but this hypothesis awaits empirical validation.
+
+References
+
+1. (acton2017genotypespecificphenotypicbehaviour pages 88-90): Erica Acton. Genotype-specific phenotypic behaviour of auxotrophic and prototrophic yeast gene deletion collections. ArXiv, Jan 2017. URL: https://doi.org/10.14288/1.0340607, doi:10.14288/1.0340607. This article has 0 citations.
+
+2. (blandin2000genomicexplorationof pages 5-6): Gaëlle Blandin, Pascal Durrens, Fredj Tekaia, Michel Aigle, Monique Bolotin-Fukuhara, Elisabeth Bon, Serge Casarégola, Jacky de Montigny, Claude Gaillardin, Andrée Lépingle, Bertrand Llorente, Alain Malpertuy, Cécile Neuvéglise, Odile Ozier-Kalogeropoulos, Arnaud Perrin, Serge Potier, Jean-Luc Souciet, Emmanuel Talla, Claire Toffano-Nioche, Micheline Wésolowski-Louvel, Christian Marck, and Bernard Dujon. Genomic exploration of the hemiascomycetous yeasts: 4. the genome of saccharomyces cerevisiae revisited. FEBS Letters, 487:31-36, Dec 2000. URL: https://doi.org/10.1016/s0014-5793(00)02275-4, doi:10.1016/s0014-5793(00)02275-4. This article has 124 citations and is from a peer-reviewed journal.
+
+3. (birney1993analysisofthe pages 10-11): Ewan Birney, Sanjay Kumar, and Adrian R. Krainer. Analysis of the rna-recognition motif and rs and rgg domains: conservation in metazoan pre-mrna splicing factors. Nucleic acids research, 21 25:5803-16, Dec 1993. URL: https://doi.org/10.1093/nar/21.25.5803, doi:10.1093/nar/21.25.5803. This article has 939 citations and is from a highest quality peer-reviewed journal.
+
+4. (ilik2020sonandsrrm2 pages 1-2): İbrahim Avşar Ilik, Michal Malszycki, Anna Katharina Lübke, Claudia Schade, David Meierhofer, and Tuğçe Aktaş. Son and srrm2 are essential for nuclear speckle formation. eLife, Oct 2020. URL: https://doi.org/10.7554/elife.60579, doi:10.7554/elife.60579. This article has 317 citations and is from a domain leading peer-reviewed journal.
+
+5. (ilik2020sonandsrrm2 pages 3-5): İbrahim Avşar Ilik, Michal Malszycki, Anna Katharina Lübke, Claudia Schade, David Meierhofer, and Tuğçe Aktaş. Son and srrm2 are essential for nuclear speckle formation. eLife, Oct 2020. URL: https://doi.org/10.7554/elife.60579, doi:10.7554/elife.60579. This article has 317 citations and is from a domain leading peer-reviewed journal.
+
+6. (wei2008lifespanextension pages 1-2): Min Wei, Paola Fabrizio, Jia Hu, Huanying Ge, Chao Cheng, Lei Li, and Valter D Longo. Life span extension by calorie restriction depends on rim15 and transcription factors downstream of ras/pka, tor, and sch9. PLoS Genetics, 4:e13, Jan 2008. URL: https://doi.org/10.1371/journal.pgen.0040013, doi:10.1371/journal.pgen.0040013. This article has 612 citations and is from a domain leading peer-reviewed journal.
+
+7. (wei2008lifespanextension pages 7-9): Min Wei, Paola Fabrizio, Jia Hu, Huanying Ge, Chao Cheng, Lei Li, and Valter D Longo. Life span extension by calorie restriction depends on rim15 and transcription factors downstream of ras/pka, tor, and sch9. PLoS Genetics, 4:e13, Jan 2008. URL: https://doi.org/10.1371/journal.pgen.0040013, doi:10.1371/journal.pgen.0040013. This article has 612 citations and is from a domain leading peer-reviewed journal.
+
+8. (wei2008lifespanextension pages 4-5): Min Wei, Paola Fabrizio, Jia Hu, Huanying Ge, Chao Cheng, Lei Li, and Valter D Longo. Life span extension by calorie restriction depends on rim15 and transcription factors downstream of ras/pka, tor, and sch9. PLoS Genetics, 4:e13, Jan 2008. URL: https://doi.org/10.1371/journal.pgen.0040013, doi:10.1371/journal.pgen.0040013. This article has 612 citations and is from a domain leading peer-reviewed journal.
+
+9. (cameroni2007structuralandfunctional pages 103-109): Structural and functional characterization of the novel yeast PAS kinase Rim 15, a central regulator of the G0 program in yeast
+
+10. (cameroni2007structuralandfunctional pages 99-103): Structural and functional characterization of the novel yeast PAS kinase Rim 15, a central regulator of the G0 program in yeast
+
+11. (konduri2020hemeametabolic pages 10-12): Purna Chaitanya Konduri, Tianyuan Wang, Narges Salamat, and Li Zhang. Heme, a metabolic sensor, directly regulates the activity of the kdm4 histone demethylase family and their interactions with partner proteins. Cells, 9:773, Mar 2020. URL: https://doi.org/10.3390/cells9030773, doi:10.3390/cells9030773. This article has 7 citations.
+
+12. (konduri2020hemeametabolic pages 7-10): Purna Chaitanya Konduri, Tianyuan Wang, Narges Salamat, and Li Zhang. Heme, a metabolic sensor, directly regulates the activity of the kdm4 histone demethylase family and their interactions with partner proteins. Cells, 9:773, Mar 2020. URL: https://doi.org/10.3390/cells9030773, doi:10.3390/cells9030773. This article has 7 citations.
+
+13. (konduri2020hemeametabolic pages 18-19): Purna Chaitanya Konduri, Tianyuan Wang, Narges Salamat, and Li Zhang. Heme, a metabolic sensor, directly regulates the activity of the kdm4 histone demethylase family and their interactions with partner proteins. Cells, 9:773, Mar 2020. URL: https://doi.org/10.3390/cells9030773, doi:10.3390/cells9030773. This article has 7 citations.
+
+14. (ilık2020sonandsrrm2 pages 1-2): İbrahim Avşar Ilık, Michal Malszycki, Anna Katharina Lübke, Claudia Schade, David Meierhofer, and Tuğçe Aktaş. Son and srrm2 form nuclear speckles in human cells. bioRxiv, Jun 2020. URL: https://doi.org/10.1101/2020.06.19.160762, doi:10.1101/2020.06.19.160762. This article has 1 citations.
+
+15. (ilik2020sonandsrrm2 pages 21-22): İbrahim Avşar Ilik, Michal Malszycki, Anna Katharina Lübke, Claudia Schade, David Meierhofer, and Tuğçe Aktaş. Son and srrm2 are essential for nuclear speckle formation. eLife, Oct 2020. URL: https://doi.org/10.7554/elife.60579, doi:10.7554/elife.60579. This article has 317 citations and is from a domain leading peer-reviewed journal.
+
+16. (severine2013yeastendosulfinescontrol pages 3-4): Séverine Bontron, Malika Jaquenoud, Stefania Vaga, Nicolas Talarek, Bernd Bodenmiller, Ruedi Aebersold, and Claudio De Virgilio. Yeast endosulfines control entry into quiescence and chronological life span by inhibiting protein phosphatase 2a. Cell reports, 3 1:16-22, Jan 2013. URL: https://doi.org/10.1016/j.celrep.2012.11.025, doi:10.1016/j.celrep.2012.11.025. This article has 108 citations and is from a highest quality peer-reviewed journal.
+
+## Artifacts
+
+- [Edison artifact artifact-00](JIP4-deep-research-falcon_artifacts/artifact-00.md)
+
+## Citations
+
+1. acton2017genotypespecificphenotypicbehaviour pages 88-90
+2. blandin2000genomicexplorationof pages 5-6
+3. cameroni2007structuralandfunctional pages 103-109
+4. konduri2020hemeametabolic pages 18-19
+5. konduri2020hemeametabolic pages 7-10
+6. birney1993analysisofthe pages 10-11
+7. severine2013yeastendosulfinescontrol pages 3-4
+8. wei2008lifespanextension pages 1-2
+9. wei2008lifespanextension pages 7-9
+10. wei2008lifespanextension pages 4-5
+11. cameroni2007structuralandfunctional pages 99-103
+12. konduri2020hemeametabolic pages 10-12
+13. https://doi.org/10.14288/1.0340607,
+14. https://doi.org/10.1016/s0014-5793(00
+15. https://doi.org/10.1093/nar/21.25.5803,
+16. https://doi.org/10.7554/elife.60579,
+17. https://doi.org/10.1371/journal.pgen.0040013,
+18. https://doi.org/10.3390/cells9030773,
+19. https://doi.org/10.1101/2020.06.19.160762,
+20. https://doi.org/10.1016/j.celrep.2012.11.025,

--- a/genes/yeast/JIP4/JIP4-deep-research-falcon_artifacts/artifact-00.md
+++ b/genes/yeast/JIP4/JIP4-deep-research-falcon_artifacts/artifact-00.md
@@ -1,0 +1,20 @@
+| Property | Summary |
+|---|---|
+| Gene name | **JIP4** |
+| Systematic name / ORF history | **YDR475C**; previously annotated as two separate ORFs, **YDR474C** and **YDR475C**, later merged into a single gene model (pqac-00000004, pqac-00000012) |
+| UniProt accession | **Q03361** |
+| Protein description | Uncharacterized protein JIP4; Jumonji-interacting protein 4 |
+| Organism | *Saccharomyces cerevisiae* strain ATCC 204508 / S288c |
+| Chromosomal location | Chromosome IV right arm; merged locus reported at coordinates **1,407,454–1,410,082** in the genome re-analysis (pqac-00000003, pqac-00000004) |
+| Protein size | **165 aa** for the merged gene model/extension reported in genomic re-annotation (pqac-00000003, pqac-00000004) |
+| Domain | **IPR052225 Ser/Arg repetitive matrix**; this domain class is associated with SRRM-family/splicing-related proteins (pqac-00000007, pqac-00000006, pqac-00000010) |
+| Paralog | **YOR019W** (reported as paralog in the fusion/extension analysis) (pqac-00000003, pqac-00000004) |
+| Essentiality | **Non-essential**; present in deletion-collection based summaries as a protein of unknown function rather than an essential gene (pqac-00000012) |
+| Current annotation status | **Protein of unknown function / uncharacterized**; deletion-collection summary explicitly notes it as such (pqac-00000012) |
+| Known interaction partner | **Gis1** inferred from the name “Jumonji-interacting protein 4”; the name indicates identification as a Gis1-associated factor, although direct mechanistic characterization remains limited (pqac-00000012, pqac-00000017) |
+| Relevant pathway context of partner | Gis1 is a Jumonji-domain zinc-finger transcription factor acting downstream of **Rim15/TOR/Sch9** nutrient signaling and calorie-restriction responses (pqac-00000017, pqac-00000018, pqac-00000019, pqac-00000020, pqac-00000021) |
+| Functional inference | Because JIP4 is uncharacterized but contains a **Ser/Arg repetitive matrix** domain, the strongest evidence-based inference is a possible role in **RNA processing/splicing-related protein interactions** and/or **nuclear gene regulation**, rather than an enzymatic role (pqac-00000007, pqac-00000006, pqac-00000010) |
+| Confidence assessment | **Low to moderate** for specific function; **high** for merged-gene status and uncharacterized annotation, but functional assignment remains inferential due to sparse direct literature (pqac-00000003, pqac-00000004, pqac-00000012) |
+
+
+*Table: This table compiles the key verified properties of the yeast JIP4/YDR475C protein, emphasizing what is established from genome annotation and what remains inferential. It is useful for separating firm facts, such as the merged ORF status and non-essentiality, from tentative functional predictions based on domain architecture and naming.*

--- a/genes/yeast/JIP4/JIP4-goa.tsv
+++ b/genes/yeast/JIP4/JIP4-goa.tsv
@@ -1,0 +1,6 @@
+GENE PRODUCT DB	GENE PRODUCT ID	SYMBOL	QUALIFIER	GO TERM	GO NAME	GO ASPECT	ECO ID	GO EVIDENCE CODE	REFERENCE	WITH/FROM	TAXON ID	TAXON NAME	ASSIGNED BY	GENE NAME	DATE
+UniProtKB	Q03361	JIP4	part_of	GO:0005681	spliceosomal complex	cellular_component	ECO:0000318	IBA	GO_REF:0000033	MGI:MGI:1858303|PANTHER:PTN000567596|UniProtKB:Q8IYB3	559292	Saccharomyces cerevisiae (strain ATCC 204508 / S288c)	GO_Central	Uncharacterized protein JIP4	20251220
+UniProtKB	Q03361	JIP4	involved_in	GO:0048024	regulation of mRNA splicing, via spliceosome	biological_process	ECO:0000318	IBA	GO_REF:0000033	FB:FBgn0036340|PANTHER:PTN000567596	559292	Saccharomyces cerevisiae (strain ATCC 204508 / S288c)	GO_Central	Uncharacterized protein JIP4	20210924
+UniProtKB	Q03361	JIP4	enables	GO:0003674	molecular_function	molecular_function	ECO:0000307	ND	GO_REF:0000015		559292	Saccharomyces cerevisiae (strain ATCC 204508 / S288c)	SGD	Uncharacterized protein JIP4	20130807
+UniProtKB	Q03361	JIP4	is_active_in	GO:0005575	cellular_component	cellular_component	ECO:0000307	ND	GO_REF:0000015		559292	Saccharomyces cerevisiae (strain ATCC 204508 / S288c)	SGD	Uncharacterized protein JIP4	20130807
+UniProtKB	Q03361	JIP4	involved_in	GO:0008150	biological_process	biological_process	ECO:0000307	ND	GO_REF:0000015		559292	Saccharomyces cerevisiae (strain ATCC 204508 / S288c)	SGD	Uncharacterized protein JIP4	20130807

--- a/genes/yeast/JIP4/JIP4-notes.md
+++ b/genes/yeast/JIP4/JIP4-notes.md
@@ -1,0 +1,174 @@
+# JIP4 (YDR475C) — curation notes
+
+Journal for the AI GO-annotation review of *Saccharomyces cerevisiae* **JIP4** (systematic
+name YDR475C; UniProt Q03361; SGD:S000002883). This is an **understudied ("dark") gene**:
+UniProt names it "Uncharacterized protein JIP4" (AltName "Jumonji-interacting protein 4"),
+and SGD classifies it as a protein of unknown function. The deliverable therefore centres
+on an honest `knowledge_gaps` section grounded in domain composition, orthology, and the
+(sparse) literature — no invented function.
+
+## Summary of what is machine-known (UniProt Q03361)
+
+- 876 aa protein, MW ~98.7 kDa. Entry version 148 (2026). `PE 1: Evidence at protein level`
+  — but the only experimental evidence is **large-scale phosphoproteomics** (see below);
+  there is **no functional assay**.
+- Highly **intrinsically disordered**: MobiDB-lite predicts 7 disordered regions
+  (37–67, 112–155, 226–254, 330–353, 490–513, 661–728, 750–876) covering a large fraction
+  of the protein. Multiple **low-complexity / compositionally biased** stretches, including
+  runs of basic+acidic residues, polar residues, and notably several **Arg/Ser (RS-type)
+  repeats** — e.g. `...RSVSSARRSRSRSRSRSICTRR...` (~aa 350–370) and
+  `SKSRSSSKSRIRDKSKPSSP` (~aa 675–695), and a C-terminal `...KSRSPSSFRKEDE...RGGLFGFGRL`.
+  These RS/RD-rich low-complexity tracts are the reason PANTHER places it in the
+  SR-repetitive-matrix family (below). [file:yeast/JIP4/JIP4-uniprot.txt]
+- **No recognizable folded/catalytic domain** is annotated in UniProt: no PWI domain, no
+  RRM, no enzymatic motif — only disorder + compositional bias. This is important: the human
+  family members that carry the splicing function have a folded **PWI** nucleic-acid-binding
+  domain; JIP4 does not have one annotated. [file:yeast/JIP4/JIP4-uniprot.txt]
+- **Phosphoprotein** (KW: Phosphoprotein). Eight phosphoserines mapped by MS:
+  - Ser-48, Ser-51, Ser-510, Ser-552, Ser-775 [PMID:19779198 — Cdk1 substrate global analysis]
+  - Ser-48, Ser-360, Ser-552 [PMID:18407956 — multidimensional chromatography phosphoproteome]
+  - Ser-577 [PMID:15665377 — pheromone-signaling phosphoproteome]
+  Several of these sites (from PMID:19779198, "Global analysis of Cdk1 substrate
+  phosphorylation sites") indicate JIP4 is among the many proteins phosphorylated in a
+  Cdk1-dependent manner; this is a large-scale substrate catalog, not a dedicated study of
+  JIP4. [file:yeast/JIP4/JIP4-uniprot.txt]
+- Cross-references indicate protein interactions exist in high-throughput datasets:
+  BioGRID 87 interactions, IntAct 6, FunCoup 117 — i.e. it appears in interactome data but
+  with no curated functional interpretation. [file:yeast/JIP4/JIP4-uniprot.txt]
+
+## Orthology / family (PANTHER PTHR23148)
+
+PANTHER assigns JIP4 to family **PTHR23148** ("Serine/arginine repetitive matrix"),
+subfamily **PTHR23148:SF0** = "SERINE/ARGININE REPETITIVE MATRIX PROTEIN 1" (SRRM1 / SRm160).
+The reviewed members of SF0 are essentially the metazoan **SRRM1** orthologs plus the two
+yeasts [file:yeast/JIP4/interpro/panther/PTHR23148/PTHR23148-entries.csv... i.e.
+interpro/panther/PTHR23148/PTHR23148-entries.csv]:
+
+| UniProt | Species | Gene | Length |
+|---------|---------|------|--------|
+| Q03361  | S. cerevisiae | JIP4 (YDR475C) | 876 |
+| Q52KI8  | Mouse | Srrm1 | 946 |
+| Q5R5Q2  | Orangutan | SRRM1 | 917 |
+| Q5ZMJ9  | Chicken | SRRM1 | 888 |
+| Q8IYB3  | Human | SRRM1 | 904 |
+| Q9USH5  | S. pombe | SPCC825.05c (PWI domain-containing) | 301 |
+
+The **human/metazoan SRRM1 (SRm160)** is a nuclear-matrix SR-related splicing coactivator:
+it promotes constitutive and ESE-dependent splicing by bridging sequence-specific SR
+proteins to snRNP components, is a component of the spliceosome / exon junction complex,
+binds RNA/DNA with low sequence specificity, and stimulates mRNA 3'-end cleavage.
+[PANTHER family description, file:yeast/JIP4/interpro/panther/PTHR23148/PTHR23148-metadata.yaml;
+corroborated by SRRM1/SRm160 literature — UniProt Q8IYB3.]
+
+This family assignment is the sole basis for the **IBA** annotations in GOA:
+- `part_of spliceosomal complex` (GO:0005681) — with/from MGI:1858303 (mouse Srrm1),
+  PANTHER:PTN000567596, UniProtKB:Q8IYB3 (human SRRM1). [file:yeast/JIP4/JIP4-goa.tsv]
+- `involved_in regulation of mRNA splicing, via spliceosome` (GO:0048024) — with/from
+  FB:FBgn0036340 (Drosophila), PANTHER:PTN000567596. [file:yeast/JIP4/JIP4-goa.tsv]
+- (UniProt DR also lists an IBA `RNA binding` GO:0003723 from GO_Central, not currently in
+  the GOA TSV row set.) [file:yeast/JIP4/JIP4-uniprot.txt]
+
+### Caveat on the IBA splicing propagation (KEY reasoning)
+
+Whether the metazoan SRRM1 splicing function transfers to yeast JIP4 is **doubtful**, for
+biological reasons that are worth stating:
+
+1. **JIP4 lacks the PWI domain.** The defining folded, nucleic-acid-binding module of the
+   SRm160/SRRM1 and RED120 (PWI-motif) splicing proteins is the PWI domain. JIP4's UniProt
+   record annotates only disorder and low-complexity bias — no PWI, no RRM. The S. pombe
+   family member (Q9USH5) is explicitly a "PWI domain-containing protein" and is only 301 aa,
+   suggesting the true PWI-splicing ortholog in fission yeast is a different, shorter protein,
+   and that JIP4's placement rests on shared RS/low-complexity composition rather than the
+   catalytic/binding domain. [file:yeast/JIP4/JIP4-uniprot.txt; PANTHER entries csv]
+2. **The budding-yeast splicing machinery is exhaustively characterized.** The S. cerevisiae
+   spliceosome has been purified and defined in great biochemical/structural detail. The
+   established yeast counterparts of the human SR-related nuclear-matrix splicing proteins are
+   **Cwc21** (YDR482C; ortholog of SRm300/SRRM2) and candidate PWI proteins such as **Snu71**
+   — *not* JIP4. JIP4 has never been reported as a spliceosome or EJC component in yeast
+   spliceosome proteomics. [web: RNA journal / genesdev PWI-motif and Cwc21 characterization —
+   background, not gene-specific experimental evidence for JIP4.]
+3. **Yeast introns are few and simple** — there is no minor (U12) spliceosome and essentially
+   no exon-junction-complex-style splicing coactivation of the metazoan kind; the specific
+   ESE-dependent activation role of SRm160 has no clear yeast equivalent.
+
+Conclusion: the IBA MF/BP splicing terms are **plausible-by-homology but unverified and
+biologically questionable** for yeast. They should be treated as low-confidence
+homology-only inferences (mark as non-core / over-annotated candidates), not as established
+JIP4 function. The RS/low-complexity composition supports at most a *possible* RNA/nucleic-
+acid-associated or nuclear role, but this is not established.
+
+## SGD / literature facts (verified via SGD, BioGRID)
+
+- **Protein of unknown function.** Previously annotated as two separate ORFs (YDR474C and
+  YDR475C) that were merged after corrections to the systematic reference sequence.
+  [SGD locus JIP4/YDR475C; web:yeastgenome.org]
+- **Paralog YOR019W**, arising from the whole-genome duplication; YOR019W is likewise
+  uncharacterized. jip4∆ is **viable**; yor019w∆ is viable (double mutant not annotated) —
+  consistent with a non-essential, possibly redundant gene. [SGD; web:yeastgenome.org]
+- Name "Jumonji-interacting protein 4" (JIP4) is a **legacy/heuristic name** (likely from an
+  interaction dataset with a Jumonji/JmjC-family protein); it does not by itself establish a
+  molecular function. No dedicated functional paper on yeast JIP4 was found.
+- Appears in high-throughput interactome data (BioGRID 87 / IntAct 6) and in
+  phosphoproteomics, but with no curated functional role.
+
+## KNOWN vs NOT-KNOWN
+
+**KNOWN (evidence-supported):**
+- It is expressed and made as a protein (PE1).
+- It is an in vivo phosphoprotein with ≥8 mapped phosphoserines, including Cdk1-dependent
+  sites (large-scale MS). [PMID:19779198; PMID:18407956; PMID:15665377]
+- It is intrinsically disordered with RS/low-complexity composition (sequence-based).
+- It is a member (by low-complexity composition) of the SR-repetitive-matrix PANTHER family
+  that in metazoa contains SRRM1/SRm160.
+- Non-essential; has a WGD paralog (YOR019W).
+
+**NOT KNOWN (genuine knowledge gaps):**
+- Molecular function — no biochemical activity demonstrated; no folded catalytic/binding
+  domain identified. RNA binding is only an IBA guess.
+- Whether it is truly part of the spliceosome / involved in splicing in yeast (IBA only;
+  biologically questionable, see caveat).
+- Subcellular localization — not experimentally established (no CC annotation beyond ND).
+  RS-rich composition *hints* at nuclear, but unverified.
+- Biological process / pathway — unknown (ND at the BP root).
+- Loss-of-function phenotype beyond "viable"; role of the phosphorylation; the identity/
+  meaning of its interactors; functional relationship to paralog YOR019W.
+- What the "Jumonji-interacting" name refers to mechanistically.
+
+## Curation plan
+
+- IBA `spliceosomal complex` (CC) and `regulation of mRNA splicing` (BP): keep but mark as
+  **non-core / over-annotated** homology-only inferences — do NOT elevate to core function;
+  document the PWI-absence + yeast-splicing-machinery caveat in the review reason. (Per
+  guidelines, IBA over-propagations may be argued against on biological grounds.)
+- ND molecular_function / cellular_component / biological_process root terms: these are
+  "no data" placeholders; keep as-is (they honestly encode "unknown"). Mark KEEP_AS_NON_CORE
+  / note that they reflect the dark-gene status.
+- `description`: project-independent — disordered RS/low-complexity protein of unknown
+  function, SR-repetitive-matrix family by composition, phosphoprotein, non-essential, WGD
+  paralog YOR019W. No curation commentary.
+- `core_functions`: only the defensible minimum (essentially none can be asserted with
+  confidence; possibly a cautious statement that no core molecular function can be assigned).
+- `knowledge_gaps`: the primary deliverable (MF, localization, BP, phenotype, splicing
+  hypothesis).
+
+## Update after falcon deep research (2026-07-05)
+
+The falcon deep-research report (`JIP4-deep-research-falcon.md`, Edison, 20 citations,
+~23 min) is consistent with the assessment above and adds one useful hypothesis about the
+gene name:
+
+- The "Jumonji-interacting protein 4" name most plausibly reflects identification of JIP4 as
+  a **Gis1-associated factor**. Gis1 is a JmjC (Jumonji-domain) zinc-finger transcription
+  factor that acts downstream of the **Rim15/TOR/Sch9** nutrient-signaling and
+  calorie-restriction response pathway [file:yeast/JIP4/JIP4-deep-research-falcon.md
+  "Gis1 is a Jumonji-domain zinc-finger transcription factor acting downstream of
+  **Rim15/TOR/Sch9** nutrient signaling"]. The report explicitly flags that "direct
+  mechanistic characterization remains limited", i.e. this is a naming-origin inference, not
+  an established function — treated here as a hypothesis in knowledge_gaps / suggested
+  questions, not as core function.
+- The report reconfirms: merged ORF (YDR474C+YDR475C), non-essential, paralog YOR019W,
+  Ser/Arg repetitive matrix (IPR052225) domain class, uncharacterized status, and that the
+  splicing/RNA-processing role is a low-to-moderate-confidence domain-based inference only.
+- CAVEAT: the report states a "165 aa" size for a "merged gene model/extension" — this is
+  inconsistent with the authoritative UniProt length of **876 aa** (Q03361) and is not used;
+  it appears to be a confused artifact from the ORF-merge re-annotation history.

--- a/genes/yeast/JIP4/JIP4-uniprot.txt
+++ b/genes/yeast/JIP4/JIP4-uniprot.txt
@@ -1,0 +1,241 @@
+ID   JIP4_YEAST              Reviewed;         876 AA.
+AC   Q03361; D6VT98; Q66RD2;
+DT   17-OCT-2006, integrated into UniProtKB/Swiss-Prot.
+DT   01-MAR-2004, sequence version 2.
+DT   10-JUN-2026, entry version 148.
+DE   RecName: Full=Uncharacterized protein JIP4;
+DE   AltName: Full=Jumonji-interacting protein 4;
+GN   Name=JIP4; OrderedLocusNames=YDR475C; ORFNames=YDR474C;
+OS   Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).
+OC   Eukaryota; Fungi; Dikarya; Ascomycota; Saccharomycotina; Saccharomycetes;
+OC   Saccharomycetales; Saccharomycetaceae; Saccharomyces.
+OX   NCBI_TaxID=559292;
+RN   [1]
+RP   NUCLEOTIDE SEQUENCE [LARGE SCALE GENOMIC DNA].
+RC   STRAIN=ATCC 204508 / S288c;
+RX   PubMed=9169867; DOI=10.1038/387s075;
+RA   Jacq C., Alt-Moerbe J., Andre B., Arnold W., Bahr A., Ballesta J.P.G.,
+RA   Bargues M., Baron L., Becker A., Biteau N., Bloecker H., Blugeon C.,
+RA   Boskovic J., Brandt P., Brueckner M., Buitrago M.J., Coster F.,
+RA   Delaveau T., del Rey F., Dujon B., Eide L.G., Garcia-Cantalejo J.M.,
+RA   Goffeau A., Gomez-Peris A., Granotier C., Hanemann V., Hankeln T.,
+RA   Hoheisel J.D., Jaeger W., Jimenez A., Jonniaux J.-L., Kraemer C.,
+RA   Kuester H., Laamanen P., Legros Y., Louis E.J., Moeller-Rieker S.,
+RA   Monnet A., Moro M., Mueller-Auer S., Nussbaumer B., Paricio N., Paulin L.,
+RA   Perea J., Perez-Alonso M., Perez-Ortin J.E., Pohl T.M., Prydz H.,
+RA   Purnelle B., Rasmussen S.W., Remacha M.A., Revuelta J.L., Rieger M.,
+RA   Salom D., Saluz H.P., Saiz J.E., Saren A.-M., Schaefer M., Scharfe M.,
+RA   Schmidt E.R., Schneider C., Scholler P., Schwarz S., Soler-Mira A.,
+RA   Urrestarazu L.A., Verhasselt P., Vissers S., Voet M., Volckaert G.,
+RA   Wagner G., Wambutt R., Wedler E., Wedler H., Woelfl S., Harris D.E.,
+RA   Bowman S., Brown D., Churcher C.M., Connor R., Dedman K., Gentles S.,
+RA   Hamlin N., Hunt S., Jones L., McDonald S., Murphy L.D., Niblett D.,
+RA   Odell C., Oliver K., Rajandream M.A., Richards C., Shore L., Walsh S.V.,
+RA   Barrell B.G., Dietrich F.S., Mulligan J.T., Allen E., Araujo R., Aviles E.,
+RA   Berno A., Carpenter J., Chen E., Cherry J.M., Chung E., Duncan M.,
+RA   Hunicke-Smith S., Hyman R.W., Komp C., Lashkari D., Lew H., Lin D.,
+RA   Mosedale D., Nakahara K., Namath A., Oefner P., Oh C., Petel F.X.,
+RA   Roberts D., Schramm S., Schroeder M., Shogren T., Shroff N., Winant A.,
+RA   Yelton M.A., Botstein D., Davis R.W., Johnston M., Andrews S., Brinkman R.,
+RA   Cooper J., Ding H., Du Z., Favello A., Fulton L., Gattung S., Greco T.,
+RA   Hallsworth K., Hawkins J., Hillier L.W., Jier M., Johnson D., Johnston L.,
+RA   Kirsten J., Kucaba T., Langston Y., Latreille P., Le T., Mardis E.,
+RA   Menezes S., Miller N., Nhan M., Pauley A., Peluso D., Rifkin L., Riles L.,
+RA   Taich A., Trevaskis E., Vignati D., Wilcox L., Wohldman P., Vaudin M.,
+RA   Wilson R., Waterston R., Albermann K., Hani J., Heumann K., Kleine K.,
+RA   Mewes H.-W., Zollner A., Zaccaria P.;
+RT   "The nucleotide sequence of Saccharomyces cerevisiae chromosome IV.";
+RL   Nature 387:75-78(1997).
+RN   [2]
+RP   SEQUENCE REVISION.
+RA   Sethuraman A., Cherry J.M.;
+RL   Submitted (OCT-2003) to the EMBL/GenBank/DDBJ databases.
+RN   [3]
+RP   GENOME REANNOTATION.
+RC   STRAIN=ATCC 204508 / S288c;
+RX   PubMed=24374639; DOI=10.1534/g3.113.008995;
+RA   Engel S.R., Dietrich F.S., Fisk D.G., Binkley G., Balakrishnan R.,
+RA   Costanzo M.C., Dwight S.S., Hitz B.C., Karra K., Nash R.S., Weng S.,
+RA   Wong E.D., Lloyd P., Skrzypek M.S., Miyasato S.R., Simison M., Cherry J.M.;
+RT   "The reference genome sequence of Saccharomyces cerevisiae: Then and now.";
+RL   G3 (Bethesda) 4:389-398(2014).
+RN   [4]
+RP   NUCLEOTIDE SEQUENCE [GENOMIC DNA] OF 322-876.
+RC   STRAIN=ATCC 204508 / S288c;
+RX   PubMed=17322287; DOI=10.1101/gr.6037607;
+RA   Hu Y., Rolfs A., Bhullar B., Murthy T.V.S., Zhu C., Berger M.F.,
+RA   Camargo A.A., Kelley F., McCarron S., Jepson D., Richardson A., Raphael J.,
+RA   Moreira D., Taycher E., Zuo D., Mohr S., Kane M.F., Williamson J.,
+RA   Simpson A.J.G., Bulyk M.L., Harlow E., Marsischky G., Kolodner R.D.,
+RA   LaBaer J.;
+RT   "Approaching a complete repository of sequence-verified protein-encoding
+RT   clones for Saccharomyces cerevisiae.";
+RL   Genome Res. 17:536-543(2007).
+RN   [5]
+RP   REVISION OF GENE MODEL.
+RX   PubMed=11152879; DOI=10.1016/s0014-5793(00)02275-4;
+RA   Blandin G., Durrens P., Tekaia F., Aigle M., Bolotin-Fukuhara M., Bon E.,
+RA   Casaregola S., de Montigny J., Gaillardin C., Lepingle A., Llorente B.,
+RA   Malpertuy A., Neuveglise C., Ozier-Kalogeropoulos O., Perrin A., Potier S.,
+RA   Souciet J.-L., Talla E., Toffano-Nioche C., Wesolowski-Louvel M., Marck C.,
+RA   Dujon B.;
+RT   "Genomic exploration of the hemiascomycetous yeasts: 4. The genome of
+RT   Saccharomyces cerevisiae revisited.";
+RL   FEBS Lett. 487:31-36(2000).
+RN   [6]
+RP   PHOSPHORYLATION [LARGE SCALE ANALYSIS] AT SER-577, AND IDENTIFICATION BY
+RP   MASS SPECTROMETRY [LARGE SCALE ANALYSIS].
+RC   STRAIN=YAL6B;
+RX   PubMed=15665377; DOI=10.1074/mcp.m400219-mcp200;
+RA   Gruhler A., Olsen J.V., Mohammed S., Mortensen P., Faergeman N.J., Mann M.,
+RA   Jensen O.N.;
+RT   "Quantitative phosphoproteomics applied to the yeast pheromone signaling
+RT   pathway.";
+RL   Mol. Cell. Proteomics 4:310-327(2005).
+RN   [7]
+RP   PHOSPHORYLATION [LARGE SCALE ANALYSIS] AT SER-48; SER-360 AND SER-552, AND
+RP   IDENTIFICATION BY MASS SPECTROMETRY [LARGE SCALE ANALYSIS].
+RX   PubMed=18407956; DOI=10.1074/mcp.m700468-mcp200;
+RA   Albuquerque C.P., Smolka M.B., Payne S.H., Bafna V., Eng J., Zhou H.;
+RT   "A multidimensional chromatography technology for in-depth phosphoproteome
+RT   analysis.";
+RL   Mol. Cell. Proteomics 7:1389-1396(2008).
+RN   [8]
+RP   PHOSPHORYLATION [LARGE SCALE ANALYSIS] AT SER-48; SER-51; SER-510; SER-552
+RP   AND SER-775, AND IDENTIFICATION BY MASS SPECTROMETRY [LARGE SCALE
+RP   ANALYSIS].
+RX   PubMed=19779198; DOI=10.1126/science.1172867;
+RA   Holt L.J., Tuch B.B., Villen J., Johnson A.D., Gygi S.P., Morgan D.O.;
+RT   "Global analysis of Cdk1 substrate phosphorylation sites provides insights
+RT   into evolution.";
+RL   Science 325:1682-1686(2009).
+CC   ---------------------------------------------------------------------------
+CC   Copyrighted by the UniProt Consortium, see https://www.uniprot.org/terms
+CC   Distributed under the Creative Commons Attribution (CC BY 4.0) License
+CC   ---------------------------------------------------------------------------
+DR   EMBL; U33050; AAB64919.2; -; Genomic_DNA.
+DR   EMBL; AY723793; AAU09710.1; -; Genomic_DNA.
+DR   EMBL; BK006938; DAA12308.1; -; Genomic_DNA.
+DR   PIR; S69642; S69642.
+DR   RefSeq; NP_010763.2; NM_001180783.1.
+DR   AlphaFoldDB; Q03361; -.
+DR   BioGRID; 32527; 87.
+DR   FunCoup; Q03361; 117.
+DR   IntAct; Q03361; 6.
+DR   MINT; Q03361; -.
+DR   STRING; 4932.YDR475C; -.
+DR   iPTMnet; Q03361; -.
+DR   PaxDb; 4932-YDR475C; -.
+DR   PeptideAtlas; Q03361; -.
+DR   EnsemblFungi; YDR475C_mRNA; YDR475C; YDR475C.
+DR   GeneID; 852086; -.
+DR   KEGG; sce:YDR475C; -.
+DR   AGR; SGD:S000002883; -.
+DR   SGD; S000002883; JIP4.
+DR   VEuPathDB; FungiDB:YDR475C; -.
+DR   eggNOG; ENOG502RISH; Eukaryota.
+DR   HOGENOM; CLU_012887_0_0_1; -.
+DR   InParanoid; Q03361; -.
+DR   OMA; IEWTSGY; -.
+DR   OrthoDB; 843225at2759; -.
+DR   BioCyc; YEAST:G3O-30001-MONOMER; -.
+DR   BioGRID-ORCS; 852086; 0 hits in 10 CRISPR screens.
+DR   PRO; PR:Q03361; -.
+DR   Proteomes; UP000002311; Chromosome IV.
+DR   RNAct; Q03361; protein.
+DR   GO; GO:0005681; C:spliceosomal complex; IBA:GO_Central.
+DR   GO; GO:0003723; F:RNA binding; IBA:GO_Central.
+DR   GO; GO:0048024; P:regulation of mRNA splicing, via spliceosome; IBA:GO_Central.
+DR   InterPro; IPR052225; Ser/Arg_repetitive_matrix.
+DR   PANTHER; PTHR23148; SERINE/ARGININE REGULATED NUCLEAR MATRIX PROTEIN; 1.
+DR   PANTHER; PTHR23148:SF0; SERINE_ARGININE REPETITIVE MATRIX PROTEIN 1; 1.
+PE   1: Evidence at protein level;
+KW   Phosphoprotein; Reference proteome.
+FT   CHAIN           1..876
+FT                   /note="Uncharacterized protein JIP4"
+FT                   /id="PRO_0000253825"
+FT   REGION          37..67
+FT                   /note="Disordered"
+FT                   /evidence="ECO:0000256|SAM:MobiDB-lite"
+FT   REGION          112..155
+FT                   /note="Disordered"
+FT                   /evidence="ECO:0000256|SAM:MobiDB-lite"
+FT   REGION          226..254
+FT                   /note="Disordered"
+FT                   /evidence="ECO:0000256|SAM:MobiDB-lite"
+FT   REGION          330..353
+FT                   /note="Disordered"
+FT                   /evidence="ECO:0000256|SAM:MobiDB-lite"
+FT   REGION          490..513
+FT                   /note="Disordered"
+FT                   /evidence="ECO:0000256|SAM:MobiDB-lite"
+FT   REGION          661..728
+FT                   /note="Disordered"
+FT                   /evidence="ECO:0000256|SAM:MobiDB-lite"
+FT   REGION          750..876
+FT                   /note="Disordered"
+FT                   /evidence="ECO:0000256|SAM:MobiDB-lite"
+FT   COMPBIAS        37..48
+FT                   /note="Basic and acidic residues"
+FT                   /evidence="ECO:0000256|SAM:MobiDB-lite"
+FT   COMPBIAS        49..58
+FT                   /note="Low complexity"
+FT                   /evidence="ECO:0000256|SAM:MobiDB-lite"
+FT   COMPBIAS        115..131
+FT                   /note="Polar residues"
+FT                   /evidence="ECO:0000256|SAM:MobiDB-lite"
+FT   COMPBIAS        689..699
+FT                   /note="Basic residues"
+FT                   /evidence="ECO:0000256|SAM:MobiDB-lite"
+FT   COMPBIAS        717..726
+FT                   /note="Low complexity"
+FT                   /evidence="ECO:0000256|SAM:MobiDB-lite"
+FT   COMPBIAS        794..808
+FT                   /note="Low complexity"
+FT                   /evidence="ECO:0000256|SAM:MobiDB-lite"
+FT   COMPBIAS        842..854
+FT                   /note="Low complexity"
+FT                   /evidence="ECO:0000256|SAM:MobiDB-lite"
+FT   MOD_RES         48
+FT                   /note="Phosphoserine"
+FT                   /evidence="ECO:0007744|PubMed:18407956,
+FT                   ECO:0007744|PubMed:19779198"
+FT   MOD_RES         51
+FT                   /note="Phosphoserine"
+FT                   /evidence="ECO:0007744|PubMed:19779198"
+FT   MOD_RES         360
+FT                   /note="Phosphoserine"
+FT                   /evidence="ECO:0007744|PubMed:18407956"
+FT   MOD_RES         510
+FT                   /note="Phosphoserine"
+FT                   /evidence="ECO:0007744|PubMed:19779198"
+FT   MOD_RES         552
+FT                   /note="Phosphoserine"
+FT                   /evidence="ECO:0007744|PubMed:18407956,
+FT                   ECO:0007744|PubMed:19779198"
+FT   MOD_RES         577
+FT                   /note="Phosphoserine"
+FT                   /evidence="ECO:0007744|PubMed:15665377"
+FT   MOD_RES         775
+FT                   /note="Phosphoserine"
+FT                   /evidence="ECO:0007744|PubMed:19779198"
+FT   CONFLICT        708
+FT                   /note="S -> N (in Ref. 4; AAU09710)"
+FT                   /evidence="ECO:0000305"
+SQ   SEQUENCE   876 AA;  98691 MW;  911BBB6FB2E90D09 CRC64;
+     MVVRDQDEAL RNSYKYVKLY VRQDQLEDTV DILAKQDEDK SNNDDRRSLA SILDSSSSVK
+     KKGKGSNEKY LPCVSFNTVP RSRVSSPLDE EKREFPGVQI SADYTMEEYY DDESGFTSDN
+     NADYFSGNSY SSRREGSASP GRYSSPPPAS KRNIKIGKMF KISENGKIVR EDYPTTPTDI
+     NDALVISRAY ANWRQLWIKK KNQIDHRLEQ KRDFFNYPTI LFPPNKKKSS EGATPTIKFN
+     PPIEDGFTPL TKSQKRKERV LSEKVGFPNT PRTILCHISG RKHTWVALDW ALRTLIQNTD
+     HIVVLANLPR LTKNNFEDND SMSERKRMLM MMDDSRSVSS ARRSRSRSRS RSICTRRALS
+     LGPEESDNKL KHQNFIEWTS GYTQNEIERK LQDLFDYVTL IIPQDRSVKV TVEILIGKTK
+     KTLLEAINIY LPDFFVSSTL RWERTDSLVR WKSNFLTDKL CTNFPIPTFI VPAKRMFDLE
+     IDLQKEFKEP EVTKQKNTSG PKPGFSHSKS ADASIPTISN IKRKQDNDYS IDSLCYAPEA
+     NGANNSSREE ASDDELNAFK DDENDVMSVK SLTSNISVKE KLCTMARKRR KSMAQQLNDA
+     DHDSSIPPGQ RHLKKLNIIL ESSLKFSLEI DSITDSIENG DVDEKRAHSM ESGFEELKRV
+     ITGGAPPRHV ATPQRSMLDV LDNPSSSRSK SKSRSSSKSR IRDKSKPSSP TATDINSSAS
+     ASRSRSPQIK FASSVKNVDG NAALGAIKSR HSLDSPGDQQ QQHHHHHHRD TDQLSVPGLP
+     HLAPSKSYSV SSGNKDSSLR KVSSSSSLRK VKSNDSNSGK RIKKPVVTSA HLKPSSGGGG
+     LFSFFKSKSR SPSSFRKEDE SKNTPKRGGL FGFGRL
+//

--- a/interpro/panther/PTHR23148/PTHR23148-entries.csv
+++ b/interpro/panther/PTHR23148/PTHR23148-entries.csv
@@ -1,0 +1,7 @@
+id,name,entry_type,source_tax_id,source_tax_name,full_tax_name,gene,length,subfamily,subfamily_name,in_alphafold
+Q03361,Uncharacterized protein JIP4,protein,559292,Saccharomyces cerevisiae (strain ATCC 204508 / S288c),Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast),JIP4,876,PTHR23148:SF0,SERINE_ARGININE REPETITIVE MATRIX PROTEIN 1,True
+Q52KI8,Serine/arginine repetitive matrix protein 1,protein,10090,Mus musculus,Mus musculus (Mouse),Srrm1,946,PTHR23148:SF0,SERINE_ARGININE REPETITIVE MATRIX PROTEIN 1,True
+Q5R5Q2,Serine/arginine repetitive matrix protein 1,protein,9601,Pongo abelii,Pongo abelii (Sumatran orangutan),SRRM1,917,PTHR23148:SF0,SERINE_ARGININE REPETITIVE MATRIX PROTEIN 1,True
+Q5ZMJ9,Serine/arginine repetitive matrix protein 1,protein,9031,Gallus gallus,Gallus gallus (Chicken),SRRM1,888,PTHR23148:SF0,SERINE_ARGININE REPETITIVE MATRIX PROTEIN 1,True
+Q8IYB3,Serine/arginine repetitive matrix protein 1,protein,9606,Homo sapiens,Homo sapiens (Human),SRRM1,904,PTHR23148:SF0,SERINE_ARGININE REPETITIVE MATRIX PROTEIN 1,True
+Q9USH5,PWI domain-containing protein C825.05c,protein,284812,Schizosaccharomyces pombe (strain 972 / ATCC 24843),Schizosaccharomyces pombe (strain 972 / ATCC 24843) (Fission yeast),SPCC825.05c,301,PTHR23148:SF0,SERINE_ARGININE REPETITIVE MATRIX PROTEIN 1,True

--- a/interpro/panther/PTHR23148/PTHR23148-metadata.yaml
+++ b/interpro/panther/PTHR23148/PTHR23148-metadata.yaml
@@ -1,0 +1,56 @@
+metadata:
+  accession: PTHR23148
+  entry_id: null
+  type: family
+  go_terms: null
+  source_database: panther
+  member_databases: null
+  integrated: IPR052225
+  hierarchy: null
+  name:
+    name: Serine/arginine repetitive matrix
+    short: Ser/Arg_repetitive_matrix
+  description:
+  - text: The Serine/arginine repetitive matrix protein family is involved in various
+      pre-mRNA splicing and processing events. Members of this family are integral
+      components of both pre- and post-splicing multiprotein mRNP complexes and play
+      a role in the splicing of U12-type introns as part of the minor spliceosome.
+      They are known to promote splicing activation, both constitutive and ESE-dependent,
+      by connecting sequence-specific splicing factors with basal snRNP components
+      of the spliceosome. Additionally, they can stimulate mRNA 3'-end cleavage independently
+      of exon junction complex formation and have the ability to bind RNA and DNA
+      with low sequence specificity, showing no marked preference for double- or single-stranded
+      substrates.
+    llm: true
+    checked: false
+    updated: false
+  wikipedia: null
+  literature: null
+  set_info: null
+  overlaps_with: null
+  counters:
+    subfamilies: 3
+    domain_architectures: 0
+    interactions: 0
+    matches: 5406
+    pathways: 0
+    proteins: 5406
+    proteomes: 3074
+    sets: 0
+    structural_models:
+      alphafold: 4403
+    structures: 9
+    taxa: 8282
+  entry_annotations:
+    hmm: 0
+    logo: 0
+  cross_references: {}
+  is_llm: true
+  is_reviewed_llm: false
+  is_updated_llm: false
+  representative_structure: null
+_fetch_info:
+  fetched_date: '2026-07-05T01:59:17.738183'
+  api_endpoint: https://www.ebi.ac.uk/interpro/api/entry/panther/PTHR23148/
+  database: panther
+  family_id: PTHR23148

--- a/publications/PMID_15665377.md
+++ b/publications/PMID_15665377.md
@@ -1,0 +1,79 @@
+---
+reference_id: PMID:15665377
+title: Quantitative phosphoproteomics applied to the yeast pheromone signaling pathway.
+authors:
+- Gruhler A
+- Olsen JV
+- Mohammed S
+- Mortensen P
+- Faergeman NJ
+- Mann M
+- Jensen ON
+journal: Mol Cell Proteomics
+year: '2005'
+doi: 10.1074/mcp.M400219-MCP200
+keywords:
+- Amino Acid Sequence
+- Carbon Isotopes
+- "Chromatography, Liquid"
+- Mass Spectrometry
+- Molecular Sequence Data
+- Peptide Mapping
+- Pheromones/metabolism
+- Phosphopeptides/metabolism
+- Phosphorylation
+- Proteomics
+- Saccharomyces cerevisiae/metabolism
+- Signal Transduction
+content_type: abstract_only
+full_text_attempted: true
+---
+
+# Quantitative phosphoproteomics applied to the yeast pheromone signaling pathway.
+**Authors:** Gruhler A, Olsen JV, Mohammed S, Mortensen P, Faergeman NJ, Mann M, Jensen ON
+**Journal:** Mol Cell Proteomics (2005)
+**DOI:** [10.1074/mcp.M400219-MCP200](https://doi.org/10.1074/mcp.M400219-MCP200)
+
+## Content
+
+1. Mol Cell Proteomics. 2005 Mar;4(3):310-27. doi: 10.1074/mcp.M400219-MCP200.
+Epub  2005 Jan 22.
+
+Quantitative phosphoproteomics applied to the yeast pheromone signaling pathway.
+
+Gruhler A(1), Olsen JV, Mohammed S, Mortensen P, Faergeman NJ, Mann M, Jensen 
+ON.
+
+Author information:
+(1)Center for Experimental Bioinformatics, Department of Biochemistry and 
+Molecular Biology, University of Southern Denmark, Odense, Campusvej 55, DK-5230 
+Odense M, Denmark.
+
+Cellular processes such as proliferation, differentiation, and adaptation to 
+environmental changes are regulated by protein phosphorylation. Development of 
+sensitive and comprehensive analytical methods for determination of protein 
+phosphorylation is therefore a necessity in the pursuit of a detailed molecular 
+view of complex biological processes. We present a quantitative 
+modification-specific proteomic approach that combines stable isotope labeling 
+by amino acids in cell culture (SILAC) for quantitation with IMAC for 
+phosphopeptide enrichment and three stages of mass spectrometry (MS/MS/MS) for 
+identification. This integrated phosphoproteomic technology identified and 
+quantified phosphorylation in key regulator and effector proteins of a 
+prototypical G-protein-coupled receptor signaling pathway, the yeast pheromone 
+response. SILAC encoding of yeast proteomes was achieved by incorporation of 
+[(13)C(6)]arginine and [(13)C(6)]lysine in a double auxotroph yeast strain. 
+Pheromone-treated yeast cells were mixed with SILAC-encoded cells as the control 
+and lysed, and extracted proteins were digested with trypsin. Phosphopeptides 
+were enriched by a combination of strong cation exchange chromatography and 
+IMAC. Phosphopeptide fractions were analyzed by LC-MS using a linear ion 
+trap-Fourier transform ion cyclotron resonance mass spectrometer. MS/MS and 
+neutral loss-directed MS/MS/MS analysis allowed detection and sequencing of 
+phosphopeptides with exceptional accuracy and specificity. Of more than 700 
+identified phosphopeptides, 139 were differentially regulated at least 2-fold in 
+response to mating pheromone. Among these regulated proteins were components 
+belonging to the mitogen-activated protein kinase signaling pathway and to 
+downstream processes including transcriptional regulation, the establishment of 
+polarized growth, and the regulation of the cell cycle.
+
+DOI: 10.1074/mcp.M400219-MCP200
+PMID: 15665377 [Indexed for MEDLINE]


### PR DESCRIPTION
## Summary

AI GO-annotation review for the understudied ("dark") *Saccharomyces cerevisiae* gene **JIP4** (systematic name YDR475C; UniProt Q03361; SGD:S000002883), a 876-residue intrinsically disordered protein of unknown function.

The assessment is grounded in UniProt domain composition, PANTHER PTHR23148 orthology, SGD facts, cached phosphoproteomics literature, and a genuine falcon (Edison) deep-research report — no invented function.

### Annotation review (5 GOA annotations)

| Action | Count | Annotations |
|--------|-------|-------------|
| MARK_AS_OVER_ANNOTATED | 2 | `spliceosomal complex` (IBA), `regulation of mRNA splicing, via spliceosome` (IBA) |
| ACCEPT | 3 | ND root terms: `molecular_function`, `cellular_component`, `biological_process` |

The two IBA splicing annotations are homology-only transfers from metazoan SRRM1/SRm160 (family placement is driven by shared Arg/Ser low-complexity composition, not a conserved folded domain). They are marked as over-annotations — with structured `propagation_review` — because JIP4 **lacks the PWI nucleic-acid-binding domain** that carries the SRm160/SRRM1 splicing function, has never been reported as a component of the exhaustively characterized yeast spliceosome, and budding yeast lacks the metazoan-style (minor-spliceosome / ESE-activation) splicing biology those terms describe. The three ND root annotations are accepted as honest "no data" placeholders.

### Knowledge gaps (primary deliverable)

JIP4 is functionally dark. (1) Its **molecular function is entirely unknown** — no biochemical activity, and no folded catalytic/binding domain (no PWI, no RRM), so even the family-based "RNA binding" inference is unverified (WHOLLY_DARK). (2) Whether the metazoan SRRM1 **splicing role transfers to yeast at all is untested** (MF_DARK). (3) Its **localization, biological process, and loss-of-function phenotype** (beyond deletion viability), and its relationship to the WGD paralog YOR019W, are undetermined (BP_DARK). (4) The "Jumonji-interacting" name suggests a hypothetical, uncharacterized association with the JmjC transcription factor Gis1 (Rim15/TOR/Sch9 pathway).

### Files
- `genes/yeast/JIP4/` — review YAML, notes, uniprot, goa, falcon deep research
- `interpro/panther/PTHR23148/` — fetched PANTHER family data
- `publications/PMID_15665377.md` — newly cached publication

All checks pass locally: `just validate`, `just validate-references`, `just validate-terms`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)