### PR TITLE
GPM3: add reviewer-requested rationale to annotation reviews

### DIFF
--- a/genes/yeast/GPM3/GPM3-ai-review.yaml
+++ b/genes/yeast/GPM3/GPM3-ai-review.yaml
@@ -112,6 +112,12 @@ existing_annotations:
         activity even when strongly overexpressed (Heinisch et al. 1998), so this is an
         over-propagation of the ancestral family activity onto a probable non-functional
         paralog. GPM1 is the sole functional yeast phosphoglycerate mutase.
+        Marked as over-annotated rather than removed because the evidence is contradictory
+        rather than merely thin: UniProt itself hedges ("Could be non-functional"), the
+        dPGM catalytic histidines are conserved in sequence, and weak, expression-limited
+        residual activity below the original assay's detection cannot be fully excluded
+        (forced overexpression did partially complement gpm1). The term should not,
+        however, be retained as a functional annotation for this paralog.
       action: MARK_AS_OVER_ANNOTATED
       supported_by:
         - reference_id: PMID:9544241
@@ -145,7 +151,10 @@ existing_annotations:
         cytoplasmic nature of the family, so the location is reasonable. Kept as
         non-core because GPM3 has no demonstrated activity for which the location would
         represent a core function; the "is_active_in" qualifier overstates a
-        demonstrated activity at this site.
+        demonstrated activity at this site. This IBA cytosol call is independently
+        corroborated by the experimental (HDA) cytoplasm localization of GPM3
+        (GO:0005737, PMID:14562095), which is why the location itself is accepted even
+        though the accompanying activity is not.
       action: KEEP_AS_NON_CORE
       supported_by:
         - reference_id: PMID:14562095
@@ -213,7 +222,10 @@ existing_annotations:
         EC/Rhea mapping (EC 5.4.2.11) attached to the BPG-dependent PGAM subfamily. As
         with the IBA copy of this term, this is a family-level inference contradicted by
         the direct experimental finding of no detectable mutase activity for GPM3; the
-        same UniProt entry states the protein "Could be non-functional".
+        same UniProt entry states the protein "Could be non-functional". Marked as
+        over-annotated rather than removed for the same reason as the IBA copy: the
+        catalytic histidines are conserved and expression-limited residual activity cannot
+        be fully excluded, so the call is deliberately conservative.
       action: MARK_AS_OVER_ANNOTATED
       supported_by:
         - reference_id: PMID:9544241


### PR DESCRIPTION
## Summary

Follow-up to #1790 (the GPM3 review), which was auto-merged immediately after `ai4c-agent` approval — before its non-blocking review suggestions could be folded in. This PR adds those prose-only clarifications to `review.reason` fields. **No action, term, or evidence changes.**

- **Mutase-activity terms (IBA `GO:0004619` + IEA `GO:0004619`)**: explain *why* `MARK_AS_OVER_ANNOTATED` rather than `REMOVE` — the evidence is contradictory-but-hedged (conserved dPGM catalytic histidines, UniProt "could be non-functional", possible expression-limited residual activity that partial gpm1Δ complementation cannot exclude), so a conservative down-grade is preferred over deletion.
- **Cytosol IBA (`GO:0005829`)**: note that this call is independently corroborated by the experimental HDA cytoplasm localization (`GO:0005737`, PMID:14562095), explaining the ACCEPT-vs-KEEP_AS_NON_CORE asymmetry.

Validates clean (`just validate`, `just validate-terms`, `just validate-references`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)