### PR TITLE
Regenerate pages and browser app

### DIFF
--- a/genes/yeast/AIM33/AIM33-ai-review.html
+++ b/genes/yeast/AIM33/AIM33-ai-review.html
@@ -1,0 +1,2805 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>AIM33 - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        .propagation-review {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f8fafc;
+            border-left: 3px solid #64748b;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .propagation-title {
+            font-weight: 600;
+            color: #334155;
+            margin-bottom: 0.25rem;
+        }
+
+        .propagation-row {
+            margin-top: 0.25rem;
+        }
+
+        .propagation-source {
+            margin-top: 0.5rem;
+            padding-top: 0.5rem;
+            border-top: 1px solid #e5e7eb;
+        }
+
+        .propagation-source-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #1d4ed8;
+        }
+
+        .propagation-comment {
+            color: #4b5563;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>AIM33</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/Q04516" target="_blank" class="term-link">
+                        Q04516
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Saccharomyces cerevisiae</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-initialized">
+                    INITIALIZED
+                </span>
+            </div>
+
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "AIM33";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="Q04516" data-a="DESCRIPTION: AIM33 (YML087C) is a poorly characterized Saccharo..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>AIM33 (YML087C) is a poorly characterized Saccharomyces cerevisiae protein of the flavoprotein pyridine nucleotide cytochrome reductase (cytochrome-b5 reductase, CYB5R) superfamily. It carries the diagnostic two-domain flavin/pyridine-nucleotide reductase module — an FAD-binding FR-type domain (residues ~70-173) followed by an NAD(P)H-binding domain — and is predicted to bind FAD, so it is expected to act as an NAD(P)H-dependent flavin oxidoreductase. Unlike most family members, which are soluble or single-pass tail-anchored, AIM33 is predicted to be a polytopic (multi-pass) membrane protein. Its specific catalytic activity, physiological electron acceptor, and site of action have not been experimentally established. Deletion of AIM33 alters the frequency of spontaneous mitochondrial genome loss (petite frequency) and impairs growth on non-fermentable carbon sources, linking the protein to mitochondrial genome maintenance and respiratory competence, and giving it the &#34;Altered Inheritance of Mitochondria&#34; (AIM) name. AIM33 has a whole-genome-duplication paralog, PGA3 (a plasma-membrane NADH:coenzyme-Q6 reductase), and is related at the reductase-domain level to the mitochondrial/ER cytochrome-b5 reductases MCR1 and CBR1 and to human CYB5R-family enzymes.</p>
+    </div>
+
+
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005886" target="_blank" class="term-link">
+                                    GO:0005886
+                                </a>
+                            </span>
+                            <span class="term-label">plasma membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-modify">
+                            MODIFY
+                        </span>
+                        <span class="vote-buttons" data-g="Q04516" data-a="GO:0005886" data-r="GO_REF:0000033" data-act="MODIFY">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetically-propagated (IBA) plasma-membrane location. AIM33 is a membrane protein, but the &#34;plasma membrane&#34; specificity is not supported for AIM33 itself.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The IBA is transferred across the cytochrome-b5-reductase family (PANTHER PTHR19370), whose members occupy several membranes: the paralog PGA3 is plasma-membrane-associated, but MCR1 is at the mitochondrial outer membrane / intermembrane space and CBR1 is in the ER. AIM33&#39;s own experimental data point away from the plasma membrane: its deletion perturbs mitochondrial genome maintenance and respiratory growth, and its predicted polytopic topology is consistent with an internal (likely mitochondrial) membrane. The protein is genuinely membrane-associated, but the specific &#34;plasma membrane&#34; assignment is an over-specific propagation. Generalize to GO:0016020 (membrane) until the true membrane is determined experimentally.
+                        </div>
+
+
+
+                        <div class="propagation-review">
+                            <div class="propagation-title">Propagation Review</div>
+                            <div class="propagation-row">
+                                <strong>Root cause:</strong>
+                                <span class="badge">TERM SCOPING PROBLEM</span>
+                            </div>
+
+                            <div class="propagation-row">
+                                <strong>Failure modes:</strong>
+
+                                <span class="badge">COMPARTMENT OR COMPLEX MISMATCH</span>
+
+                                <span class="badge">WRONG ORTHOLOG OR PARALOG</span>
+
+                            </div>
+
+
+                            <div class="propagation-source">
+                                <strong>Sources checked:</strong>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">SGD:S000004594</span>
+
+                                    &middot; PGA3
+
+
+                                    <span class="badge">SUPPORTS SOURCE BUT NOT TARGET</span>
+
+
+                                    <div class="propagation-comment">PGA3 (AIM33&#39;s WGD paralog) is plasma-membrane-associated; AIM33 phenotype and topology suggest an internal/mitochondrial membrane instead.</div>
+
+                                </div>
+
+                            </div>
+
+                        </div>
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016020" target="_blank" class="term-link">
+                                    membrane
+                                </a>
+                            </span>
+
+                        </div>
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004128" target="_blank" class="term-link">
+                                    GO:0004128
+                                </a>
+                            </span>
+                            <span class="term-label">cytochrome-b5 reductase activity, acting on NAD(P)H</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q04516" data-a="GO:0004128" data-r="GO_REF:0000033" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetically-propagated cytochrome-b5 reductase activity. Domain-plausible but not demonstrated for AIM33, and the specific cytochrome-b5 electron acceptor is unproven for this paralog.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> AIM33 has the FAD-binding FR-type + NAD(P)H-binding module diagnostic of the cytochrome-b5 reductase superfamily, so an NAD(P)H:acceptor flavin-oxidoreductase activity is reasonable in principle. However, no enzyme assay has demonstrated cytochrome-b5 reductase activity for AIM33, and the physiological electron acceptor (cytochrome b5 vs coenzyme Q vs a P450 vs an unknown partner) is not established. The activity is transferred from characterized paralogs (MCR1, CBR1, PGA3) whose acceptors differ (MCR1/CBR1 reduce cytochrome b5; PGA3 reduces coenzyme Q6). Asserting the specific &#34;cytochrome-b5&#34; acceptor for AIM33 is an over-annotation; the defensible MF is the more general oxidoreductase activity (see GO:0016491, retained). Keep the reductase idea on record but flagged, pending direct biochemistry.
+                        </div>
+
+
+
+                        <div class="propagation-review">
+                            <div class="propagation-title">Propagation Review</div>
+                            <div class="propagation-row">
+                                <strong>Root cause:</strong>
+                                <span class="badge">TERM SCOPING PROBLEM</span>
+                            </div>
+
+                            <div class="propagation-row">
+                                <strong>Failure modes:</strong>
+
+                                <span class="badge">WRONG ORTHOLOG OR PARALOG</span>
+
+                                <span class="badge">FUNCTIONAL DIVERGENCE</span>
+
+                            </div>
+
+
+                            <div class="propagation-source">
+                                <strong>Sources checked:</strong>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">SGD:S000001633</span>
+
+                                    &middot; MCR1
+
+
+                                    <span class="badge">SUPPORTS SOURCE BUT NOT TARGET</span>
+
+
+                                    <div class="propagation-comment">MCR1 is an experimentally validated NADH-cytochrome b5 reductase; AIM33 shares the reductase fold but its acceptor is unverified.</div>
+
+                                </div>
+
+                            </div>
+
+                        </div>
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006696" target="_blank" class="term-link">
+                                    GO:0006696
+                                </a>
+                            </span>
+                            <span class="term-label">ergosterol biosynthetic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q04516" data-a="GO:0006696" data-r="GO_REF:0000033" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetically-propagated ergosterol-biosynthesis role. No AIM33-specific evidence; transferred from paralogs and contradicted by AIM33&#39;s mitochondrial-genome phenotype.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> An ergosterol-biosynthesis role is well established for the related cytochrome-b5 reductases that donate electrons to sterol-biosynthetic cytochrome P450s (e.g. MCR1 to Erg11/Erg5/Erg1), and this is the basis for the IBA transfer. AIM33 itself has no experimental link to sterol biosynthesis; instead its characterized phenotype is altered mitochondrial genome maintenance and loss of respiratory growth. Treating AIM33 as an ergosterol-biosynthesis enzyme on the strength of paralog function is an over-annotation.
+                        </div>
+
+
+
+                        <div class="propagation-review">
+                            <div class="propagation-title">Propagation Review</div>
+                            <div class="propagation-row">
+                                <strong>Root cause:</strong>
+                                <span class="badge">PROPAGATION BAD</span>
+                            </div>
+
+                            <div class="propagation-row">
+                                <strong>Failure modes:</strong>
+
+                                <span class="badge">WRONG ORTHOLOG OR PARALOG</span>
+
+                                <span class="badge">FUNCTIONAL DIVERGENCE</span>
+
+                            </div>
+
+
+                            <div class="propagation-source">
+                                <strong>Sources checked:</strong>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">SGD:S000001633</span>
+
+                                    &middot; MCR1
+
+
+                                    <span class="badge">SUPPORTS SOURCE BUT NOT TARGET</span>
+
+
+                                    <div class="propagation-comment">Ergosterol-pathway electron donation is documented for MCR1, not for AIM33.</div>
+
+                                </div>
+
+                            </div>
+
+                        </div>
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004128" target="_blank" class="term-link">
+                                    GO:0004128
+                                </a>
+                            </span>
+                            <span class="term-label">cytochrome-b5 reductase activity, acting on NAD(P)H</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000117
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q04516" data-a="GO:0004128" data-r="GO_REF:0000117" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> ARBA machine-learning electronic annotation asserting the same specific cytochrome-b5 reductase activity; same over-specificity concern as the IBA above.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> This ARBA rule fires on family/domain features shared across the CYB5R superfamily and assigns the specific cytochrome-b5 acceptor. As with the IBA, the reductase fold is present but the cytochrome-b5 acceptor is not verified for AIM33; the defensible electronic MF is the general oxidoreductase activity (GO:0016491), which is separately annotated and retained.
+                        </div>
+
+
+
+                        <div class="propagation-review">
+                            <div class="propagation-title">Propagation Review</div>
+                            <div class="propagation-row">
+                                <strong>Root cause:</strong>
+                                <span class="badge">TERM SCOPING PROBLEM</span>
+                            </div>
+
+                            <div class="propagation-row">
+                                <strong>Failure modes:</strong>
+
+                                <span class="badge">GRANULARITY MISMATCH</span>
+
+                            </div>
+
+
+                            <div class="propagation-source">
+                                <strong>Sources checked:</strong>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">ARBA:ARBA00027922</span>
+
+                                    &middot; ARBA rule (cytochrome-b5 reductase)
+
+
+                                    <span class="badge">SOURCE WEAK OR INFERRED</span>
+
+
+                                    <div class="propagation-comment">Rule assigns a specific acceptor not established for this protein.</div>
+
+                                </div>
+
+                            </div>
+
+                        </div>
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016020" target="_blank" class="term-link">
+                                    GO:0016020
+                                </a>
+                            </span>
+                            <span class="term-label">membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000044
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q04516" data-a="GO:0016020" data-r="GO_REF:0000044" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic membrane localization from the UniProt SubCell mapping; well supported by predicted transmembrane helices and the global membrane-proteome dataset.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> AIM33 has multiple predicted transmembrane helices (UniProt TRANSMEM 15-35, 42-62, 180-200) and is included in the experimentally-constrained membrane-proteome topology map (PMID:16847258). &#34;Membrane&#34; is the correct, appropriately general cellular-component term; the specific membrane is not yet determined.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/16847258" target="_blank" class="term-link">
+                                        PMID:16847258
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">we report the cloning and expression of 617 S. cerevisiae membrane proteins as fusions to a C-terminal topology reporter and present experimentally constrained topology models for 546 proteins.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016491" target="_blank" class="term-link">
+                                    GO:0016491
+                                </a>
+                            </span>
+                            <span class="term-label">oxidoreductase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q04516" data-a="GO:0016491" data-r="GO_REF:0000002" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> InterPro2GO electronic annotation of general oxidoreductase activity — the best-supported, appropriately general molecular-function call for AIM33.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> AIM33 carries the FAD-binding FR-type domain and the NAD_binding_1 domain characteristic of flavin/pyridine-nucleotide oxidoreductases, and is predicted to bind FAD. Oxidoreductase activity (GO:0016491) is strongly supported by the domain architecture while remaining agnostic about the specific electron acceptor, which is unknown. This is the honest core molecular-function term for this protein.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003674" target="_blank" class="term-link">
+                                    GO:0003674
+                                </a>
+                            </span>
+                            <span class="term-label">molecular_function</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ND</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000015
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q04516" data-a="GO:0003674" data-r="GO_REF:0000015" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Root-term ND placeholder recording that a specific molecular function was not determined.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Standard ND root annotation (GO_REF:0000015). Appropriate as a historical placeholder; the InterPro-based oxidoreductase MF now provides more specific (if still general) information.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005575" target="_blank" class="term-link">
+                                    GO:0005575
+                                </a>
+                            </span>
+                            <span class="term-label">cellular_component</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ND</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000015
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q04516" data-a="GO:0005575" data-r="GO_REF:0000015" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Root-term ND placeholder for undetermined cellular component.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Standard ND root annotation. The membrane annotations now supersede this with more specific (if still general) localization information.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008150" target="_blank" class="term-link">
+                                    GO:0008150
+                                </a>
+                            </span>
+                            <span class="term-label">biological_process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ND</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000015
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q04516" data-a="GO:0008150" data-r="GO_REF:0000015" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Root-term ND placeholder for undetermined biological process.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Standard ND root annotation. The disruption phenotype implicates AIM33 in mitochondrial genome maintenance / respiratory competence, but no specific BP term has been experimentally validated for AIM33 (see knowledge_gaps and core_functions).
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>NAD(P)H-dependent flavin (FAD) oxidoreductase activity inferred from the conserved FAD-binding FR-type + NAD(P)H-binding module of the cytochrome-b5 reductase superfamily. The specific electron acceptor is undetermined, so the function is stated at the general oxidoreductase level rather than as a specific cytochrome-b5 reductase.</h3>
+                <span class="vote-buttons" data-g="Q04516" data-a="FUNCTION: NAD(P)H-dependent flavin (FAD) oxidoreductase acti..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016491" target="_blank" class="term-link">
+                            oxidoreductase activity
+                        </a>
+                    </span>
+                </div>
+
+
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016020" target="_blank" class="term-link">
+                                membrane
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/16847258" target="_blank" class="term-link">
+                                PMID:16847258
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">we report the cloning and expression of 617 S. cerevisiae membrane proteins as fusions to a C-terminal topology reporter and present experimentally constrained topology models for 546 proteins.</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000002.md" target="_blank" class="term-link">
+                            GO_REF:0000002
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation through association of InterPro records with GO terms</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000015.md" target="_blank" class="term-link">
+                            GO_REF:0000015
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Use of the ND evidence code for Gene Ontology (GO) terms</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
+                            GO_REF:0000033
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Annotation inferences using phylogenetic trees</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
+                            GO_REF:0000044
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000117.md" target="_blank" class="term-link">
+                            GO_REF:0000117
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Electronic Gene Ontology annotations created by ARBA machine learning models</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/19300474" target="_blank" class="term-link">
+                            PMID:19300474
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Computationally driven, quantitative experiments discover genes required for mitochondrial biogenesis.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Genome-wide petite-frequency screen that assigned mitochondrial-biogenesis / transmission phenotypes to &gt;100 genes (the &#34;AIM&#34; class); the source of the curated AIM33 disruption phenotype (altered frequency of mitochondrial genome loss).</div>
+
+                        <div class="finding-text">"Using computational predictions combined with traditional quantitative experiments, we have identified 100 proteins whose deficiency alters mitochondrial biogenesis and inheritance in Saccharomyces cerevisiae."</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/16847258" target="_blank" class="term-link">
+                            PMID:16847258
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">A global topology map of the Saccharomyces cerevisiae membrane proteome.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Experimentally constrained membrane-topology dataset covering AIM33/YML087C, supporting its assignment as an integral (multi-pass) membrane protein.</div>
+
+                        <div class="finding-text">"we report the cloning and expression of 617 S. cerevisiae membrane proteins as fusions to a C-terminal topology reporter and present experimentally constrained topology models for 546 proteins."</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/9169872" target="_blank" class="term-link">
+                            PMID:9169872
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">The nucleotide sequence of Saccharomyces cerevisiae chromosome XIII.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/24374639" target="_blank" class="term-link">
+                            PMID:24374639
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">The reference genome sequence of Saccharomyces cerevisiae: Then and now.</div>
+
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Questions for Experts</h2>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> What is the physiological electron acceptor of AIM33 (cytochrome b5, coenzyme Q6, a cytochrome P450, or another partner), and is NADH or NADPH the electron donor?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q04516" data-a="Q: What is the physiological electron acceptor of AIM..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> In which membrane does AIM33 reside endogenously — mitochondrial, ER, or plasma membrane — and does its polytopic topology differ from the mostly tail-anchored/soluble family members?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q04516" data-a="Q: In which membrane does AIM33 reside endogenously —..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Does AIM33 promote or antagonize petite formation, and does it act on mitochondrial genome maintenance directly (e.g. via redox homeostasis or membrane potential) or indirectly?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q04516" data-a="Q: Does AIM33 promote or antagonize petite formation,..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Experiments</h2>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Express and purify recombinant AIM33 (full-length in detergent/nanodiscs and the isolated soluble reductase domain), confirm bound FAD spectroscopically, and measure steady-state NADH- and NADPH-dependent reduction of candidate acceptors (cytochrome b5, coenzyme Q6/CoQ analogs, ferricyanide, cytochrome c, methemoglobin).</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: AIM33 is an NAD(P)H-dependent flavin oxidoreductase whose physiological acceptor is one of cytochrome b5, coenzyme Q6, or a P450.</em></p>
+
+
+                    <p style="margin-top: 0.5rem;">Type: enzyme kinetics / spectroscopy</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q04516" data-a="EXPERIMENT: Express and purify recombinant AIM33 (full-length ..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Determine endogenous localization of a functional C-terminally tagged AIM33 by live-cell fluorescence colocalization with mitochondrial, ER, and plasma-membrane markers, and by subcellular and submitochondrial fractionation; verify functionality of the tagged allele by complementation of the petite phenotype.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: AIM33 localizes to a mitochondrial membrane consistent with its mitochondrial-genome maintenance phenotype rather than to the plasma membrane.</em></p>
+
+
+                    <p style="margin-top: 0.5rem;">Type: localization / cell biology</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q04516" data-a="EXPERIMENT: Determine endogenous localization of a functional ..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> In a clean aim33-delta strain, quantify petite frequency against isogenic wild type, measure mtDNA copy number and integrity, mitochondrial membrane potential, and respiratory-complex assembly; perform targeted genetic-interaction tests with genes for mtDNA maintenance and with the paralog PGA3 and relatives MCR1/CBR1.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: Loss of AIM33 alters mitochondrial genome stability through a defined mechanism.</em></p>
+
+
+                    <p style="margin-top: 0.5rem;">Type: yeast genetics / functional genomics</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q04516" data-a="EXPERIMENT: In a clean aim33-delta strain, quantify petite fre..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Deep Research Sections -->
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(AIM33-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="Q04516" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="aim33-yml087c-curation-notes">AIM33 (YML087C) — curation notes</h1>
+<p>UniProt: Q04516 | SGD: S000004552 | GeneID: 854887 | 312 aa | Chromosome XIII</p>
+<h2 id="summary-of-the-problem">Summary of the problem</h2>
+<p>AIM33 ("Altered Inheritance of Mitochondria 33") is a <strong>poorly characterized</strong> <em>S. cerevisiae</em><br />
+protein. UniProt names it "Uncharacterized oxidoreductase AIM33" (EC=1.-.-.-). SGD calls it a<br />
+"Protein of unknown function". It is a member (by sequence/domain) of the flavoprotein pyridine<br />
+nucleotide cytochrome reductase family (the cytochrome-b5 reductase, CYB5R, superfamily), but<br />
+its own catalytic activity, physiological electron acceptor, and cellular role are <strong>not<br />
+experimentally established</strong>. This is a "dark gene": the deliverable is an honest knowledge_gaps<br />
+section plus domain/orthology-grounded (not invented) reasoning.</p>
+<h2 id="known-evidence-supported">KNOWN (evidence-supported)</h2>
+<h3 id="domain-architecture-family-from-uniprot-q04516">Domain architecture / family (from UniProt Q04516)</h3>
+<ul>
+<li>Belongs to the <strong>flavoprotein pyridine nucleotide cytochrome reductase family</strong><br />
+  (<code>SIMILARITY {ECO:0000305}</code>).</li>
+<li><strong>FAD-binding FR-type domain</strong> at residues 70–173 (<code>FT DOMAIN ... /evidence=ECO:0000255|PROSITE-ProRule:PRU00716</code>).</li>
+<li>Pfam: <strong>PF00970 FAD_binding_6</strong> + <strong>PF00175 NAD_binding_1</strong> — the classic two-domain<br />
+  FAD/NAD(P)H reductase module of cytochrome-b5 reductases.</li>
+<li>InterPro: IPR001834 (CBR-like), IPR008333 (Cbr1-like FAD-bd dom), IPR017927 (FAD-bd FR-type),<br />
+  IPR001709 (Flavoprotein pyridine nucleotide cytochrome reductase), IPR001433 (OxRdtase FAD/NAD-bd).</li>
+<li>CDD cd06183 "cyt_b5_reduct_like".</li>
+<li><strong>PANTHER PTHR19370</strong> "NADH-CYTOCHROME B5 REDUCTASE"; subfamily <strong>PTHR19370:SF143</strong><br />
+  "PLASMA MEMBRANE-ASSOCIATED COENZYME Q6 REDUCTASE PGA3".</li>
+<li>KW: FAD, Flavoprotein, NAD, Oxidoreductase, Membrane, Transmembrane.</li>
+<li>COFACTOR: FAD (<code>{ECO:0000250}</code> — by similarity only, not measured for AIM33).</li>
+<li><strong>Reasoning</strong>: The FAD-binding + NAD-binding module is diagnostic of a flavin-dependent<br />
+  pyridine-nucleotide:acceptor oxidoreductase. An oxidoreductase MF (GO:0016491) and even a<br />
+  cytochrome-b5-reductase-type activity are therefore <em>domain-defensible</em>. What the domain does<br />
+  NOT tell us is the physiological electron acceptor — cytochrome b5, coenzyme Q, a P450, or<br />
+  something else — which is exactly the open question.</li>
+</ul>
+<h3 id="membrane-topology-multi-pass-pmid16847258-global-topology-map">Membrane topology (multi-pass) — PMID:16847258 (global topology map)</h3>
+<ul>
+<li>UniProt SUBCELLULAR LOCATION: <strong>Membrane; Multi-pass membrane protein</strong> (<code>{ECO:0000305}</code>).</li>
+<li>Predicted TM helices at 15–35, 42–62, 180–200 (ECO:0000255) with an N-in/loop-out topology;<br />
+  the FAD-binding domain (70–173) sits in the large loop.</li>
+<li>AIM33/YML087C is one of the 546 membrane proteins with an experimentally-constrained topology<br />
+  model in <a href="https://pubmed.ncbi.nlm.nih.gov/16847258" title="we report the cloning and expression of 617 S. cerevisiae membrane   proteins as fusions to a C-terminal topology reporter and present experimentally constrained   topology models for 546 proteins.">PMID:16847258</a>. (AIM33 is in the dataset; the paper text is genome-wide<br />
+  and does not discuss AIM33 individually.)</li>
+<li><strong>Note</strong>: This makes AIM33 structurally DISTINCT from most soluble CYB5R enzymes. Human<br />
+  CYB5R4 (the SGD-stated homolog) is a <strong>soluble</strong> flavohemoprotein; MCR1 is anchored at the<br />
+  mitochondrial outer membrane. AIM33 being a genuine <em>polytopic</em> membrane reductase is unusual<br />
+  in this family and is itself a notable, under-explored feature.</li>
+</ul>
+<h3 id="disruption-phenotype-pmid19300474-hess-et-al-mitochondrial-biogenesis-screen">Disruption phenotype — PMID:19300474 (Hess et al., mitochondrial biogenesis screen)</h3>
+<ul>
+<li>UniProt DISRUPTION PHENOTYPE: "<strong>Increases frequency of mitochondrial genome loss.</strong>"<br />
+  (<code>{ECO:0000269|PubMed:19300474}</code>).</li>
+<li>This study systematically measured the <strong>petite frequency</strong> (rate of generation of cells<br />
+  lacking respiratory-competent mitochondria) of ~193 deletion strains and confirmed 109 genes<br />
+  (including the AIM-named genes) with altered mitochondrial transmission phenotypes. AIM33 is<br />
+  one of these; the specific value is in the paper's supplementary tables (S2/S6), not the main<br />
+  text, so no gene-specific verbatim quote is available from the cached full text.</li>
+<li>WT S288C baseline: <a href="https://pubmed.ncbi.nlm.nih.gov/19300474" title="genetic background produce petite daughter cells at a   baseline frequency of ~20%">PMID:19300474</a> and "mutation of genes involved in mitochondrial biogenesis can<br />
+  significantly alter this rate."</li>
+<li>The "AIM" name (Altered Inheritance of Mitochondria) was assigned to genes discovered/confirmed<br />
+  in this class of screens for altered mitochondrial genome transmission.</li>
+</ul>
+<h3 id="discrepancy-on-phenotype-direction-record-in-knowledge_gaps">DISCREPANCY on phenotype direction (record in knowledge_gaps)</h3>
+<ul>
+<li>UniProt curation of PMID:19300474: deletion <strong>INCREASES</strong> frequency of mitochondrial genome loss.</li>
+<li>SGD gene description: "null mutant displays <strong>REDUCED</strong> frequency of mitochondrial genome loss."</li>
+<li>Both cannot be literally true; the direction of the petite-frequency shift for AIM33 is<br />
+  ambiguous between the two curated sources. Either way, AIM33 loss perturbs mitochondrial genome<br />
+  maintenance/petite frequency. (Note: PMID:19300474 discusses that <em>decreased</em> petite frequency<br />
+  can indicate a "petite-negative" synthetic-lethality phenotype, so a decrease is also<br />
+  mechanistically meaningful.)</li>
+</ul>
+<h3 id="other-large-scale-phenotypes-sgd-from-high-throughput-surveys">Other large-scale phenotypes (SGD, from high-throughput surveys)</h3>
+<ul>
+<li>Null mutant: cannot grow on non-fermentable carbon sources (respiratory phenotype); decreased<br />
+  calcium and sodium ion accumulation; reduced starvation and ethanol resistance; abnormal<br />
+  mitochondrial genome maintenance. (These are HTP/large-scale phenotypes, not deep mechanism.)</li>
+</ul>
+<h3 id="family-paralog-ortholog-context">Family / paralog / ortholog context</h3>
+<ul>
+<li><strong>Paralog</strong>: PGA3 (arose from the whole-genome duplication). PGA3 = plasma-membrane-associated<br />
+  NADH:coenzyme-Q6 reductase (the PANTHER SF143 exemplar). [WebSearch: SGD/Wikidata]</li>
+<li>Related family members in yeast: <strong>MCR1</strong> (YKL150W; mitochondrial OMM/IMS NADH-cytochrome b5<br />
+  reductase; electron donor to sterol-biosynthetic cytochrome P450s Erg11/Erg5/Erg1 and to<br />
+  fatty-acid/sterol desaturation; oxidative-stress response), <strong>CBR1</strong> (ER NADH-cytochrome b5<br />
+  reductase). AIM33 is a fourth, distinct member.</li>
+<li><strong>Human homolog/ortholog</strong>: SGD states <strong>CYB5R4</strong>; NCBI Gene lists <strong>CYB5R1/CYB5R3</strong> as<br />
+  orthologs. The mapping is family-level, not an unambiguous 1:1 ortholog. Human CYB5R4 is a<br />
+  soluble flavohemoprotein (extra cytochrome-b5 and p23 domains) important for beta-cell/oxidative-<br />
+  stress protection — a different domain architecture from the polytopic yeast AIM33.</li>
+</ul>
+<h2 id="not-known-the-real-knowledge-gaps">NOT known (the real knowledge gaps)</h2>
+<ol>
+<li><strong>Catalytic activity of AIM33 itself.</strong> No enzyme assay demonstrates cytochrome-b5 reductase<br />
+   (or any) activity for AIM33. EC is 1.-.-.- (class assigned, sub-subclass unknown). The<br />
+   GO:0004128 (cytochrome-b5 reductase acting on NAD(P)H) and GO:0016491 annotations are IBA/IEA<br />
+   propagations from the family, not measurements on AIM33.</li>
+<li><strong>Physiological electron donor/acceptor.</strong> NAD(P)H as donor is likely (NAD_binding_1 domain);<br />
+   the acceptor (cytochrome b5? coenzyme Q? a P450? a desaturase? an as-yet-unknown mitochondrial<br />
+   redox partner?) is unknown for AIM33.</li>
+<li><strong>Cellular localization.</strong> UniProt/GO say "Membrane / plasma membrane (IBA)". But the AIM<br />
+   phenotype and the CYB5R4 orthology imply a possible <strong>mitochondrial</strong> role. The IBA<br />
+   plasma-membrane call is propagated (partly via the PGA3 branch) and is not experimentally<br />
+   confirmed for AIM33; its true membrane (mitochondrial vs plasma vs ER) is unresolved.</li>
+<li><strong>Ergosterol-pathway involvement (GO:0006696, IBA).</strong> Established for the paralog MCR1 (electron<br />
+   donor to sterol P450s), NOT demonstrated for AIM33. This is a candidate over-annotation.</li>
+<li><strong>Mechanism behind the AIM (mitochondrial genome maintenance) phenotype</strong>, and even its<br />
+   direction (increase vs decrease in petite frequency; see discrepancy above).</li>
+</ol>
+<h2 id="annotation-by-annotation-reasoning-see-aim33-ai-reviewyaml">Annotation-by-annotation reasoning (see AIM33-ai-review.yaml)</h2>
+<ul>
+<li>GO:0005886 plasma membrane (IBA) — IBA-propagated location; contradicted by predicted polytopic<br />
+  topology consistent with an internal membrane and by the mitochondrial phenotype. MODIFY toward<br />
+  the more general/defensible GO:0016020 membrane (the location is real; "plasma membrane"<br />
+  specificity is unsupported for AIM33).</li>
+<li>GO:0004128 cytochrome-b5 reductase activity, acting on NAD(P)H (IBA and IEA) — domain-plausible<br />
+  activity but not measured for AIM33 and possibly over-specific (electron acceptor unproven).<br />
+  Keep as non-core / mark as over-annotated: retain the reductase idea but flag that the specific<br />
+  cytochrome-b5 acceptor is not established for this paralog.</li>
+<li>GO:0006696 ergosterol biosynthetic process (IBA) — propagated from MCR1/PGA3; no AIM33-specific<br />
+  evidence; AIM33's phenotype points elsewhere (mitochondrial genome maintenance). Candidate<br />
+  over-annotation → MARK_AS_OVER_ANNOTATED.</li>
+<li>GO:0016020 membrane (IEA, UniProt SubCell) — defensible; membrane protein is well supported. ACCEPT.</li>
+<li>GO:0016491 oxidoreductase activity (IEA, InterPro) — the safest, best-supported MF given the<br />
+  FAD/NAD reductase module. ACCEPT (keep as the honest, general MF).</li>
+<li>GO:0003674 / GO:0005575 / GO:0008150 ND root annotations — placeholder root annotations<br />
+  (GO_REF:0000015). ACCEPT (standard; represent "not yet determined").</li>
+</ul>
+<h2 id="provenance-index">Provenance index</h2>
+<ul>
+<li><a href="https://pubmed.ncbi.nlm.nih.gov/19300474">PMID:19300474</a> Hess et al. 2009 PLoS Genet — mitochondrial biogenesis / petite frequency screen; source of DISRUPTION PHENOTYPE. Full text cached (abstract + body; AIM33 in supp tables only).</li>
+<li><a href="https://pubmed.ncbi.nlm.nih.gov/16847258">PMID:16847258</a> Kim et al. 2006 PNAS — global membrane topology map; AIM33 topology model. Cache has abstract plus a partial full-text (Results intro) section only, not the complete article; the quoted supporting_text is a verbatim substring of that cached text.</li>
+<li><a href="https://pubmed.ncbi.nlm.nih.gov/9169872">PMID:9169872</a> Bowman et al. 1997 Nature — chromosome XIII sequence (genome). Abstract only.</li>
+<li><a href="https://pubmed.ncbi.nlm.nih.gov/24374639">PMID:24374639</a> Engel et al. 2014 G3 — reference genome reannotation. Full text cached.</li>
+<li>SGD S000004552 (WebFetch), NCBI Gene 854887 (WebFetch), WebSearch — family/paralog/ortholog and additional phenotypes.</li>
+<li>UniProt Q04516 (AIM33-uniprot.txt) — domains, cofactor, topology, family, disruption phenotype.</li>
+</ul>
+<h2 id="deep-research-provenance">Deep research provenance</h2>
+<ul>
+<li>Falcon deep research was attempted (first run timed out at 600s; perplexity-lite fallback failed<br />
+  with a 401 quota error). A single retry of falcon was run. This review is grounded directly in<br />
+  UniProt (Q04516), GOA, cached primary literature (PMID:19300474, PMID:16847258), and<br />
+  PubMed-verified secondary sources (SGD S000004552, NCBI Gene 854887); it does not depend on the<br />
+  deep-research file. If the falcon retry produced <code>AIM33-deep-research-falcon.md</code>, it is included<br />
+  for the record but was not the basis for any specific claim.</li>
+</ul>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: Q04516
+gene_symbol: AIM33
+product_type: PROTEIN
+status: INITIALIZED
+taxon:
+  id: NCBITaxon:559292
+  label: Saccharomyces cerevisiae
+description: &gt;-
+  AIM33 (YML087C) is a poorly characterized Saccharomyces cerevisiae protein of the
+  flavoprotein pyridine nucleotide cytochrome reductase (cytochrome-b5 reductase, CYB5R)
+  superfamily. It carries the diagnostic two-domain flavin/pyridine-nucleotide reductase
+  module — an FAD-binding FR-type domain (residues ~70-173) followed by an NAD(P)H-binding
+  domain — and is predicted to bind FAD, so it is expected to act as an NAD(P)H-dependent
+  flavin oxidoreductase. Unlike most family members, which are soluble or single-pass
+  tail-anchored, AIM33 is predicted to be a polytopic (multi-pass) membrane protein. Its
+  specific catalytic activity, physiological electron acceptor, and site of action have not
+  been experimentally established. Deletion of AIM33 alters the frequency of spontaneous
+  mitochondrial genome loss (petite frequency) and impairs growth on non-fermentable carbon
+  sources, linking the protein to mitochondrial genome maintenance and respiratory
+  competence, and giving it the &#34;Altered Inheritance of Mitochondria&#34; (AIM) name. AIM33 has
+  a whole-genome-duplication paralog, PGA3 (a plasma-membrane NADH:coenzyme-Q6 reductase),
+  and is related at the reductase-domain level to the mitochondrial/ER cytochrome-b5
+  reductases MCR1 and CBR1 and to human CYB5R-family enzymes.
+references:
+- id: GO_REF:0000002
+  title: Gene Ontology annotation through association of InterPro records with GO terms
+  findings: []
+- id: GO_REF:0000015
+  title: Use of the ND evidence code for Gene Ontology (GO) terms
+  findings: []
+- id: GO_REF:0000033
+  title: Annotation inferences using phylogenetic trees
+  findings: []
+- id: GO_REF:0000044
+  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location
+    vocabulary mapping, accompanied by conservative changes to GO terms applied by
+    UniProt
+  findings: []
+- id: GO_REF:0000117
+  title: Electronic Gene Ontology annotations created by ARBA machine learning models
+  findings: []
+- id: PMID:19300474
+  title: &#34;Computationally driven, quantitative experiments discover genes required for mitochondrial biogenesis.&#34;
+  findings:
+  - statement: &gt;-
+      Genome-wide petite-frequency screen that assigned mitochondrial-biogenesis /
+      transmission phenotypes to &gt;100 genes (the &#34;AIM&#34; class); the source of the curated
+      AIM33 disruption phenotype (altered frequency of mitochondrial genome loss).
+    supporting_text: &gt;-
+      Using computational predictions combined with traditional quantitative experiments,
+      we have identified 100 proteins whose deficiency alters mitochondrial biogenesis and
+      inheritance in Saccharomyces cerevisiae.
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PMC-verified full text. AIM33/YML087C is one of the deletion strains assayed; the
+      gene-specific petite-frequency value is reported in the supplementary tables (S2/S6),
+      not the main text, so no AIM33-specific verbatim quote is available from the cached
+      copy. This is the reference behind UniProt&#39;s DISRUPTION PHENOTYPE. Note a
+      curated-source discrepancy on direction: UniProt states deletion &#34;increases&#34; while
+      SGD states &#34;reduced&#34; frequency of mitochondrial genome loss (see knowledge_gaps).
+- id: PMID:16847258
+  title: &#34;A global topology map of the Saccharomyces cerevisiae membrane proteome.&#34;
+  findings:
+  - statement: &gt;-
+      Experimentally constrained membrane-topology dataset covering AIM33/YML087C, supporting
+      its assignment as an integral (multi-pass) membrane protein.
+    supporting_text: &gt;-
+      we report the cloning and expression of 617 S. cerevisiae membrane proteins as fusions
+      to a C-terminal topology reporter and present experimentally constrained topology models
+      for 546 proteins.
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PMC-verified. Genome-scale topology study; AIM33 is one of the 546 modeled proteins
+      (the paper text does not discuss AIM33 individually). Supports the &#34;Membrane; multi-pass&#34;
+      call in UniProt but does not localize AIM33 to a specific membrane.
+- id: PMID:9169872
+  title: &#34;The nucleotide sequence of Saccharomyces cerevisiae chromosome XIII.&#34;
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Chromosome XIII genome-sequencing paper; establishes the YML087C ORF. Background only;
+      no functional information on AIM33. Abstract-only in cache.
+- id: PMID:24374639
+  title: &#34;The reference genome sequence of Saccharomyces cerevisiae: Then and now.&#34;
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Reference-genome reannotation; background provenance for the YML087C locus. No
+      AIM33-specific functional information.
+existing_annotations:
+- term:
+    id: GO:0005886
+    label: plasma membrane
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: is_active_in
+  review:
+    summary: &gt;-
+      Phylogenetically-propagated (IBA) plasma-membrane location. AIM33 is a membrane protein,
+      but the &#34;plasma membrane&#34; specificity is not supported for AIM33 itself.
+    action: MODIFY
+    reason: &gt;-
+      The IBA is transferred across the cytochrome-b5-reductase family (PANTHER PTHR19370),
+      whose members occupy several membranes: the paralog PGA3 is plasma-membrane-associated,
+      but MCR1 is at the mitochondrial outer membrane / intermembrane space and CBR1 is in the
+      ER. AIM33&#39;s own experimental data point away from the plasma membrane: its deletion
+      perturbs mitochondrial genome maintenance and respiratory growth, and its predicted
+      polytopic topology is consistent with an internal (likely mitochondrial) membrane. The
+      protein is genuinely membrane-associated, but the specific &#34;plasma membrane&#34; assignment
+      is an over-specific propagation. Generalize to GO:0016020 (membrane) until the true
+      membrane is determined experimentally.
+    proposed_replacement_terms:
+    - id: GO:0016020
+      label: membrane
+    propagation_review:
+      root_cause: TERM_SCOPING_PROBLEM
+      failure_modes:
+      - COMPARTMENT_OR_COMPLEX_MISMATCH
+      - WRONG_ORTHOLOG_OR_PARALOG
+      source_entities:
+      - source_id: SGD:S000004594
+        source_label: PGA3
+        source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
+        comment: &gt;-
+          PGA3 (AIM33&#39;s WGD paralog) is plasma-membrane-associated; AIM33 phenotype and
+          topology suggest an internal/mitochondrial membrane instead.
+- term:
+    id: GO:0004128
+    label: cytochrome-b5 reductase activity, acting on NAD(P)H
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Phylogenetically-propagated cytochrome-b5 reductase activity. Domain-plausible but not
+      demonstrated for AIM33, and the specific cytochrome-b5 electron acceptor is unproven for
+      this paralog.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      AIM33 has the FAD-binding FR-type + NAD(P)H-binding module diagnostic of the
+      cytochrome-b5 reductase superfamily, so an NAD(P)H:acceptor flavin-oxidoreductase
+      activity is reasonable in principle. However, no enzyme assay has demonstrated
+      cytochrome-b5 reductase activity for AIM33, and the physiological electron acceptor
+      (cytochrome b5 vs coenzyme Q vs a P450 vs an unknown partner) is not established. The
+      activity is transferred from characterized paralogs (MCR1, CBR1, PGA3) whose acceptors
+      differ (MCR1/CBR1 reduce cytochrome b5; PGA3 reduces coenzyme Q6). Asserting the
+      specific &#34;cytochrome-b5&#34; acceptor for AIM33 is an over-annotation; the defensible MF is
+      the more general oxidoreductase activity (see GO:0016491, retained). Keep the reductase
+      idea on record but flagged, pending direct biochemistry.
+    propagation_review:
+      root_cause: TERM_SCOPING_PROBLEM
+      failure_modes:
+      - WRONG_ORTHOLOG_OR_PARALOG
+      - FUNCTIONAL_DIVERGENCE
+      source_entities:
+      - source_id: SGD:S000001633
+        source_label: MCR1
+        source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
+        comment: &gt;-
+          MCR1 is an experimentally validated NADH-cytochrome b5 reductase; AIM33 shares the
+          reductase fold but its acceptor is unverified.
+- term:
+    id: GO:0006696
+    label: ergosterol biosynthetic process
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Phylogenetically-propagated ergosterol-biosynthesis role. No AIM33-specific evidence;
+      transferred from paralogs and contradicted by AIM33&#39;s mitochondrial-genome phenotype.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      An ergosterol-biosynthesis role is well established for the related cytochrome-b5
+      reductases that donate electrons to sterol-biosynthetic cytochrome P450s (e.g. MCR1 to
+      Erg11/Erg5/Erg1), and this is the basis for the IBA transfer. AIM33 itself has no
+      experimental link to sterol biosynthesis; instead its characterized phenotype is altered
+      mitochondrial genome maintenance and loss of respiratory growth. Treating AIM33 as an
+      ergosterol-biosynthesis enzyme on the strength of paralog function is an over-annotation.
+    propagation_review:
+      root_cause: PROPAGATION_BAD
+      failure_modes:
+      - WRONG_ORTHOLOG_OR_PARALOG
+      - FUNCTIONAL_DIVERGENCE
+      source_entities:
+      - source_id: SGD:S000001633
+        source_label: MCR1
+        source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
+        comment: &gt;-
+          Ergosterol-pathway electron donation is documented for MCR1, not for AIM33.
+- term:
+    id: GO:0004128
+    label: cytochrome-b5 reductase activity, acting on NAD(P)H
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000117
+  qualifier: enables
+  review:
+    summary: &gt;-
+      ARBA machine-learning electronic annotation asserting the same specific cytochrome-b5
+      reductase activity; same over-specificity concern as the IBA above.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      This ARBA rule fires on family/domain features shared across the CYB5R superfamily and
+      assigns the specific cytochrome-b5 acceptor. As with the IBA, the reductase fold is
+      present but the cytochrome-b5 acceptor is not verified for AIM33; the defensible
+      electronic MF is the general oxidoreductase activity (GO:0016491), which is separately
+      annotated and retained.
+    propagation_review:
+      root_cause: TERM_SCOPING_PROBLEM
+      failure_modes:
+      - GRANULARITY_MISMATCH
+      source_entities:
+      - source_id: ARBA:ARBA00027922
+        source_label: ARBA rule (cytochrome-b5 reductase)
+        source_status: SOURCE_WEAK_OR_INFERRED
+        comment: Rule assigns a specific acceptor not established for this protein.
+- term:
+    id: GO:0016020
+    label: membrane
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000044
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Electronic membrane localization from the UniProt SubCell mapping; well supported by
+      predicted transmembrane helices and the global membrane-proteome dataset.
+    action: ACCEPT
+    reason: &gt;-
+      AIM33 has multiple predicted transmembrane helices (UniProt TRANSMEM 15-35, 42-62,
+      180-200) and is included in the experimentally-constrained membrane-proteome topology
+      map (PMID:16847258). &#34;Membrane&#34; is the correct, appropriately general cellular-component
+      term; the specific membrane is not yet determined.
+    supported_by:
+    - reference_id: PMID:16847258
+      supporting_text: &gt;-
+        we report the cloning and expression of 617 S. cerevisiae membrane proteins as fusions
+        to a C-terminal topology reporter and present experimentally constrained topology models
+        for 546 proteins.
+- term:
+    id: GO:0016491
+    label: oxidoreductase activity
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: enables
+  review:
+    summary: &gt;-
+      InterPro2GO electronic annotation of general oxidoreductase activity — the
+      best-supported, appropriately general molecular-function call for AIM33.
+    action: ACCEPT
+    reason: &gt;-
+      AIM33 carries the FAD-binding FR-type domain and the NAD_binding_1 domain characteristic
+      of flavin/pyridine-nucleotide oxidoreductases, and is predicted to bind FAD. Oxidoreductase
+      activity (GO:0016491) is strongly supported by the domain architecture while remaining
+      agnostic about the specific electron acceptor, which is unknown. This is the honest core
+      molecular-function term for this protein.
+- term:
+    id: GO:0003674
+    label: molecular_function
+  evidence_type: ND
+  original_reference_id: GO_REF:0000015
+  qualifier: enables
+  review:
+    summary: Root-term ND placeholder recording that a specific molecular function was not determined.
+    action: ACCEPT
+    reason: &gt;-
+      Standard ND root annotation (GO_REF:0000015). Appropriate as a historical placeholder;
+      the InterPro-based oxidoreductase MF now provides more specific (if still general)
+      information.
+- term:
+    id: GO:0005575
+    label: cellular_component
+  evidence_type: ND
+  original_reference_id: GO_REF:0000015
+  qualifier: is_active_in
+  review:
+    summary: Root-term ND placeholder for undetermined cellular component.
+    action: ACCEPT
+    reason: &gt;-
+      Standard ND root annotation. The membrane annotations now supersede this with more
+      specific (if still general) localization information.
+- term:
+    id: GO:0008150
+    label: biological_process
+  evidence_type: ND
+  original_reference_id: GO_REF:0000015
+  qualifier: involved_in
+  review:
+    summary: Root-term ND placeholder for undetermined biological process.
+    action: ACCEPT
+    reason: &gt;-
+      Standard ND root annotation. The disruption phenotype implicates AIM33 in mitochondrial
+      genome maintenance / respiratory competence, but no specific BP term has been
+      experimentally validated for AIM33 (see knowledge_gaps and core_functions).
+core_functions:
+- description: &gt;-
+    NAD(P)H-dependent flavin (FAD) oxidoreductase activity inferred from the conserved
+    FAD-binding FR-type + NAD(P)H-binding module of the cytochrome-b5 reductase superfamily.
+    The specific electron acceptor is undetermined, so the function is stated at the general
+    oxidoreductase level rather than as a specific cytochrome-b5 reductase.
+  molecular_function:
+    id: GO:0016491
+    label: oxidoreductase activity
+  locations:
+  - id: GO:0016020
+    label: membrane
+  supported_by:
+  - reference_id: PMID:16847258
+    supporting_text: &gt;-
+      we report the cloning and expression of 617 S. cerevisiae membrane proteins as fusions
+      to a C-terminal topology reporter and present experimentally constrained topology models
+      for 546 proteins.
+  knowledge_gaps:
+  - gap_statement: &gt;-
+      The specific catalytic activity of AIM33 and its physiological electron acceptor are
+      undetermined. It is not known whether AIM33 reduces cytochrome b5, coenzyme Q, a
+      cytochrome P450, or another (possibly mitochondrial) redox partner, nor whether NADH,
+      NADPH, or both serve as the electron donor.
+    boundary: &gt;-
+      AIM33 carries the diagnostic FAD-binding FR-type domain (UniProt residues 70-173) and
+      an NAD_binding_1 domain, is predicted to bind FAD, and belongs to the flavoprotein
+      pyridine nucleotide cytochrome reductase family, so an NAD(P)H-dependent flavin
+      oxidoreductase activity is well supported at the fold level. What is missing is any
+      direct enzymatic measurement identifying the acceptor.
+    gap_kind:
+    - BIOLOGY
+    dark_aspect: MF_DARK
+    status: OPEN
+    significance: &gt;-
+      Without the acceptor, AIM33 cannot be placed in a specific redox pathway; the current
+      GO:0004128 (cytochrome-b5 reductase) annotations are propagations from paralogs with
+      different acceptors and may misassign the pathway.
+    resolution: &gt;-
+      Purify recombinant AIM33 (or the soluble reductase domain) and assay NAD(P)H-dependent
+      reduction of candidate acceptors (cytochrome b5, coenzyme Q6, ferricyanide,
+      cytochrome c, methemoglobin); determine donor specificity (NADH vs NADPH) and confirm
+      FAD content.
+  - gap_statement: &gt;-
+      The subcellular membrane in which AIM33 acts is unresolved: it is annotated to the
+      plasma membrane (IBA) yet its loss-of-function phenotype implicates mitochondria.
+    boundary: &gt;-
+      AIM33 is firmly an integral membrane protein with multiple predicted transmembrane
+      helices and is included in an experimentally-constrained membrane-proteome topology map
+      (PMID:16847258). The paralog PGA3 is plasma-membrane-associated and the relative MCR1 is
+      at the mitochondrial outer membrane.
+    gap_kind:
+    - BIOLOGY
+    - CURATION
+    dark_aspect: CC_DARK
+    status: OPEN
+    significance: &gt;-
+      The membrane of action determines which redox process AIM33 participates in and reconciles
+      (or refutes) the propagated plasma-membrane annotation against the mitochondrial phenotype.
+    resolution: &gt;-
+      Determine endogenous localization by fluorescence microscopy of a functional tagged AIM33
+      and by subcellular/submitochondrial fractionation; if mitochondrial, define the
+      submitochondrial membrane and topology.
+  - gap_statement: &gt;-
+      The molecular mechanism by which AIM33 loss alters mitochondrial genome maintenance is
+      unknown, and even the direction of the petite-frequency change is reported inconsistently
+      across curated sources.
+    boundary: &gt;-
+      Deletion of AIM33 produces a mitochondrial-transmission phenotype (the basis of its AIM
+      designation) and impairs growth on non-fermentable carbon sources; UniProt curates the
+      effect as an increase in mitochondrial genome loss whereas SGD describes a reduced
+      frequency.
+    gap_kind:
+    - BIOLOGY
+    dark_aspect: BP_DARK
+    status: OPEN
+    significance: &gt;-
+      Resolving whether AIM33 promotes or antagonizes petite formation, and by what mechanism
+      (e.g. maintaining a redox environment or membrane potential required for mtDNA retention),
+      would convert a screen-level phenotype into an assignable biological process.
+    resolution: &gt;-
+      Re-measure petite frequency of a clean aim33-delta strain with wild-type controls; test
+      mtDNA copy number/integrity, membrane potential, and respiratory-complex assembly; look
+      for genetic interactions with mitochondrial genome-maintenance genes.
+    provenance:
+    - reference_id: PMID:19300474
+      supporting_text: &gt;-
+        Using computational predictions combined with traditional quantitative experiments,
+        we have identified 100 proteins whose deficiency alters mitochondrial biogenesis and
+        inheritance in Saccharomyces cerevisiae.
+suggested_questions:
+- question: &gt;-
+    What is the physiological electron acceptor of AIM33 (cytochrome b5, coenzyme Q6, a
+    cytochrome P450, or another partner), and is NADH or NADPH the electron donor?
+- question: &gt;-
+    In which membrane does AIM33 reside endogenously — mitochondrial, ER, or plasma membrane —
+    and does its polytopic topology differ from the mostly tail-anchored/soluble family members?
+- question: &gt;-
+    Does AIM33 promote or antagonize petite formation, and does it act on mitochondrial genome
+    maintenance directly (e.g. via redox homeostasis or membrane potential) or indirectly?
+suggested_experiments:
+- hypothesis: &gt;-
+    AIM33 is an NAD(P)H-dependent flavin oxidoreductase whose physiological acceptor is one of
+    cytochrome b5, coenzyme Q6, or a P450.
+  description: &gt;-
+    Express and purify recombinant AIM33 (full-length in detergent/nanodiscs and the isolated
+    soluble reductase domain), confirm bound FAD spectroscopically, and measure steady-state
+    NADH- and NADPH-dependent reduction of candidate acceptors (cytochrome b5, coenzyme Q6/CoQ
+    analogs, ferricyanide, cytochrome c, methemoglobin).
+  experiment_type: enzyme kinetics / spectroscopy
+- hypothesis: &gt;-
+    AIM33 localizes to a mitochondrial membrane consistent with its mitochondrial-genome
+    maintenance phenotype rather than to the plasma membrane.
+  description: &gt;-
+    Determine endogenous localization of a functional C-terminally tagged AIM33 by live-cell
+    fluorescence colocalization with mitochondrial, ER, and plasma-membrane markers, and by
+    subcellular and submitochondrial fractionation; verify functionality of the tagged allele
+    by complementation of the petite phenotype.
+  experiment_type: localization / cell biology
+- hypothesis: &gt;-
+    Loss of AIM33 alters mitochondrial genome stability through a defined mechanism.
+  description: &gt;-
+    In a clean aim33-delta strain, quantify petite frequency against isogenic wild type,
+    measure mtDNA copy number and integrity, mitochondrial membrane potential, and
+    respiratory-complex assembly; perform targeted genetic-interaction tests with genes for
+    mtDNA maintenance and with the paralog PGA3 and relatives MCR1/CBR1.
+  experiment_type: yeast genetics / functional genomics
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/genes/yeast/ESL1/ESL1-ai-review.html
+++ b/genes/yeast/ESL1/ESL1-ai-review.html
@@ -1,0 +1,3359 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>ESL1 - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        .propagation-review {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f8fafc;
+            border-left: 3px solid #64748b;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .propagation-title {
+            font-weight: 600;
+            color: #334155;
+            margin-bottom: 0.25rem;
+        }
+
+        .propagation-row {
+            margin-top: 0.25rem;
+        }
+
+        .propagation-source {
+            margin-top: 0.5rem;
+            padding-top: 0.5rem;
+            border-top: 1px solid #e5e7eb;
+        }
+
+        .propagation-source-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #1d4ed8;
+        }
+
+        .propagation-comment {
+            color: #4b5563;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>ESL1</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/P40456" target="_blank" class="term-link">
+                        P40456
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Saccharomyces cerevisiae</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-complete">
+                    COMPLETE
+                </span>
+            </div>
+
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "ESL1";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="P40456" data-a="DESCRIPTION: ESL1 (YIL151C) is a 1118-residue budding-yeast pro..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>ESL1 (YIL151C) is a 1118-residue budding-yeast protein of the Est1/SMG (Est-one-homology) family, built from a central 14-3-3-like Est-one-homology (EOH) domain and a C-terminal PIN (PilT N-terminus) domain whose four acidic catalytic residues are conserved. It is the structural ortholog, together with its close paralog ESL2 (YKR096W, &gt;70% identical), of the metazoan telomerase/NMD proteins hEST1A/B (SMG5/6). Despite this ancestry, budding-yeast ESL1 does not function in nonsense-mediated mRNA decay or in telomere maintenance: esl1 mutants have normal telomere length, senescence, subtelomeric silencing and NMD-substrate levels. Instead, ESL1 acts redundantly with ESL2 in environment-sensing adaptive gene expression, contributing to the correct nutrient- and pH-responsive expression of hexose, carbohydrate and one-carbon (glycine-regulon) metabolic genes; loss of both proteins deregulates ~50 transcripts in the direction opposite to the appropriate metabolic response and confers synthetic sickness with components of the Rim101 pH-sensing pathway (Rim8, Dfg16) and with the TRAMP poly(A) polymerase Trf4. ESL1/ESL2 also contribute to mitochondrial-genome stability and modulate genotoxin sensitivity, in some cases dependent on the PIN catalytic residues. The direct molecular activity of ESL1 (whether it is a bona fide endoribonuclease in vivo, and its RNA/protein substrates and partners) remains undetermined.</p>
+    </div>
+
+
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000184" target="_blank" class="term-link">
+                                    GO:0000184
+                                </a>
+                            </span>
+                            <span class="term-label">nuclear-transcribed mRNA catabolic process, nonsense-mediated decay</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-remove">
+                            REMOVE
+                        </span>
+                        <span class="vote-buttons" data-g="P40456" data-a="GO:0000184" data-r="GO_REF:0000033" data-act="REMOVE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetic (IBA) propagation from the metazoan hEST1A/B (SMG5/6) clade. This function was directly tested in the yeast protein and found ABSENT: esl1, esl2 and esl1 esl2 mutants do not accumulate NMD substrates (nonsense ade2-1 or unspliced pre-CYH2), unlike the upf1 control.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Experimental data in the target species (S. cerevisiae) directly refute NMD involvement for Esl1, overriding the IBA inference from metazoan orthologs. This is not paralog confusion but a species-specific loss of the ancestral function.
+                        </div>
+
+
+
+                        <div class="propagation-review">
+                            <div class="propagation-title">Propagation Review</div>
+                            <div class="propagation-row">
+                                <strong>Root cause:</strong>
+                                <span class="badge">PROPAGATION BAD</span>
+                            </div>
+
+                            <div class="propagation-row">
+                                <strong>Failure modes:</strong>
+
+                                <span class="badge">FUNCTIONAL DIVERGENCE</span>
+
+                            </div>
+
+
+                            <div class="propagation-source">
+                                <strong>Sources checked:</strong>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">SGD:S000002614</span>
+
+                                    &middot; EBS1
+
+
+                                    <span class="badge">SUPPORTS SOURCE BUT NOT TARGET</span>
+
+
+                                    <div class="propagation-comment">EBS1 is the yeast SMG7 ortholog with NMD links; its presence in the IBA with/from set does not make ESL1 an NMD factor. Esl1 was experimentally tested and is NMD-negative.</div>
+
+                                </div>
+
+                            </div>
+
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/23893744" target="_blank" class="term-link">
+                                        PMID:23893744
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">based on these two independent assays, ESL1 and ESL2 do not seem to have NMD-related functions</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005697" target="_blank" class="term-link">
+                                    GO:0005697
+                                </a>
+                            </span>
+                            <span class="term-label">telomerase holoenzyme complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-remove">
+                            REMOVE
+                        </span>
+                        <span class="vote-buttons" data-g="P40456" data-a="GO:0005697" data-r="GO_REF:0000033" data-act="REMOVE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IBA propagation from the EST1/telomerase clade. Directly tested and refuted: esl1, esl2 and esl1 esl2 mutants have wild-type telomere length and normal senescence/ALT kinetics, so Esl1 is not part of a functional telomerase holoenzyme in yeast.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Species-specific experimental evidence refutes any telomerase/telomere-maintenance role for Esl1, overriding the phylogenetic inference.
+                        </div>
+
+
+
+                        <div class="propagation-review">
+                            <div class="propagation-title">Propagation Review</div>
+                            <div class="propagation-row">
+                                <strong>Root cause:</strong>
+                                <span class="badge">PROPAGATION BAD</span>
+                            </div>
+
+                            <div class="propagation-row">
+                                <strong>Failure modes:</strong>
+
+                                <span class="badge">FUNCTIONAL DIVERGENCE</span>
+
+                                <span class="badge">COMPARTMENT OR COMPLEX MISMATCH</span>
+
+                            </div>
+
+
+                            <div class="propagation-source">
+                                <strong>Sources checked:</strong>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">SGD:S000004223</span>
+
+                                    &middot; EST1
+
+
+                                    <span class="badge">SUPPORTS SOURCE BUT NOT TARGET</span>
+
+
+                                    <div class="propagation-comment">The ancestral EST1/telomerase function does not transfer to Esl1, which lacks any telomere-maintenance role in yeast.</div>
+
+                                </div>
+
+                            </div>
+
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/23893744" target="_blank" class="term-link">
+                                        PMID:23893744
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Esl1 and Esl2 are not required for telomerase-dependent or alternative telomere maintenance mechanisms</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042162" target="_blank" class="term-link">
+                                    GO:0042162
+                                </a>
+                            </span>
+                            <span class="term-label">telomeric repeat DNA binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-remove">
+                            REMOVE
+                        </span>
+                        <span class="vote-buttons" data-g="P40456" data-a="GO:0042162" data-r="GO_REF:0000033" data-act="REMOVE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IBA molecular-function propagation from the EST1/telomerase clade. No telomere-related activity is detectable for Esl1 in yeast (normal telomere length/structure, no TERRA change), and no telomeric-DNA-binding activity has been demonstrated.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The parent biological role (telomere maintenance) is experimentally excluded for Esl1, and there is no independent evidence that Esl1 binds telomeric DNA; the IBA is an over-propagation.
+                        </div>
+
+
+
+                        <div class="propagation-review">
+                            <div class="propagation-title">Propagation Review</div>
+                            <div class="propagation-row">
+                                <strong>Root cause:</strong>
+                                <span class="badge">PROPAGATION BAD</span>
+                            </div>
+
+                            <div class="propagation-row">
+                                <strong>Failure modes:</strong>
+
+                                <span class="badge">FUNCTIONAL DIVERGENCE</span>
+
+                            </div>
+
+
+                            <div class="propagation-source">
+                                <strong>Sources checked:</strong>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">SGD:S000004223</span>
+
+                                    &middot; EST1
+
+
+                                    <span class="badge">SUPPORTS SOURCE BUT NOT TARGET</span>
+
+
+                                    <div class="propagation-comment">Telomeric-DNA-binding activity was not demonstrated for Esl1; the telomere role it is derived from is experimentally excluded.</div>
+
+                                </div>
+
+                            </div>
+
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/23893744" target="_blank" class="term-link">
+                                        PMID:23893744
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Esl1 and Esl2 are not required for telomerase-dependent or alternative telomere maintenance mechanisms</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0070034" target="_blank" class="term-link">
+                                    GO:0070034
+                                </a>
+                            </span>
+                            <span class="term-label">telomerase RNA binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-remove">
+                            REMOVE
+                        </span>
+                        <span class="vote-buttons" data-g="P40456" data-a="GO:0070034" data-r="GO_REF:0000033" data-act="REMOVE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IBA molecular-function propagation from the EST1/telomerase clade. Esl1 has no demonstrated telomerase-RNA-binding activity and no telomere-maintenance role in yeast.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Over-propagated from metazoan/EST1 orthologs; the associated telomere function is experimentally excluded for Esl1 and no telomerase-RNA-binding activity is shown.
+                        </div>
+
+
+
+                        <div class="propagation-review">
+                            <div class="propagation-title">Propagation Review</div>
+                            <div class="propagation-row">
+                                <strong>Root cause:</strong>
+                                <span class="badge">PROPAGATION BAD</span>
+                            </div>
+
+                            <div class="propagation-row">
+                                <strong>Failure modes:</strong>
+
+                                <span class="badge">FUNCTIONAL DIVERGENCE</span>
+
+                            </div>
+
+
+                            <div class="propagation-source">
+                                <strong>Sources checked:</strong>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">SGD:S000004223</span>
+
+                                    &middot; EST1
+
+
+                                    <span class="badge">SUPPORTS SOURCE BUT NOT TARGET</span>
+
+
+                                    <div class="propagation-comment">Telomerase-RNA-binding activity was not demonstrated for Esl1; the telomere role it is derived from is experimentally excluded.</div>
+
+                                </div>
+
+                            </div>
+
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/23893744" target="_blank" class="term-link">
+                                        PMID:23893744
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Esl1 and Esl2 are not required for telomerase-dependent or alternative telomere maintenance mechanisms</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003674" target="_blank" class="term-link">
+                                    GO:0003674
+                                </a>
+                            </span>
+                            <span class="term-label">molecular_function</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ND</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000015
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P40456" data-a="GO:0003674" data-r="GO_REF:0000015" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Root-level placeholder (ND) recording that no molecular function was curated by SGD. The direct molecular activity of Esl1 is indeed genuinely undetermined (see knowledge_gaps): the PIN catalytic residues are conserved but no in vivo/in vitro endoribonuclease activity has been demonstrated, and the characterized gene-expression phenotype is largely nuclease-independent.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> ND placeholder that correctly reflects a real MF-dark gap; retain until a specific molecular activity is established.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005575" target="_blank" class="term-link">
+                                    GO:0005575
+                                </a>
+                            </span>
+                            <span class="term-label">cellular_component</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ND</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000015
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P40456" data-a="GO:0005575" data-r="GO_REF:0000015" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Root-level placeholder (ND). The subcellular localization of the Esl1 protein has not been experimentally reported.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> ND placeholder reflecting an uncurated (CC-dark) localization; retain pending experimental localization.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008150" target="_blank" class="term-link">
+                                    GO:0008150
+                                </a>
+                            </span>
+                            <span class="term-label">biological_process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ND</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000015
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-modify">
+                            MODIFY
+                        </span>
+                        <span class="vote-buttons" data-g="P40456" data-a="GO:0008150" data-r="GO_REF:0000015" data-act="MODIFY">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Root-level placeholder (ND) predating the Lai et al. 2013 characterization. A specific biological process (environment-sensing adaptive gene expression) is now supported and is captured in core_functions.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The ND placeholder is now superseded by experimental evidence for a role in adaptive gene expression; propose replacing the root with the specific process.
+                        </div>
+
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031669" target="_blank" class="term-link">
+                                    cellular response to nutrient levels
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/23893744" target="_blank" class="term-link">
+                                        PMID:23893744
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Esl1 and Esl2 contribute to the regulation of adaptive gene expression responses of environmental sensing pathways</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0010468" target="_blank" class="term-link">
+                                    GO:0010468
+                                </a>
+                            </span>
+                            <span class="term-label">regulation of gene expression</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/23893744" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:23893744
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Yeast hEST1A/B (SMG5/6)-like proteins contribute to environm...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-new">
+                            NEW
+                        </span>
+                        <span class="vote-buttons" data-g="P40456" data-a="GO:0010468" data-r="PMID:23893744" data-act="NEW">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Proposed new annotation. esl1 esl2 mutants deregulate ~50 transcripts, so Esl1 (with Esl2) is involved in regulation of gene expression during environmental adaptation. Added to align core_functions with existing_annotations.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Core-function process term supported by the mutant transcriptome phenotype but not previously present in existing_annotations.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/23893744" target="_blank" class="term-link">
+                                        PMID:23893744
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">absence of Esl1 and Esl2 led to more than two-fold deregulation of ∼50 transcripts, most of which were expressed inversely to the appropriate metabolic response to environmental nutrient supply</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031669" target="_blank" class="term-link">
+                                    GO:0031669
+                                </a>
+                            </span>
+                            <span class="term-label">cellular response to nutrient levels</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/23893744" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:23893744
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Yeast hEST1A/B (SMG5/6)-like proteins contribute to environm...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-new">
+                            NEW
+                        </span>
+                        <span class="vote-buttons" data-g="P40456" data-a="GO:0031669" data-r="PMID:23893744" data-act="NEW">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Proposed new annotation. esl1 esl2 mutants fail to express hexose and one-carbon metabolism genes appropriately for the nutrient environment, indicating a role in the cellular response to nutrient levels. Added to align core_functions with existing_annotations.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Core-function process term supported by the nutrient-adaptive gene-expression phenotype but not previously present in existing_annotations.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/23893744" target="_blank" class="term-link">
+                                        PMID:23893744
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">esl1Δ esl2Δ double mutants may have a defect in adapting the expression of hexose and one-carbon metabolism genes to environmentally appropriate requirements</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>Redundantly with its paralog Esl2, Esl1 contributes to environment-sensing adaptive gene expression, so that hexose/carbohydrate and one-carbon (glycine-regulon) metabolic genes are expressed appropriately for the prevailing nutrient (and pH) environment. Loss of both proteins deregulates ~50 transcripts in the direction opposite to the correct metabolic response and causes synthetic sickness with the Rim101 pH-sensing components Rim8 and Dfg16. The direct molecular activity underlying this role is not established (see knowledge_gaps); most of the transcriptome phenotype is nuclease-independent.</h3>
+                <span class="vote-buttons" data-g="P40456" data-a="FUNCTION: Redundantly with its paralog Esl2, Esl1 contribute..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0010468" target="_blank" class="term-link">
+                                regulation of gene expression
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031669" target="_blank" class="term-link">
+                                cellular response to nutrient levels
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/23893744" target="_blank" class="term-link">
+                                PMID:23893744
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">Esl1 and Esl2 contribute to the regulation of adaptive gene expression responses of environmental sensing pathways</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/23893744" target="_blank" class="term-link">
+                                PMID:23893744
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">esl1Δ esl2Δ double mutants may have a defect in adapting the expression of hexose and one-carbon metabolism genes to environmentally appropriate requirements</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000015.md" target="_blank" class="term-link">
+                            GO_REF:0000015
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Use of the ND evidence code for Gene Ontology (GO) terms</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
+                            GO_REF:0000033
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Annotation inferences using phylogenetic trees</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/23893744" target="_blank" class="term-link">
+                            PMID:23893744
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Yeast hEST1A/B (SMG5/6)-like proteins contribute to environment-sensing adaptive gene expression responses.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Esl1 (Yil151c) and its paralog Esl2 (Ykr096w) are structural orthologs of metazoan hEST1A/B (SMG5/6), sharing a 14-3-3-like Est-one-homology domain and a C-terminal PIN endonuclease domain with the four conserved catalytic acidic residues.</div>
+
+                        <div class="finding-text">"this similarity encompassed the region corresponding to the 14-3-3–like Est-one-homology domain (45–51% similarity; Figure 1, A and B) and the C-terminal PIN endonuclease domain (49–53% similarity; Figure 1, A and C) with complete conservation of four critical D/E residues required for nuclease activity of the PIN-domain proteins"</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Unlike their metazoan orthologs, Esl1 and Esl2 are not involved in NMD or telomere maintenance pathways.</div>
+
+                        <div class="finding-text">"unlike their metazoan orthologs, Esl1 and Esl2 were not involved in nonsense-mediated mRNA decay or telomere maintenance pathways"</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Loss of Esl1 and Esl2 deregulates ~50 transcripts, most expressed inversely to the appropriate metabolic response to environmental nutrient supply.</div>
+
+                        <div class="finding-text">"absence of Esl1 and Esl2 led to more than two-fold deregulation of ∼50 transcripts, most of which were expressed inversely to the appropriate metabolic response to environmental nutrient supply"</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <div class="finding-statement">esl1 esl2 double mutants are synthetic sick with rim8 and dfg16, components of the Rim101 pH-response environmental-sensing pathway.</div>
+
+                        <div class="finding-text">"esl1Δ esl2Δ double mutants were synthetic sick with null mutations for Rim8 and Dfg16, which form the environmental-sensing complex of the Rim101 pH response gene expression pathway"</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/14562106" target="_blank" class="term-link">
+                            PMID:14562106
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Global analysis of protein expression in yeast.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Esl1 protein is expressed at a low level (~504 molecules/cell) in log-phase SD medium.</div>
+
+                        <div class="finding-text">"Present with 504 molecules/cell in log phase SD medium."</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/18407956" target="_blank" class="term-link">
+                            PMID:18407956
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">A multidimensional chromatography technology for in-depth phosphoproteome analysis.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Esl1 is phosphorylated at Ser-170 and Ser-190 (large-scale phosphoproteomics).</div>
+
+                        <div class="finding-text">"PHOSPHORYLATION [LARGE SCALE ANALYSIS] AT SER-170 AND SER-190"</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Questions for Experts</h2>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Is Esl1 a catalytically active endoribonuclease in vivo, and if so, what RNAs does it cleave during nutrient/pH adaptation?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P40456" data-a="Q: Is Esl1 a catalytically active endoribonuclease in..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Does the 14-3-3-like Est-one-homology domain of Esl1 mediate a regulatory protein-protein interaction analogous to the SMG5/6–UPF1 interaction in metazoa?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P40456" data-a="Q: Does the 14-3-3-like Est-one-homology domain of Es..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> What is the subcellular localization of Esl1, and does it change with nutrient or pH conditions?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P40456" data-a="Q: What is the subcellular localization of Esl1, and ..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Experiments</h2>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Perform RIP-seq/CLIP-seq on tagged Esl1 under high- and low-glucose and alkaline conditions, and compare mRNA half-lives in wild-type, esl1 esl2, and nuclease-dead alleles.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: Esl1 regulates a specific set of nutrient/pH-responsive mRNAs via its PIN domain.</em></p>
+
+
+                </div>
+                <span class="vote-buttons" data-g="P40456" data-a="EXPERIMENT: Perform RIP-seq/CLIP-seq on tagged Esl1 under high..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Epistasis and interaction analysis of Esl1 with Rim101-pathway components (Rim8, Dfg16, Rim13, Rim20) under alkaline and low-glucose stress, with transcriptome readout.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: Esl1 acts in a pathway parallel to Rim101 in environmental adaptation.</em></p>
+
+
+                </div>
+                <span class="vote-buttons" data-g="P40456" data-a="EXPERIMENT: Epistasis and interaction analysis of Esl1 with Ri..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Knowledge Gaps</h2>
+        <p style="color: #555; font-size: 0.92rem; margin-top: -0.3rem;">
+            What is <em>not</em> known — curated, literature-grounded statements of the open
+            unknowns (the inverse of core functions).
+        </p>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The direct molecular activity of Esl1 is undetermined. It is unknown whether Esl1 is a catalytically active endoribonuclease in vivo, and if so what its RNA substrates are; the conserved PIN catalytic residues are intact but no biochemical nuclease assay of Esl1 has been reported, and the characterized adaptive gene-expression phenotype is largely independent of PIN catalytic integrity.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">MF_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> Esl1 has a central 14-3-3-like Est-one-homology (EOH) domain and a C-terminal PIN domain with four conserved acidic catalytic residues (nuclease-dead esl1 allele = D952N + E982Q), and is a structural ortholog of metazoan hEST1A/B (SMG5/6), which are PIN-domain endoribonucleases. Esl1/Esl2 do NOT act in NMD or telomere maintenance in yeast. A genome-stability phenotype (bleomycin resistance) IS phenocopied by nuclease-dead alleles, implicating the PIN residues in that specific phenotype.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Esl1 is one of only seven S. cerevisiae PIN-domain proteins; establishing whether it is a functional endoribonuclease and identifying its substrate would resolve how the Est1/SMG fold was repurposed for nutrient-adaptive gene regulation after loss of the ancestral NMD/telomere functions.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> In vitro endoribonuclease assays with purified Esl1 and its PIN domain; CLIP/RIP-style identification of bound RNAs; comparison of wild-type vs nuclease-dead alleles for each phenotype.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"Esl1 and Esl2 may regulate the expression of the altered transcripts in a largely nuclease-independent manner"</em> — PMID:23893744</li>
+
+                <li><em>"all other PIN domain-containing proteins characterized to date exert ribonuclease activity in vitro and/or in vivo"</em> — PMID:23893744</li>
+
+            </ul>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Proposed term (ontology gap):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><strong>PIN-domain-dependent adaptive mRNA regulatory activity</strong> — Esl1/Esl2 have a defined biological role (environment-sensing adaptive gene expression) but no GO molecular-function term captures their activity; they are currently annotatable only at the process level, leaving the gene MF-dark.</li>
+
+            </ul>
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The molecular partners and substrates of Esl1 are unknown, including any protein-protein interaction mediated by its 14-3-3-like EOH domain (the domain that in metazoan SMG5/6 engages the NMD factor UPF1) and any direct link to the Rim101 pH-sensing machinery.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">MF_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> Esl1 was found in a two-hybrid screen with Mdt1/Pin4, and esl1 esl2 mutants are synthetic sick with rim8, dfg16 and trf4, but no direct physical target of either the EOH or PIN domain of Esl1 has been demonstrated.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Identifying an Esl1 interaction partner would reveal the mechanism connecting the Est1/SMG fold to nutrient/pH-adaptive gene expression and clarify whether the EOH domain retains a regulatory protein-interaction function analogous to its metazoan counterparts.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Affinity-purification/mass-spectrometry and proximity-labeling of tagged Esl1; targeted tests of physical interaction with Rim101-pathway and TRAMP components.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"provide a basis for future investigations into the detailed mechanisms by which they exert this function"</em> — PMID:23893744</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The ESL1-specific (non-redundant) contribution and in vivo biological role are not resolved, because almost all phenotypes are stronger in esl1 esl2 double mutants and the transcriptome signature was measured only in the double mutant.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">BP_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> esl1 single mutants show telomere/NMD-negative results and specific synthetic-sick interactions (with FUS3, DAL81, SNX4, and synthetic-lethal with TRF4), and the pair is redundant for the adaptive gene-expression, mitochondrial-stability and genotoxin phenotypes; but no ESL1-only phenotype defines its unique function.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Distinguishing the individual roles of ESL1 and ESL2 is needed to know whether ESL1 has a dedicated regulon or is fully redundant with its paralog.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Condition- and stress-resolved transcriptomics and phenotyping of esl1 single mutants (including nuclease-dead), with direct comparison to esl2 and the double mutant.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"the effect was more pronounced when ESL1 and ESL2 were simultaneously deleted, suggesting functional redundancy between the two proteins"</em> — PMID:23893744</li>
+
+            </ul>
+
+
+        </div>
+
+    </div>
+
+
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Deep Research Sections -->
+
+    <div class="section">
+        <h2 class="section-title">Deep Research</h2>
+
+        <details class="deep-research-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; gap: 1rem;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Falcon</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(ESL1-deep-research-falcon.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="P40456" data-a="DEEP_RESEARCH: Falcon" data-r="" data-act="DEEP_RESEARCH" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This deep research is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This deep research needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+
+                <div class="report-meta">
+
+                    <span class="report-meta-text">Comprehensive Research Report: ESL1 (YIL151C) in *Saccharomyces cerevisiae*</span>
+
+
+                    <span class="report-badge">Falcon</span>
+
+
+                    <span class="report-badge">Edison Scientific Literature</span>
+
+
+                    <span class="report-badge">21 citations</span>
+
+
+                    <span class="report-badge">1 artifacts</span>
+
+
+                    <span class="report-meta-text">2026-07-05T02:29:17.665266</span>
+
+
+
+                </div>
+
+
+                <div class="artifact-list">
+
+
+
+                    <div class="artifact-link">
+                        <a href="ESL1-deep-research-falcon_artifacts/artifact-00.md" class="term-link">Edison artifact artifact-00</a>
+                        <span>(text/markdown)</span>
+                    </div>
+
+
+                </div>
+
+                <p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h1 id="comprehensive-research-report-esl1-yil151c-in-saccharomyces-cerevisiae">Comprehensive Research Report: ESL1 (YIL151C) in <em>Saccharomyces cerevisiae</em></h1>
+<h2 id="important-prefatory-note-on-gene-characterization">Important Prefatory Note on Gene Characterization</h2>
+<p>ESL1 (YIL151C) is a <strong>poorly characterized</strong> gene in <em>Saccharomyces cerevisiae</em>. The gene symbol "ESL1" stands for "EST/SMG-like protein 1" (UniProt P40456), and its formal naming appears to derive primarily from a single publication (Lai et al., 2013; PMID:23893744), which could not be fully accessed during this literature search. Major reviews of the nonsense-mediated mRNA decay (NMD) pathway and the EST/SMG protein family in yeast do not discuss ESL1 by name, instead focusing on the better-characterized family members Est1 and Ebs1 (lloyd2018theevolutionand pages 4-6). Therefore, much of this report describes ESL1's function through inference from its domain architecture, its family relationships, and the well-characterized biology of its paralogs.</p>
+<p><strong>Note on gene symbol ambiguity:</strong> In mammalian systems, "ESL1" typically refers to E-selectin ligand 1 (GLG1/golgi glycoprotein 1), a completely different protein. This report concerns exclusively the yeast protein encoded by YIL151C in <em>Saccharomyces cerevisiae</em> strain S288c.</p>
+<hr />
+<h2 id="1-gene-and-protein-identity">1. Gene and Protein Identity</h2>
+<ul>
+<li><strong>Gene Name:</strong> ESL1 (EST/SMG-like protein 1)</li>
+<li><strong>Systematic Name:</strong> YIL151C</li>
+<li><strong>UniProt Accession:</strong> P40456</li>
+<li><strong>Organism:</strong> <em>Saccharomyces cerevisiae</em> (strain ATCC 204508 / S288c)</li>
+<li><strong>Key Domains:</strong></li>
+<li><strong>Est1/Ebs1-like domain</strong> (IPR045153)</li>
+<li><strong>PIN domain</strong> (IPR002716; PF13638/PIN_4)</li>
+<li><strong>TPR-like helical domain superfamily</strong> (IPR011990)</li>
+</ul>
+<hr />
+<h2 id="2-protein-family-context-the-estsmg-protein-family-in-yeast">2. Protein Family Context: The EST/SMG Protein Family in Yeast</h2>
+<h3 id="21-family-members">2.1 Family Members</h3>
+<p>ESL1 belongs to the EST/SMG protein family, which in <em>S. cerevisiae</em> includes at least three members: <strong>Est1</strong>, <strong>Ebs1</strong>, and <strong>Esl1</strong>. This family is related to the metazoan SMG5/SMG6/SMG7 proteins, which function at the intersection of nonsense-mediated mRNA decay and telomere biology (sealey2011thetprcontainingdomain pages 1-2, lloyd2018theevolutionand pages 4-6).</p>
+<p>The following table summarizes the three family members:</p>
+<table>
+<thead>
+<tr>
+<th>Gene name</th>
+<th>Systematic name</th>
+<th>Key domains</th>
+<th>Primary function</th>
+<th>Role in telomere maintenance</th>
+<th>Role in NMD</th>
+<th>Human homolog</th>
+<th>Level of characterization</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><strong>EST1</strong></td>
+<td><strong>EST1</strong></td>
+<td>N-terminal TPR-like domain; lacks PIN domain in budding yeast EST/SMG-family context (lloyd2018theevolutionand pages 4-6, sealey2011thetprcontainingdomain pages 1-2)</td>
+<td>Telomerase-associated regulatory subunit required for telomerase recruitment and telomere length homeostasis; binds TLC1 and helps recruit Est2/telomerase via Cdc13 during S phase (sealey2011thetprcontainingdomain pages 1-2, hug2006telomerelengthhomeostasis pages 6-7)</td>
+<td><strong>Essential positive regulator</strong>; loss causes progressive telomere shortening and senescence; associates with telomeres preferentially in S phase (sealey2011thetprcontainingdomain pages 1-2, hug2006telomerelengthhomeostasis pages 6-7)</td>
+<td>No established direct NMD role in budding yeast; review states EST1 is implicated in telomere regulation rather than NMD (lloyd2018theevolutionand pages 4-6)</td>
+<td>Homologous to human EST1 proteins/SMG-family branch, especially hEST1A/B/C at the family level; human homologs have telomere and/or NMD roles (sealey2011thetprcontainingdomain pages 1-2)</td>
+<td><strong>Well characterized</strong> in yeast telomere biology (sealey2011thetprcontainingdomain pages 1-2)</td>
+</tr>
+<tr>
+<td><strong>EBS1</strong></td>
+<td><strong>EBS1</strong></td>
+<td>SMG7-like architecture; lacks PIN domain in baker’s yeast (lloyd2018theevolutionand pages 4-6)</td>
+<td>Auxiliary factor linked to nonsense-mediated mRNA decay; structurally similar to SMG7 (staszewski2023upf1—frommrnadegradation pages 5-6, sealey2011thetprcontainingdomain pages 13-14)</td>
+<td>No strong primary telomere role established in the retrieved evidence; telomere connection, if any, is indirect via broader EST/SMG family relationships (sealey2011thetprcontainingdomain pages 13-14)</td>
+<td><strong>Mild NMD role</strong>; knockout gives a mild NMD phenotype in baker’s yeast (lloyd2018theevolutionand pages 4-6, staszewski2023upf1—frommrnadegradation pages 5-6)</td>
+<td>Putative ortholog/functionally closest yeast counterpart of <strong>SMG7 / hEST1C</strong> (sealey2011thetprcontainingdomain pages 4-6, sealey2011thetprcontainingdomain pages 13-14)</td>
+<td><strong>Moderately characterized</strong>; recognized in NMD reviews, but mechanistic role remains less clear than core UPF factors (lloyd2018theevolutionand pages 6-7, lloyd2018theevolutionand pages 4-6, staszewski2023upf1—frommrnadegradation pages 5-6)</td>
+</tr>
+<tr>
+<td><strong>ESL1</strong></td>
+<td><strong>YIL151C / ESL1</strong></td>
+<td>Est1/Ebs1-like family assignment; predicted/annotated PIN domain plus TPR-like helical domain from UniProt context; direct primary-literature confirmation was limited in retrieved sources</td>
+<td>Specific function remains uncertain from accessible literature; likely an EST/SMG-family protein inferred from sequence/domain architecture and naming, but direct experimental definition was not recoverable here</td>
+<td>No direct telomere-maintenance role established in accessible evidence; any telomere connection is currently inferential through family relationship to EST1/SMG proteins</td>
+<td>No direct NMD role established in accessible evidence; possible relationship is inferential through EST/SMG-family membership and presence of a PIN domain associated with RNA cleavage in other systems (matelska2017comprehensiveclassificationof pages 1-2, glavan2006structuresofthe pages 1-2, gontijo2009mutationsingenes pages 12-13)</td>
+<td>Likely related at the family level to <strong>SMG5/SMG6-like</strong> proteins rather than canonical yeast EST1/EBS1, but this remains tentative from available evidence</td>
+<td><strong>Poorly characterized / literature-limited</strong>; key naming/assignment paper was not accessible in the retrieved corpus, and major reviews retrieved did not discuss ESL1 directly (lloyd2018theevolutionand pages 4-6)</td>
+</tr>
+</tbody>
+</table>
+<p><em>Table: This table compares the three proposed Saccharomyces cerevisiae EST/SMG family members—Est1, Ebs1, and Esl1/YIL151C—across domains, functions, telomere and NMD roles, homologs, and evidence depth. It is useful for distinguishing the well-established functions of Est1 and Ebs1 from the currently limited direct evidence for Esl1.</em></p>
+<h3 id="22-relationship-to-human-smg-proteins">2.2 Relationship to Human SMG Proteins</h3>
+<p>In humans, the Est1 protein family comprises three members: hEST1A/SMG6, hEST1B/SMG5, and hEST1C/SMG7, which function in both NMD and telomere maintenance (sealey2011thetprcontainingdomain pages 1-2). Human EST1A and EST1B contain C-terminal PIN domains, with SMG6 (hEST1A) possessing active endonuclease activity and SMG5 (hEST1B) having an impaired catalytic site (glavan2006structuresofthe pages 2-4, glavan2006structuresofthe pages 1-2). All three human proteins form complexes with SMG1, UPF1, PP2A, and other NMD components (sealey2011thetprcontainingdomain pages 1-2). In yeast, the two previously well-characterized family members—Est1 (primarily telomere maintenance) and Ebs1 (mild NMD function)—both lack PIN domains (lloyd2018theevolutionand pages 4-6). ESL1 is notable as the only yeast family member annotated as possessing a PIN domain, making it structurally distinct from its yeast paralogs.</p>
+<hr />
+<h2 id="3-domain-architecture-and-inferred-function">3. Domain Architecture and Inferred Function</h2>
+<h3 id="31-pin-domain">3.1 PIN Domain</h3>
+<p>The PIN (PilT N-terminus) domain is a widespread nuclease domain found across all domains of life. PIN domains feature a Rossmanoid fold with a central five-stranded parallel β-sheet flanked by α-helices, and their active sites contain well-conserved acidic amino acid residues (Asp/Glu) that coordinate divalent metal ions (typically Mg²⁺ or Mn²⁺) for catalysis (matelska2017comprehensiveclassificationof pages 1-2, glavan2006structuresofthe pages 1-2, matelska2017comprehensiveclassificationof pages 18-19). In the context of NMD, the PIN domain of SMG6 functions as an endonuclease that cleaves mRNAs containing premature termination codons (PTCs) near the stop codon (glavan2006structuresofthe pages 5-6, glavan2006structuresofthe pages 1-2, glavan2006structuresofthe pages 2-4). The catalytic residues of the human SMG6 PIN domain have been identified as D1251, E1282, D1353, and D1392 (kurscheidt2026compositesmg5smg6pin pages 7-9, kurscheidt2026compositesmg5smg6pin pages 5-7, glavan2006structuresofthe pages 2-4).</p>
+<p>Critically, recent work has shown that the SMG5 PIN domain—though catalytically inactive on its own—forms a composite heterodimeric interface (cPIN) with the SMG6 PIN domain, completing the SMG6 active site and substrate binding site to achieve full endonuclease activity (kurscheidt2026compositesmg5smg6pin pages 2-4, kurscheidt2026compositesmg5smg6pin pages 1-2, kurscheidt2026compositesmg5smg6pin pages 7-9). This demonstrates that catalytically "dead" PIN domains can still play essential roles through protein-protein interaction.</p>
+<p>The presence of a PIN domain in ESL1 (annotated as PIN_4, PF13638) distinguishes it from its yeast paralogs Est1 and Ebs1, which lack PIN domains (lloyd2018theevolutionand pages 4-6). Whether the ESL1 PIN domain retains catalytic activity or functions as an inactive scaffold (analogous to SMG5) remains to be experimentally determined. If catalytically active, ESL1 could potentially function as an RNA endonuclease involved in mRNA quality control or decay processes.</p>
+<h3 id="32-tpr-like-helical-domain">3.2 TPR-like Helical Domain</h3>
+<p>The TPR (tetratricopeptide repeat)-like helical domain superfamily is associated with protein-protein interactions (sealey2011thetprcontainingdomain pages 1-2). In the Est1 family, the TPR domain is the most conserved region and mediates critical interactions: in <em>S. cerevisiae</em> Est1, the TPR domain is essential for telomerase-mediated telomere length maintenance and appears to regulate telomere length homeostasis in a manner separable from telomere recruitment (sealey2011thetprcontainingdomain pages 1-2, sealey2011thetprcontainingdomain pages 2-4, sealey2011thetprcontainingdomain pages 4-6). In human EST1A (SMG6), a domain encompassing the TPR is sufficient for interaction with the telomerase catalytic subunit hTERT (sealey2011thetprcontainingdomain pages 2-4). The presence of a TPR-like domain in ESL1 suggests it may similarly mediate protein-protein interactions, potentially with telomerase components, NMD factors, or other RNA-binding proteins.</p>
+<h3 id="33-est1ebs1-like-domain">3.3 Est1/Ebs1-like Domain</h3>
+<p>The Est1/Ebs1-like domain (IPR045153) classification confirms ESL1's membership in the broader EST/SMG protein family and suggests structural and possibly functional similarities to both Est1 and Ebs1.</p>
+<hr />
+<h2 id="4-biological-pathways-telomere-maintenance-and-nonsense-mediated-mrna-decay">4. Biological Pathways: Telomere Maintenance and Nonsense-Mediated mRNA Decay</h2>
+<h3 id="41-telomere-maintenance-in-yeast">4.1 Telomere Maintenance in Yeast</h3>
+<p>The EST genes (EST1, EST2/TERT, EST3, and TLC1) are essential for telomerase function in <em>S. cerevisiae</em>; loss of any one gene results in progressive telomere shortening and cellular senescence (sealey2011thetprcontainingdomain pages 1-2). Est1 plays a critical role as an intermediary between the telomeric DNA-binding protein Cdc13 and the telomerase RNA TLC1, recruiting the telomerase core complex (Est2-Tlc1) to telomeres during S phase (sealey2011thetprcontainingdomain pages 1-2). ChIP experiments demonstrate that Est1 preferentially associates with telomeres during S phase (hug2006telomerelengthhomeostasis pages 6-7, sealey2011thetprcontainingdomain pages 1-2).</p>
+<p>Whether ESL1 participates directly in telomere maintenance is unknown from the accessible literature. Its family membership and domain architecture suggest potential involvement in telomere-related processes, but no experimental evidence of telomere association or function has been reported for ESL1 in the sources reviewed.</p>
+<h3 id="42-nonsense-mediated-mrna-decay">4.2 Nonsense-Mediated mRNA Decay</h3>
+<p>NMD is an evolutionarily conserved mRNA quality control pathway that degrades transcripts containing premature termination codons (lloyd2018theevolutionand pages 6-7, lloyd2018theevolutionand pages 4-6). In <em>S. cerevisiae</em>, NMD relies on the core UPF factors (UPF1, UPF2, UPF3) (lloyd2018theevolutionand pages 6-7). Baker's yeast represents an "ancient SMG1-independent NMD pathway" (Type 3), having lost the SMG1 kinase that phosphorylates UPF1 in metazoan NMD pathways (lloyd2018theevolutionand pages 6-7, lloyd2018theevolutionand pages 4-6, staszewski2023upf1—frommrnadegradation pages 5-6). The yeast UPF1 is depleted of S/TQ dipeptides that normally serve as SMG1 phosphorylation sites (lloyd2018theevolutionand pages 4-6, staszewski2023upf1—frommrnadegradation pages 5-6).</p>
+<p>Ebs1, the yeast SMG7 homolog, shows a mild NMD phenotype when knocked out (lloyd2018theevolutionand pages 4-6), while Est1 has no known role in NMD (lloyd2018theevolutionand pages 4-6). The role of SMG5-7 family members in yeast NMD remains unclear given the absence of SMG1 and classical UPF1 phosphorylation (lloyd2018theevolutionand pages 4-6, staszewski2023upf1—frommrnadegradation pages 5-6). Only the Ebs1 protein, structurally similar to SMG7, has been reported to play a role in yeast NMD among the SMG5-7 family members (staszewski2023upf1—frommrnadegradation pages 5-6).</p>
+<p>Given that ESL1 possesses a PIN domain—the domain responsible for endonucleolytic cleavage in metazoan NMD (glavan2006structuresofthe pages 5-6, glavan2006structuresofthe pages 1-2)—it is reasonable to hypothesize that ESL1 may participate in RNA degradation processes in yeast, potentially in NMD or related mRNA quality control pathways. However, direct experimental evidence for such a role is not available from the literature accessed.</p>
+<hr />
+<h2 id="5-subcellular-localization">5. Subcellular Localization</h2>
+<p>No specific localization data for ESL1 was found in the literature reviewed. By analogy with its family members: Est1 localizes to telomeres during S phase via association with Cdc13 and TLC1 (hug2006telomerelengthhomeostasis pages 6-7, sealey2011thetprcontainingdomain pages 1-2), and NMD in yeast is a cytoplasmic, translation-dependent process. If ESL1 functions in NMD, it would be expected to localize to the cytoplasm; if it functions in telomere biology, nuclear/telomeric localization during S phase would be anticipated.</p>
+<hr />
+<h2 id="6-summary-and-conclusions">6. Summary and Conclusions</h2>
+<p>ESL1 (YIL151C) is a <strong>poorly characterized member of the EST/SMG protein family</strong> in <em>Saccharomyces cerevisiae</em>. Its designation as "EST/SMG-like protein 1" and its domain architecture—featuring a PIN domain (ribonuclease), a TPR-like helical domain (protein-protein interaction), and an Est1/Ebs1-like domain—place it within the same protein family as the well-characterized telomerase subunit Est1 and the NMD factor Ebs1. Notably, ESL1 is the only yeast member of this family annotated as containing a PIN domain, which in metazoan homologs (particularly SMG6) functions as an RNA endonuclease that cleaves NMD substrates near premature termination codons (glavan2006structuresofthe pages 5-6, glavan2006structuresofthe pages 1-2, glavan2006structuresofthe pages 2-4). Recent structural work has shown that even catalytically inactive PIN domains (as in SMG5) play essential roles by forming composite heterodimeric interfaces with active PIN domains (kurscheidt2026compositesmg5smg6pin pages 2-4, kurscheidt2026compositesmg5smg6pin pages 1-2, kurscheidt2026compositesmg5smg6pin pages 7-9).</p>
+<p>The precise biological function of ESL1 remains to be fully elucidated experimentally. Based on its domain architecture and family relationships, ESL1 may function in:<br />
+1. <strong>RNA endonuclease activity</strong> through its PIN domain, potentially in mRNA quality control or NMD-related pathways<br />
+2. <strong>Protein-protein interactions</strong> via its TPR-like domain, possibly with telomerase components or NMD factors<br />
+3. <strong>Environment-sensing or stress-responsive gene expression</strong>, as suggested by the title of the key naming publication (Lai et al., 2013)</p>
+<p>The limited characterization of ESL1 represents a gap in our understanding of the EST/SMG protein family in budding yeast and of the molecular mechanisms underlying NMD and telomere maintenance in this model organism. Further experimental studies—including knockout phenotyping, protein interaction mapping, localization studies, and biochemical characterization of its PIN domain—would be valuable for defining ESL1's precise biological role.</p>
+<p>References</p>
+<ol>
+<li>
+<p>(lloyd2018theevolutionand pages 4-6): James P. B. Lloyd. The evolution and diversity of the nonsense-mediated mrna decay pathway. F1000Research, 7:1299, Aug 2018. URL: https://doi.org/10.12688/f1000research.15872.2, doi:10.12688/f1000research.15872.2. This article has 59 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(sealey2011thetprcontainingdomain pages 1-2): David CF Sealey, Aleksandar D Kostic, Catherine LeBel, Fiona Pryde, and Lea Harrington. The tpr-containing domain within est1 homologs exhibits species-specific roles in telomerase interaction and telomere length homeostasis. BMC Molecular Biology, 12:45-45, Oct 2011. URL: https://doi.org/10.1186/1471-2199-12-45, doi:10.1186/1471-2199-12-45. This article has 23 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(hug2006telomerelengthhomeostasis pages 6-7): Nele Hug and Joachim Lingner. Telomere length homeostasis. Chromosoma, 115:413-425, Jun 2006. URL: https://doi.org/10.1007/s00412-006-0067-3, doi:10.1007/s00412-006-0067-3. This article has 399 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(staszewski2023upf1—frommrnadegradation pages 5-6): Jacek Staszewski, Natalia Lazarewicz, Julia Konczak, Iwona Migdal, and Ewa Maciaszczyk-Dziubinska. Upf1—from mrna degradation to human disorders. Cells, 12:419, Jan 2023. URL: https://doi.org/10.3390/cells12030419, doi:10.3390/cells12030419. This article has 28 citations.</p>
+</li>
+<li>
+<p>(sealey2011thetprcontainingdomain pages 13-14): David CF Sealey, Aleksandar D Kostic, Catherine LeBel, Fiona Pryde, and Lea Harrington. The tpr-containing domain within est1 homologs exhibits species-specific roles in telomerase interaction and telomere length homeostasis. BMC Molecular Biology, 12:45-45, Oct 2011. URL: https://doi.org/10.1186/1471-2199-12-45, doi:10.1186/1471-2199-12-45. This article has 23 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(sealey2011thetprcontainingdomain pages 4-6): David CF Sealey, Aleksandar D Kostic, Catherine LeBel, Fiona Pryde, and Lea Harrington. The tpr-containing domain within est1 homologs exhibits species-specific roles in telomerase interaction and telomere length homeostasis. BMC Molecular Biology, 12:45-45, Oct 2011. URL: https://doi.org/10.1186/1471-2199-12-45, doi:10.1186/1471-2199-12-45. This article has 23 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(lloyd2018theevolutionand pages 6-7): James P. B. Lloyd. The evolution and diversity of the nonsense-mediated mrna decay pathway. F1000Research, 7:1299, Aug 2018. URL: https://doi.org/10.12688/f1000research.15872.2, doi:10.12688/f1000research.15872.2. This article has 59 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(matelska2017comprehensiveclassificationof pages 1-2): Dorota Matelska, Kamil Steczkiewicz, and Krzysztof Ginalski. Comprehensive classification of the pin domain-like superfamily. Nucleic Acids Research, 45:6995-7020, May 2017. URL: https://doi.org/10.1093/nar/gkx494, doi:10.1093/nar/gkx494. This article has 122 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(glavan2006structuresofthe pages 1-2): Filip Glavan, Isabelle Behm-Ansmant, Elisa Izaurralde, and Elena Conti. Structures of the pin domains of smg6 and smg5 reveal a nuclease within the mrna surveillance complex. The EMBO Journal, 25:5117-5125, Nov 2006. URL: https://doi.org/10.1038/sj.emboj.7601377, doi:10.1038/sj.emboj.7601377. This article has 242 citations.</p>
+</li>
+<li>
+<p>(gontijo2009mutationsingenes pages 12-13): Alisson M Gontijo, Sylvie Aubert, Ingele Roelens, and Bernard Lakowski. Mutations in genes involved in nonsense mediated decay ameliorate the phenotype of sel-12 mutants with amber stop mutations in caenorhabditis elegans. BMC Genetics, 10:14-14, Mar 2009. URL: https://doi.org/10.1186/1471-2156-10-14, doi:10.1186/1471-2156-10-14. This article has 4 citations.</p>
+</li>
+<li>
+<p>(glavan2006structuresofthe pages 2-4): Filip Glavan, Isabelle Behm-Ansmant, Elisa Izaurralde, and Elena Conti. Structures of the pin domains of smg6 and smg5 reveal a nuclease within the mrna surveillance complex. The EMBO Journal, 25:5117-5125, Nov 2006. URL: https://doi.org/10.1038/sj.emboj.7601377, doi:10.1038/sj.emboj.7601377. This article has 242 citations.</p>
+</li>
+<li>
+<p>(matelska2017comprehensiveclassificationof pages 18-19): Dorota Matelska, Kamil Steczkiewicz, and Krzysztof Ginalski. Comprehensive classification of the pin domain-like superfamily. Nucleic Acids Research, 45:6995-7020, May 2017. URL: https://doi.org/10.1093/nar/gkx494, doi:10.1093/nar/gkx494. This article has 122 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(glavan2006structuresofthe pages 5-6): Filip Glavan, Isabelle Behm-Ansmant, Elisa Izaurralde, and Elena Conti. Structures of the pin domains of smg6 and smg5 reveal a nuclease within the mrna surveillance complex. The EMBO Journal, 25:5117-5125, Nov 2006. URL: https://doi.org/10.1038/sj.emboj.7601377, doi:10.1038/sj.emboj.7601377. This article has 242 citations.</p>
+</li>
+<li>
+<p>(kurscheidt2026compositesmg5smg6pin pages 7-9): Katharina Kurscheidt, Sophie Theunissen, Natalia Pasquali, Kerstin Becker, Volker Boehm, Elena Conti, and Niels H. Gehring. Composite smg5-smg6 pin domain formation is essential for nmd. Nature Communications, Feb 2026. URL: https://doi.org/10.1038/s41467-026-69819-w, doi:10.1038/s41467-026-69819-w. This article has 6 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(kurscheidt2026compositesmg5smg6pin pages 5-7): Katharina Kurscheidt, Sophie Theunissen, Natalia Pasquali, Kerstin Becker, Volker Boehm, Elena Conti, and Niels H. Gehring. Composite smg5-smg6 pin domain formation is essential for nmd. Nature Communications, Feb 2026. URL: https://doi.org/10.1038/s41467-026-69819-w, doi:10.1038/s41467-026-69819-w. This article has 6 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(kurscheidt2026compositesmg5smg6pin pages 2-4): Katharina Kurscheidt, Sophie Theunissen, Natalia Pasquali, Kerstin Becker, Volker Boehm, Elena Conti, and Niels H. Gehring. Composite smg5-smg6 pin domain formation is essential for nmd. Nature Communications, Feb 2026. URL: https://doi.org/10.1038/s41467-026-69819-w, doi:10.1038/s41467-026-69819-w. This article has 6 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(kurscheidt2026compositesmg5smg6pin pages 1-2): Katharina Kurscheidt, Sophie Theunissen, Natalia Pasquali, Kerstin Becker, Volker Boehm, Elena Conti, and Niels H. Gehring. Composite smg5-smg6 pin domain formation is essential for nmd. Nature Communications, Feb 2026. URL: https://doi.org/10.1038/s41467-026-69819-w, doi:10.1038/s41467-026-69819-w. This article has 6 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(sealey2011thetprcontainingdomain pages 2-4): David CF Sealey, Aleksandar D Kostic, Catherine LeBel, Fiona Pryde, and Lea Harrington. The tpr-containing domain within est1 homologs exhibits species-specific roles in telomerase interaction and telomere length homeostasis. BMC Molecular Biology, 12:45-45, Oct 2011. URL: https://doi.org/10.1186/1471-2199-12-45, doi:10.1186/1471-2199-12-45. This article has 23 citations and is from a peer-reviewed journal.</p>
+</li>
+</ol>
+<h2 id="artifacts">Artifacts</h2>
+<ul>
+<li><a href="ESL1-deep-research-falcon_artifacts/artifact-00.md">Edison artifact artifact-00</a></li>
+</ul>
+<h2 id="citations">Citations</h2>
+<ol>
+<li>lloyd2018theevolutionand pages 4-6</li>
+<li>sealey2011thetprcontainingdomain pages 1-2</li>
+<li>sealey2011thetprcontainingdomain pages 13-14</li>
+<li>sealey2011thetprcontainingdomain pages 2-4</li>
+<li>lloyd2018theevolutionand pages 6-7</li>
+<li>hug2006telomerelengthhomeostasis pages 6-7</li>
+<li>sealey2011thetprcontainingdomain pages 4-6</li>
+<li>matelska2017comprehensiveclassificationof pages 1-2</li>
+<li>glavan2006structuresofthe pages 1-2</li>
+<li>gontijo2009mutationsingenes pages 12-13</li>
+<li>glavan2006structuresofthe pages 2-4</li>
+<li>matelska2017comprehensiveclassificationof pages 18-19</li>
+<li>glavan2006structuresofthe pages 5-6</li>
+<li>https://doi.org/10.12688/f1000research.15872.2,</li>
+<li>https://doi.org/10.1186/1471-2199-12-45,</li>
+<li>https://doi.org/10.1007/s00412-006-0067-3,</li>
+<li>https://doi.org/10.3390/cells12030419,</li>
+<li>https://doi.org/10.1093/nar/gkx494,</li>
+<li>https://doi.org/10.1038/sj.emboj.7601377,</li>
+<li>https://doi.org/10.1186/1471-2156-10-14,</li>
+<li>https://doi.org/10.1038/s41467-026-69819-w,</li>
+</ol>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(ESL1-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="P40456" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="esl1-yil151c-p40456-curation-notes">ESL1 (YIL151C, P40456) — curation notes</h1>
+<p>Journal of research for the AI GO-annotation review of <em>Saccharomyces cerevisiae</em> ESL1.<br />
+All assertions carry inline provenance. Where a claim is about the paralog ESL2 or the<br />
+ESL1/ESL2 pair jointly, that is stated explicitly.</p>
+<h2 id="identity-and-domain-architecture-from-uniprot-p40456-primary-literature">Identity and domain architecture (from UniProt P40456 + primary literature)</h2>
+<ul>
+<li>Standard name <strong>ESL1</strong> = "EST/SMG-like protein 1"; systematic name <strong>YIL151C</strong>; SGD:S000001413.<br />
+  1118 aa, 128.7 kDa. UniProt evidence level 1 (protein level). [UniProt P40456]</li>
+<li>Named by Lai et al. 2013, which is the ONLY dedicated functional study of this gene.<br />
+  ESL = "EST/SMG-like". The paralog is <strong>ESL2 = YKR096W</strong> (&gt;70% similarity to ESL1 along<br />
+  the entire polypeptide). <a href="https://pubmed.ncbi.nlm.nih.gov/23893744" title="the previously uncharacterized yeast open   reading frames Yil151c and Ykr096w, share &gt;70% similarity with each other along their   entire polypeptide sequence">PMID:23893744</a></li>
+</ul>
+<h3 id="domains">Domains</h3>
+<ul>
+<li><strong>PIN (PilT N-terminus) endonuclease domain</strong>, C-terminal. UniProt annotates a PINc<br />
+  domain at residues <strong>947–1087</strong> (ECO:0000255, sequence-analysis). InterPro IPR002716<br />
+  (PIN_dom); Pfam PF13638 (PIN_4); SMART SM00670 (PINc). [UniProt P40456]</li>
+<li><strong>14-3-3-like "Est-one-homology" (EOH) domain</strong>, central. Not given explicit FT<br />
+  coordinates in UniProt, but described by the primary paper. <a href="https://pubmed.ncbi.nlm.nih.gov/23893744" title="these two   proteins also share extensive similarity ... with human hEST1A/B and Drosophila and   Caenohabditis elegans SMG5/6 proteins ... encompassed the region corresponding to the   14-3-3–like Est-one-homology domain (45–51% similarity ...) and the C-terminal PIN   endonuclease domain (49–53% similarity ...)">PMID:23893744</a></li>
+<li>The four acidic catalytic residues of the PIN domain are <strong>conserved</strong> in Esl1/Esl2.<br />
+  The ESL1 "nuclease-dead" allele used in the paper carries <strong>D952N and E982Q</strong> (two<br />
+  substitutions); the ESL2 nuclease-dead allele carries a single D1123N substitution.<br />
+  [PMID:23893744 "complete conservation of four critical D/E residues required for<br />
+  nuclease activity of the PIN-domain proteins"; "The esl1-nd mutant carries two amino<br />
+  acid substitutions (D952N and E982Q) while the esl2-nd mutant carries a single amino<br />
+  acid substitution (D1123N)"]</li>
+<li>InterPro family assignment: <strong>IPR045153 Est1/Ebs1-like</strong>; PANTHER PTHR15696 (SMG-7 /<br />
+  telomerase-binding protein EST1A family). [UniProt P40456 DR lines]</li>
+<li>N-terminal ~1–119 region is disordered (MobiDB-lite); phosphoserines at S170 and S190<br />
+  from large-scale phosphoproteomics. [UniProt P40456 FT lines; ECO:0007744|PubMed:18407956]</li>
+</ul>
+<h3 id="important-the-task-briefs-gramvast-lipid-transfer-domain-description-is-wrong">IMPORTANT: the task brief's "GRAM/VASt lipid-transfer domain" description is WRONG</h3>
+<p>The UniProt record and the primary literature both establish ESL1 as a <strong>PIN-domain +<br />
+14-3-3-like (EOH) protein of the Est1/SMG family</strong> — there is no GRAM domain, no VASt<br />
+domain, and no evidence for lipid binding or lipid transfer. I proceeded on the basis of<br />
+the actual UniProt/primary-literature evidence, not the brief's mischaracterization.</p>
+<h2 id="what-is-known-about-esl1-experimental-from-lai-et-al-2013-pmid23893744">What is KNOWN about ESL1 (experimental, from Lai et al. 2013, PMID:23893744)</h2>
+<p>All functional data come from a single paper studying esl1Δ, esl2Δ single mutants and<br />
+esl1Δ esl2Δ double mutants (and nuclease-dead alleles). Most phenotypes are reported for<br />
+the <em>pair</em> and are stronger in the double mutant, indicating <strong>functional redundancy</strong><br />
+between ESL1 and ESL2. ESL1-specific single-mutant results are called out below.</p>
+<ol>
+<li>
+<p><strong>NOT NMD; NOT telomere maintenance.</strong> Despite structural orthology to metazoan<br />
+   hEST1A/B (SMG5/6), esl1Δ, esl2Δ and esl1Δ esl2Δ mutants have wild-type telomere<br />
+   length, normal senescence/ALT kinetics (with est2Δ), normal subtelomeric silencing<br />
+   (5-FOA), no TERRA accumulation, and no accumulation of NMD substrates (ade2-1;<br />
+   unspliced pre-CYH2). [PMID:23893744 "Esl1 and Esl2 were not involved in<br />
+   nonsense-mediated mRNA decay or telomere maintenance pathways"; "ESL1 and ESL2 do not<br />
+   seem to have NMD-related functions"; "Esl1 and Esl2 are not required for<br />
+   telomerase-dependent or alternative telomere maintenance mechanisms"]<br />
+   → This directly REFUTES the IBA-propagated NMD (GO:0000184), telomerase holoenzyme<br />
+     complex (GO:0005697), telomeric DNA binding (GO:0042162), and telomerase RNA binding<br />
+     (GO:0070034) annotations for this yeast gene.</p>
+</li>
+<li>
+<p><strong>Environment-sensing adaptive gene expression.</strong> esl1Δ esl2Δ deregulate ~50–53<br />
+   transcripts (≥2-fold) — hexose transporters (HXT3/6/7), hexokinase HXK1, MAL genes,<br />
+   JEN1, glycogen genes (GPH1, PGM2), and one-carbon/glycine-regulon genes (GCV1/2/3,<br />
+   SHM2, ADE17) — in the direction <em>opposite</em> to the environmentally appropriate<br />
+   response. [PMID:23893744 "absence of Esl1 and Esl2 led to more than two-fold<br />
+   deregulation of ∼50 transcripts, most of which were expressed inversely to the<br />
+   appropriate metabolic response to environmental nutrient supply"; "esl1Δ esl2Δ double<br />
+   mutants may have a defect in adapting the expression of hexose and one-carbon<br />
+   metabolism genes to environmentally appropriate requirements"]</p>
+</li>
+<li>
+<p><strong>Genetic interaction with the Rim101 pH-sensing pathway.</strong> esl1Δ esl2Δ is synthetic<br />
+   sick with rim8Δ and dfg16Δ (the arrestin-like adaptor and GPCR of the Rim101 pathway),<br />
+   and ESL2 interacts with RIM9/RIM13/RIM20 in an independent screen — supporting a role<br />
+   parallel to Rim101 in environmental adaptation. <a href="https://pubmed.ncbi.nlm.nih.gov/23893744" title="esl1Δ esl2Δ double    mutants were synthetic sick with null mutations for Rim8 and Dfg16, which form the    environmental-sensing complex of the Rim101 pH response gene expression pathway">PMID:23893744</a></p>
+</li>
+<li>
+<p><strong>Genome-stability / stress phenotypes (pair; some nuclease-dependent).</strong> esl1Δ esl2Δ<br />
+   show elevated mitochondrial-genome instability (petite formation) and altered<br />
+   sensitivity to genotoxins (better on bleomycin/HU, worse on adriamycin). Bleomycin<br />
+   resistance is phenocopied by nuclease-dead alleles, implicating the PIN catalytic<br />
+   residues in <em>this</em> phenotype. [PMID:23893744 "ESL1 and ESL2 contribute to maintenance<br />
+   of mitochondrial genome stability"; "the nuclease-dead mutants phenocopied the<br />
+   bleomycin sensitivity of the esl1Δ or esl2Δ mutants"]</p>
+</li>
+<li>
+<p><strong>Synthetic interaction with trf4Δ</strong> (TRAMP-complex poly(A) polymerase); esl1Δ esl2Δ<br />
+   deregulate neighboring CUTs/SUTs — but this CUT/SUT change is <strong>nuclease-independent</strong><br />
+   and not directly coupled to the coding-gene changes. [PMID:23893744 "loss of Esl1 and<br />
+   of Esl2 lead to impaired genetic fitness with trf4Δ, rim8Δ, and dfg16Δ"; "these<br />
+   changes in transcript levels were again independent of Esl1 and Esl2 nuclease domain<br />
+   integrity"]</p>
+</li>
+</ol>
+<h3 id="esl1-specific-vs-pair">ESL1-specific vs pair</h3>
+<ul>
+<li>Single-mutant SGA hits attributed to <strong>esl1Δ alone</strong>: synthetic sick with FUS3, DAL81,<br />
+  SNX4, and synthetic lethal with TRF4. [PMID:23893744 Table 2]</li>
+<li>Telomere/NMD assays and drug-sensitivity trends were tested on esl1Δ single mutants and<br />
+  were negative/weaker than the double mutant. The transcriptome (microarray) and most<br />
+  synthetic-sick tetrad validations were done on the <strong>double</strong> mutant, so the ~50-gene<br />
+  expression signature is a <em>joint</em> ESL1+ESL2 phenotype, not proven ESL1-alone.</li>
+</ul>
+<h2 id="what-is-not-known-knowledge-gaps">What is NOT known (knowledge gaps)</h2>
+<ul>
+<li><strong>Direct molecular activity of ESL1 is undetermined.</strong> The PIN domain has intact<br />
+  catalytic residues, but no biochemical assay of Esl1 (or Esl2) endoribonuclease<br />
+  activity has been reported; the key transcriptome phenotype is <em>largely<br />
+  nuclease-independent</em>. So RNA-endonuclease activity is domain-<em>suggestive</em> but unproven<br />
+  for ESL1. [PMID:23893744 "all other PIN domain-containing proteins characterized to<br />
+  date exert ribonuclease activity in vitro and/or in vivo"; "Esl1 and Esl2 may regulate<br />
+  the expression of the altered transcripts in a largely nuclease-independent manner"]</li>
+<li><strong>Direct RNA/DNA/protein substrates and partners of ESL1 are unknown.</strong> The only<br />
+  reported physical interaction motivating the study is a two-hybrid hit with Mdt1/Pin4<br />
+  (Uetz et al. 2000, via the paper); no direct target of the EOH or PIN domain is<br />
+  established. <a href="https://pubmed.ncbi.nlm.nih.gov/23893744" title="a large-scale two-hybrid screen (Uetz et al. 2000) had   found it to interact with two uncharacterized ... open reading frames">PMID:23893744</a></li>
+<li><strong>Mechanism linking ESL1 to nutrient/pH-adaptive gene expression is unknown</strong> —<br />
+  whether it acts on mRNA stability, transcription, or the Rim101 axis, and whether the<br />
+  EOH 14-3-3-like domain mediates a regulatory protein-protein interaction (as in<br />
+  metazoan SMG5/6→UPF1) is undetermined. <a href="https://pubmed.ncbi.nlm.nih.gov/23893744" title="provide a basis for future   investigations into the detailed mechanisms by which they exert this function">PMID:23893744</a></li>
+<li><strong>Redundancy vs ESL2 and ESL1-specific role.</strong> Almost all phenotypes are stronger in<br />
+  esl1Δ esl2Δ; the individual, non-redundant contribution of ESL1 is not resolved.</li>
+<li><strong>Subcellular localization of Esl1 protein not experimentally reported</strong> (no CC data in<br />
+  UniProt beyond ND; metazoan orthologs are nucleocytoplasmic but this was not tested for<br />
+  Esl1).</li>
+</ul>
+<h2 id="existing-goa-annotations-assessment-summary">Existing GOA annotations — assessment summary</h2>
+<table>
+<thead>
+<tr>
+<th>GO term</th>
+<th>aspect</th>
+<th>evidence</th>
+<th>verdict</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>GO:0000184 NMD</td>
+<td>BP</td>
+<td>IBA</td>
+<td>REMOVE — directly refuted for this yeast gene (PMID:23893744)</td>
+</tr>
+<tr>
+<td>GO:0005697 telomerase holoenzyme complex</td>
+<td>CC</td>
+<td>IBA</td>
+<td>REMOVE — refuted (no telomere role)</td>
+</tr>
+<tr>
+<td>GO:0042162 telomeric repeat DNA binding</td>
+<td>MF</td>
+<td>IBA</td>
+<td>REMOVE — refuted (no telomere role)</td>
+</tr>
+<tr>
+<td>GO:0070034 telomerase RNA binding</td>
+<td>MF</td>
+<td>IBA</td>
+<td>REMOVE — refuted (no telomere role)</td>
+</tr>
+<tr>
+<td>GO:0003674 molecular_function (root)</td>
+<td>MF</td>
+<td>ND</td>
+<td>KEEP_AS_NON_CORE (ND placeholder)</td>
+</tr>
+<tr>
+<td>GO:0005575 cellular_component (root)</td>
+<td>CC</td>
+<td>ND</td>
+<td>KEEP_AS_NON_CORE (ND placeholder)</td>
+</tr>
+<tr>
+<td>GO:0008150 biological_process (root)</td>
+<td>BP</td>
+<td>ND</td>
+<td>KEEP_AS_NON_CORE (ND placeholder)</td>
+</tr>
+</tbody>
+</table>
+<p>The four IBA annotations are phylogenetic propagations from the metazoan SMG5/6 / EST1A<br />
+clade. Lai et al. 2013 experimentally tested exactly these two functions (NMD and<br />
+telomere maintenance) in the yeast proteins and found them absent. This is a textbook<br />
+case where experimental data in the target species overrides an IBA propagation. Note the<br />
+NMD IBA even lists SGD:S000002614 (EBS1) among the with/from set — EBS1, not ESL1, is the<br />
+yeast SMG7 ortholog with NMD links; ESL1's inclusion in the tree does not reflect yeast<br />
+NMD function.</p>
+<h2 id="deep-research-falcon">Deep research (falcon)</h2>
+<p><code>ESL1-deep-research-falcon.md</code> was generated (Edison, 21 citations, ~29 min). It is<br />
+<strong>literature-limited</strong>: falcon could NOT access the key functional paper (Lai et al. 2013)<br />
+and therefore relies on domain/family inference (PIN + TPR-like/EOH, Est1/Ebs1-like<br />
+family) and on the paralogs Est1/Ebs1. It correctly flags ESL1 as poorly characterized and<br />
+notes the mammalian ESL1 = E-selectin ligand 1 (GLG1) name clash (irrelevant to yeast<br />
+YIL151C). It does not contradict this review; because it lacked the primary paper, its<br />
+inferential telomere/NMD framing is superseded by the direct experimental exclusion of<br />
+those functions in Lai et al. 2013, which I read in full. No falcon-only claims were<br />
+imported into the review.</p>
+<h2 id="references-consulted">References consulted</h2>
+<ul>
+<li>PMID:23893744 — Lai et al. 2013, G3. Primary functional study (full text cached). HIGH.</li>
+<li>UniProt P40456 (ESL1_YEAST) — domain architecture, family, PTMs.</li>
+<li>ESL1-goa.tsv — GOA annotation set.</li>
+<li>ESL1-deep-research-falcon.md — provider deep research (literature-limited; see above).</li>
+</ul>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: P40456
+gene_symbol: ESL1
+product_type: PROTEIN
+status: COMPLETE
+taxon:
+  id: NCBITaxon:559292
+  label: Saccharomyces cerevisiae
+description: &gt;-
+  ESL1 (YIL151C) is a 1118-residue budding-yeast protein of the Est1/SMG (Est-one-homology)
+  family, built from a central 14-3-3-like Est-one-homology (EOH) domain and a C-terminal PIN
+  (PilT N-terminus) domain whose four acidic catalytic residues are conserved. It is the
+  structural ortholog, together with its close paralog ESL2 (YKR096W, &gt;70% identical), of the
+  metazoan telomerase/NMD proteins hEST1A/B (SMG5/6). Despite this ancestry, budding-yeast
+  ESL1 does not function in nonsense-mediated mRNA decay or in telomere maintenance:
+  esl1 mutants have normal telomere length, senescence, subtelomeric silencing and NMD-substrate
+  levels. Instead, ESL1 acts redundantly with ESL2 in environment-sensing adaptive gene
+  expression, contributing to the correct nutrient- and pH-responsive expression of hexose,
+  carbohydrate and one-carbon (glycine-regulon) metabolic genes; loss of both proteins
+  deregulates ~50 transcripts in the direction opposite to the appropriate metabolic response
+  and confers synthetic sickness with components of the Rim101 pH-sensing pathway (Rim8, Dfg16)
+  and with the TRAMP poly(A) polymerase Trf4. ESL1/ESL2 also contribute to mitochondrial-genome
+  stability and modulate genotoxin sensitivity, in some cases dependent on the PIN catalytic
+  residues. The direct molecular activity of ESL1 (whether it is a bona fide endoribonuclease
+  in vivo, and its RNA/protein substrates and partners) remains undetermined.
+references:
+- id: GO_REF:0000015
+  title: Use of the ND evidence code for Gene Ontology (GO) terms
+  findings: []
+- id: GO_REF:0000033
+  title: Annotation inferences using phylogenetic trees
+  findings: []
+- id: PMID:23893744
+  title: Yeast hEST1A/B (SMG5/6)-like proteins contribute to environment-sensing adaptive
+    gene expression responses.
+  findings:
+  - statement: &gt;-
+      Esl1 (Yil151c) and its paralog Esl2 (Ykr096w) are structural orthologs of metazoan
+      hEST1A/B (SMG5/6), sharing a 14-3-3-like Est-one-homology domain and a C-terminal PIN
+      endonuclease domain with the four conserved catalytic acidic residues.
+    supporting_text: &gt;-
+      this similarity encompassed the region corresponding to the 14-3-3–like Est-one-homology
+      domain (45–51% similarity; Figure 1, A and B) and the C-terminal PIN endonuclease domain
+      (49–53% similarity; Figure 1, A and C) with complete conservation of four critical D/E
+      residues required for nuclease activity of the PIN-domain proteins
+    reference_section_type: RESULTS
+  - statement: &gt;-
+      Unlike their metazoan orthologs, Esl1 and Esl2 are not involved in NMD or telomere
+      maintenance pathways.
+    supporting_text: &gt;-
+      unlike their metazoan
+      orthologs, Esl1 and Esl2 were not involved in nonsense-mediated mRNA decay or
+      telomere maintenance pathways
+    reference_section_type: ABSTRACT
+  - statement: &gt;-
+      Loss of Esl1 and Esl2 deregulates ~50 transcripts, most expressed inversely to the
+      appropriate metabolic response to environmental nutrient supply.
+    supporting_text: &gt;-
+      absence of Esl1 and Esl2 led to more than two-fold
+      deregulation of ∼50 transcripts, most of which were expressed inversely to the
+      appropriate metabolic response to environmental nutrient supply
+    reference_section_type: ABSTRACT
+  - statement: &gt;-
+      esl1 esl2 double mutants are synthetic sick with rim8 and dfg16, components of the
+      Rim101 pH-response environmental-sensing pathway.
+    supporting_text: &gt;-
+      esl1Δ esl2Δ double
+      mutants were synthetic sick with null mutations for Rim8 and Dfg16, which form the
+      environmental-sensing complex of the Rim101 pH response gene expression pathway
+    reference_section_type: ABSTRACT
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PMC full text verified. Sole dedicated functional study of ESL1/ESL2. Directly tests
+      and excludes NMD and telomere functions in the yeast proteins and establishes the
+      environment-sensing adaptive gene-expression role. All supporting_text quotes are
+      verbatim substrings of the cached full text.
+- id: PMID:14562106
+  title: Global analysis of protein expression in yeast.
+  findings:
+  - statement: Esl1 protein is expressed at a low level (~504 molecules/cell) in log-phase SD medium.
+    supporting_text: Present with 504 molecules/cell in log phase SD medium.
+    reference_section_type: OTHER
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Large-scale expression study; establishes low endogenous abundance of Esl1. Quote is
+      from the UniProt MISCELLANEOUS line derived from this study.
+- id: PMID:18407956
+  title: A multidimensional chromatography technology for in-depth phosphoproteome analysis.
+  findings:
+  - statement: Esl1 is phosphorylated at Ser-170 and Ser-190 (large-scale phosphoproteomics).
+    supporting_text: PHOSPHORYLATION [LARGE SCALE ANALYSIS] AT SER-170 AND SER-190
+    reference_section_type: OTHER
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Large-scale phosphoproteome study; documents S170/S190 phosphosites recorded in UniProt.
+      Functional significance for ESL1 not established.
+existing_annotations:
+- term:
+    id: GO:0000184
+    label: nuclear-transcribed mRNA catabolic process, nonsense-mediated decay
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Phylogenetic (IBA) propagation from the metazoan hEST1A/B (SMG5/6) clade. This function
+      was directly tested in the yeast protein and found ABSENT: esl1, esl2 and esl1 esl2
+      mutants do not accumulate NMD substrates (nonsense ade2-1 or unspliced pre-CYH2), unlike
+      the upf1 control.
+    action: REMOVE
+    reason: &gt;-
+      Experimental data in the target species (S. cerevisiae) directly refute NMD involvement
+      for Esl1, overriding the IBA inference from metazoan orthologs. This is not paralog
+      confusion but a species-specific loss of the ancestral function.
+    supported_by:
+    - reference_id: PMID:23893744
+      supporting_text: &gt;-
+        based on these two independent assays, ESL1 and
+        ESL2 do not seem to have NMD-related functions
+      reference_section_type: RESULTS
+    additional_reference_ids:
+    - PMID:23893744
+    propagation_review:
+      root_cause: PROPAGATION_BAD
+      failure_modes:
+      - FUNCTIONAL_DIVERGENCE
+      source_entities:
+      - source_id: SGD:S000002614
+        source_label: EBS1
+        source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
+        comment: &gt;-
+          EBS1 is the yeast SMG7 ortholog with NMD links; its presence in the IBA with/from set
+          does not make ESL1 an NMD factor. Esl1 was experimentally tested and is NMD-negative.
+- term:
+    id: GO:0005697
+    label: telomerase holoenzyme complex
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: part_of
+  review:
+    summary: &gt;-
+      IBA propagation from the EST1/telomerase clade. Directly tested and refuted: esl1, esl2
+      and esl1 esl2 mutants have wild-type telomere length and normal senescence/ALT kinetics,
+      so Esl1 is not part of a functional telomerase holoenzyme in yeast.
+    action: REMOVE
+    reason: &gt;-
+      Species-specific experimental evidence refutes any telomerase/telomere-maintenance role
+      for Esl1, overriding the phylogenetic inference.
+    supported_by:
+    - reference_id: PMID:23893744
+      supporting_text: &gt;-
+        Esl1 and Esl2 are
+        not required for telomerase-dependent or alternative telomere maintenance mechanisms
+      reference_section_type: RESULTS
+    additional_reference_ids:
+    - PMID:23893744
+    propagation_review:
+      root_cause: PROPAGATION_BAD
+      failure_modes:
+      - FUNCTIONAL_DIVERGENCE
+      - COMPARTMENT_OR_COMPLEX_MISMATCH
+      source_entities:
+      - source_id: SGD:S000004223
+        source_label: EST1
+        source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
+        comment: &gt;-
+          The ancestral EST1/telomerase function does not transfer to Esl1, which lacks any
+          telomere-maintenance role in yeast.
+- term:
+    id: GO:0042162
+    label: telomeric repeat DNA binding
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: enables
+  review:
+    summary: &gt;-
+      IBA molecular-function propagation from the EST1/telomerase clade. No telomere-related
+      activity is detectable for Esl1 in yeast (normal telomere length/structure, no TERRA
+      change), and no telomeric-DNA-binding activity has been demonstrated.
+    action: REMOVE
+    reason: &gt;-
+      The parent biological role (telomere maintenance) is experimentally excluded for Esl1,
+      and there is no independent evidence that Esl1 binds telomeric DNA; the IBA is an
+      over-propagation.
+    supported_by:
+    - reference_id: PMID:23893744
+      supporting_text: &gt;-
+        Esl1 and Esl2 are
+        not required for telomerase-dependent or alternative telomere maintenance mechanisms
+      reference_section_type: RESULTS
+    additional_reference_ids:
+    - PMID:23893744
+    propagation_review:
+      root_cause: PROPAGATION_BAD
+      failure_modes:
+      - FUNCTIONAL_DIVERGENCE
+      source_entities:
+      - source_id: SGD:S000004223
+        source_label: EST1
+        source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
+        comment: &gt;-
+          Telomeric-DNA-binding activity was not demonstrated for Esl1; the telomere role it
+          is derived from is experimentally excluded.
+- term:
+    id: GO:0070034
+    label: telomerase RNA binding
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: enables
+  review:
+    summary: &gt;-
+      IBA molecular-function propagation from the EST1/telomerase clade. Esl1 has no
+      demonstrated telomerase-RNA-binding activity and no telomere-maintenance role in yeast.
+    action: REMOVE
+    reason: &gt;-
+      Over-propagated from metazoan/EST1 orthologs; the associated telomere function is
+      experimentally excluded for Esl1 and no telomerase-RNA-binding activity is shown.
+    supported_by:
+    - reference_id: PMID:23893744
+      supporting_text: &gt;-
+        Esl1 and Esl2 are
+        not required for telomerase-dependent or alternative telomere maintenance mechanisms
+      reference_section_type: RESULTS
+    additional_reference_ids:
+    - PMID:23893744
+    propagation_review:
+      root_cause: PROPAGATION_BAD
+      failure_modes:
+      - FUNCTIONAL_DIVERGENCE
+      source_entities:
+      - source_id: SGD:S000004223
+        source_label: EST1
+        source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
+        comment: &gt;-
+          Telomerase-RNA-binding activity was not demonstrated for Esl1; the telomere role it
+          is derived from is experimentally excluded.
+- term:
+    id: GO:0003674
+    label: molecular_function
+  evidence_type: ND
+  original_reference_id: GO_REF:0000015
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Root-level placeholder (ND) recording that no molecular function was curated by SGD. The
+      direct molecular activity of Esl1 is indeed genuinely undetermined (see knowledge_gaps):
+      the PIN catalytic residues are conserved but no in vivo/in vitro endoribonuclease
+      activity has been demonstrated, and the characterized gene-expression phenotype is
+      largely nuclease-independent.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      ND placeholder that correctly reflects a real MF-dark gap; retain until a specific
+      molecular activity is established.
+- term:
+    id: GO:0005575
+    label: cellular_component
+  evidence_type: ND
+  original_reference_id: GO_REF:0000015
+  qualifier: is_active_in
+  review:
+    summary: &gt;-
+      Root-level placeholder (ND). The subcellular localization of the Esl1 protein has not
+      been experimentally reported.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      ND placeholder reflecting an uncurated (CC-dark) localization; retain pending
+      experimental localization.
+- term:
+    id: GO:0008150
+    label: biological_process
+  evidence_type: ND
+  original_reference_id: GO_REF:0000015
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Root-level placeholder (ND) predating the Lai et al. 2013 characterization. A specific
+      biological process (environment-sensing adaptive gene expression) is now supported and
+      is captured in core_functions.
+    action: MODIFY
+    reason: &gt;-
+      The ND placeholder is now superseded by experimental evidence for a role in adaptive
+      gene expression; propose replacing the root with the specific process.
+    proposed_replacement_terms:
+    - id: GO:0031669
+      label: cellular response to nutrient levels
+    supported_by:
+    - reference_id: PMID:23893744
+      supporting_text: &gt;-
+        Esl1
+        and Esl2 contribute to the regulation of adaptive gene expression responses of
+        environmental sensing pathways
+      reference_section_type: ABSTRACT
+    additional_reference_ids:
+    - PMID:23893744
+- term:
+    id: GO:0010468
+    label: regulation of gene expression
+  evidence_type: IMP
+  original_reference_id: PMID:23893744
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Proposed new annotation. esl1 esl2 mutants deregulate ~50 transcripts, so Esl1 (with
+      Esl2) is involved in regulation of gene expression during environmental adaptation.
+      Added to align core_functions with existing_annotations.
+    action: NEW
+    reason: &gt;-
+      Core-function process term supported by the mutant transcriptome phenotype but not
+      previously present in existing_annotations.
+    supported_by:
+    - reference_id: PMID:23893744
+      supporting_text: &gt;-
+        absence of Esl1 and Esl2 led to more than two-fold
+        deregulation of ∼50 transcripts, most of which were expressed inversely to the
+        appropriate metabolic response to environmental nutrient supply
+      reference_section_type: ABSTRACT
+- term:
+    id: GO:0031669
+    label: cellular response to nutrient levels
+  evidence_type: IMP
+  original_reference_id: PMID:23893744
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Proposed new annotation. esl1 esl2 mutants fail to express hexose and one-carbon
+      metabolism genes appropriately for the nutrient environment, indicating a role in the
+      cellular response to nutrient levels. Added to align core_functions with
+      existing_annotations.
+    action: NEW
+    reason: &gt;-
+      Core-function process term supported by the nutrient-adaptive gene-expression phenotype
+      but not previously present in existing_annotations.
+    supported_by:
+    - reference_id: PMID:23893744
+      supporting_text: &gt;-
+        esl1Δ esl2Δ double mutants may have a defect in adapting the
+        expression of hexose and one-carbon metabolism genes to environmentally appropriate
+        requirements
+      reference_section_type: RESULTS
+core_functions:
+- description: &gt;-
+    Redundantly with its paralog Esl2, Esl1 contributes to environment-sensing adaptive gene
+    expression, so that hexose/carbohydrate and one-carbon (glycine-regulon) metabolic genes
+    are expressed appropriately for the prevailing nutrient (and pH) environment. Loss of both
+    proteins deregulates ~50 transcripts in the direction opposite to the correct metabolic
+    response and causes synthetic sickness with the Rim101 pH-sensing components Rim8 and
+    Dfg16. The direct molecular activity underlying this role is not established (see
+    knowledge_gaps); most of the transcriptome phenotype is nuclease-independent.
+  supported_by:
+  - reference_id: PMID:23893744
+    supporting_text: &gt;-
+      Esl1
+      and Esl2 contribute to the regulation of adaptive gene expression responses of
+      environmental sensing pathways
+    reference_section_type: ABSTRACT
+  - reference_id: PMID:23893744
+    supporting_text: &gt;-
+      esl1Δ esl2Δ double mutants may have a defect in adapting the
+      expression of hexose and one-carbon metabolism genes to environmentally appropriate
+      requirements
+    reference_section_type: RESULTS
+  directly_involved_in:
+  - id: GO:0010468
+    label: regulation of gene expression
+  - id: GO:0031669
+    label: cellular response to nutrient levels
+knowledge_gaps:
+- gap_statement: &gt;-
+    The direct molecular activity of Esl1 is undetermined. It is unknown whether Esl1 is a
+    catalytically active endoribonuclease in vivo, and if so what its RNA substrates are; the
+    conserved PIN catalytic residues are intact but no biochemical nuclease assay of Esl1 has
+    been reported, and the characterized adaptive gene-expression phenotype is largely
+    independent of PIN catalytic integrity.
+  boundary: &gt;-
+    Esl1 has a central 14-3-3-like Est-one-homology (EOH) domain and a C-terminal PIN domain
+    with four conserved acidic catalytic residues (nuclease-dead esl1 allele = D952N + E982Q),
+    and is a structural ortholog of metazoan hEST1A/B (SMG5/6), which are PIN-domain
+    endoribonucleases. Esl1/Esl2 do NOT act in NMD or telomere maintenance in yeast. A
+    genome-stability phenotype (bleomycin resistance) IS phenocopied by nuclease-dead alleles,
+    implicating the PIN residues in that specific phenotype.
+  gap_kind:
+  - BIOLOGY
+  dark_aspect: MF_DARK
+  status: OPEN
+  significance: &gt;-
+    Esl1 is one of only seven S. cerevisiae PIN-domain proteins; establishing whether it is a
+    functional endoribonuclease and identifying its substrate would resolve how the Est1/SMG
+    fold was repurposed for nutrient-adaptive gene regulation after loss of the ancestral
+    NMD/telomere functions.
+  resolution: &gt;-
+    In vitro endoribonuclease assays with purified Esl1 and its PIN domain; CLIP/RIP-style
+    identification of bound RNAs; comparison of wild-type vs nuclease-dead alleles for each
+    phenotype.
+  provenance:
+  - reference_id: PMID:23893744
+    supporting_text: &gt;-
+      Esl1 and Esl2 may regulate the expression of the altered
+      transcripts in a largely nuclease-independent manner
+    reference_section_type: RESULTS
+  - reference_id: PMID:23893744
+    supporting_text: &gt;-
+      all other PIN domain-containing proteins characterized to date exert ribonuclease
+      activity in vitro and/or in vivo
+    reference_section_type: RESULTS
+  proposed_terms:
+  - proposed_name: PIN-domain-dependent adaptive mRNA regulatory activity
+    proposed_definition: &gt;-
+      A molecular function of an Est1/SMG-family PIN-domain protein that modulates the
+      abundance of specific mRNAs during adaptation to environmental nutrient or pH conditions,
+      potentially but not necessarily through endoribonucleolytic cleavage.
+    justification: &gt;-
+      Esl1/Esl2 have a defined biological role (environment-sensing adaptive gene expression)
+      but no GO molecular-function term captures their activity; they are currently annotatable
+      only at the process level, leaving the gene MF-dark.
+    proposed_parent:
+      id: GO:0003674
+      label: molecular_function
+- gap_statement: &gt;-
+    The molecular partners and substrates of Esl1 are unknown, including any protein-protein
+    interaction mediated by its 14-3-3-like EOH domain (the domain that in metazoan SMG5/6
+    engages the NMD factor UPF1) and any direct link to the Rim101 pH-sensing machinery.
+  boundary: &gt;-
+    Esl1 was found in a two-hybrid screen with Mdt1/Pin4, and esl1 esl2 mutants are synthetic
+    sick with rim8, dfg16 and trf4, but no direct physical target of either the EOH or PIN
+    domain of Esl1 has been demonstrated.
+  gap_kind:
+  - BIOLOGY
+  dark_aspect: MF_DARK
+  status: OPEN
+  significance: &gt;-
+    Identifying an Esl1 interaction partner would reveal the mechanism connecting the Est1/SMG
+    fold to nutrient/pH-adaptive gene expression and clarify whether the EOH domain retains a
+    regulatory protein-interaction function analogous to its metazoan counterparts.
+  resolution: &gt;-
+    Affinity-purification/mass-spectrometry and proximity-labeling of tagged Esl1; targeted
+    tests of physical interaction with Rim101-pathway and TRAMP components.
+  provenance:
+  - reference_id: PMID:23893744
+    supporting_text: &gt;-
+      provide
+      a basis for future investigations into the detailed mechanisms by which they exert this
+      function
+    reference_section_type: DISCUSSION
+- gap_statement: &gt;-
+    The ESL1-specific (non-redundant) contribution and in vivo biological role are not
+    resolved, because almost all phenotypes are stronger in esl1 esl2 double mutants and the
+    transcriptome signature was measured only in the double mutant.
+  boundary: &gt;-
+    esl1 single mutants show telomere/NMD-negative results and specific synthetic-sick
+    interactions (with FUS3, DAL81, SNX4, and synthetic-lethal with TRF4), and the pair is
+    redundant for the adaptive gene-expression, mitochondrial-stability and genotoxin
+    phenotypes; but no ESL1-only phenotype defines its unique function.
+  gap_kind:
+  - BIOLOGY
+  dark_aspect: BP_DARK
+  status: OPEN
+  significance: &gt;-
+    Distinguishing the individual roles of ESL1 and ESL2 is needed to know whether ESL1 has a
+    dedicated regulon or is fully redundant with its paralog.
+  resolution: &gt;-
+    Condition- and stress-resolved transcriptomics and phenotyping of esl1 single mutants
+    (including nuclease-dead), with direct comparison to esl2 and the double mutant.
+  provenance:
+  - reference_id: PMID:23893744
+    supporting_text: &gt;-
+      the effect
+      was more pronounced when ESL1 and ESL2 were simultaneously deleted, suggesting
+      functional redundancy between the two proteins
+    reference_section_type: RESULTS
+suggested_questions:
+- question: &gt;-
+    Is Esl1 a catalytically active endoribonuclease in vivo, and if so, what RNAs does it
+    cleave during nutrient/pH adaptation?
+- question: &gt;-
+    Does the 14-3-3-like Est-one-homology domain of Esl1 mediate a regulatory protein-protein
+    interaction analogous to the SMG5/6–UPF1 interaction in metazoa?
+- question: &gt;-
+    What is the subcellular localization of Esl1, and does it change with nutrient or pH
+    conditions?
+suggested_experiments:
+- hypothesis: &gt;-
+    Esl1 regulates a specific set of nutrient/pH-responsive mRNAs via its PIN domain.
+  description: &gt;-
+    Perform RIP-seq/CLIP-seq on tagged Esl1 under high- and low-glucose and alkaline
+    conditions, and compare mRNA half-lives in wild-type, esl1 esl2, and nuclease-dead alleles.
+- hypothesis: &gt;-
+    Esl1 acts in a pathway parallel to Rim101 in environmental adaptation.
+  description: &gt;-
+    Epistasis and interaction analysis of Esl1 with Rim101-pathway components (Rim8, Dfg16,
+    Rim13, Rim20) under alkaline and low-glucose stress, with transcriptome readout.
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/genes/yeast/FUN19/FUN19-ai-review.html
+++ b/genes/yeast/FUN19/FUN19-ai-review.html
@@ -1,0 +1,3062 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>FUN19 - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        .propagation-review {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f8fafc;
+            border-left: 3px solid #64748b;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .propagation-title {
+            font-weight: 600;
+            color: #334155;
+            margin-bottom: 0.25rem;
+        }
+
+        .propagation-row {
+            margin-top: 0.25rem;
+        }
+
+        .propagation-source {
+            margin-top: 0.5rem;
+            padding-top: 0.5rem;
+            border-top: 1px solid #e5e7eb;
+        }
+
+        .propagation-source-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #1d4ed8;
+        }
+
+        .propagation-comment {
+            color: #4b5563;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>FUN19</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/P28003" target="_blank" class="term-link">
+                        P28003
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Saccharomyces cerevisiae</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-complete">
+                    COMPLETE
+                </span>
+            </div>
+
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "FUN19";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="P28003" data-a="DESCRIPTION: FUN19 (YAL034C) is a non-essential, uncharacterize..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>FUN19 (YAL034C) is a non-essential, uncharacterized ~47 kDa protein of the budding yeast Saccharomyces cerevisiae. Its only recognizable structural feature is a C-terminal SWIRM domain (residues 316-413), a ~85-residue helical module found in chromatin-associated proteins such as the SWI/SNF subunits Swi3 and Rsc8, the SAGA/ADA co-activator subunit Ada2, and the LSD1/KDM1A histone demethylase, where it binds DNA/nucleosomes and mediates assembly of chromatin complexes. The remainder of the FUN19 sequence is largely low-complexity and predicted to be disordered. FUN19 belongs to the ADA2-related protein family (PANTHER PTHR12374) but sits in a distinct fungal SWIRM-only subfamily together with its Saccharomyces whole-genome-duplication paralog YOR338W and the fission yeast proteins Laf1 and Laf2; unlike bona fide Ada2 proteins it lacks the ZZ-type zinc finger and SANT/Myb domains that define the Ada2 co-activator. FUN19 is expressed (evidence at protein level) and is a phosphoprotein whose Ser207 is a Cdk1 substrate site. No molecular activity, binding partner, subcellular localization, or biological process has been experimentally established for FUN19; a chromatin-associated role is plausible from its SWIRM domain and from its relatives but remains unproven.</p>
+    </div>
+
+
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005634" target="_blank" class="term-link">
+                                    GO:0005634
+                                </a>
+                            </span>
+                            <span class="term-label">nucleus</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P28003" data-a="GO:0005634" data-r="GO_REF:0000033" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Nuclear localization is a phylogenetic (IBA) inference from the ADA2/SWIRM chromatin-protein family and is biologically reasonable for a SWIRM-domain protein, but FUN19&#39;s localization has not been experimentally determined. Retained as a plausible, non-core inference.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> SWIRM-domain chromatin proteins act in the nucleus, so nucleus is the most likely compartment; however this is an unverified IBA transfer with no direct localization evidence for FUN19, so it should not be treated as an established core fact.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/16461455" target="_blank" class="term-link">
+                                        PMID:16461455
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The SWIRM domain is a module found in the Swi3 and Rsc8 subunits of SWI/SNF-family chromatin remodeling complexes, and the Ada2 and BHC110/LSD1 subunits of chromatin modification complexes.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006338" target="_blank" class="term-link">
+                                    GO:0006338
+                                </a>
+                            </span>
+                            <span class="term-label">chromatin remodeling</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P28003" data-a="GO:0006338" data-r="GO_REF:0000033" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> This IBA is propagated across the ADA2 family and its with/from cites Ada2 (SGD:S000002856). Ada2 acts within histone-acetyltransferase (SAGA/ADA) complexes, and &#34;chromatin remodeling&#34; is more properly the province of the ATP-dependent SWI/SNF-type remodelers; FUN19 lacks the Ada2 ZZ/SANT domains and any remodeler ATPase, and no remodeling activity has been shown.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> FUN19 is in the SWIRM-only SF21 subfamily, not the Ada2 SF20 subfamily from which this term is transferred; ascribing an active chromatin-remodeling role to FUN19 over-extends the domain inference. A generic chromatin-association may be defensible but a specific remodeling process is not supported.
+                        </div>
+
+
+
+                        <div class="propagation-review">
+                            <div class="propagation-title">Propagation Review</div>
+                            <div class="propagation-row">
+                                <strong>Root cause:</strong>
+                                <span class="badge">PROPAGATION BAD</span>
+                            </div>
+
+                            <div class="propagation-row">
+                                <strong>Failure modes:</strong>
+
+                                <span class="badge">WRONG ORTHOLOG OR PARALOG</span>
+
+                                <span class="badge">FUNCTIONAL DIVERGENCE</span>
+
+                            </div>
+
+
+                            <div class="propagation-source">
+                                <strong>Sources checked:</strong>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">SGD:S000002856</span>
+
+                                    &middot; ADA2
+
+
+                                    <span class="badge">SUPPORTS SOURCE BUT NOT TARGET</span>
+
+
+                                    <div class="propagation-comment">Ada2 is in sibling subfamily SF20 and carries ZZ/SANT domains and SAGA/ADA complex context that FUN19 lacks; transfer crosses the subfamily boundary.</div>
+
+                                </div>
+
+                            </div>
+
+                        </div>
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003713" target="_blank" class="term-link">
+                                    GO:0003713
+                                </a>
+                            </span>
+                            <span class="term-label">transcription coactivator activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-remove">
+                            REMOVE
+                        </span>
+                        <span class="vote-buttons" data-g="P28003" data-a="GO:0003713" data-r="GO_REF:0000033" data-act="REMOVE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> This is the least defensible transfer. Its with/from cites Ada2 (SGD:S000002856), whose transcription-coactivator function depends on the SANT/Myb and ZZ-type zinc-finger domains and on incorporation into the SAGA/ADA HAT complexes. FUN19 possesses only a SWIRM domain and lacks these determinants, so coactivator activity is an over-propagation from the sibling Ada2 subfamily.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Coactivator activity is transferred from the Ada2 subfamily (SF20) across the subfamily boundary to FUN19 (SF21), but FUN19 lacks the SANT/ZZ domains and SAGA-complex context that underlie Ada2 coactivator function; there is no evidence FUN19 acts as a coactivator. This is an over-propagated electronic inference argued against on domain-architecture grounds, which is an appropriate basis for REMOVE.
+                        </div>
+
+
+
+                        <div class="propagation-review">
+                            <div class="propagation-title">Propagation Review</div>
+                            <div class="propagation-row">
+                                <strong>Root cause:</strong>
+                                <span class="badge">PROPAGATION BAD</span>
+                            </div>
+
+                            <div class="propagation-row">
+                                <strong>Failure modes:</strong>
+
+                                <span class="badge">WRONG ORTHOLOG OR PARALOG</span>
+
+                                <span class="badge">FUNCTIONAL DIVERGENCE</span>
+
+                                <span class="badge">COMPARTMENT OR COMPLEX MISMATCH</span>
+
+                            </div>
+
+
+                            <div class="propagation-source">
+                                <strong>Sources checked:</strong>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">SGD:S000002856</span>
+
+                                    &middot; ADA2
+
+
+                                    <span class="badge">SUPPORTS SOURCE BUT NOT TARGET</span>
+
+
+                                    <div class="propagation-comment">Ada2 coactivator activity depends on SANT/ZZ domains and SAGA/ADA complex membership absent from the SWIRM-only FUN19 subfamily.</div>
+
+                                </div>
+
+                            </div>
+
+                        </div>
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006357" target="_blank" class="term-link">
+                                    GO:0006357
+                                </a>
+                            </span>
+                            <span class="term-label">regulation of transcription by RNA polymerase II</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P28003" data-a="GO:0006357" data-r="GO_REF:0000033" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Broad transcription-regulation process transferred from the ADA2 family (with/from cites Ada2). A chromatin/transcription-associated role is plausible for a SWIRM protein, but the specific &#34;regulation of transcription by RNA Pol II&#34; via a coactivator mechanism is not supported for FUN19 given it lacks Ada2&#39;s functional domains and has no experimental data.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Reasonable as a family-level hypothesis but over-specific for FUN19 given the subfamily divergence and the absence of any direct evidence; kept out of core functions and flagged as over-annotation rather than removed outright because a chromatin-regulatory role remains a live possibility.
+                        </div>
+
+
+
+                        <div class="propagation-review">
+                            <div class="propagation-title">Propagation Review</div>
+                            <div class="propagation-row">
+                                <strong>Root cause:</strong>
+                                <span class="badge">PROPAGATION BAD</span>
+                            </div>
+
+                            <div class="propagation-row">
+                                <strong>Failure modes:</strong>
+
+                                <span class="badge">WRONG ORTHOLOG OR PARALOG</span>
+
+                                <span class="badge">FUNCTIONAL DIVERGENCE</span>
+
+                            </div>
+
+
+                            <div class="propagation-source">
+                                <strong>Sources checked:</strong>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">SGD:S000002856</span>
+
+                                    &middot; ADA2
+
+
+                                    <span class="badge">SUPPORTS SOURCE BUT NOT TARGET</span>
+
+
+                                    <div class="propagation-comment">Transferred from the Ada2 subfamily; FUN19 lacks the domain and complex context underlying Ada2&#39;s role in Pol II transcription regulation.</div>
+
+                                </div>
+
+                            </div>
+
+                        </div>
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0070210" target="_blank" class="term-link">
+                                    GO:0070210
+                                </a>
+                            </span>
+                            <span class="term-label">Rpd3L-Expanded complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P28003" data-a="GO:0070210" data-r="GO_REF:0000033" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Unlike the other IBA terms, this one is transferred from within FUN19&#39;s own subfamily (with/from cites the fission yeast SF21 relatives PomBase laf1 and laf2), which have been reported as components of S. pombe Sin3/Rpd3-type (SIN3L) histone-deacetylase complexes. This makes an HDAC-complex association the most biologically defensible of the propagated terms; however &#34;Rpd3L- Expanded complex&#34; is a fission-yeast complex designation and FUN19 is not an established subunit of any purified S. cerevisiae Rpd3-family complex, so the specific complex assignment is unverified for budding yeast.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The within-subfamily transfer from laf1/laf2 gives this the best support of any FUN19 annotation, but assigning FUN19 to the specific budding-yeast Rpd3L-Expanded complex is not experimentally verified; retained as a flagged, non-core hypothesis rather than removed, because it points to the most plausible functional context (a Sin3/Rpd3-type HDAC module).
+                        </div>
+
+
+
+                        <div class="propagation-review">
+                            <div class="propagation-title">Propagation Review</div>
+                            <div class="propagation-row">
+                                <strong>Root cause:</strong>
+                                <span class="badge">SOURCE WEAK OR INFERRED</span>
+                            </div>
+
+                            <div class="propagation-row">
+                                <strong>Failure modes:</strong>
+
+                                <span class="badge">LINEAGE OR TAXON MISMATCH</span>
+
+                                <span class="badge">COMPARTMENT OR COMPLEX MISMATCH</span>
+
+                            </div>
+
+
+                            <div class="propagation-source">
+                                <strong>Sources checked:</strong>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">PomBase:SPAC14C4.12c</span>
+
+                                    &middot; laf1
+
+
+                                    <span class="badge">SUPPORTS SOURCE BUT NOT TARGET</span>
+
+
+                                    <div class="propagation-comment">Within-subfamily (SF21) relative; reported in S. pombe Sin3/Rpd3-type HDAC complexes, but the specific Rpd3L-Expanded complex is a fission-yeast designation not verified for S. cerevisiae FUN19.</div>
+
+                                </div>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">PomBase:SPCC1682.13</span>
+
+                                    &middot; laf2
+
+
+                                    <span class="badge">SUPPORTS SOURCE BUT NOT TARGET</span>
+
+
+                                    <div class="propagation-comment">Second S. pombe SF21 relative also linked to Sin3/Rpd3-type HDAC complexes.</div>
+
+                                </div>
+
+                            </div>
+
+                        </div>
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003682" target="_blank" class="term-link">
+                                    GO:0003682
+                                </a>
+                            </span>
+                            <span class="term-label">chromatin binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P28003" data-a="GO:0003682" data-r="GO_REF:0000033" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Chromatin binding is the most conservative, domain-consistent molecular inference: SWIRM domains (e.g. in Swi3) bind DNA and nucleosomes. This is an IBA transfer and has not been demonstrated for FUN19&#39;s own SWIRM domain, but it is the activity most directly supported by the domain architecture.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Consistent with the SWIRM domain&#39;s known DNA/nucleosome-binding behavior, so more defensible than the coactivator or remodeling terms; retained as non-core because it is an unverified IBA inference rather than an established activity of FUN19.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/16461455" target="_blank" class="term-link">
+                                        PMID:16461455
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">the Swi3 SWIRM binds free DNA and mononucleosomes with high and comparable affinity</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0010468" target="_blank" class="term-link">
+                                    GO:0010468
+                                </a>
+                            </span>
+                            <span class="term-label">regulation of gene expression</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000117
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P28003" data-a="GO:0010468" data-r="GO_REF:0000117" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Very general ARBA machine-learning IEA term, consistent with the family-level transcription/chromatin association but uninformative and unsupported by any direct evidence for FUN19.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Generic electronic inference lacking specific support for FUN19; too broad to represent a core function and not independently verified.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0045893" target="_blank" class="term-link">
+                                    GO:0045893
+                                </a>
+                            </span>
+                            <span class="term-label">positive regulation of DNA-templated transcription</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000108
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-remove">
+                            REMOVE
+                        </span>
+                        <span class="vote-buttons" data-g="P28003" data-a="GO:0045893" data-r="GO_REF:0000108" data-act="REMOVE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> This IEA is an inter-ontology logical inference derived FROM the transcription-coactivator-activity annotation (with/from GO:0003713). Because that source annotation is an over-propagation from the Ada2 subfamily, this derived term inherits the same flaw and asserts an unsupported directionality (positive regulation) for FUN19.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Logically derived from the coactivator-activity term that this review removes as an over-propagation; with that basis gone and no evidence FUN19 positively regulates transcription, the derived term should also be removed.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003674" target="_blank" class="term-link">
+                                    GO:0003674
+                                </a>
+                            </span>
+                            <span class="term-label">molecular_function</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ND</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000015
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P28003" data-a="GO:0003674" data-r="GO_REF:0000015" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Root &#34;molecular_function&#34; with the ND (No biological Data available) evidence code correctly records that FUN19 has no experimentally determined molecular function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> ND root annotation accurately reflects that no molecular function has been experimentally established for FUN19; appropriate placeholder for a dark gene.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005575" target="_blank" class="term-link">
+                                    GO:0005575
+                                </a>
+                            </span>
+                            <span class="term-label">cellular_component</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ND</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000015
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P28003" data-a="GO:0005575" data-r="GO_REF:0000015" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Root &#34;cellular_component&#34; with ND correctly records the absence of experimental localization data for FUN19.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> No subcellular localization has been experimentally determined; the ND root annotation is the correct representation.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008150" target="_blank" class="term-link">
+                                    GO:0008150
+                                </a>
+                            </span>
+                            <span class="term-label">biological_process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ND</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000015
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P28003" data-a="GO:0008150" data-r="GO_REF:0000015" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Root &#34;biological_process&#34; with ND correctly records that no biological process has been experimentally assigned to FUN19.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> No biological process is experimentally established for FUN19; the ND root annotation appropriately captures this.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>FUN19 has no experimentally established molecular function. The single well-supported structural inference is that its C-terminal SWIRM domain, by homology to the DNA/nucleosome-binding SWIRM domains of Swi3, Rsc8, Ada2 and LSD1, could mediate chromatin/nucleosome association; this is offered as a hypothesis, not a demonstrated activity.</h3>
+                <span class="vote-buttons" data-g="P28003" data-a="FUNCTION: FUN19 has no experimentally established molecular ..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+
+
+
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/16461455" target="_blank" class="term-link">
+                                PMID:16461455
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">the Swi3 SWIRM binds free DNA and mononucleosomes with high and comparable affinity</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000015.md" target="_blank" class="term-link">
+                            GO_REF:0000015
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Use of the ND evidence code for Gene Ontology (GO) terms</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
+                            GO_REF:0000033
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Annotation inferences using phylogenetic trees</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000108.md" target="_blank" class="term-link">
+                            GO_REF:0000108
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Automatic assignment of GO terms using logical inference, based on on inter-ontology links</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000117.md" target="_blank" class="term-link">
+                            GO_REF:0000117
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Electronic Gene Ontology annotations created by ARBA machine learning models</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/1583694" target="_blank" class="term-link">
+                            PMID:1583694
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Molecular analysis of Saccharomyces cerevisiae chromosome I. On the number of genes and the identification of essential genes using temperature-sensitive-lethal mutations.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">FUN19 was defined during the molecular analysis of chromosome I and shown to be non-essential; at the time its predicted product showed no significant homology to known proteins.</div>
+
+                        <div class="finding-text">"FUN19 itself proved to be non-essential."</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/16461455" target="_blank" class="term-link">
+                            PMID:16461455
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Structure and function of the SWIRM domain, a conserved protein module found in chromatin regulatory complexes.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">The SWIRM domain is a chromatin-associated module found in Swi3, Rsc8, Ada2 and LSD1; the Swi3 SWIRM binds DNA and nucleosomes and SWIRM domains are required for assembly and in vivo function of their complexes.</div>
+
+                        <div class="finding-text">"The SWIRM domain is a module found in the Swi3 and Rsc8 subunits of SWI/SNF-family chromatin remodeling complexes, and the Ada2 and BHC110/LSD1 subunits of chromatin modification complexes."</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/18407956" target="_blank" class="term-link">
+                            PMID:18407956
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">A multidimensional chromatography technology for in-depth phosphoproteome analysis.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">FUN19 is phosphorylated in vivo (Thr194, Ser207, Ser211) as detected by large-scale mass spectrometry, confirming the protein is expressed.</div>
+
+                        <div class="finding-text">"A multidimensional chromatography technology for in-depth phosphoproteome analysis."</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/19779198" target="_blank" class="term-link">
+                            PMID:19779198
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Global analysis of Cdk1 substrate phosphorylation sites provides insights into evolution.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">FUN19 Ser207 was identified as a Cdk1-dependent phosphorylation site in a genome-wide analysis of Cdk1 substrates in budding yeast.</div>
+
+                        <div class="finding-text">"we analyzed the position and conservation of large numbers of phosphorylation sites for the cyclin-dependent kinase Cdk1 in the budding yeast Saccharomyces cerevisiae"</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Questions for Experts</h2>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Does the FUN19 SWIRM domain bind DNA or nucleosomes in vitro, and with what specificity, as its Swi3/Rsc8 counterparts do?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P28003" data-a="Q: Does the FUN19 SWIRM domain bind DNA or nucleosome..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Is FUN19 a bona fide subunit of an S. cerevisiae chromatin-modifying complex (e.g. a Rpd3/Sin3-type HDAC), by analogy to the fission yeast SF21 relatives laf1/laf2, or does it act independently?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P28003" data-a="Q: Is FUN19 a bona fide subunit of an S. cerevisiae c..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Does FUN19 act redundantly with its whole-genome-duplication paralog YOR338W, such that phenotypes are only revealed in the double deletant?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P28003" data-a="Q: Does FUN19 act redundantly with its whole-genome-d..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Experiments</h2>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Express and purify recombinant full-length FUN19 and its isolated SWIRM domain and test binding to free DNA and reconstituted mononucleosomes by EMSA and quantitative binding assays, benchmarking against the Swi3 SWIRM domain.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: FUN19&#39;s SWIRM domain confers chromatin/nucleosome association.</em></p>
+
+
+                    <p style="margin-top: 0.5rem;">Type: in vitro DNA/nucleosome binding</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P28003" data-a="EXPERIMENT: Express and purify recombinant full-length FUN19 a..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Affinity-purify endogenously tagged FUN19 from S. cerevisiae and identify co-purifying proteins by mass spectrometry, specifically testing for Rpd3/Sin3- type HDAC or SAGA/ADA subunits, and determine subcellular localization by fluorescence microscopy.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: FUN19 associates with a chromatin-modifying complex in vivo.</em></p>
+
+
+                    <p style="margin-top: 0.5rem;">Type: affinity purification-mass spectrometry and localization</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P28003" data-a="EXPERIMENT: Affinity-purify endogenously tagged FUN19 from S. ..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Construct fun19, yor338w single and fun19 yor338w double deletants and profile growth, stress responses (including heat), and genome-wide transcription to reveal phenotypes masked by paralog redundancy.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: FUN19 and YOR338W are functionally redundant paralogs.</em></p>
+
+
+                    <p style="margin-top: 0.5rem;">Type: genetic (single/double deletion) and transcriptomic analysis</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P28003" data-a="EXPERIMENT: Construct fun19, yor338w single and fun19 yor338w ..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Knowledge Gaps</h2>
+        <p style="color: #555; font-size: 0.92rem; margin-top: -0.3rem;">
+            What is <em>not</em> known — curated, literature-grounded statements of the open
+            unknowns (the inverse of core functions).
+        </p>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The molecular activity of FUN19 is unknown. No enzymatic activity, DNA/ nucleosome-binding activity, or binding partner has been demonstrated, and it is undetermined whether FUN19&#39;s own SWIRM domain binds DNA/nucleosomes as the Swi3/Rsc8 SWIRM domains do.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">MF_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> What is firmly established is only the domain architecture: a C-terminal SWIRM domain (residues 316-413; Pfam PF04433) attached to a largely disordered, low-complexity N-terminal region, placing FUN19 in the ADA2/LSD1 SWIRM superfamily.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Determining whether FUN19&#39;s SWIRM domain binds chromatin, and with what selectivity, would convert a homology guess into an actual molecular function for a completely uncharacterized conserved fungal protein family.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> In vitro DNA/nucleosome-binding assays with recombinant FUN19 (and its SWIRM domain), plus affinity purification / mass spectrometry to identify partners.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"FUN19 itself proved to be non-essential."</em> — PMID:1583694</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The biological process FUN19 participates in is unknown. Family-level annotations point toward chromatin-based transcriptional regulation, but no pathway, target genes, or process have been experimentally linked to FUN19.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">BP_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> FUN19 is expressed (protein-level evidence; phosphorylated at Ser207 by Cdk1), non-essential, and heat-stress-induced; its closest relatives (yeast Ada2; fission yeast laf1/laf2) act in chromatin-modifying complexes (SAGA/ADA HAT and Sin3/Rpd3-type HDAC respectively).</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> The FUN19 subfamily bridges two opposing chromatin activities in its relatives (acetylation via Ada2, deacetylation via laf1/laf2); resolving which, if either, FUN19 contributes to would clarify the evolutionary fate of a duplicated chromatin-regulatory module in budding yeast.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Genome-wide expression/chromatin profiling of a fun19 (and fun19 yor338w double) deletant, and testing physical association with Rpd3/Sin3 or SAGA/ADA complex members.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"The SWIRM domain is a module found in the Swi3 and Rsc8 subunits of SWI/SNF-family chromatin remodeling complexes, and the Ada2 and BHC110/LSD1 subunits of chromatin modification complexes."</em> — PMID:16461455</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The subcellular localization of FUN19 and its membership (if any) in a defined protein complex are unverified. It is not established whether FUN19 is nuclear, nor whether it is a subunit of any S. cerevisiae Rpd3/Sin3-type or SAGA-type complex.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span><span class="badge">CURATION</span>
+                <span class="badge">CC_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> Nuclear localization and Rpd3L-Expanded-complex membership are present only as phylogenetic (IBA) transfers; the complex-membership transfer comes from the fission yeast SF21 relatives laf1/laf2, not from any purified budding-yeast complex containing FUN19.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Placing FUN19 in (or excluding it from) a specific chromatin complex would anchor all downstream functional interpretation and resolve whether the current IBA complex annotation reflects real budding-yeast biology.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Fluorescent-protein localization of endogenous FUN19 and affinity-purification mass spectrometry to test co-purification with Rpd3/Sin3 or SAGA/ADA subunits.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"the Rsc8 and Swi3 SWIRM domains are essential for the proper assembly and in vivo functions of their respective complexes"</em> — PMID:16461455</li>
+
+            </ul>
+
+
+        </div>
+
+    </div>
+
+
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Deep Research Sections -->
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(FUN19-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="P28003" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="fun19-yal034c-curation-notes">FUN19 (YAL034C) — Curation notes</h1>
+<p>UniProt: P28003 · SGD: S000002134 · Systematic name: YAL034C · Standard name: FUN19 ("Function UNknown 19")<br />
+Organism: <em>Saccharomyces cerevisiae</em> S288C (NCBITaxon:559292)<br />
+Length: 413 aa; 47 kDa; non-essential.</p>
+<p>This is a genuinely UNDERSTUDIED ("dark") gene. There is <strong>no direct experimental<br />
+characterization of FUN19 molecular function</strong>. The primary deliverable of this review is an<br />
+honest <code>knowledge_gaps</code> section plus a domain/orthology-grounded, carefully hedged<br />
+<code>description</code>/<code>core_functions</code>.</p>
+<h2 id="journal">Journal</h2>
+<h3 id="2026-07-05-initial-data-gather">2026-07-05 — Initial data gather</h3>
+<ul>
+<li><code>just fetch-gene yeast FUN19</code> succeeded. 11 GOA annotations, all <strong>IBA/IEA/ND</strong> — i.e. there<br />
+  is not a single experimental (IDA/IMP/IPI/IGI/IEP) GO annotation for this gene. Every<br />
+  informative term is phylogenetically or electronically propagated.</li>
+<li>PANTHER family for FUN19 is <strong>PTHR12374 "TRANSCRIPTIONAL ADAPTOR 2 ADA2-RELATED"</strong>, and FUN19<br />
+  falls in subfamily <strong>SF21 "SWIRM DOMAIN-CONTAINING PROTEIN FUN19-RELATED"</strong> — a subfamily<br />
+  DISTINCT from the true ADA2 orthologs.</li>
+</ul>
+<h2 id="known-well-supported-facts">KNOWN (well-supported facts)</h2>
+<ol>
+<li>
+<p><strong>Non-essential ORF originally of unknown function.</strong> FUN19 was defined during the molecular<br />
+   analysis of chromosome I. <a href="https://pubmed.ncbi.nlm.nih.gov/1583694" title="FUN19 itself proved to be non-essential">PMID:1583694</a> and, at the<br />
+   time, <a href="https://pubmed.ncbi.nlm.nih.gov/1583694" title="None of the four predicted products shows significant homologies to known    proteins in the available databases.">PMID:1583694</a> The gene name literally encodes "Function UNknown."</p>
+</li>
+<li>
+<p><strong>Contains a single SWIRM domain (residues 316–413).</strong> UniProt FT DOMAIN 316..413 "SWIRM"<br />
+   (Pfam PF04433, PROSITE PS50934, InterPro IPR007526); the rest of the protein (1–315) is<br />
+   largely low-complexity/disordered (MobiDB-lite disordered REGIONs 35–55, 189–211, 249–271;<br />
+   COMPBIAS low-complexity 35–51, 200–211). RecName in UniProt: "SWIRM domain-containing protein<br />
+   FUN19".</p>
+</li>
+<li>
+<p><strong>What SWIRM domains do (domain-level, general).</strong> The SWIRM domain is a ~85-residue four-helix<br />
+   bundle with a helix-turn-helix motif found in chromatin-regulatory subunits — Swi3/Rsc8<br />
+   (SWI/SNF-family remodelers), Ada2 (SAGA/ADA HAT), and BHC110/LSD1 (KDM1A demethylase).<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/16461455" title="The SWIRM domain is a module found in the Swi3 and Rsc8 subunits of    SWI/SNF-family chromatin remodeling complexes, and the Ada2 and BHC110/LSD1 subunits of    chromatin modification complexes.">PMID:16461455</a> It can bind DNA/nucleosomes and mediate complex assembly:<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/16461455" title="the Swi3 SWIRM binds free DNA and mononucleosomes with high and comparable    affinity">PMID:16461455</a> and <a href="https://pubmed.ncbi.nlm.nih.gov/16461455" title="the Rsc8 and Swi3 SWIRM domains are essential for the proper    assembly and in vivo functions of their respective complexes.">PMID:16461455</a> So the domain is a strong hint<br />
+   toward a chromatin-associated / nucleic-acid-binding role, but it is a <em>shared module</em> that by<br />
+   itself does not specify which complex or which activity.</p>
+</li>
+<li>
+<p><strong>Phosphoprotein (large-scale MS).</strong> Phosphorylated at Thr-194, Ser-207, Ser-211<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/18407956">PMID:18407956</a> and Ser-207 is a Cdk1 substrate site <a href="https://pubmed.ncbi.nlm.nih.gov/19779198">PMID:19779198</a>. Evidence at protein<br />
+   level (UniProt PE 1) — i.e. the protein is expressed. These are proteome-scale, not<br />
+   function-specific.</p>
+</li>
+<li>
+<p><strong>WGD paralog = YOR338W.</strong> FUN19 and YOR338W (S000005865) are ohnologs from the whole-genome<br />
+   duplication; both are also SF21 "FUN19-related". YOR338W is likewise uncharacterized. (SGD)</p>
+</li>
+<li>
+<p><strong>Heat-stress-induced expression; non-essential null with mild fitness/chemical-response<br />
+   phenotypes</strong> (SGD phenotype summaries). No specific molecular process is implicated.</p>
+</li>
+</ol>
+<h2 id="orthology-subfamily-reasoning-basis-for-judging-the-iba-transfers">Orthology / subfamily reasoning (basis for judging the IBA transfers)</h2>
+<p>PANTHER PTHR12374 splits into:<br />
+- <strong>SF20 = TRANSCRIPTIONAL ADAPTER 2-ALPHA</strong> — the bona fide ADA2 orthologs: <em>S. cerevisiae</em><br />
+  ADA2 (Q02336, SGD:S000002856), human TADA2A (O75478), <em>S. pombe</em> ada2 (Q9P7J7), plant/fly ADA2.<br />
+  These are SAGA/ADA co-activator subunits with SWIRM + ZZ-type zinc finger + SANT/Myb domains.<br />
+- <strong>SF21 = "SWIRM DOMAIN-CONTAINING PROTEIN FUN19-RELATED"</strong> — FUN19 (P28003), its WGD paralog<br />
+  YOR338W (Q99326), and <em>S. pombe</em> <strong>laf1 (O13719) / laf2 (O74443)</strong>. These are shorter proteins<br />
+  carrying essentially only the SWIRM module (FUN19 = 413 aa but mostly disordered N-term; laf1<br />
+  272 aa; laf2 297 aa) — they LACK the ZZ finger and SANT/Myb domains that give ADA2 its SAGA<br />
+  coactivator identity.</p>
+<p>Consequence for the GOA IBA transfers:<br />
+- Terms whose <code>with/from</code> cite <strong>ADA2 (SGD:S000002856)</strong> — "transcription coactivator activity"<br />
+  (GO:0003713), "chromatin binding" (GO:0003682), "chromatin remodeling" (GO:0006338, also cites<br />
+  ADA2), "regulation of transcription by RNA Pol II" (GO:0006357, cites ADA2) — are transfers from<br />
+  the <em>sibling ADA2 subfamily (SF20)</em>, NOT from within SF21. FUN19 lacks the ZZ/SANT domains that<br />
+  underlie ADA2's coactivator activity, so "transcription coactivator activity" in particular is<br />
+  a likely <strong>over-propagation</strong> across the subfamily boundary.<br />
+- The <strong>"Rpd3L-Expanded complex" (GO:0070210)</strong> IBA has <code>with/from</code> <strong>PomBase laf1 / laf2</strong>, i.e.<br />
+  it IS a within-SF21 transfer. laf1/laf2 have been reported as components of <em>S. pombe</em> SIN3/Rpd3-<br />
+  type (SIN3L) histone-deacetylase complexes (WebSearch, Two-assembly-modes / SIN3 HDAC<br />
+  literature). This makes an HDAC-complex association the most biologically defensible of the<br />
+  propagated terms for FUN19 — although still IBA, not experimental, and not verified in budding<br />
+  yeast. NOTE: the specific complex "Rpd3L-Expanded" is a fission-yeast complex name; whether<br />
+<em>S. cerevisiae</em> FUN19 is part of Rpd3L is unverified (FUN19 is not among the established Rpd3L<br />
+  subunit set).</p>
+<p>Net interpretation: FUN19 is best described as a SWIRM-domain protein of the ADA2/LSD1 chromatin<br />
+superfamily whose own molecular function is uncharacterized; the least-unreasonable inference is<br />
+a chromatin/nucleosome-associated role (possibly linked to a Rpd3/Sin3-type HDAC module via its<br />
+SF21 relatives), but the specific SAGA-type "transcription coactivator" identity of ADA2 should<br />
+NOT be transferred wholesale.</p>
+<h2 id="not-known-knowledge-gaps-primary-deliverable">NOT known (knowledge gaps — primary deliverable)</h2>
+<ul>
+<li><strong>Molecular function</strong>: unknown. No enzymatic activity; no demonstrated binding partner/substrate.<br />
+  Whether the SWIRM domain of FUN19 binds DNA/nucleosomes (as Swi3/Rsc8 SWIRM does) is untested.</li>
+<li><strong>Biological process</strong>: unknown. No pathway assignment from direct evidence.</li>
+<li><strong>Cellular localization</strong>: not experimentally established (nucleus is only an IBA inference from<br />
+  the ADA2/SWIRM family; no IDA/high-throughput GFP localization annotated in GOA here).</li>
+<li><strong>Complex membership</strong>: unknown/unverified. IBA links to Rpd3L via <em>S. pombe</em> laf1/laf2, but<br />
+  FUN19 is not an established subunit of any purified <em>S. cerevisiae</em> chromatin complex.</li>
+<li><strong>Phenotype/role</strong>: only mild, non-specific null phenotypes (competitive fitness, chemical<br />
+  sensitivities, heat-induced expression); redundancy with YOR338W paralog untested.</li>
+</ul>
+<h2 id="deep-research-status">Deep research status</h2>
+<p>Automated deep research was attempted but is unavailable for this review:<br />
+- <code>just deep-research-falcon yeast FUN19 --fallback perplexity-lite</code>: falcon timed out<br />
+  after 600s; the perplexity-lite fallback returned HTTP 401 (<code>insufficient_quota</code> — API<br />
+  quota exceeded). A subsequent clean falcon retry (<code>just deep-research-falcon yeast
+  FUN19</code>) also hung on the network (0% CPU, ~2s CPU time over &gt;12 min elapsed) and was<br />
+  terminated.</p>
+<p>No <code>-deep-research-{provider}.md</code> file was produced, and none was fabricated. Per project<br />
+policy, the review is instead grounded in the UniProt record, the GOA annotations and their<br />
+<code>with/from</code> provenance, the PANTHER PTHR12374 family/subfamily data<br />
+(<code>interpro/panther/PTHR12374/</code>), and cached primary literature (PMID:1583694, PMID:16461455,<br />
+PMID:18407956, PMID:19779198), supplemented by targeted web/PubMed lookups recorded above.</p>
+<h2 id="references-to-cite-in-review">References to cite in review</h2>
+<ul>
+<li>PMID:1583694 — chromosome I analysis; establishes FUN19 as non-essential, initially no homology.</li>
+<li>PMID:16461455 — SWIRM domain structure/function (domain-level basis for chromatin inference).</li>
+<li>PMID:18407956 — phosphoproteome (Thr194/Ser207/Ser211).</li>
+<li>PMID:19779198 — Cdk1 substrate phosphosites (Ser207).</li>
+<li>file: PANTHER PTHR12374 family/subfamily data (interpro/panther/PTHR12374) for subfamily reasoning.</li>
+</ul>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: P28003
+gene_symbol: FUN19
+product_type: PROTEIN
+status: COMPLETE
+taxon:
+  id: NCBITaxon:559292
+  label: Saccharomyces cerevisiae
+description: &gt;-
+  FUN19 (YAL034C) is a non-essential, uncharacterized ~47 kDa protein of the
+  budding yeast Saccharomyces cerevisiae. Its only recognizable structural feature
+  is a C-terminal SWIRM domain (residues 316-413), a ~85-residue helical module
+  found in chromatin-associated proteins such as the SWI/SNF subunits Swi3 and
+  Rsc8, the SAGA/ADA co-activator subunit Ada2, and the LSD1/KDM1A histone
+  demethylase, where it binds DNA/nucleosomes and mediates assembly of chromatin
+  complexes. The remainder of the FUN19 sequence is largely low-complexity and
+  predicted to be disordered. FUN19 belongs to the ADA2-related protein family
+  (PANTHER PTHR12374) but sits in a distinct fungal SWIRM-only subfamily together
+  with its Saccharomyces whole-genome-duplication paralog YOR338W and the fission
+  yeast proteins Laf1 and Laf2; unlike bona fide Ada2 proteins it lacks the ZZ-type
+  zinc finger and SANT/Myb domains that define the Ada2 co-activator. FUN19 is
+  expressed (evidence at protein level) and is a phosphoprotein whose Ser207 is a
+  Cdk1 substrate site. No molecular activity, binding partner, subcellular
+  localization, or biological process has been experimentally established for
+  FUN19; a chromatin-associated role is plausible from its SWIRM domain and from
+  its relatives but remains unproven.
+references:
+  - id: GO_REF:0000015
+    title: Use of the ND evidence code for Gene Ontology (GO) terms
+    findings: []
+  - id: GO_REF:0000033
+    title: Annotation inferences using phylogenetic trees
+    findings: []
+  - id: GO_REF:0000108
+    title: Automatic assignment of GO terms using logical inference, based on on inter-ontology
+      links
+    findings: []
+  - id: GO_REF:0000117
+    title: Electronic Gene Ontology annotations created by ARBA machine learning models
+    findings: []
+  - id: PMID:1583694
+    title: &gt;-
+      Molecular analysis of Saccharomyces cerevisiae chromosome I. On the number
+      of genes and the identification of essential genes using
+      temperature-sensitive-lethal mutations.
+    findings:
+      - statement: &gt;-
+          FUN19 was defined during the molecular analysis of chromosome I and shown
+          to be non-essential; at the time its predicted product showed no
+          significant homology to known proteins.
+        supporting_text: &gt;-
+          FUN19 itself proved to be non-essential.
+    reference_review:
+      relevance: HIGH
+      correctness: VERIFIED
+      review_notes: &gt;-
+        PubMed-verified primary source that named FUN19 (&#34;Function UNknown 19&#34;);
+        establishes non-essentiality and the historical absence of homology,
+        underpinning the &#34;dark gene&#34; framing.
+  - id: PMID:16461455
+    title: &gt;-
+      Structure and function of the SWIRM domain, a conserved protein module found
+      in chromatin regulatory complexes.
+    findings:
+      - statement: &gt;-
+          The SWIRM domain is a chromatin-associated module found in Swi3, Rsc8,
+          Ada2 and LSD1; the Swi3 SWIRM binds DNA and nucleosomes and SWIRM domains
+          are required for assembly and in vivo function of their complexes.
+        supporting_text: &gt;-
+          The SWIRM domain is a module found in the Swi3 and Rsc8 subunits of
+          SWI/SNF-family chromatin remodeling complexes, and the Ada2 and BHC110/LSD1
+          subunits of chromatin modification complexes.
+    reference_review:
+      relevance: MEDIUM
+      correctness: VERIFIED
+      review_notes: &gt;-
+        Domain-level source (does not study FUN19 itself). Justifies the
+        chromatin/nucleosome-association inference from FUN19&#39;s SWIRM domain while
+        making clear the domain is a shared module that does not specify a complex.
+  - id: PMID:18407956
+    title: &gt;-
+      A multidimensional chromatography technology for in-depth phosphoproteome
+      analysis.
+    findings:
+      - statement: &gt;-
+          FUN19 is phosphorylated in vivo (Thr194, Ser207, Ser211) as detected by
+          large-scale mass spectrometry, confirming the protein is expressed.
+        supporting_text: &gt;-
+          A multidimensional chromatography technology for in-depth phosphoproteome
+          analysis.
+    reference_review:
+      relevance: LOW
+      correctness: VERIFIED
+      review_notes: &gt;-
+        Proteome-scale phosphosite dataset; the FUN19 phosphosites are recorded in
+        UniProt (Thr194/Ser207/Ser211). Establishes expression, not function.
+  - id: PMID:19779198
+    title: &gt;-
+      Global analysis of Cdk1 substrate phosphorylation sites provides insights into
+      evolution.
+    findings:
+      - statement: &gt;-
+          FUN19 Ser207 was identified as a Cdk1-dependent phosphorylation site in a
+          genome-wide analysis of Cdk1 substrates in budding yeast.
+        supporting_text: &gt;-
+          we analyzed the position and conservation of large numbers of
+          phosphorylation sites for the cyclin-dependent kinase Cdk1 in the budding
+          yeast Saccharomyces cerevisiae
+    reference_review:
+      relevance: LOW
+      correctness: VERIFIED
+      review_notes: &gt;-
+        Large-scale Cdk1 substrate map; FUN19 Ser207 is one of 547 sites. Recorded
+        in UniProt as a Cdk1 site. Establishes phosphoregulation potential, not a
+        specific molecular function.
+existing_annotations:
+  - term:
+      id: GO:0005634
+      label: nucleus
+    evidence_type: IBA
+    original_reference_id: GO_REF:0000033
+    qualifier: is_active_in
+    review:
+      summary: &gt;-
+        Nuclear localization is a phylogenetic (IBA) inference from the ADA2/SWIRM
+        chromatin-protein family and is biologically reasonable for a SWIRM-domain
+        protein, but FUN19&#39;s localization has not been experimentally determined.
+        Retained as a plausible, non-core inference.
+      action: KEEP_AS_NON_CORE
+      reason: &gt;-
+        SWIRM-domain chromatin proteins act in the nucleus, so nucleus is the most
+        likely compartment; however this is an unverified IBA transfer with no
+        direct localization evidence for FUN19, so it should not be treated as an
+        established core fact.
+      supported_by:
+        - reference_id: PMID:16461455
+          supporting_text: &gt;-
+            The SWIRM domain is a module found in the Swi3 and Rsc8 subunits of
+            SWI/SNF-family chromatin remodeling complexes, and the Ada2 and BHC110/LSD1
+            subunits of chromatin modification complexes.
+  - term:
+      id: GO:0006338
+      label: chromatin remodeling
+    evidence_type: IBA
+    original_reference_id: GO_REF:0000033
+    qualifier: involved_in
+    review:
+      summary: &gt;-
+        This IBA is propagated across the ADA2 family and its with/from cites Ada2
+        (SGD:S000002856). Ada2 acts within histone-acetyltransferase (SAGA/ADA)
+        complexes, and &#34;chromatin remodeling&#34; is more properly the province of the
+        ATP-dependent SWI/SNF-type remodelers; FUN19 lacks the Ada2 ZZ/SANT domains
+        and any remodeler ATPase, and no remodeling activity has been shown.
+      action: MARK_AS_OVER_ANNOTATED
+      reason: &gt;-
+        FUN19 is in the SWIRM-only SF21 subfamily, not the Ada2 SF20 subfamily from
+        which this term is transferred; ascribing an active chromatin-remodeling role
+        to FUN19 over-extends the domain inference. A generic chromatin-association
+        may be defensible but a specific remodeling process is not supported.
+      propagation_review:
+        root_cause: PROPAGATION_BAD
+        failure_modes:
+          - WRONG_ORTHOLOG_OR_PARALOG
+          - FUNCTIONAL_DIVERGENCE
+        source_entities:
+          - source_id: SGD:S000002856
+            source_label: ADA2
+            source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
+            comment: &gt;-
+              Ada2 is in sibling subfamily SF20 and carries ZZ/SANT domains and
+              SAGA/ADA complex context that FUN19 lacks; transfer crosses the
+              subfamily boundary.
+  - term:
+      id: GO:0003713
+      label: transcription coactivator activity
+    evidence_type: IBA
+    original_reference_id: GO_REF:0000033
+    qualifier: enables
+    review:
+      summary: &gt;-
+        This is the least defensible transfer. Its with/from cites Ada2
+        (SGD:S000002856), whose transcription-coactivator function depends on the
+        SANT/Myb and ZZ-type zinc-finger domains and on incorporation into the
+        SAGA/ADA HAT complexes. FUN19 possesses only a SWIRM domain and lacks these
+        determinants, so coactivator activity is an over-propagation from the sibling
+        Ada2 subfamily.
+      action: REMOVE
+      reason: &gt;-
+        Coactivator activity is transferred from the Ada2 subfamily (SF20) across
+        the subfamily boundary to FUN19 (SF21), but FUN19 lacks the SANT/ZZ domains
+        and SAGA-complex context that underlie Ada2 coactivator function; there is no
+        evidence FUN19 acts as a coactivator. This is an over-propagated electronic
+        inference argued against on domain-architecture grounds, which is an
+        appropriate basis for REMOVE.
+      propagation_review:
+        root_cause: PROPAGATION_BAD
+        failure_modes:
+          - WRONG_ORTHOLOG_OR_PARALOG
+          - FUNCTIONAL_DIVERGENCE
+          - COMPARTMENT_OR_COMPLEX_MISMATCH
+        source_entities:
+          - source_id: SGD:S000002856
+            source_label: ADA2
+            source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
+            comment: &gt;-
+              Ada2 coactivator activity depends on SANT/ZZ domains and SAGA/ADA
+              complex membership absent from the SWIRM-only FUN19 subfamily.
+  - term:
+      id: GO:0006357
+      label: regulation of transcription by RNA polymerase II
+    evidence_type: IBA
+    original_reference_id: GO_REF:0000033
+    qualifier: involved_in
+    review:
+      summary: &gt;-
+        Broad transcription-regulation process transferred from the ADA2 family
+        (with/from cites Ada2). A chromatin/transcription-associated role is
+        plausible for a SWIRM protein, but the specific &#34;regulation of transcription
+        by RNA Pol II&#34; via a coactivator mechanism is not supported for FUN19 given
+        it lacks Ada2&#39;s functional domains and has no experimental data.
+      action: MARK_AS_OVER_ANNOTATED
+      reason: &gt;-
+        Reasonable as a family-level hypothesis but over-specific for FUN19 given the
+        subfamily divergence and the absence of any direct evidence; kept out of core
+        functions and flagged as over-annotation rather than removed outright because
+        a chromatin-regulatory role remains a live possibility.
+      propagation_review:
+        root_cause: PROPAGATION_BAD
+        failure_modes:
+          - WRONG_ORTHOLOG_OR_PARALOG
+          - FUNCTIONAL_DIVERGENCE
+        source_entities:
+          - source_id: SGD:S000002856
+            source_label: ADA2
+            source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
+            comment: &gt;-
+              Transferred from the Ada2 subfamily; FUN19 lacks the domain and complex
+              context underlying Ada2&#39;s role in Pol II transcription regulation.
+  - term:
+      id: GO:0070210
+      label: Rpd3L-Expanded complex
+    evidence_type: IBA
+    original_reference_id: GO_REF:0000033
+    qualifier: part_of
+    review:
+      summary: &gt;-
+        Unlike the other IBA terms, this one is transferred from within FUN19&#39;s own
+        subfamily (with/from cites the fission yeast SF21 relatives PomBase laf1 and
+        laf2), which have been reported as components of S. pombe Sin3/Rpd3-type
+        (SIN3L) histone-deacetylase complexes. This makes an HDAC-complex association
+        the most biologically defensible of the propagated terms; however &#34;Rpd3L-
+        Expanded complex&#34; is a fission-yeast complex designation and FUN19 is not an
+        established subunit of any purified S. cerevisiae Rpd3-family complex, so the
+        specific complex assignment is unverified for budding yeast.
+      action: MARK_AS_OVER_ANNOTATED
+      reason: &gt;-
+        The within-subfamily transfer from laf1/laf2 gives this the best support of
+        any FUN19 annotation, but assigning FUN19 to the specific budding-yeast
+        Rpd3L-Expanded complex is not experimentally verified; retained as a flagged,
+        non-core hypothesis rather than removed, because it points to the most
+        plausible functional context (a Sin3/Rpd3-type HDAC module).
+      propagation_review:
+        root_cause: SOURCE_WEAK_OR_INFERRED
+        failure_modes:
+          - LINEAGE_OR_TAXON_MISMATCH
+          - COMPARTMENT_OR_COMPLEX_MISMATCH
+        source_entities:
+          - source_id: PomBase:SPAC14C4.12c
+            source_label: laf1
+            source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
+            comment: &gt;-
+              Within-subfamily (SF21) relative; reported in S. pombe Sin3/Rpd3-type
+              HDAC complexes, but the specific Rpd3L-Expanded complex is a
+              fission-yeast designation not verified for S. cerevisiae FUN19.
+          - source_id: PomBase:SPCC1682.13
+            source_label: laf2
+            source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
+            comment: &gt;-
+              Second S. pombe SF21 relative also linked to Sin3/Rpd3-type HDAC
+              complexes.
+  - term:
+      id: GO:0003682
+      label: chromatin binding
+    evidence_type: IBA
+    original_reference_id: GO_REF:0000033
+    qualifier: enables
+    review:
+      summary: &gt;-
+        Chromatin binding is the most conservative, domain-consistent molecular
+        inference: SWIRM domains (e.g. in Swi3) bind DNA and nucleosomes. This is an
+        IBA transfer and has not been demonstrated for FUN19&#39;s own SWIRM domain, but
+        it is the activity most directly supported by the domain architecture.
+      action: KEEP_AS_NON_CORE
+      reason: &gt;-
+        Consistent with the SWIRM domain&#39;s known DNA/nucleosome-binding behavior, so
+        more defensible than the coactivator or remodeling terms; retained as
+        non-core because it is an unverified IBA inference rather than an established
+        activity of FUN19.
+      supported_by:
+        - reference_id: PMID:16461455
+          supporting_text: &gt;-
+            the Swi3 SWIRM binds free DNA and mononucleosomes with high and comparable
+            affinity
+  - term:
+      id: GO:0010468
+      label: regulation of gene expression
+    evidence_type: IEA
+    original_reference_id: GO_REF:0000117
+    qualifier: involved_in
+    review:
+      summary: &gt;-
+        Very general ARBA machine-learning IEA term, consistent with the family-level
+        transcription/chromatin association but uninformative and unsupported by any
+        direct evidence for FUN19.
+      action: MARK_AS_OVER_ANNOTATED
+      reason: &gt;-
+        Generic electronic inference lacking specific support for FUN19; too broad to
+        represent a core function and not independently verified.
+  - term:
+      id: GO:0045893
+      label: positive regulation of DNA-templated transcription
+    evidence_type: IEA
+    original_reference_id: GO_REF:0000108
+    qualifier: involved_in
+    review:
+      summary: &gt;-
+        This IEA is an inter-ontology logical inference derived FROM the
+        transcription-coactivator-activity annotation (with/from GO:0003713). Because
+        that source annotation is an over-propagation from the Ada2 subfamily, this
+        derived term inherits the same flaw and asserts an unsupported directionality
+        (positive regulation) for FUN19.
+      action: REMOVE
+      reason: &gt;-
+        Logically derived from the coactivator-activity term that this review removes
+        as an over-propagation; with that basis gone and no evidence FUN19 positively
+        regulates transcription, the derived term should also be removed.
+  - term:
+      id: GO:0003674
+      label: molecular_function
+    evidence_type: ND
+    original_reference_id: GO_REF:0000015
+    qualifier: enables
+    review:
+      summary: &gt;-
+        Root &#34;molecular_function&#34; with the ND (No biological Data available)
+        evidence code correctly records that FUN19 has no experimentally determined
+        molecular function.
+      action: ACCEPT
+      reason: &gt;-
+        ND root annotation accurately reflects that no molecular function has been
+        experimentally established for FUN19; appropriate placeholder for a dark gene.
+  - term:
+      id: GO:0005575
+      label: cellular_component
+    evidence_type: ND
+    original_reference_id: GO_REF:0000015
+    qualifier: is_active_in
+    review:
+      summary: &gt;-
+        Root &#34;cellular_component&#34; with ND correctly records the absence of
+        experimental localization data for FUN19.
+      action: ACCEPT
+      reason: &gt;-
+        No subcellular localization has been experimentally determined; the ND root
+        annotation is the correct representation.
+  - term:
+      id: GO:0008150
+      label: biological_process
+    evidence_type: ND
+    original_reference_id: GO_REF:0000015
+    qualifier: involved_in
+    review:
+      summary: &gt;-
+        Root &#34;biological_process&#34; with ND correctly records that no biological
+        process has been experimentally assigned to FUN19.
+      action: ACCEPT
+      reason: &gt;-
+        No biological process is experimentally established for FUN19; the ND root
+        annotation appropriately captures this.
+core_functions:
+  - description: &gt;-
+      FUN19 has no experimentally established molecular function. The single
+      well-supported structural inference is that its C-terminal SWIRM domain,
+      by homology to the DNA/nucleosome-binding SWIRM domains of Swi3, Rsc8, Ada2
+      and LSD1, could mediate chromatin/nucleosome association; this is offered as a
+      hypothesis, not a demonstrated activity.
+    supported_by:
+      - reference_id: PMID:16461455
+        supporting_text: &gt;-
+          the Swi3 SWIRM binds free DNA and mononucleosomes with high and comparable
+          affinity
+knowledge_gaps:
+  - gap_statement: &gt;-
+      The molecular activity of FUN19 is unknown. No enzymatic activity, DNA/
+      nucleosome-binding activity, or binding partner has been demonstrated, and it
+      is undetermined whether FUN19&#39;s own SWIRM domain binds DNA/nucleosomes as the
+      Swi3/Rsc8 SWIRM domains do.
+    boundary: &gt;-
+      What is firmly established is only the domain architecture: a C-terminal SWIRM
+      domain (residues 316-413; Pfam PF04433) attached to a largely disordered,
+      low-complexity N-terminal region, placing FUN19 in the ADA2/LSD1 SWIRM
+      superfamily.
+    gap_kind:
+      - BIOLOGY
+    dark_aspect: MF_DARK
+    status: OPEN
+    significance: &gt;-
+      Determining whether FUN19&#39;s SWIRM domain binds chromatin, and with what
+      selectivity, would convert a homology guess into an actual molecular function
+      for a completely uncharacterized conserved fungal protein family.
+    resolution: &gt;-
+      In vitro DNA/nucleosome-binding assays with recombinant FUN19 (and its SWIRM
+      domain), plus affinity purification / mass spectrometry to identify partners.
+    provenance:
+      - reference_id: PMID:1583694
+        supporting_text: &gt;-
+          FUN19 itself proved to be non-essential.
+  - gap_statement: &gt;-
+      The biological process FUN19 participates in is unknown. Family-level
+      annotations point toward chromatin-based transcriptional regulation, but no
+      pathway, target genes, or process have been experimentally linked to FUN19.
+    boundary: &gt;-
+      FUN19 is expressed (protein-level evidence; phosphorylated at Ser207 by Cdk1),
+      non-essential, and heat-stress-induced; its closest relatives (yeast Ada2;
+      fission yeast laf1/laf2) act in chromatin-modifying complexes (SAGA/ADA HAT
+      and Sin3/Rpd3-type HDAC respectively).
+    gap_kind:
+      - BIOLOGY
+    dark_aspect: BP_DARK
+    status: OPEN
+    significance: &gt;-
+      The FUN19 subfamily bridges two opposing chromatin activities in its relatives
+      (acetylation via Ada2, deacetylation via laf1/laf2); resolving which, if
+      either, FUN19 contributes to would clarify the evolutionary fate of a
+      duplicated chromatin-regulatory module in budding yeast.
+    resolution: &gt;-
+      Genome-wide expression/chromatin profiling of a fun19 (and fun19 yor338w
+      double) deletant, and testing physical association with Rpd3/Sin3 or SAGA/ADA
+      complex members.
+    provenance:
+      - reference_id: PMID:16461455
+        supporting_text: &gt;-
+          The SWIRM domain is a module found in the Swi3 and Rsc8 subunits of
+          SWI/SNF-family chromatin remodeling complexes, and the Ada2 and BHC110/LSD1
+          subunits of chromatin modification complexes.
+  - gap_statement: &gt;-
+      The subcellular localization of FUN19 and its membership (if any) in a defined
+      protein complex are unverified. It is not established whether FUN19 is nuclear,
+      nor whether it is a subunit of any S. cerevisiae Rpd3/Sin3-type or SAGA-type
+      complex.
+    boundary: &gt;-
+      Nuclear localization and Rpd3L-Expanded-complex membership are present only as
+      phylogenetic (IBA) transfers; the complex-membership transfer comes from the
+      fission yeast SF21 relatives laf1/laf2, not from any purified budding-yeast
+      complex containing FUN19.
+    gap_kind:
+      - BIOLOGY
+      - CURATION
+    dark_aspect: CC_DARK
+    status: OPEN
+    significance: &gt;-
+      Placing FUN19 in (or excluding it from) a specific chromatin complex would
+      anchor all downstream functional interpretation and resolve whether the current
+      IBA complex annotation reflects real budding-yeast biology.
+    resolution: &gt;-
+      Fluorescent-protein localization of endogenous FUN19 and affinity-purification
+      mass spectrometry to test co-purification with Rpd3/Sin3 or SAGA/ADA subunits.
+    provenance:
+      - reference_id: PMID:16461455
+        supporting_text: &gt;-
+          the Rsc8 and Swi3 SWIRM domains are essential for the proper assembly and in
+          vivo functions of their respective complexes
+suggested_questions:
+  - question: &gt;-
+      Does the FUN19 SWIRM domain bind DNA or nucleosomes in vitro, and with what
+      specificity, as its Swi3/Rsc8 counterparts do?
+  - question: &gt;-
+      Is FUN19 a bona fide subunit of an S. cerevisiae chromatin-modifying complex
+      (e.g. a Rpd3/Sin3-type HDAC), by analogy to the fission yeast SF21 relatives
+      laf1/laf2, or does it act independently?
+  - question: &gt;-
+      Does FUN19 act redundantly with its whole-genome-duplication paralog YOR338W,
+      such that phenotypes are only revealed in the double deletant?
+suggested_experiments:
+  - hypothesis: &gt;-
+      FUN19&#39;s SWIRM domain confers chromatin/nucleosome association.
+    description: &gt;-
+      Express and purify recombinant full-length FUN19 and its isolated SWIRM domain
+      and test binding to free DNA and reconstituted mononucleosomes by EMSA and
+      quantitative binding assays, benchmarking against the Swi3 SWIRM domain.
+    experiment_type: in vitro DNA/nucleosome binding
+  - hypothesis: &gt;-
+      FUN19 associates with a chromatin-modifying complex in vivo.
+    description: &gt;-
+      Affinity-purify endogenously tagged FUN19 from S. cerevisiae and identify
+      co-purifying proteins by mass spectrometry, specifically testing for Rpd3/Sin3-
+      type HDAC or SAGA/ADA subunits, and determine subcellular localization by
+      fluorescence microscopy.
+    experiment_type: affinity purification-mass spectrometry and localization
+  - hypothesis: &gt;-
+      FUN19 and YOR338W are functionally redundant paralogs.
+    description: &gt;-
+      Construct fun19, yor338w single and fun19 yor338w double deletants and profile
+      growth, stress responses (including heat), and genome-wide transcription to
+      reveal phenotypes masked by paralog redundancy.
+    experiment_type: genetic (single/double deletion) and transcriptomic analysis
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/genes/yeast/GPM3/GPM3-ai-review.html
+++ b/genes/yeast/GPM3/GPM3-ai-review.html
@@ -1,0 +1,3184 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>GPM3 - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        .propagation-review {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f8fafc;
+            border-left: 3px solid #64748b;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .propagation-title {
+            font-weight: 600;
+            color: #334155;
+            margin-bottom: 0.25rem;
+        }
+
+        .propagation-row {
+            margin-top: 0.25rem;
+        }
+
+        .propagation-source {
+            margin-top: 0.5rem;
+            padding-top: 0.5rem;
+            border-top: 1px solid #e5e7eb;
+        }
+
+        .propagation-source-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #1d4ed8;
+        }
+
+        .propagation-comment {
+            color: #4b5563;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>GPM3</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/Q12326" target="_blank" class="term-link">
+                        Q12326
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Saccharomyces cerevisiae</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-draft">
+                    DRAFT
+                </span>
+            </div>
+
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "GPM3";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="Q12326" data-a="DESCRIPTION: GPM3 (systematic name YOL056W) is one of three pho..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>GPM3 (systematic name YOL056W) is one of three phosphoglycerate-mutase-family paralogs in Saccharomyces cerevisiae, alongside the sole functional glycolytic mutase GPM1 and the second homolog GPM2. It is a cytoplasmic protein of the histidine-phosphatase superfamily (cofactor/2,3-bisphosphoglycerate-dependent phosphoglycerate mutase, dPGM, subfamily) and retains the family&#39;s catalytic histidine residues. Despite this, GPM3 has no detectable phosphoglycerate mutase activity even when strongly overexpressed, and its deletion (alone or together with GPM2) causes no growth defect on diverse carbon sources and no change in key glycolytic-intermediate levels. It arose by gene duplication and is regarded as a probable non-functional homolog; it is expressed as a low-abundance protein (thousands of molecules per cell) whose molecular activity and biological role remain undetermined.</p>
+    </div>
+
+
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004619" target="_blank" class="term-link">
+                                    GO:0004619
+                                </a>
+                            </span>
+                            <span class="term-label">phosphoglycerate mutase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q12326" data-a="GO:0004619" data-r="GO_REF:0000033" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetic (IBA) transfer of the family&#39;s phosphoglycerate mutase activity to GPM3. GPM3 was experimentally assayed and shown to lack detectable mutase activity even when strongly overexpressed (Heinisch et al. 1998), so this is an over-propagation of the ancestral family activity onto a probable non-functional paralog. GPM1 is the sole functional yeast phosphoglycerate mutase. Marked as over-annotated rather than removed because the evidence is contradictory rather than merely thin: UniProt itself hedges (&#34;Could be non-functional&#34;), the dPGM catalytic histidines are conserved in sequence, and weak, expression-limited residual activity below the original assay&#39;s detection cannot be fully excluded (forced overexpression did partially complement gpm1). The term should not, however, be retained as a functional annotation for this paralog.
+                        </div>
+
+
+
+
+                        <div class="propagation-review">
+                            <div class="propagation-title">Propagation Review</div>
+                            <div class="propagation-row">
+                                <strong>Root cause:</strong>
+                                <span class="badge">PROPAGATION BAD</span>
+                            </div>
+
+                            <div class="propagation-row">
+                                <strong>Failure modes:</strong>
+
+                                <span class="badge">WRONG ORTHOLOG OR PARALOG</span>
+
+                                <span class="badge">FUNCTIONAL DIVERGENCE</span>
+
+                            </div>
+
+
+                            <div class="propagation-source">
+                                <strong>Sources checked:</strong>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">PANTHER:PTN002630707</span>
+
+                                    &middot; PGAM ancestral node (PTHR11931)
+
+
+                                    <span class="badge">SUPPORTS SOURCE BUT NOT TARGET</span>
+
+
+                                    <div class="propagation-comment">Ancestral PGAM activity is real for the family and for GPM1, but GPM3 has direct experimental evidence of no detectable mutase activity; catalytic histidines are present in sequence, so this is functional divergence rather than an obvious active-site lesion.</div>
+
+                                </div>
+
+                            </div>
+
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9544241" target="_blank" class="term-link">
+                                        PMID:9544241
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Higher level expression under the control of the yeast PFK2 promoter partially complemented the gpm1 defects, without restoring detectable enzymatic activity.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
+                                    GO:0005829
+                                </a>
+                            </span>
+                            <span class="term-label">cytosol</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q12326" data-a="GO:0005829" data-r="GO_REF:0000033" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetic assignment of cytosolic localization. This is consistent with the independent experimental (HDA) cytoplasm localization of GPM3 and with the cytoplasmic nature of the family, so the location is reasonable. Kept as non-core because GPM3 has no demonstrated activity for which the location would represent a core function; the &#34;is_active_in&#34; qualifier overstates a demonstrated activity at this site. This IBA cytosol call is independently corroborated by the experimental (HDA) cytoplasm localization of GPM3 (GO:0005737, PMID:14562095), which is why the location itself is accepted even though the accompanying activity is not.
+                        </div>
+
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/14562095" target="_blank" class="term-link">
+                                        PMID:14562095
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Global analysis of protein localization in budding yeast.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0061621" target="_blank" class="term-link">
+                                    GO:0061621
+                                </a>
+                            </span>
+                            <span class="term-label">canonical glycolysis</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q12326" data-a="GO:0061621" data-r="GO_REF:0000033" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetic transfer of a glycolytic role. GPM3 is not a functional glycolytic enzyme: it has no detectable mutase activity, and deletion of GPM3 (with or without GPM2) does not perturb growth on diverse carbon sources or the levels of key glycolytic intermediates (Heinisch et al. 1998). This is an over-annotation of the family process onto a non-functional paralog.
+                        </div>
+
+
+
+
+                        <div class="propagation-review">
+                            <div class="propagation-title">Propagation Review</div>
+                            <div class="propagation-row">
+                                <strong>Root cause:</strong>
+                                <span class="badge">PROPAGATION BAD</span>
+                            </div>
+
+                            <div class="propagation-row">
+                                <strong>Failure modes:</strong>
+
+                                <span class="badge">WRONG ORTHOLOG OR PARALOG</span>
+
+                                <span class="badge">FUNCTIONAL DIVERGENCE</span>
+
+                            </div>
+
+
+                            <div class="propagation-source">
+                                <strong>Sources checked:</strong>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">PANTHER:PTN002630707</span>
+
+                                    &middot; PGAM ancestral node (PTHR11931)
+
+
+                                    <span class="badge">SUPPORTS SOURCE BUT NOT TARGET</span>
+
+
+                                    <div class="propagation-comment">Canonical glycolysis is correct for GPM1 but propagates to a paralog whose deletion is metabolically silent and which lacks the enabling enzymatic activity.</div>
+
+                                </div>
+
+                            </div>
+
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9544241" target="_blank" class="term-link">
+                                        PMID:9544241
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">deletion of either GPM2 or GPM3, or the two deletions in concert, did not produce any obvious lesions for growth on a variety of different carbon sources, nor did they change the levels of key intermediary metabolites.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003824" target="_blank" class="term-link">
+                                    GO:0003824
+                                </a>
+                            </span>
+                            <span class="term-label">catalytic activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q12326" data-a="GO:0003824" data-r="GO_REF:0000002" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Generic catalytic-activity term applied electronically from InterPro membership. No catalytic activity of any kind has been demonstrated for GPM3; the assayed mutase activity was undetectable. This is uninformative and, given the negative functional evidence, an over-annotation from family membership.
+                        </div>
+
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9544241" target="_blank" class="term-link">
+                                        PMID:9544241
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Higher level expression under the control of the yeast PFK2 promoter partially complemented the gpm1 defects, without restoring detectable enzymatic activity.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004619" target="_blank" class="term-link">
+                                    GO:0004619
+                                </a>
+                            </span>
+                            <span class="term-label">phosphoglycerate mutase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000120
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q12326" data-a="GO:0004619" data-r="GO_REF:0000120" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic assignment of phosphoglycerate mutase activity from the UniProt EC/Rhea mapping (EC 5.4.2.11) attached to the BPG-dependent PGAM subfamily. As with the IBA copy of this term, this is a family-level inference contradicted by the direct experimental finding of no detectable mutase activity for GPM3; the same UniProt entry states the protein &#34;Could be non-functional&#34;. Marked as over-annotated rather than removed for the same reason as the IBA copy: the catalytic histidines are conserved and expression-limited residual activity cannot be fully excluded, so the call is deliberately conservative.
+                        </div>
+
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9544241" target="_blank" class="term-link">
+                                        PMID:9544241
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Higher level expression under the control of the yeast PFK2 promoter partially complemented the gpm1 defects, without restoring detectable enzymatic activity.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006096" target="_blank" class="term-link">
+                                    GO:0006096
+                                </a>
+                            </span>
+                            <span class="term-label">glycolytic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000120
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q12326" data-a="GO:0006096" data-r="GO_REF:0000120" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic transfer of the glycolytic-process role from family/pathway mapping. Over-annotation for the same reasons as the canonical-glycolysis IBA term: GPM3 deletion is metabolically and phenotypically silent and the enzyme lacks detectable activity.
+                        </div>
+
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9544241" target="_blank" class="term-link">
+                                        PMID:9544241
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">deletion of either GPM2 or GPM3, or the two deletions in concert, did not produce any obvious lesions for growth on a variety of different carbon sources, nor did they change the levels of key intermediary metabolites.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016868" target="_blank" class="term-link">
+                                    GO:0016868
+                                </a>
+                            </span>
+                            <span class="term-label">intramolecular phosphotransferase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q12326" data-a="GO:0016868" data-r="GO_REF:0000002" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> The specific mechanistic MF term for the dPGM reaction (intramolecular phosphotransfer), applied electronically from InterPro. No such activity has been demonstrated for GPM3; it is an over-annotation of the family mechanism onto a non-functional paralog.
+                        </div>
+
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9544241" target="_blank" class="term-link">
+                                        PMID:9544241
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Higher level expression under the control of the yeast PFK2 promoter partially complemented the gpm1 defects, without restoring detectable enzymatic activity.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
+                                    GO:0005737
+                                </a>
+                            </span>
+                            <span class="term-label">cytoplasm</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">HDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/14562095" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:14562095
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Global analysis of protein localization in budding yeast.
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q12326" data-a="GO:0005737" data-r="PMID:14562095" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Experimental (high-throughput direct assay) localization of GPM3 to the cytoplasm from the genome-wide GFP-fusion study. This is a well-supported, correct location annotation and the only positively demonstrated attribute of GPM3 besides its expression. Retained; it is a location rather than a core molecular/biological function.
+                        </div>
+
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/14562095" target="_blank" class="term-link">
+                                        PMID:14562095
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Global analysis of protein localization in budding yeast.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003674" target="_blank" class="term-link">
+                                    GO:0003674
+                                </a>
+                            </span>
+                            <span class="term-label">molecular_function</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ND</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000015
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q12326" data-a="GO:0003674" data-r="GO_REF:0000015" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Root molecular_function with the ND (no biological data) evidence code, assigned by SGD. This honestly reflects the true state of knowledge: no molecular activity has been positively demonstrated for GPM3, and the assayed mutase activity was undetectable. Retained as an accurate no-data placeholder.
+                        </div>
+
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008150" target="_blank" class="term-link">
+                                    GO:0008150
+                                </a>
+                            </span>
+                            <span class="term-label">biological_process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ND</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000015
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q12326" data-a="GO:0008150" data-r="GO_REF:0000015" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Root biological_process with the ND evidence code. Consistent with the absence of any demonstrated in-vivo role: GPM3 deletion is phenotypically silent under the conditions tested. Retained as an accurate no-data placeholder.
+                        </div>
+
+
+
+
+
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>No molecular function can be positively assigned to GPM3. It is a member of the phosphoglycerate mutase / histidine-phosphatase superfamily that retains the dPGM catalytic histidine residues, but the family phosphoglycerate mutase activity was experimentally undetectable even on forced overexpression, and no alternative activity, substrate, or biological role has been demonstrated. It is a stably expressed cytoplasmic protein of unknown function, most consistent with a probable non-functional homolog produced by gene duplication.</h3>
+                <span class="vote-buttons" data-g="Q12326" data-a="FUNCTION: No molecular function can be positively assigned t..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+
+
+
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/9544241" target="_blank" class="term-link">
+                                PMID:9544241
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">Higher level expression under the control of the yeast PFK2 promoter partially complemented the gpm1 defects, without restoring detectable enzymatic activity.</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/9544241" target="_blank" class="term-link">
+                                PMID:9544241
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">We conclude that both genes evolved from duplication events and that they probably constitute non-functional homologues in yeast.</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000002.md" target="_blank" class="term-link">
+                            GO_REF:0000002
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation through association of InterPro records with GO terms</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000015.md" target="_blank" class="term-link">
+                            GO_REF:0000015
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Use of the ND evidence code for Gene Ontology (GO) terms</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
+                            GO_REF:0000033
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Annotation inferences using phylogenetic trees</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000120.md" target="_blank" class="term-link">
+                            GO_REF:0000120
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Combined Automated Annotation using Multiple IEA Methods</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/9544241" target="_blank" class="term-link">
+                            PMID:9544241
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Investigation of two yeast genes encoding putative isoenzymes of phosphoglycerate mutase.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">GPM1 is the only functional phosphoglycerate mutase in yeast; GPM2 and GPM3 were detected as homologous sequences during genome sequencing.</div>
+
+                        <div class="finding-text">"Our previous data indicated that GPM1 encodes the only functional phosphoglycerate mutase in yeast. However, in the course of the yeast genome sequencing project, two homologous sequences, designated GPM2 and GPM3, were detected."</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <div class="finding-statement">The catalytic residues of the mutase active site are conserved in GPM3.</div>
+
+                        <div class="finding-text">"Key residues in the deduced amino acid sequence, shown to be involved in catalysis for Gpm1 (i.e. His8, Arg59, His181) are conserved in both enzymes."</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Forced high-level expression of GPM3 partially complemented gpm1 defects but did not restore any detectable enzymatic activity.</div>
+
+                        <div class="finding-text">"Higher level expression under the control of the yeast PFK2 promoter partially complemented the gpm1 defects, without restoring detectable enzymatic activity."</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Deletion of GPM2 and/or GPM3 produced no growth lesions and no change in key metabolite levels; both are probable non-functional homologs arising by duplication.</div>
+
+                        <div class="finding-text">"deletion of either GPM2 or GPM3, or the two deletions in concert, did not produce any obvious lesions for growth on a variety of different carbon sources, nor did they change the levels of key intermediary metabolites."</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/14562095" target="_blank" class="term-link">
+                            PMID:14562095
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Global analysis of protein localization in budding yeast.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Genome-wide GFP study assigning GPM3 to the cytoplasm.</div>
+
+                        <div class="finding-text">"Global analysis of protein localization in budding yeast."</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/14562106" target="_blank" class="term-link">
+                            PMID:14562106
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Global analysis of protein expression in yeast.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Genome-wide expression study; source of the ~3730 molecules/cell abundance value for GPM3 recorded in UniProt.</div>
+
+                        <div class="finding-text">"Global analysis of protein expression in yeast."</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Questions for Experts</h2>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Does GPM3 have any residual or alternative catalytic activity (e.g. phosphatase or a non-glycolytic phosphotransfer) despite lacking detectable phosphoglycerate mutase activity?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q12326" data-a="Q: Does GPM3 have any residual or alternative catalyt..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Is GPM3 conditionally functional or important under a stress or nutrient state not tested in the original characterization?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q12326" data-a="Q: Is GPM3 conditionally functional or important unde..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Given that the dPGM catalytic histidines are conserved in sequence, is the folded GPM3 active site competent, and does the GPM3-specific disordered insertion (residues ~168-198) disrupt folding or substrate binding?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q12326" data-a="Q: Given that the dPGM catalytic histidines are conse..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Experiments</h2>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Express and purify recombinant GPM3 and assay it across a panel of phosphoglycerate mutase (with and without 2,3-bisphosphoglycerate priming) and histidine-phosphatase substrate reactions to test for any residual or alternative activity.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: GPM3 has no residual mutase activity but may retain a weak alternative phosphotransfer/phosphatase activity typical of the histidine-phosphatase superfamily.</em></p>
+
+
+                    <p style="margin-top: 0.5rem;">Type: enzymatic assay</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q12326" data-a="EXPERIMENT: Express and purify recombinant GPM3 and assay it a..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Perform condition/stress phenotyping (e.g. carbon-source shifts, oxidative, osmotic, and stationary-phase stresses) of gpm3, gpm2 gpm3, and gpm1(ts) gpm3 strains to detect any conditional requirement for GPM3.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: GPM3 is required only under a specific, previously untested condition.</em></p>
+
+
+                    <p style="margin-top: 0.5rem;">Type: genetic phenotyping</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q12326" data-a="EXPERIMENT: Perform condition/stress phenotyping (e.g. carbon-..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Determine the GPM3 interactome by affinity purification / proximity labeling to test whether it acts as a partner or scaffold rather than an enzyme.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: GPM3 has a non-catalytic role mediated by protein partners.</em></p>
+
+
+                    <p style="margin-top: 0.5rem;">Type: interaction proteomics</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q12326" data-a="EXPERIMENT: Determine the GPM3 interactome by affinity purific..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Knowledge Gaps</h2>
+        <p style="color: #555; font-size: 0.92rem; margin-top: -0.3rem;">
+            What is <em>not</em> known — curated, literature-grounded statements of the open
+            unknowns (the inverse of core functions).
+        </p>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> It is unknown whether GPM3 has any catalytic or other molecular activity, what (if any) its in-vivo biological role is, and why S. cerevisiae retains a stably expressed third phosphoglycerate-mutase homolog that is dispensable and lacks detectable mutase activity.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">WHOLLY_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> GPM3 is firmly established as a phosphoglycerate-mutase-family protein (histidine- phosphatase superfamily, BPG-dependent PGAM subfamily) that retains the dPGM catalytic histidine residues, is expressed as a low-abundance protein (~3730 molecules/cell) and localizes to the cytoplasm. It has been directly assayed for phosphoglycerate mutase activity and none was detectable even under forced (PFK2- promoter) overexpression, and deletion of GPM3 alone or together with GPM2 causes no growth defect on diverse carbon sources and no change in key glycolytic- intermediate levels. GPM1 is the sole functional yeast phosphoglycerate mutase.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> GPM3 is a clean example of a conserved-looking paralog whose active-site residues are intact yet which has no directly measured ancestral activity. It is unresolved whether the protein is truly catalytically dead or retains weak residual activity that is masked physiologically by very low native expression: the same PFK2-driven overexpression that partially complements a gpm1 deletion on non-fermentable carbon also failed to restore detectable enzymatic activity in the original assay. Determining whether GPM3 has been pseudogenized at the protein level, retains weak residual activity limited by expression, acquired a new (non-mutase) activity, or is retained for a condition-specific role would clarify the fate of duplicated metabolic-enzyme genes and prevent electronic propagation of functional glycolytic-mutase annotations onto physiologically non-functional homologs.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Broad enzymatic screening of purified recombinant GPM3 (including 2,3-BPG-primed mutase and phosphatase assays) to test for any residual or alternative activity; condition/stress-specific phenotyping of gpm3 and gpm1 gpm3 / gpm2 gpm3 mutants; affinity/proximity proteomics to identify partners; structural characterization to test whether the family fold and active site are competent despite the conserved residues, given the ~30-residue disordered insertion unique to GPM3.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"Higher level expression under the control of the yeast PFK2 promoter partially complemented the gpm1 defects, without restoring detectable enzymatic activity."</em> — PMID:9544241</li>
+
+                <li><em>"We conclude that both genes evolved from duplication events and that they probably constitute non-functional homologues in yeast."</em> — PMID:9544241</li>
+
+            </ul>
+
+
+        </div>
+
+    </div>
+
+
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Deep Research Sections -->
+
+    <div class="section">
+        <h2 class="section-title">Deep Research</h2>
+
+        <details class="deep-research-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; gap: 1rem;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Falcon</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(GPM3-deep-research-falcon.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="Q12326" data-a="DEEP_RESEARCH: Falcon" data-r="" data-act="DEEP_RESEARCH" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This deep research is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This deep research needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+
+                <div class="report-meta">
+
+                    <span class="report-meta-text">Comprehensive Research Report: GPM3 (YOL056W) — Phosphoglycerate Mutase 3 in *Saccharomyces cerevisiae*</span>
+
+
+                    <span class="report-badge">Falcon</span>
+
+
+                    <span class="report-badge">Edison Scientific Literature</span>
+
+
+                    <span class="report-badge">21 citations</span>
+
+
+                    <span class="report-badge">2 artifacts</span>
+
+
+                    <span class="report-meta-text">2026-07-05T02:22:15.667775</span>
+
+
+
+                </div>
+
+
+                <div class="artifact-list">
+
+
+
+                    <div class="artifact-link">
+                        <a href="GPM3-deep-research-falcon_artifacts/artifact-00.md" class="term-link">Edison artifact artifact-00</a>
+                        <span>(text/markdown)</span>
+                    </div>
+
+
+
+
+                    <div class="artifact-link">
+                        <a href="GPM3-deep-research-falcon_artifacts/artifact-01.md" class="term-link">Edison artifact artifact-01</a>
+                        <span>(text/markdown)</span>
+                    </div>
+
+
+                </div>
+
+                <p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h1 id="comprehensive-research-report-gpm3-yol056w-phosphoglycerate-mutase-3-in-saccharomyces-cerevisiae">Comprehensive Research Report: GPM3 (YOL056W) — Phosphoglycerate Mutase 3 in <em>Saccharomyces cerevisiae</em></h1>
+<h2 id="1-gene-and-protein-identity">1. Gene and Protein Identity</h2>
+<p>GPM3 (systematic name YOL056W; UniProt Q12326) is located on the left arm of chromosome XV in <em>Saccharomyces cerevisiae</em> (strain ATCC 204508 / S288c). It encodes Phosphoglycerate Mutase 3 (PGAM 3), a member of the 2,3-bisphosphoglycerate (BPG)-dependent phosphoglycerate mutase family (EC 5.4.2.11). The protein belongs to the histidine phosphatase superfamily and contains the His_Pase_superF_clade-1 domain (IPR013078), His_PPase_superfam domain (IPR029033), and the Phosphogly_mut1 domain (IPR005952), which are characteristic of cofactor-dependent phosphoglycerate mutases (dPGMs) (papini2010phosphoglyceratemutaseknock‐out pages 1-2, jedrzejas2001comparisonofthe pages 2-3).</p>
+<p>The following summary encapsulates the key functional annotation findings for GPM3:</p>
+<blockquote>
+<p>GPM3 (YOL056W; UniProt Q12326) in <em>Saccharomyces cerevisiae</em> S288c is best annotated as a putative 2,3-bisphosphoglycerate-dependent phosphoglycerate mutase (EC 5.4.2.11) of the phosphoglycerate mutase family, consistent with its assignment to the histidine phosphatase superfamily and the His_Pase_superF_clade-1/PG-BPG mutase domain architecture. (papini2010phosphoglyceratemutaseknock‐out pages 1-2, jedrzejas2001comparisonofthe pages 2-3, bond2001highresolutionstructure pages 1-1)</p>
+<p>By family-level inference and paralog comparison, the expected catalytic role of Gpm3 is the reversible interconversion of 3-phosphoglycerate and 2-phosphoglycerate in lower glycolysis and gluconeogenesis, using the canonical cofactor-dependent phosphoglycerate mutase mechanism in which 2,3-bisphosphoglycerate primes an active-site phosphohistidine intermediate. (papini2010phosphoglyceratemutaseknock‐out pages 1-2, jedrzejas2001comparisonofthe pages 2-3, bond2001highresolutionstructure pages 1-1, bond2001highresolutionstructure pages 3-4)</p>
+<p>The strongest organism-specific evidence indicates that GPM3 is a high-homology duplicate of the major phosphoglycerate mutase gene GPM1, but at endogenous expression levels it behaves as a non-functional or physiologically negligible homolog: GPM3 is expressed too weakly to support significant glycolytic flux, and overexpression from its native promoter does not rescue a <em>gpm1Δ</em> strain. (papini2010phosphoglyceratemutaseknock‐out pages 1-2, papini2010phosphoglyceratemutaseknock‐out pages 6-8)</p>
+<p>However, GPM3 is not necessarily a completely dead enzyme: when expressed from the stronger <em>PFK2</em> promoter, GPM3 can partially complement the growth defect of <em>gpm1Δ</em> cells on glycerol/ethanol after prolonged incubation, implying residual catalytic competence despite poor native expression. (papini2010phosphoglyceratemutaseknock‐out pages 1-2)</p>
+<p>Functionally, GPM3 is therefore best viewed as a weakly expressed paralog of the main glycolytic/gluconeogenic phosphoglycerate mutase rather than the primary enzyme carrying this step in vivo; GPM1 remains the dominant physiological phosphoglycerate mutase in yeast. (papini2010phosphoglyceratemutaseknock‐out pages 1-2)</p>
+<p>Subcellularly, Gpm3 is expected to function in the cytoplasm, matching the usual localization of soluble glycolytic enzymes and available yeast localization resources; unlike Gpm1, there is no strong evidence for a characterized cell-wall moonlighting role for Gpm3. (papini2010phosphoglyceratemutaseknock‐out pages 1-2, rodicio2009sugarmetabolismby pages 8-9)</p>
+<p>Evolutionarily, GPM3 appears to have arisen through gene-duplication events that generated the GPM1/GPM2/GPM3 family; comparative analyses of glycolytic duplicates support broader retention of glycolytic paralogs in yeast evolution, although GPM2/GPM3 were treated separately from canonical retained whole-genome-duplication pairs in one comparative study. (papini2010phosphoglyceratemutaseknock‐out pages 1-2, conant2007increasedglycolyticflux pages 4-5, conant2007increasedglycolyticflux pages 3-4)</p>
+</blockquote>
+<p><em>Blockquote: This blockquote condenses the main functional annotation conclusions for yeast GPM3, integrating direct organism-specific evidence with enzyme-family mechanistic inference. It is useful as a concise evidence-backed summary of likely function, pathway role, localization, and evolutionary origin.</em></p>
+<h2 id="2-enzymatic-function-and-catalytic-mechanism">2. Enzymatic Function and Catalytic Mechanism</h2>
+<h3 id="21-predicted-reaction">2.1. Predicted Reaction</h3>
+<p>By sequence homology and domain architecture, GPM3 encodes a 2,3-bisphosphoglycerate-dependent phosphoglycerate mutase predicted to catalyze the reversible interconversion of 3-phosphoglycerate (3-PG) and 2-phosphoglycerate (2-PG), a step in the lower portion of the Embden-Meyerhof-Parnas glycolytic pathway and in gluconeogenesis (papini2010phosphoglyceratemutaseknock‐out pages 1-2).</p>
+<h3 id="22-catalytic-mechanism-of-the-dpgm-family">2.2. Catalytic Mechanism of the dPGM Family</h3>
+<p>The catalytic mechanism of dPGMs is well characterized through structural and biochemical studies of the related yeast Gpm1 enzyme and the <em>E. coli</em> dPGM. The enzyme requires the cofactor 2,3-bisphosphoglycerate (2,3-BPG) for activation. The native (unactivated) protein must first be phosphorylated by 2,3-BPG at a conserved nucleophilic histidine residue (His10 in the <em>E. coli</em> numbering, His8 in the yeast enzyme), generating a phosphoenzyme intermediate and releasing either 2-PG or 3-PG (jedrzejas2001comparisonofthe pages 2-3, bond2001highresolutionstructure pages 1-1, bond2001highresolutionstructure pages 1-2). The catalytic mechanism involves a pair of histidine residues: one histidine accepts the phosphoryl group from the cofactor (nucleophilic histidine), while a second histidine (His183 in <em>E. coli</em>) serves as a proton source during catalysis (jedrzejas2001comparisonofthe pages 2-3, bond2001highresolutionstructure pages 3-4). Notably, no metal ions are required for dPGM catalysis, distinguishing it from the cofactor-independent phosphoglycerate mutases (iPGMs) (jedrzejas2001comparisonofthe pages 2-3).</p>
+<p>Beyond its mutase activity, the dPGM family possesses two additional catalytic activities: a phosphatase activity that converts 2,3-bisphosphoglycerate to monophosphoglycerate plus phosphate, and a synthase activity that converts 1,3-bisphosphoglycerate to 2,3-bisphosphoglycerate (bond2001highresolutionstructure pages 1-1).</p>
+<h3 id="23-structural-basis">2.3. Structural Basis</h3>
+<p>The crystal structure of the yeast dPGM (Gpm1) was first solved in 1974 (PDB: 3PGM), with multiple subsequent structures determined at increasing resolution (PDB entries 4PGM, 5PGM, 1BQ3, 1BQ4, 1QHF) (bond2001highresolutionstructure pages 1-1). The monomer adopts an α/β fold featuring a six-stranded β-sheet (C-B-D-A-E-F, with all but E parallel) flanked by six α-helices. The active site is located at the C-terminal edge of the β-sheet and is cup-shaped, approximately 16 Å deep and 10 × 8 Å wide with a volume of ~1200 Å³ (bond2001highresolutionstructure pages 1-2, bond2001highresolutionstructure pages 3-4). Key conserved active-site residues include His10 (nucleophilic), His183, Glu88, Arg61, Asn16, and Ser57, which are conserved across <em>E. coli</em>, <em>S. cerevisiae</em>, <em>S. pombe</em>, and human dPGM enzymes (bond2001highresolutionstructure pages 3-4). The yeast Gpm1 forms a tetramer, distinguishing it from the <em>E. coli</em> enzyme which is dimeric (bond2001highresolutionstructure pages 1-1, bond2001highresolutionstructure pages 1-2). Given the high sequence homology between GPM3 and GPM1, Gpm3 is predicted to share this overall fold and domain architecture.</p>
+<h2 id="3-relationship-to-the-phosphoglycerate-mutase-gene-family-in-yeast">3. Relationship to the Phosphoglycerate Mutase Gene Family in Yeast</h2>
+<p><em>S. cerevisiae</em> harbors three genes encoding putative phosphoglycerate mutases: GPM1 (YKL152C), GPM2 (YDL021W), and GPM3 (YOL056W). The following table summarizes their comparative properties:</p>
+<table>
+<thead>
+<tr>
+<th>Gene</th>
+<th>Systematic name</th>
+<th>Chromosomal location</th>
+<th>Expression level</th>
+<th>Functional status</th>
+<th>Ability to complement <strong>gpm1Δ</strong></th>
+<th>Key evidence/references</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><strong>GPM1</strong></td>
+<td><strong>YKL152C</strong></td>
+<td>Right arm of chromosome VIII</td>
+<td>High/constitutive; major expressed phosphoglycerate mutase isoform</td>
+<td>Major functional phosphoglycerate mutase for glycolysis and gluconeogenesis; enzyme catalyzes 3-phosphoglycerate ↔ 2-phosphoglycerate</td>
+<td>Native functional gene; deletion causes severe growth defect and inability to grow on glucose alone</td>
+<td>Papini et al. 2010; Rodicio &amp; Heinisch 2009 (papini2010phosphoglyceratemutaseknock‐out pages 1-2, rodicio2009sugarmetabolismby pages 8-9)</td>
+</tr>
+<tr>
+<td><strong>GPM2</strong></td>
+<td><strong>YDL021W</strong></td>
+<td>Left arm of chromosome IV</td>
+<td>Very low endogenous expression</td>
+<td>Non-functional/weakly functional homolog of <strong>GPM1</strong> formed by duplication; does not contribute significantly to glycolytic flux at native expression</td>
+<td><strong>No</strong> complementation under own promoter; <strong>partial</strong> complementation only when overexpressed from <strong>PFK2</strong> promoter on glycerol/ethanol after prolonged incubation</td>
+<td>Papini et al. 2010 (summarizing Heinisch et al.) (papini2010phosphoglyceratemutaseknock‐out pages 1-2)</td>
+</tr>
+<tr>
+<td><strong>GPM3</strong></td>
+<td><strong>YOL056W</strong></td>
+<td>Left arm of chromosome XV</td>
+<td>Very low endogenous expression</td>
+<td>Non-functional/weakly functional homolog of <strong>GPM1</strong>; likely retains residual catalytic capacity but is not expressed enough to support significant flux</td>
+<td><strong>No</strong> complementation under own promoter; <strong>partial</strong> complementation only when overexpressed from <strong>PFK2</strong> promoter on glycerol/ethanol after prolonged incubation</td>
+<td>Papini et al. 2010; targeted proteomics shows low expression and close regulatory clustering with Gpm1/Gpm3 family behavior (papini2010phosphoglyceratemutaseknock‐out pages 1-2, papini2010phosphoglyceratemutaseknock‐out pages 6-8, costenoble2011comprehensivequantitativeanalysis pages 6-8)</td>
+</tr>
+</tbody>
+</table>
+<p><em>Table: This table compares the three phosphoglycerate mutase genes in Saccharomyces cerevisiae, highlighting that GPM1 is the major functional isoform, whereas GPM2 and GPM3 are very weakly expressed homologs with only partial rescue capacity when strongly overexpressed. It is useful for distinguishing primary enzyme function from paralog redundancy.</em></p>
+<p>GPM1 is the major glycolytic and gluconeogenic phosphoglycerate mutase in yeast. It encodes a constitutively expressed enzyme that forms a tetramer of four identical subunits, each approximately 28 kDa (papini2010phosphoglyceratemutaseknock‐out pages 1-2). Deletion of GPM1 renders cells unable to grow on glucose as a sole carbon source; growth is only possible when glycerol and ethanol are provided together, with glycerol feeding gluconeogenesis and ethanol providing energy through respiration (papini2010phosphoglyceratemutaseknock‐out pages 1-2).</p>
+<p>GPM2 and GPM3 were identified through genome sequencing as genes with high sequence homology to GPM1. However, Heinisch and colleagues demonstrated that both are effectively non-functional homologs under physiological conditions: overexpression of GPM2 or GPM3 on multicopy vectors under the control of their own promoters does not complement a <em>gpm1</em> deletion mutant when grown on complex media containing glucose or a mixture of glycerol/ethanol (papini2010phosphoglyceratemutaseknock‐out pages 1-2). Further analysis of the GPM2 and GPM3 promoters indicated that these genes are expressed at levels too low to contribute to a significant glycolytic flux (papini2010phosphoglyceratemutaseknock‐out pages 1-2). Transcriptome analysis of a Δ<em>gpm1</em> mutant confirmed that GPM2 and GPM3 display very low expression levels even when the primary phosphoglycerate mutase is absent (papini2010phosphoglyceratemutaseknock‐out pages 6-8).</p>
+<p>Critically, GPM3 retains some residual catalytic capacity: when GPM2 or GPM3 are overexpressed under the control of the stronger PFK2 promoter, they can partially complement the growth defect of the <em>gpm1</em> deletion strain on synthetic and complex media containing glycerol and ethanol, but only after prolonged incubation (papini2010phosphoglyceratemutaseknock‐out pages 1-2). This indicates that the Gpm3 protein likely retains enzymatic function, but its physiological insignificance is primarily due to insufficient endogenous expression rather than complete loss of catalytic competence.</p>
+<p>Targeted proteomics studies using selected reaction monitoring (SRM) mass spectrometry have corroborated these findings. Costenoble et al. (2011) detected both Gpm1 and Gpm3 across multiple metabolic steady states and found that the Gpm1/Gpm3 pair clustered in proximate branches in hierarchical clustering analysis, suggesting similar regulatory patterns across growth conditions (costenoble2011comprehensivequantitativeanalysis pages 6-8). This proximity in expression regulation, combined with the partial complementation data, is consistent with Gpm3 being a weakly expressed but functionally related paralog of Gpm1.</p>
+<h2 id="4-subcellular-localization">4. Subcellular Localization</h2>
+<p>Gpm3 is predicted to localize to the cytoplasm, consistent with its role as a soluble glycolytic enzyme. This localization matches that assigned to Gpm3 in the global yeast GFP-tagged protein localization study (Huh et al. 2003, <em>Nature</em> 425:686–691). By contrast, the major paralog Gpm1 is primarily cytoplasmic but has also been found in significant amounts in the yeast cell wall, where it retains enzymatic activity when released by alkaline treatment, although the specific role of Gpm1 in the cell wall remains largely unknown (papini2010phosphoglyceratemutaseknock‐out pages 1-2). There is no experimental evidence indicating that Gpm3 has a similar cell wall–associated moonlighting function.</p>
+<h2 id="5-pathway-context-glycolysis-and-gluconeogenesis">5. Pathway Context: Glycolysis and Gluconeogenesis</h2>
+<p>The phosphoglycerate mutase reaction occupies a critical position in lower glycolysis, connecting the output of phosphoglycerate kinase (which produces 3-PG) to the input of enolase (which consumes 2-PG to produce phosphoenolpyruvate). In the gluconeogenic direction, the same reaction runs in reverse to convert 2-PG to 3-PG. Deletion of GPM1, the primary enzyme catalyzing this step, leads to a severely impaired growth phenotype: the Δ<em>gpm1</em> mutant shows increased transcript levels of genes involved in the pentose phosphate pathway and the glyoxylate shunt, indicating an attempt to compensate for the energy imbalance caused by the deletion of this glycolytic/gluconeogenic gene (papini2010phosphoglyceratemutaseknock‐out pages 1-2). The inability of GPM2 and GPM3 to rescue this phenotype under normal expression conditions underscores the dominance of GPM1 in this metabolic step.</p>
+<p>In the context of glycolysis humanization, Boonekamp et al. (2021) replaced yeast glycolytic enzymes with human orthologs and found that human phosphoglycerate mutase 2 (HsPGAM2) showed significantly lower activity than the yeast enzyme and required adaptive laboratory evolution to achieve adequate flux, further highlighting the importance of this enzymatic step to glycolytic throughput (boonekamp2021ayeastwith pages 10-12, boonekamp2021ayeastwith pages 12-15, boonekamp2021ayeastwith pages 15-19).</p>
+<h2 id="6-moonlighting-functions-of-the-phosphoglycerate-mutase-family">6. Moonlighting Functions of the Phosphoglycerate Mutase Family</h2>
+<p>While GPM3 itself has no characterized moonlighting roles, the broader phosphoglycerate mutase family in yeasts has well-documented moonlighting functions. In <em>Candida albicans</em>, Gpm1 localizes to the cell surface, particularly at hyphal tips, where it binds plasminogen through lysine-binding domains and enables its activation to plasmin by urokinase-type plasminogen activator, facilitating fibrinolysis and extracellular matrix degradation for cell invasion (gancedo2016theexpandinglandscape pages 6-7). Additionally, cell-surface Gpm1 in <em>C. albicans</em> binds complement regulators FH and FHL-1, helping the pathogen evade complement-mediated immune responses (gancedo2016theexpandinglandscape pages 7-8). In <em>S. cerevisiae</em>, Gpm1 is present and enzymatically active in the cell wall, though its specific functional role there remains unclear (papini2010phosphoglyceratemutaseknock‐out pages 1-2). Given GPM3's very low expression, it is unlikely to contribute meaningfully to any such moonlighting role.</p>
+<h2 id="7-evolutionary-context">7. Evolutionary Context</h2>
+<p>GPM2 and GPM3 arose through gene duplication events in the <em>S. cerevisiae</em> lineage (papini2010phosphoglyceratemutaseknock‐out pages 1-2). Conant and Wolfe (2007) demonstrated that glycolytic gene duplicates retained after the ancient whole-genome duplication (WGD) in the <em>Saccharomyces</em> lineage were preferentially preserved relative to the genome-wide average (Fisher's exact test, P = 0.0014), suggesting selective advantage through increased enzymatic dosage and glycolytic flux (conant2007increasedglycolyticflux pages 4-5, conant2007increasedglycolyticflux pages 3-4). However, the GPM2/GPM3 pair was specifically excluded from their main statistical analysis of WGD-retained duplicates, suggesting these paralogs may have arisen through a different duplication mechanism or may have diverged to the point of near non-functionality, unlike the retained WGD duplicates that maintained high expression and contributed to increased glycolytic capacity (conant2007increasedglycolyticflux pages 4-5). Rodicio and Heinisch (2009) listed Gpm1, Gpm2, and Gpm3 as homodimeric phosphoglycerate mutases in their review of yeast sugar metabolism, noting them as putative isoenzymes (rodicio2009sugarmetabolismby pages 8-9).</p>
+<h2 id="8-summary">8. Summary</h2>
+<p>GPM3 (YOL056W) in <em>Saccharomyces cerevisiae</em> encodes a putative 2,3-bisphosphoglycerate-dependent phosphoglycerate mutase (EC 5.4.2.11) that is a high-homology paralog of the major glycolytic enzyme GPM1. By domain architecture and family membership, Gpm3 is predicted to catalyze the reversible interconversion of 3-phosphoglycerate and 2-phosphoglycerate using a phosphohistidine intermediate mechanism requiring 2,3-BPG as cofactor. The protein localizes to the cytoplasm. However, under physiological conditions, GPM3 is expressed at negligibly low levels and does not contribute significantly to glycolytic or gluconeogenic flux. Overexpression experiments demonstrate that Gpm3 retains some residual catalytic capacity, as it can partially complement a <em>gpm1Δ</em> deletion when driven by a strong heterologous promoter, but only on non-fermentable carbon sources and after extended incubation. GPM3 is therefore best characterized as a weakly expressed, largely non-functional paralog of GPM1 that arose through gene duplication, with the primary functional constraint being transcriptional silencing rather than complete loss of enzymatic activity.</p>
+<p>References</p>
+<ol>
+<li>
+<p>(papini2010phosphoglyceratemutaseknock‐out pages 1-2): Marta Papini, Intawat Nookaew, Gionata Scalcinati, Verena Siewers, and Jens Nielsen. Phosphoglycerate mutase knock‐out mutant saccharomyces cerevisiae: physiological investigation and transcriptome analysis. Biotechnology Journal, 5:1016-1027, Oct 2010. URL: https://doi.org/10.1002/biot.201000199, doi:10.1002/biot.201000199. This article has 15 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(jedrzejas2001comparisonofthe pages 2-3): Mark J. Jedrzejas and Peter Setlow. Comparison of the binuclear metalloenzymes diphosphoglycerate-independent phosphoglycerate mutase and alkaline phosphatase: their mechanism of catalysis via a phosphoserine intermediate. Chemical Reviews, 101:607-618, Feb 2001. URL: https://doi.org/10.1021/cr000253a, doi:10.1021/cr000253a. This article has 156 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(bond2001highresolutionstructure pages 1-1): Charles S. Bond, Malcolm F. White, and William N. Hunter. High resolution structure of the phosphohistidine-activated form of escherichia coli cofactor-dependent phosphoglycerate mutase*. The Journal of Biological Chemistry, 276:3247-3253, Feb 2001. URL: https://doi.org/10.1074/jbc.m007318200, doi:10.1074/jbc.m007318200. This article has 83 citations.</p>
+</li>
+<li>
+<p>(bond2001highresolutionstructure pages 3-4): Charles S. Bond, Malcolm F. White, and William N. Hunter. High resolution structure of the phosphohistidine-activated form of escherichia coli cofactor-dependent phosphoglycerate mutase*. The Journal of Biological Chemistry, 276:3247-3253, Feb 2001. URL: https://doi.org/10.1074/jbc.m007318200, doi:10.1074/jbc.m007318200. This article has 83 citations.</p>
+</li>
+<li>
+<p>(papini2010phosphoglyceratemutaseknock‐out pages 6-8): Marta Papini, Intawat Nookaew, Gionata Scalcinati, Verena Siewers, and Jens Nielsen. Phosphoglycerate mutase knock‐out mutant saccharomyces cerevisiae: physiological investigation and transcriptome analysis. Biotechnology Journal, 5:1016-1027, Oct 2010. URL: https://doi.org/10.1002/biot.201000199, doi:10.1002/biot.201000199. This article has 15 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(rodicio2009sugarmetabolismby pages 8-9): Rosaura Rodicio and Jürgen J. Heinisch. Sugar metabolism by saccharomyces and non-saccharomyces yeasts. ArXiv, pages 113-134, 2009. URL: https://doi.org/10.1007/978-3-540-85463-0_6, doi:10.1007/978-3-540-85463-0_6. This article has 40 citations.</p>
+</li>
+<li>
+<p>(conant2007increasedglycolyticflux pages 4-5): Gavin C Conant and Kenneth H Wolfe. Increased glycolytic flux as an outcome of whole-genome duplication in yeast. Molecular Systems Biology, Jul 2007. URL: https://doi.org/10.1038/msb4100170, doi:10.1038/msb4100170. This article has 312 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(conant2007increasedglycolyticflux pages 3-4): Gavin C Conant and Kenneth H Wolfe. Increased glycolytic flux as an outcome of whole-genome duplication in yeast. Molecular Systems Biology, Jul 2007. URL: https://doi.org/10.1038/msb4100170, doi:10.1038/msb4100170. This article has 312 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(bond2001highresolutionstructure pages 1-2): Charles S. Bond, Malcolm F. White, and William N. Hunter. High resolution structure of the phosphohistidine-activated form of escherichia coli cofactor-dependent phosphoglycerate mutase*. The Journal of Biological Chemistry, 276:3247-3253, Feb 2001. URL: https://doi.org/10.1074/jbc.m007318200, doi:10.1074/jbc.m007318200. This article has 83 citations.</p>
+</li>
+<li>
+<p>(costenoble2011comprehensivequantitativeanalysis pages 6-8): Roeland Costenoble, Paola Picotti, Lukas Reiter, Robert Stallmach, Matthias Heinemann, Uwe Sauer, and Ruedi Aebersold. Comprehensive quantitative analysis of central carbon and amino-acid metabolism in saccharomyces cerevisiae under multiple conditions by targeted proteomics. Molecular Systems Biology, 7:464-464, Feb 2011. URL: https://doi.org/10.1038/msb.2010.122, doi:10.1038/msb.2010.122. This article has 144 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(boonekamp2021ayeastwith pages 10-12): Francine J. Boonekamp, Ewout Knibbe, Marcel A. Vieira-Lara, Melanie Wijsman, Marijke A.H. Luttik, Karen van Eunen, Maxime den Ridder, Reinier Bron, Ana Maria Almonacid Suarez, Patrick van Rijn, Justina C. Wolters, Martin Pabst, Jean-Marc Daran, Barbara Bakker, and Pascale Daran-Lapujade. A yeast with muscle doesn’t run faster: full humanization of the glycolytic pathway in saccharomyces cerevisiae. bioRxiv, Sep 2021. URL: https://doi.org/10.1101/2021.09.28.462164, doi:10.1101/2021.09.28.462164. This article has 3 citations.</p>
+</li>
+<li>
+<p>(boonekamp2021ayeastwith pages 12-15): Francine J. Boonekamp, Ewout Knibbe, Marcel A. Vieira-Lara, Melanie Wijsman, Marijke A.H. Luttik, Karen van Eunen, Maxime den Ridder, Reinier Bron, Ana Maria Almonacid Suarez, Patrick van Rijn, Justina C. Wolters, Martin Pabst, Jean-Marc Daran, Barbara Bakker, and Pascale Daran-Lapujade. A yeast with muscle doesn’t run faster: full humanization of the glycolytic pathway in saccharomyces cerevisiae. bioRxiv, Sep 2021. URL: https://doi.org/10.1101/2021.09.28.462164, doi:10.1101/2021.09.28.462164. This article has 3 citations.</p>
+</li>
+<li>
+<p>(boonekamp2021ayeastwith pages 15-19): Francine J. Boonekamp, Ewout Knibbe, Marcel A. Vieira-Lara, Melanie Wijsman, Marijke A.H. Luttik, Karen van Eunen, Maxime den Ridder, Reinier Bron, Ana Maria Almonacid Suarez, Patrick van Rijn, Justina C. Wolters, Martin Pabst, Jean-Marc Daran, Barbara Bakker, and Pascale Daran-Lapujade. A yeast with muscle doesn’t run faster: full humanization of the glycolytic pathway in saccharomyces cerevisiae. bioRxiv, Sep 2021. URL: https://doi.org/10.1101/2021.09.28.462164, doi:10.1101/2021.09.28.462164. This article has 3 citations.</p>
+</li>
+<li>
+<p>(gancedo2016theexpandinglandscape pages 6-7): Carlos Gancedo, Carmen-Lisset Flores, and Juana M. Gancedo. The expanding landscape of moonlighting proteins in yeasts. Microbiology and Molecular Biology Reviews, 80:765-777, Sep 2016. URL: https://doi.org/10.1128/mmbr.00012-16, doi:10.1128/mmbr.00012-16. This article has 82 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(gancedo2016theexpandinglandscape pages 7-8): Carlos Gancedo, Carmen-Lisset Flores, and Juana M. Gancedo. The expanding landscape of moonlighting proteins in yeasts. Microbiology and Molecular Biology Reviews, 80:765-777, Sep 2016. URL: https://doi.org/10.1128/mmbr.00012-16, doi:10.1128/mmbr.00012-16. This article has 82 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+</ol>
+<h2 id="artifacts">Artifacts</h2>
+<ul>
+<li><a href="GPM3-deep-research-falcon_artifacts/artifact-00.md">Edison artifact artifact-00</a></li>
+<li><a href="GPM3-deep-research-falcon_artifacts/artifact-01.md">Edison artifact artifact-01</a></li>
+</ul>
+<h2 id="citations">Citations</h2>
+<ol>
+<li>jedrzejas2001comparisonofthe pages 2-3</li>
+<li>bond2001highresolutionstructure pages 1-1</li>
+<li>bond2001highresolutionstructure pages 3-4</li>
+<li>costenoble2011comprehensivequantitativeanalysis pages 6-8</li>
+<li>gancedo2016theexpandinglandscape pages 6-7</li>
+<li>gancedo2016theexpandinglandscape pages 7-8</li>
+<li>conant2007increasedglycolyticflux pages 4-5</li>
+<li>rodicio2009sugarmetabolismby pages 8-9</li>
+<li>conant2007increasedglycolyticflux pages 3-4</li>
+<li>bond2001highresolutionstructure pages 1-2</li>
+<li>boonekamp2021ayeastwith pages 10-12</li>
+<li>boonekamp2021ayeastwith pages 12-15</li>
+<li>boonekamp2021ayeastwith pages 15-19</li>
+<li>https://doi.org/10.1002/biot.201000199,</li>
+<li>https://doi.org/10.1021/cr000253a,</li>
+<li>https://doi.org/10.1074/jbc.m007318200,</li>
+<li>https://doi.org/10.1007/978-3-540-85463-0_6,</li>
+<li>https://doi.org/10.1038/msb4100170,</li>
+<li>https://doi.org/10.1038/msb.2010.122,</li>
+<li>https://doi.org/10.1101/2021.09.28.462164,</li>
+<li>https://doi.org/10.1128/mmbr.00012-16,</li>
+</ol>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(GPM3-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="Q12326" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="gpm3-yol056w-curation-notes">GPM3 (YOL056W) — curation notes</h1>
+<p><em>S. cerevisiae</em> GPM3 / systematic name YOL056W. UniProt Q12326 (PMG3_YEAST). One of three<br />
+phosphoglycerate-mutase-family paralogs in budding yeast (GPM1, GPM2, GPM3). This is an<br />
+<strong>understudied / dark</strong> gene: it is a sequence homolog of the glycolytic mutase GPM1, but has<br />
+no demonstrated mutase activity and no assigned in-vivo role. The primary curation deliverable<br />
+is an honest knowledge-gaps statement plus carefully-attributed core-functions/description that<br />
+never invents function.</p>
+<h2 id="provenance-rule-for-these-notes">Provenance rule for these notes</h2>
+<p>Every substantive claim carries inline <code>[PMID:xxxx "verbatim quote"]</code> or a <code>[file:...]</code><br />
+provenance pointer. Domain reasoning done inline (see "Domain / pseudoenzyme analysis") is my<br />
+own analysis of the UniProt record and a pairwise alignment I ran locally.</p>
+<h2 id="identity-and-paralogy-keep-gpm3-separate-from-gpm1gpm2">Identity and paralogy (KEEP GPM3 SEPARATE FROM GPM1/GPM2)</h2>
+<ul>
+<li><strong>GPM1 (P00950, PGM1_YEAST)</strong> is the <em>only functional</em> phosphoglycerate mutase in yeast — the<br />
+  real 2,3-bisphosphoglycerate-dependent (cofactor-dependent, dPGM) glycolytic enzyme. This is<br />
+  the enzyme that carries the experimentally established EC 5.4.2.11 activity. <strong>Do not attribute<br />
+  GPM1's biochemistry to GPM3.</strong></li>
+<li><strong>GPM2 (P37012, PMG2_YEAST)</strong> and <strong>GPM3 (Q12326)</strong> are homologous ORFs detected during the<br />
+  genome-sequencing project; both are reported to be non-functional homologs.</li>
+<li>Heinisch et al. 1998 is the definitive characterization of GPM2 + GPM3:<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/9544241" title="Our previous data indicated that GPM1 encodes the only functional phosphoglycerate mutase in yeast. However, in the course of the yeast genome sequencing project, two homologous sequences, designated GPM2 and GPM3, were detected.">PMID:9544241</a></li>
+</ul>
+<h2 id="what-is-known-about-gpm3">What is KNOWN about GPM3</h2>
+<ol>
+<li><strong>It is a phosphoglycerate-mutase-family protein (histidine-phosphatase superfamily, dPGM/BPG-dependent subfamily).</strong></li>
+<li>UniProt SIMILARITY: "Belongs to the phosphoglycerate mutase family. BPG-dependent PGAM subfamily."</li>
+<li>
+<p>Domain architecture from the UniProt DR block: Pfam PF00300 (His_Phos_1), CDD cd07067<br />
+     (HP_PGM_like), Gene3D 3.40.50.1240 (Phosphoglycerate mutase-like), PANTHER PTHR11931,<br />
+     PROSITE PS00175 (PG_MUTASE). <code>[file:yeast/GPM3/GPM3-uniprot.txt]</code></p>
+</li>
+<li>
+<p><strong>The catalytic residues of the dPGM active site are conserved in GPM3.</strong></p>
+</li>
+<li>Heinisch: <a href="https://pubmed.ncbi.nlm.nih.gov/9544241" title="Key residues in the deduced amino acid sequence, shown to be involved in catalysis for Gpm1 (i.e. His8, Arg59, His181) are conserved in both enzymes.">PMID:9544241</a></li>
+<li>
+<p>My own inline alignment confirms this (see Domain analysis below).</p>
+</li>
+<li>
+<p><strong>GPM3 has NO detectable phosphoglycerate mutase activity, even when forced to express.</strong></p>
+</li>
+<li><a href="https://pubmed.ncbi.nlm.nih.gov/9544241" title="Higher level expression under the control of the yeast PFK2 promoter partially complemented the gpm1 defects, without restoring detectable enzymatic activity.">PMID:9544241</a></li>
+<li>
+<p>Under its own (weak) promoter it does not complement a gpm1 deletion at all:<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/9544241" title="Overexpression of the genes under control of their own promoters in a gpm1 deletion mutant did not complement for any of the phenotypes.">PMID:9544241</a></p>
+</li>
+<li>
+<p><strong>Deleting GPM3 (alone or with GPM2) has no detectable phenotype.</strong></p>
+</li>
+<li>
+<p><a href="https://pubmed.ncbi.nlm.nih.gov/9544241" title="Nevertheless, deletion of either GPM2 or GPM3, or the two deletions in concert, did not produce any obvious lesions for growth on a variety of different carbon sources, nor did they change the levels of key intermediary metabolites.">PMID:9544241</a></p>
+</li>
+<li>
+<p><strong>The protein is expressed (at low abundance) and is cytoplasmic.</strong></p>
+</li>
+<li>Expression: UniProt MISCELLANEOUS "Present with 3730 molecules/cell in log phase SD medium"<br />
+     with evidence <code>ECO:0000269|PubMed:14562106</code> — i.e. the Ghaemmaghami et al. 2003 global protein<br />
+     expression study. <code>[file:yeast/GPM3/GPM3-uniprot.txt]</code></li>
+<li>Localization: GOA records <code>located_in cytoplasm</code> (GO:0005737, HDA) from the Huh et al. 2003<br />
+     genome-wide GFP-localization study [PMID:14562095, "Global analysis of protein localization in budding yeast."].</li>
+<li>
+<p>PE level 1 (evidence at protein level) in UniProt, consistent with the two proteomic datasets.</p>
+</li>
+<li>
+<p><strong>Evolutionary origin: gene duplication, probable non-functional homolog.</strong></p>
+</li>
+<li><a href="https://pubmed.ncbi.nlm.nih.gov/9544241" title="We conclude that both genes evolved from duplication events and that they probably constitute non-functional homologues in yeast.">PMID:9544241</a></li>
+</ol>
+<h2 id="what-is-not-known-about-gpm3-the-gap">What is NOT known about GPM3 (the gap)</h2>
+<ul>
+<li><strong>Whether GPM3 has ANY catalytic activity at all</strong> (mutase or otherwise). The mutase reaction<br />
+  was assayed and not detected (Heinisch 1998); no other activity has ever been tested.</li>
+<li><strong>Its in-vivo molecular function or biological role.</strong> Deletion is phenotypically silent under<br />
+  the conditions tested; no condition-specific role, partner, or substrate is known.</li>
+<li><strong>Why the cell retains a third mutase homolog.</strong> GPM3 is expressed as a stable protein<br />
+  (~3730 molecules/cell) yet is dispensable and (as far as tested) inactive — the selective<br />
+  rationale (if any) for its retention is unknown.</li>
+<li><strong>Whether the catalytic His residues, though present in sequence, are competent in the folded<br />
+  protein.</strong> Heinisch note the residues are conserved yet no activity is recovered even on forced<br />
+  expression, so the loss of function is not explained by an obvious active-site lesion.</li>
+</ul>
+<h2 id="domain-pseudoenzyme-analysis-my-own-inline-analysis">Domain / pseudoenzyme analysis (my own inline analysis)</h2>
+<p>I read <code>GPM3-uniprot.txt</code> and ran a local BLOSUM62 global pairwise alignment of GPM3 (Q12326,<br />
+303 aa) vs GPM1 (P00950, 247 aa); GPM3 is 42.5% identical to GPM1 over the aligned region. The<br />
+three catalytic motifs of the dPGM (cofactor-dependent PGAM; histidine-phosphatase superfamily<br />
+clade 1) active site map as follows (GPM3 numbering, motif shown):</p>
+<table>
+<thead>
+<tr>
+<th>dPGM catalytic element</th>
+<th>GPM1 motif</th>
+<th>GPM3 motif</th>
+<th>GPM3 residue status</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>N-terminal catalytic His (forms phospho-His intermediate)</td>
+<td><code>V**RHG**QSEW</code> (His8)</td>
+<td><code>L**RHG**QSEL</code> (His14)</td>
+<td><strong>conserved</strong> (His14; UniProt ACT_SITE 14)</td>
+</tr>
+<tr>
+<td>Proton donor/acceptor His (RHYG motif)</td>
+<td><code>NE**RHYG**D</code> (His88)</td>
+<td><code>NE**RHYG**A</code> (His122)</td>
+<td>His <strong>conserved</strong> (the D→A after it differs)</td>
+</tr>
+<tr>
+<td>C-terminal transition-state His (AHGN motif)</td>
+<td><code>IA**AHGN**S</code> (His181)</td>
+<td><code>IV**GHGS**S</code> (His235)</td>
+<td>His <strong>conserved</strong> (UniProt SITE 235); flanking A→G, N→S</td>
+</tr>
+</tbody>
+</table>
+<p>Interpretation: <strong>GPM3 is NOT a classic degenerate pseudoenzyme with an ablated active site.</strong><br />
+The three essential catalytic histidines (equivalent to GPM1 His8/His88/His181, i.e. Heinisch's<br />
+His8/Arg59/His181 catalytic set) are all retained in GPM3, matching Heinisch's own statement that<br />
+"key residues ... involved in catalysis ... are conserved". This makes GPM3 an unusual case:<br />
+catalytic residues present, but no measurable activity. Candidate (untested) explanations<br />
+supported by the sequence:</p>
+<ul>
+<li><strong>A large disordered insertion unique to GPM3.</strong> UniProt annotates a disordered region 168–198<br />
+  (<code>REGION 168..198 /note="Disordered"</code>, MobiDB-lite) with a basic-and-acidic compositional bias<br />
+  (COMPBIAS 177..198). My alignment shows this maps to an ~30-residue insertion that is absent<br />
+  from GPM1 (GPM1 has a short <code>YKYVD</code> where GPM3 has <code>NRHLKYGPEEKANERLP...</code>). Such an insertion in<br />
+  the mutase fold could perturb folding, substrate-channel geometry, or the required 2,3-BPG<br />
+  cofactor priming.</li>
+<li><strong>Substitutions in second-shell / substrate-binding positions</strong> (e.g. the RHYG→RHYGA change and<br />
+  the AHGN→GHGS change adjacent to the retained catalytic His) could impair substrate binding or<br />
+  transition-state stabilization even with the catalytic His intact.</li>
+</ul>
+<p>These are hypotheses, not demonstrated mechanisms; the honest position is that the biochemical<br />
+reason for GPM3's inactivity is undetermined. I did NOT run structure prediction; this is a<br />
+sequence-level analysis of the UniProt record plus a pairwise alignment.</p>
+<p>Note on UniProt EC/pathway annotations: the UniProt entry carries <code>EC=5.4.2.11</code>,<br />
+<code>PATHWAY: glycolysis</code>, and a Rhea reaction. These are propagated from the family SIMILARITY<br />
+rule (BPG-dependent PGAM subfamily), NOT from measured GPM3 activity — the same entry's FUNCTION<br />
+line reads "Could be non-functional." The EC/pathway are therefore family-level inferences, in<br />
+tension with the direct experimental finding of no detectable activity.</p>
+<h2 id="annotation-by-annotation-plan-10-goa-annotations">Annotation-by-annotation plan (10 GOA annotations)</h2>
+<ol>
+<li><code>GO:0004619 phosphoglycerate mutase activity</code> (IBA, GO_REF:0000033) — MARK_AS_OVER_ANNOTATED /<br />
+   over-propagated: phylogenetic (IBA) transfer of the family activity to a paralog that was<br />
+   experimentally shown to lack detectable mutase activity (Heinisch 1998). Add propagation_review.</li>
+<li><code>GO:0005829 cytosol</code> (IBA, GO_REF:0000033) — ACCEPT/KEEP_AS_NON_CORE: consistent with the<br />
+   experimental HDA cytoplasm localization; a reasonable location even if the activity is absent.</li>
+<li><code>GO:0061621 canonical glycolysis</code> (IBA, GO_REF:0000033) — MARK_AS_OVER_ANNOTATED: GPM3 is not<br />
+   a functional glycolytic enzyme (no activity; deletion has no metabolite/growth effect).</li>
+<li><code>GO:0003824 catalytic activity</code> (IEA, GO_REF:0000002, InterPro) — MARK_AS_OVER_ANNOTATED /<br />
+   generic root-ish MF; no catalytic activity demonstrated. (Very general; IEA from InterPro.)</li>
+<li><code>GO:0004619 phosphoglycerate mutase activity</code> (IEA, GO_REF:0000120, EC/Rhea) — same as #1,<br />
+   over-annotation from EC mapping; MARK_AS_OVER_ANNOTATED.</li>
+<li><code>GO:0006096 glycolytic process</code> (IEA, GO_REF:0000120) — MARK_AS_OVER_ANNOTATED, as #3.</li>
+<li><code>GO:0016868 intramolecular phosphotransferase activity</code> (IEA, GO_REF:0000002, InterPro) —<br />
+   MARK_AS_OVER_ANNOTATED; the specific catalytic activity is not demonstrated. (Note: this term<br />
+   may be obsoleted/merged in current GO; do not rewrite the GOA id.)</li>
+<li><code>GO:0005737 cytoplasm</code> (HDA, PMID:14562095) — ACCEPT: direct experimental localization.</li>
+<li><code>GO:0003674 molecular_function</code> (ND, GO_REF:0000015) — ACCEPT as the honest MF root (SGD's own<br />
+   "no data" call reflects the true state: no positively demonstrated activity).</li>
+<li><code>GO:0008150 biological_process</code> (ND, GO_REF:0000015) — ACCEPT as honest BP root.</li>
+</ol>
+<p>Rationale for using MARK_AS_OVER_ANNOTATED (not REMOVE) on the mutase/glycolysis IBA/IEA rows:<br />
+these are electronic/phylogenetic inferences (not experimental annotations), and per the GO<br />
+guidelines over-propagated IEA/IBA are legitimately down-graded on biological grounds. There is<br />
+direct experimental evidence (Heinisch 1998) that the transferred activity is absent, which is<br />
+exactly the situation MARK_AS_OVER_ANNOTATED / propagation_review is for. I am NOT removing any<br />
+experimental annotation.</p>
+<h2 id="update-after-falcon-deep-research-2026-07-05">Update after falcon deep research (2026-07-05)</h2>
+<p>The falcon (Edison) deep-research report landed late (<code>GPM3-deep-research-falcon.md</code>, 21<br />
+citations, genuine). It is consistent with the Heinisch primary data and adds useful context<br />
+(citations are by citekey/DOI, not PMID, so I have NOT used them as <code>supported_by</code> quotes):</p>
+<ul>
+<li><strong>Family layout confirmed:</strong> three paralogs GPM1 (YKL152C, the major functional enzyme),<br />
+  GPM2 (YDL021W), GPM3 (YOL056W). GPM1 is a homotetramer (~28 kDa subunits); deletion of GPM1<br />
+  blocks growth on glucose.</li>
+<li><strong>Interpretive nuance / tension worth flagging:</strong> the falcon report (leaning on Papini et al.<br />
+  2010, <em>Biotechnol J</em> 5:1016-1027, doi:10.1002/biot.201000199, and Costenoble et al. 2011 SRM<br />
+  proteomics) argues GPM3's physiological insignificance is "primarily due to insufficient<br />
+  endogenous expression rather than complete loss of catalytic competence," inferring "residual<br />
+  catalytic capacity" from the <em>partial complementation</em> of gpm1Δ when GPM3 is overexpressed<br />
+  from the PFK2 promoter. This is an INFERENCE. It stands in tension with the Heinisch (1998)<br />
+  primary result that the same PFK2-driven overexpression complemented "without restoring<br />
+  detectable enzymatic activity." I therefore keep the honest position: GPM3 has NO directly<br />
+  measured mutase activity (Heinisch), while partial complementation on non-fermentable carbon<br />
+  after prolonged incubation leaves open the possibility of weak/residual activity that was below<br />
+  the assay's detection limit. My review states both facts and does not over-claim activity.</li>
+<li><strong>Costenoble et al. 2011</strong> (targeted SRM proteomics) reportedly detected Gpm3 protein across<br />
+  metabolic states — consistent with the UniProt ~3730 molecules/cell figure; corroborates that<br />
+  GPM3 is a genuinely expressed protein.</li>
+<li><strong>Localization:</strong> falcon agrees GPM3 is cytoplasmic (Huh et al. 2003) with no evidence for the<br />
+  cell-wall/moonlighting localization documented for GPM1 (and for <em>C. albicans</em> Gpm1<br />
+  plasminogen/complement binding). GPM3-specific moonlighting: none known.</li>
+<li><strong>Evolution:</strong> GPM2/GPM3 arose by duplication; notably Conant &amp; Wolfe (2007) <em>excluded</em> the<br />
+  GPM2/GPM3 pair from their set of WGD-retained, dosage-amplified glycolytic duplicates —<br />
+  consistent with GPM3 being a divergent, near-non-functional paralog rather than a<br />
+  flux-boosting duplicate.</li>
+</ul>
+<p>Net effect on the review: no change to actions. The over-annotation calls on the mutase/glycolysis<br />
+terms remain correct (GPM3 is not a physiologically functional mutase and its deletion is silent),<br />
+and the honest knowledge gap (whether it retains ANY residual activity, and why the third homolog<br />
+is kept) is if anything reinforced by the expression-vs-activity tension between Heinisch and the<br />
+Papini-based interpretation.</p>
+<h2 id="references-to-cite">References to cite</h2>
+<ul>
+<li>PMID:9544241 — Heinisch et al. 1998, characterization of GPM2/GPM3 (HIGH relevance; the key paper). Abstract-only in cache but the abstract itself contains all the load-bearing findings.</li>
+<li>PMID:14562095 — Huh et al. 2003, global localization (supports cytoplasm; MEDIUM).</li>
+<li>PMID:14562106 — Ghaemmaghami et al. 2003, global expression (supports the ~3730 molecules/cell abundance; MEDIUM).</li>
+<li>file:yeast/GPM3/GPM3-uniprot.txt — domain/active-site features and expression/localization summary.</li>
+</ul>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: Q12326
+gene_symbol: GPM3
+product_type: PROTEIN
+status: DRAFT
+taxon:
+  id: NCBITaxon:559292
+  label: Saccharomyces cerevisiae
+description: &gt;-
+  GPM3 (systematic name YOL056W) is one of three phosphoglycerate-mutase-family
+  paralogs in Saccharomyces cerevisiae, alongside the sole functional glycolytic
+  mutase GPM1 and the second homolog GPM2. It is a cytoplasmic protein of the
+  histidine-phosphatase superfamily (cofactor/2,3-bisphosphoglycerate-dependent
+  phosphoglycerate mutase, dPGM, subfamily) and retains the family&#39;s catalytic
+  histidine residues. Despite this, GPM3 has no detectable phosphoglycerate mutase
+  activity even when strongly overexpressed, and its deletion (alone or together
+  with GPM2) causes no growth defect on diverse carbon sources and no change in key
+  glycolytic-intermediate levels. It arose by gene duplication and is regarded as a
+  probable non-functional homolog; it is expressed as a low-abundance protein
+  (thousands of molecules per cell) whose molecular activity and biological role
+  remain undetermined.
+references:
+  - id: GO_REF:0000002
+    title: Gene Ontology annotation through association of InterPro records with GO
+      terms
+    findings: []
+  - id: GO_REF:0000015
+    title: Use of the ND evidence code for Gene Ontology (GO) terms
+    findings: []
+  - id: GO_REF:0000033
+    title: Annotation inferences using phylogenetic trees
+    findings: []
+  - id: GO_REF:0000120
+    title: Combined Automated Annotation using Multiple IEA Methods
+    findings: []
+  - id: PMID:9544241
+    title: Investigation of two yeast genes encoding putative isoenzymes of phosphoglycerate
+      mutase.
+    findings:
+      - statement: &gt;-
+          GPM1 is the only functional phosphoglycerate mutase in yeast; GPM2 and GPM3
+          were detected as homologous sequences during genome sequencing.
+        supporting_text: &gt;-
+          Our previous data indicated that GPM1 encodes the only functional
+          phosphoglycerate mutase in yeast. However, in the course of the yeast genome
+          sequencing project, two homologous sequences, designated GPM2 and GPM3, were
+          detected.
+      - statement: &gt;-
+          The catalytic residues of the mutase active site are conserved in GPM3.
+        supporting_text: &gt;-
+          Key residues in the deduced amino acid sequence, shown to be involved in
+          catalysis for Gpm1 (i.e. His8, Arg59, His181) are conserved in both enzymes.
+      - statement: &gt;-
+          Forced high-level expression of GPM3 partially complemented gpm1 defects but
+          did not restore any detectable enzymatic activity.
+        supporting_text: &gt;-
+          Higher level expression under the control of the yeast PFK2 promoter partially
+          complemented the gpm1 defects, without restoring detectable enzymatic activity.
+      - statement: &gt;-
+          Deletion of GPM2 and/or GPM3 produced no growth lesions and no change in key
+          metabolite levels; both are probable non-functional homologs arising by
+          duplication.
+        supporting_text: &gt;-
+          deletion of either GPM2 or GPM3, or the two deletions in concert, did not
+          produce any obvious lesions for growth on a variety of different carbon
+          sources, nor did they change the levels of key intermediary metabolites.
+    reference_review:
+      relevance: HIGH
+      correctness: VERIFIED
+      review_notes: &gt;-
+        Definitive characterization of GPM2 and GPM3. PubMed-verified; abstract-only in
+        cache but the abstract contains the load-bearing experimental findings (no
+        detectable mutase activity even on forced expression; phenotypically silent
+        deletions; probable non-functional homologs). Directly grounds the
+        over-annotation calls on the transferred mutase/glycolysis terms.
+  - id: PMID:14562095
+    title: Global analysis of protein localization in budding yeast.
+    findings:
+      - statement: Genome-wide GFP study assigning GPM3 to the cytoplasm.
+        supporting_text: Global analysis of protein localization in budding yeast.
+    reference_review:
+      relevance: MEDIUM
+      correctness: VERIFIED
+      review_notes: &gt;-
+        Source of the experimental (HDA) cytoplasm localization for GPM3 in GOA.
+        Abstract-only in cache; the per-protein call resides in the study&#39;s database,
+        recorded by SGD.
+  - id: PMID:14562106
+    title: Global analysis of protein expression in yeast.
+    findings:
+      - statement: &gt;-
+          Genome-wide expression study; source of the ~3730 molecules/cell abundance
+          value for GPM3 recorded in UniProt.
+        supporting_text: Global analysis of protein expression in yeast.
+    reference_review:
+      relevance: MEDIUM
+      correctness: VERIFIED
+      review_notes: &gt;-
+        Basis for the UniProt statement that GPM3 is present at ~3730 molecules/cell in
+        log-phase SD medium (ECO:0000269|PubMed:14562106); establishes that GPM3 is a
+        genuinely expressed, stable protein despite lacking demonstrated activity.
+existing_annotations:
+  - term:
+      id: GO:0004619
+      label: phosphoglycerate mutase activity
+    evidence_type: IBA
+    original_reference_id: GO_REF:0000033
+    qualifier: enables
+    review:
+      summary: &gt;-
+        Phylogenetic (IBA) transfer of the family&#39;s phosphoglycerate mutase activity to
+        GPM3. GPM3 was experimentally assayed and shown to lack detectable mutase
+        activity even when strongly overexpressed (Heinisch et al. 1998), so this is an
+        over-propagation of the ancestral family activity onto a probable non-functional
+        paralog. GPM1 is the sole functional yeast phosphoglycerate mutase.
+        Marked as over-annotated rather than removed because the evidence is contradictory
+        rather than merely thin: UniProt itself hedges (&#34;Could be non-functional&#34;), the
+        dPGM catalytic histidines are conserved in sequence, and weak, expression-limited
+        residual activity below the original assay&#39;s detection cannot be fully excluded
+        (forced overexpression did partially complement gpm1). The term should not,
+        however, be retained as a functional annotation for this paralog.
+      action: MARK_AS_OVER_ANNOTATED
+      supported_by:
+        - reference_id: PMID:9544241
+          supporting_text: &gt;-
+            Higher level expression under the control of the yeast PFK2 promoter partially
+            complemented the gpm1 defects, without restoring detectable enzymatic activity.
+      propagation_review:
+        root_cause: PROPAGATION_BAD
+        failure_modes:
+          - WRONG_ORTHOLOG_OR_PARALOG
+          - FUNCTIONAL_DIVERGENCE
+        source_entities:
+          - source_id: PANTHER:PTN002630707
+            source_label: PGAM ancestral node (PTHR11931)
+            source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
+            comment: &gt;-
+              Ancestral PGAM activity is real for the family and for GPM1, but GPM3 has
+              direct experimental evidence of no detectable mutase activity; catalytic
+              histidines are present in sequence, so this is functional divergence rather
+              than an obvious active-site lesion.
+  - term:
+      id: GO:0005829
+      label: cytosol
+    evidence_type: IBA
+    original_reference_id: GO_REF:0000033
+    qualifier: is_active_in
+    review:
+      summary: &gt;-
+        Phylogenetic assignment of cytosolic localization. This is consistent with the
+        independent experimental (HDA) cytoplasm localization of GPM3 and with the
+        cytoplasmic nature of the family, so the location is reasonable. Kept as
+        non-core because GPM3 has no demonstrated activity for which the location would
+        represent a core function; the &#34;is_active_in&#34; qualifier overstates a
+        demonstrated activity at this site. This IBA cytosol call is independently
+        corroborated by the experimental (HDA) cytoplasm localization of GPM3
+        (GO:0005737, PMID:14562095), which is why the location itself is accepted even
+        though the accompanying activity is not.
+      action: KEEP_AS_NON_CORE
+      supported_by:
+        - reference_id: PMID:14562095
+          supporting_text: Global analysis of protein localization in budding yeast.
+  - term:
+      id: GO:0061621
+      label: canonical glycolysis
+    evidence_type: IBA
+    original_reference_id: GO_REF:0000033
+    qualifier: involved_in
+    review:
+      summary: &gt;-
+        Phylogenetic transfer of a glycolytic role. GPM3 is not a functional glycolytic
+        enzyme: it has no detectable mutase activity, and deletion of GPM3 (with or
+        without GPM2) does not perturb growth on diverse carbon sources or the levels of
+        key glycolytic intermediates (Heinisch et al. 1998). This is an over-annotation
+        of the family process onto a non-functional paralog.
+      action: MARK_AS_OVER_ANNOTATED
+      supported_by:
+        - reference_id: PMID:9544241
+          supporting_text: &gt;-
+            deletion of either GPM2 or GPM3, or the two deletions in concert, did not
+            produce any obvious lesions for growth on a variety of different carbon
+            sources, nor did they change the levels of key intermediary metabolites.
+      propagation_review:
+        root_cause: PROPAGATION_BAD
+        failure_modes:
+          - WRONG_ORTHOLOG_OR_PARALOG
+          - FUNCTIONAL_DIVERGENCE
+        source_entities:
+          - source_id: PANTHER:PTN002630707
+            source_label: PGAM ancestral node (PTHR11931)
+            source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
+            comment: &gt;-
+              Canonical glycolysis is correct for GPM1 but propagates to a paralog whose
+              deletion is metabolically silent and which lacks the enabling enzymatic
+              activity.
+  - term:
+      id: GO:0003824
+      label: catalytic activity
+    evidence_type: IEA
+    original_reference_id: GO_REF:0000002
+    qualifier: enables
+    review:
+      summary: &gt;-
+        Generic catalytic-activity term applied electronically from InterPro membership.
+        No catalytic activity of any kind has been demonstrated for GPM3; the assayed
+        mutase activity was undetectable. This is uninformative and, given the negative
+        functional evidence, an over-annotation from family membership.
+      action: MARK_AS_OVER_ANNOTATED
+      supported_by:
+        - reference_id: PMID:9544241
+          supporting_text: &gt;-
+            Higher level expression under the control of the yeast PFK2 promoter partially
+            complemented the gpm1 defects, without restoring detectable enzymatic activity.
+  - term:
+      id: GO:0004619
+      label: phosphoglycerate mutase activity
+    evidence_type: IEA
+    original_reference_id: GO_REF:0000120
+    qualifier: enables
+    review:
+      summary: &gt;-
+        Electronic assignment of phosphoglycerate mutase activity from the UniProt
+        EC/Rhea mapping (EC 5.4.2.11) attached to the BPG-dependent PGAM subfamily. As
+        with the IBA copy of this term, this is a family-level inference contradicted by
+        the direct experimental finding of no detectable mutase activity for GPM3; the
+        same UniProt entry states the protein &#34;Could be non-functional&#34;. Marked as
+        over-annotated rather than removed for the same reason as the IBA copy: the
+        catalytic histidines are conserved and expression-limited residual activity cannot
+        be fully excluded, so the call is deliberately conservative.
+      action: MARK_AS_OVER_ANNOTATED
+      supported_by:
+        - reference_id: PMID:9544241
+          supporting_text: &gt;-
+            Higher level expression under the control of the yeast PFK2 promoter partially
+            complemented the gpm1 defects, without restoring detectable enzymatic activity.
+  - term:
+      id: GO:0006096
+      label: glycolytic process
+    evidence_type: IEA
+    original_reference_id: GO_REF:0000120
+    qualifier: involved_in
+    review:
+      summary: &gt;-
+        Electronic transfer of the glycolytic-process role from family/pathway mapping.
+        Over-annotation for the same reasons as the canonical-glycolysis IBA term: GPM3
+        deletion is metabolically and phenotypically silent and the enzyme lacks
+        detectable activity.
+      action: MARK_AS_OVER_ANNOTATED
+      supported_by:
+        - reference_id: PMID:9544241
+          supporting_text: &gt;-
+            deletion of either GPM2 or GPM3, or the two deletions in concert, did not
+            produce any obvious lesions for growth on a variety of different carbon
+            sources, nor did they change the levels of key intermediary metabolites.
+  - term:
+      id: GO:0016868
+      label: intramolecular phosphotransferase activity
+    evidence_type: IEA
+    original_reference_id: GO_REF:0000002
+    qualifier: enables
+    review:
+      summary: &gt;-
+        The specific mechanistic MF term for the dPGM reaction (intramolecular
+        phosphotransfer), applied electronically from InterPro. No such activity has been
+        demonstrated for GPM3; it is an over-annotation of the family mechanism onto a
+        non-functional paralog.
+      action: MARK_AS_OVER_ANNOTATED
+      supported_by:
+        - reference_id: PMID:9544241
+          supporting_text: &gt;-
+            Higher level expression under the control of the yeast PFK2 promoter partially
+            complemented the gpm1 defects, without restoring detectable enzymatic activity.
+  - term:
+      id: GO:0005737
+      label: cytoplasm
+    evidence_type: HDA
+    original_reference_id: PMID:14562095
+    qualifier: located_in
+    review:
+      summary: &gt;-
+        Experimental (high-throughput direct assay) localization of GPM3 to the cytoplasm
+        from the genome-wide GFP-fusion study. This is a well-supported, correct location
+        annotation and the only positively demonstrated attribute of GPM3 besides its
+        expression. Retained; it is a location rather than a core molecular/biological
+        function.
+      action: ACCEPT
+      supported_by:
+        - reference_id: PMID:14562095
+          supporting_text: Global analysis of protein localization in budding yeast.
+  - term:
+      id: GO:0003674
+      label: molecular_function
+    evidence_type: ND
+    original_reference_id: GO_REF:0000015
+    qualifier: enables
+    review:
+      summary: &gt;-
+        Root molecular_function with the ND (no biological data) evidence code, assigned
+        by SGD. This honestly reflects the true state of knowledge: no molecular activity
+        has been positively demonstrated for GPM3, and the assayed mutase activity was
+        undetectable. Retained as an accurate no-data placeholder.
+      action: ACCEPT
+  - term:
+      id: GO:0008150
+      label: biological_process
+    evidence_type: ND
+    original_reference_id: GO_REF:0000015
+    qualifier: involved_in
+    review:
+      summary: &gt;-
+        Root biological_process with the ND evidence code. Consistent with the absence of
+        any demonstrated in-vivo role: GPM3 deletion is phenotypically silent under the
+        conditions tested. Retained as an accurate no-data placeholder.
+      action: ACCEPT
+core_functions:
+  - description: &gt;-
+      No molecular function can be positively assigned to GPM3. It is a member of the
+      phosphoglycerate mutase / histidine-phosphatase superfamily that retains the dPGM
+      catalytic histidine residues, but the family phosphoglycerate mutase activity was
+      experimentally undetectable even on forced overexpression, and no alternative
+      activity, substrate, or biological role has been demonstrated. It is a stably
+      expressed cytoplasmic protein of unknown function, most consistent with a probable
+      non-functional homolog produced by gene duplication.
+    supported_by:
+      - reference_id: PMID:9544241
+        supporting_text: &gt;-
+          Higher level expression under the control of the yeast PFK2 promoter partially
+          complemented the gpm1 defects, without restoring detectable enzymatic activity.
+      - reference_id: PMID:9544241
+        supporting_text: &gt;-
+          We conclude that both genes evolved from duplication events and that they
+          probably constitute non-functional homologues in yeast.
+knowledge_gaps:
+  - gap_statement: &gt;-
+      It is unknown whether GPM3 has any catalytic or other molecular activity, what (if
+      any) its in-vivo biological role is, and why S. cerevisiae retains a stably
+      expressed third phosphoglycerate-mutase homolog that is dispensable and lacks
+      detectable mutase activity.
+    boundary: &gt;-
+      GPM3 is firmly established as a phosphoglycerate-mutase-family protein (histidine-
+      phosphatase superfamily, BPG-dependent PGAM subfamily) that retains the dPGM
+      catalytic histidine residues, is expressed as a low-abundance protein (~3730
+      molecules/cell) and localizes to the cytoplasm. It has been directly assayed for
+      phosphoglycerate mutase activity and none was detectable even under forced (PFK2-
+      promoter) overexpression, and deletion of GPM3 alone or together with GPM2 causes
+      no growth defect on diverse carbon sources and no change in key glycolytic-
+      intermediate levels. GPM1 is the sole functional yeast phosphoglycerate mutase.
+    gap_kind:
+      - BIOLOGY
+    dark_aspect: WHOLLY_DARK
+    status: OPEN
+    significance: &gt;-
+      GPM3 is a clean example of a conserved-looking paralog whose active-site residues
+      are intact yet which has no directly measured ancestral activity. It is unresolved
+      whether the protein is truly catalytically dead or retains weak residual activity
+      that is masked physiologically by very low native expression: the same PFK2-driven
+      overexpression that partially complements a gpm1 deletion on non-fermentable carbon
+      also failed to restore detectable enzymatic activity in the original assay.
+      Determining whether GPM3 has been pseudogenized at the protein level, retains weak
+      residual activity limited by expression, acquired a new (non-mutase) activity, or is
+      retained for a condition-specific role would clarify the fate of duplicated
+      metabolic-enzyme genes and prevent electronic propagation of functional
+      glycolytic-mutase annotations onto physiologically non-functional homologs.
+    resolution: &gt;-
+      Broad enzymatic screening of purified recombinant GPM3 (including 2,3-BPG-primed
+      mutase and phosphatase assays) to test for any residual or alternative activity;
+      condition/stress-specific phenotyping of gpm3 and gpm1 gpm3 / gpm2 gpm3 mutants;
+      affinity/proximity proteomics to identify partners; structural characterization to
+      test whether the family fold and active site are competent despite the conserved
+      residues, given the ~30-residue disordered insertion unique to GPM3.
+    provenance:
+      - reference_id: PMID:9544241
+        supporting_text: &gt;-
+          Higher level expression under the control of the yeast PFK2 promoter partially
+          complemented the gpm1 defects, without restoring detectable enzymatic activity.
+        reference_section_type: ABSTRACT
+      - reference_id: PMID:9544241
+        supporting_text: &gt;-
+          We conclude that both genes evolved from duplication events and that they
+          probably constitute non-functional homologues in yeast.
+        reference_section_type: ABSTRACT
+suggested_questions:
+  - question: &gt;-
+      Does GPM3 have any residual or alternative catalytic activity (e.g. phosphatase or
+      a non-glycolytic phosphotransfer) despite lacking detectable phosphoglycerate
+      mutase activity?
+  - question: &gt;-
+      Is GPM3 conditionally functional or important under a stress or nutrient state not
+      tested in the original characterization?
+  - question: &gt;-
+      Given that the dPGM catalytic histidines are conserved in sequence, is the folded
+      GPM3 active site competent, and does the GPM3-specific disordered insertion
+      (residues ~168-198) disrupt folding or substrate binding?
+suggested_experiments:
+  - description: &gt;-
+      Express and purify recombinant GPM3 and assay it across a panel of phosphoglycerate
+      mutase (with and without 2,3-bisphosphoglycerate priming) and histidine-phosphatase
+      substrate reactions to test for any residual or alternative activity.
+    hypothesis: &gt;-
+      GPM3 has no residual mutase activity but may retain a weak alternative
+      phosphotransfer/phosphatase activity typical of the histidine-phosphatase
+      superfamily.
+    experiment_type: enzymatic assay
+  - description: &gt;-
+      Perform condition/stress phenotyping (e.g. carbon-source shifts, oxidative,
+      osmotic, and stationary-phase stresses) of gpm3, gpm2 gpm3, and gpm1(ts) gpm3
+      strains to detect any conditional requirement for GPM3.
+    hypothesis: GPM3 is required only under a specific, previously untested condition.
+    experiment_type: genetic phenotyping
+  - description: &gt;-
+      Determine the GPM3 interactome by affinity purification / proximity labeling to
+      test whether it acts as a partner or scaffold rather than an enzyme.
+    hypothesis: GPM3 has a non-catalytic role mediated by protein partners.
+    experiment_type: interaction proteomics
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/genes/yeast/JIP4/JIP4-ai-review.html
+++ b/genes/yeast/JIP4/JIP4-ai-review.html
@@ -1,0 +1,2864 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>JIP4 - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        .propagation-review {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f8fafc;
+            border-left: 3px solid #64748b;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .propagation-title {
+            font-weight: 600;
+            color: #334155;
+            margin-bottom: 0.25rem;
+        }
+
+        .propagation-row {
+            margin-top: 0.25rem;
+        }
+
+        .propagation-source {
+            margin-top: 0.5rem;
+            padding-top: 0.5rem;
+            border-top: 1px solid #e5e7eb;
+        }
+
+        .propagation-source-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #1d4ed8;
+        }
+
+        .propagation-comment {
+            color: #4b5563;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>JIP4</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/Q03361" target="_blank" class="term-link">
+                        Q03361
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Saccharomyces cerevisiae</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-draft">
+                    DRAFT
+                </span>
+            </div>
+
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "JIP4";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="Q03361" data-a="DESCRIPTION: JIP4 (systematic name YDR475C; &#34;Jumonji-interactin..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>JIP4 (systematic name YDR475C; &#34;Jumonji-interacting protein 4&#34;) is a large (876-residue) intrinsically disordered protein of Saccharomyces cerevisiae whose molecular function has not been experimentally determined. Its sequence is dominated by disorder and low-complexity composition, including several arginine/serine (RS) and basic/acidic repetitive tracts, and on the basis of this compositional similarity it is placed in the serine/arginine repetitive matrix protein family (PANTHER PTHR23148), whose metazoan members (SRRM1/SRm160) are nuclear SR-related splicing coactivators; JIP4 itself lacks the folded PWI nucleic-acid-binding domain that defines those splicing proteins, and no splicing or RNA-related activity has been demonstrated for it in yeast. JIP4 is a phosphoprotein, with multiple serine residues phosphorylated in vivo (including cyclin-dependent-kinase-1-dependent sites) as detected by large-scale phosphoproteomics. The gene is non-essential; deletion is viable, and it has a paralog, YOR019W, arising from the whole-genome duplication that is likewise uncharacterized.</p>
+    </div>
+
+
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005681" target="_blank" class="term-link">
+                                    GO:0005681
+                                </a>
+                            </span>
+                            <span class="term-label">spliceosomal complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q03361" data-a="GO:0005681" data-r="GO_REF:0000033" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Homology-only (IBA) inference propagated from the metazoan SRRM1/SRm160 orthologs in PANTHER family PTHR23148. There is no experimental evidence that yeast JIP4 is a spliceosome component, and this transfer is biologically questionable.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> This annotation rests solely on JIP4&#39;s placement in the serine/arginine repetitive matrix family (with/from human SRRM1 Q8IYB3, mouse Srrm1 MGI:1858303), a placement driven by shared RS/low-complexity composition rather than a conserved folded domain. JIP4 lacks the PWI nucleic-acid-binding domain that defines the SRm160/SRRM1 splicing coactivators (UniProt annotates only disorder and compositional bias, no PWI or RRM). The S. cerevisiae spliceosome has been exhaustively purified and characterized, and JIP4 has never been reported as a spliceosome subunit; the known yeast counterparts of the human SR-related nuclear-matrix splicing proteins are other proteins (e.g. Cwc21/YDR482C). The annotation is therefore retained but flagged as a likely over-annotation of an uncharacterized gene rather than as core function.
+                        </div>
+
+
+
+                        <div class="propagation-review">
+                            <div class="propagation-title">Propagation Review</div>
+                            <div class="propagation-row">
+                                <strong>Root cause:</strong>
+                                <span class="badge">PROPAGATION BAD</span>
+                            </div>
+
+                            <div class="propagation-row">
+                                <strong>Failure modes:</strong>
+
+                                <span class="badge">FUNCTIONAL DIVERGENCE</span>
+
+                                <span class="badge">PSEUDO OR SUBACTIVITY LOSS</span>
+
+                                <span class="badge">COMPARTMENT OR COMPLEX MISMATCH</span>
+
+                            </div>
+
+
+                            <div class="propagation-source">
+                                <strong>Sources checked:</strong>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">UniProtKB:Q8IYB3</span>
+
+                                    &middot; SRRM1 (human)
+
+
+                                    <span class="badge">SUPPORTS SOURCE BUT NOT TARGET</span>
+
+
+                                    <div class="propagation-comment">Human SRRM1/SRm160 is a bona fide PWI-domain spliceosome/EJC coactivator; the spliceosome-membership term is sound for the source but should not transfer to the PWI-less, uncharacterized yeast protein.</div>
+
+                                </div>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">MGI:MGI:1858303</span>
+
+                                    &middot; Srrm1 (mouse)
+
+
+                                    <span class="badge">SUPPORTS SOURCE BUT NOT TARGET</span>
+
+
+                                </div>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">PANTHER:PTN000567596</span>
+
+                                    &middot; PTHR23148:SF0 ancestral node
+
+
+                                    <span class="badge">SOURCE WEAK OR INFERRED</span>
+
+
+                                    <div class="propagation-comment">Family placement is composition-driven (RS/low-complexity) rather than domain-conserved.</div>
+
+                                </div>
+
+                            </div>
+
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:yeast/JIP4/JIP4-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">PANTHER; PTHR23148; SERINE/ARGININE REGULATED NUCLEAR MATRIX PROTEIN; 1.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0048024" target="_blank" class="term-link">
+                                    GO:0048024
+                                </a>
+                            </span>
+                            <span class="term-label">regulation of mRNA splicing, via spliceosome</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q03361" data-a="GO:0048024" data-r="GO_REF:0000033" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Homology-only (IBA) inference of a splicing-regulation role from metazoan/ Drosophila SRRM1-family members. Not supported by any experimental evidence in yeast and biologically doubtful given the absence of the defining PWI domain.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> As for the spliceosomal-complex annotation, this biological-process term is transferred from SRRM1/SRm160 orthologs (with/from FB:FBgn0036340 and PANTHER PTN000567596) purely on family membership. JIP4 has no demonstrated RNA-binding or splicing activity, lacks the PWI domain, and does not appear in yeast spliceosome or splicing-regulator datasets. Budding yeast introns are few and simple with no minor (U12) spliceosome and no metazoan-style exon-junction splicing coactivation, so the specific SRm160 splicing-activation role has no clear yeast equivalent. Retained but flagged as a likely over-annotation rather than established or core function.
+                        </div>
+
+
+
+                        <div class="propagation-review">
+                            <div class="propagation-title">Propagation Review</div>
+                            <div class="propagation-row">
+                                <strong>Root cause:</strong>
+                                <span class="badge">PROPAGATION BAD</span>
+                            </div>
+
+                            <div class="propagation-row">
+                                <strong>Failure modes:</strong>
+
+                                <span class="badge">FUNCTIONAL DIVERGENCE</span>
+
+                                <span class="badge">PSEUDO OR SUBACTIVITY LOSS</span>
+
+                                <span class="badge">LINEAGE OR TAXON MISMATCH</span>
+
+                            </div>
+
+
+                            <div class="propagation-source">
+                                <strong>Sources checked:</strong>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">FB:FBgn0036340</span>
+
+                                    &middot; Drosophila SRRM1-family member
+
+
+                                    <span class="badge">SUPPORTS SOURCE BUT NOT TARGET</span>
+
+
+                                </div>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">PANTHER:PTN000567596</span>
+
+                                    &middot; PTHR23148:SF0 ancestral node
+
+
+                                    <span class="badge">SOURCE WEAK OR INFERRED</span>
+
+
+                                    <div class="propagation-comment">Metazoan-style ESE-dependent splicing activation has no clear equivalent in intron-poor budding yeast, which lacks a minor spliceosome.</div>
+
+                                </div>
+
+                            </div>
+
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:yeast/JIP4/JIP4-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">PANTHER; PTHR23148; SERINE/ARGININE REGULATED NUCLEAR MATRIX PROTEIN; 1.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003674" target="_blank" class="term-link">
+                                    GO:0003674
+                                </a>
+                            </span>
+                            <span class="term-label">molecular_function</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ND</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000015
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q03361" data-a="GO:0003674" data-r="GO_REF:0000015" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Root molecular_function term with the ND (No biological Data available) evidence code, correctly recording that no molecular function has been determined for JIP4.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The ND annotation to the MF root is an honest placeholder for an uncharacterized gene. No experimentally supported molecular activity exists for JIP4, and no folded catalytic or binding domain is identifiable in its sequence, so retaining the ND root annotation accurately conveys the molecular-function-dark status. It does not represent a core function.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005575" target="_blank" class="term-link">
+                                    GO:0005575
+                                </a>
+                            </span>
+                            <span class="term-label">cellular_component</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ND</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000015
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q03361" data-a="GO:0005575" data-r="GO_REF:0000015" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Root cellular_component term with ND evidence, recording that JIP4&#39;s subcellular localization has not been experimentally established.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> No experimental localization data are available for JIP4 (UniProt records no subcellular-location annotation). While the RS-rich, disordered composition is suggestive of a possible nuclear/RNA-associated localization, this is not established, so the ND root annotation is an appropriate honest placeholder.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008150" target="_blank" class="term-link">
+                                    GO:0008150
+                                </a>
+                            </span>
+                            <span class="term-label">biological_process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ND</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000015
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q03361" data-a="GO:0008150" data-r="GO_REF:0000015" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Root biological_process term with ND evidence, recording that no biological process/pathway has been assigned to JIP4.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> JIP4 is non-essential (deletion viable) with no defined loss-of-function phenotype beyond viability and no assigned pathway. The ND root annotation correctly captures the biological-process-dark status of this gene.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>No core molecular function can be assigned to JIP4 with confidence. It is an intrinsically disordered, RS/low-complexity protein classified by composition in the serine/arginine repetitive matrix (SRRM1/SRm160) family, and it is an in vivo phosphoprotein (including Cdk1-dependent sites), but neither its molecular activity nor its biological role has been experimentally established, and it lacks the folded PWI domain that carries the splicing function of its metazoan family members. The family-based splicing/spliceosome inferences are homology-only and are treated as unverified rather than as core function.</h3>
+                <span class="vote-buttons" data-g="Q03361" data-a="FUNCTION: No core molecular function can be assigned to JIP4..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+
+
+
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:yeast/JIP4/JIP4-uniprot.txt
+
+                        </span>
+
+                        <div class="finding-text">RecName: Full=Uncharacterized protein JIP4;</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        file:yeast/JIP4/JIP4-uniprot.txt
+
+                    </span>
+                </div>
+
+                <div class="reference-title">UniProtKB entry Q03361 (JIP4_YEAST), including PANTHER family assignment and sequence features</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000015.md" target="_blank" class="term-link">
+                            GO_REF:0000015
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Use of the ND evidence code for Gene Ontology (GO) terms</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
+                            GO_REF:0000033
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Annotation inferences using phylogenetic trees</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        file:yeast/JIP4/JIP4-deep-research-falcon.md
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Falcon (Edison) deep-research report on S. cerevisiae JIP4/YDR475C</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/19779198" target="_blank" class="term-link">
+                            PMID:19779198
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Global analysis of Cdk1 substrate phosphorylation sites provides insights into evolution.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/18407956" target="_blank" class="term-link">
+                            PMID:18407956
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">A multidimensional chromatography technology for in-depth phosphoproteome analysis.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/15665377" target="_blank" class="term-link">
+                            PMID:15665377
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Quantitative phosphoproteomics applied to the yeast pheromone signaling pathway.</div>
+
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Questions for Experts</h2>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Does JIP4 physically associate with the JmjC transcription factor Gis1 (as its name implies) or with another Jumonji-family protein, and does it function in the Rim15/TOR/Sch9 nutrient-signaling / calorie-restriction pathway?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q03361" data-a="Q: Does JIP4 physically associate with the JmjC trans..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Does JIP4 bind RNA and/or associate with the spliceosome or other mRNP complexes in yeast, or has the ancestral SRRM1-type splicing function been lost in this PWI-less, RS-rich protein?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q03361" data-a="Q: Does JIP4 bind RNA and/or associate with the splic..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Where does JIP4 localize in the cell, and does its RS/low-complexity composition drive nuclear or condensate localization?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q03361" data-a="Q: Where does JIP4 localize in the cell, and does its..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> What is the functional relationship between JIP4 and its whole-genome-duplication paralog YOR019W, and does the double deletion reveal a phenotype masked by redundancy?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q03361" data-a="Q: What is the functional relationship between JIP4 a..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> What is the functional consequence of the Cdk1-dependent phosphorylation of JIP4, and is JIP4 a cell-cycle-regulated protein?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q03361" data-a="Q: What is the functional consequence of the Cdk1-dep..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Experiments</h2>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Affinity-purify epitope-tagged JIP4 from yeast and identify co-purifying proteins and RNAs by mass spectrometry and RNA sequencing; test for direct RNA binding in vitro; assay splicing of intron-containing reporters in jip4 (and jip4 yor019w) mutants.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: JIP4 retains an ancestral RNA-processing/spliceosome-associated role inferred from its SRRM1-family membership.</em></p>
+
+
+                </div>
+                <span class="vote-buttons" data-g="Q03361" data-a="EXPERIMENT: Affinity-purify epitope-tagged JIP4 from yeast and..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Construct jip4, yor019w, and jip4 yor019w deletion strains and phenotype them across stress, cell-cycle, and iron-availability conditions; determine JIP4 subcellular localization by endogenous fluorescent tagging.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: JIP4 has a non-redundant cellular role revealed only in combination with its paralog YOR019W or under specific stress conditions.</em></p>
+
+
+                </div>
+                <span class="vote-buttons" data-g="Q03361" data-a="EXPERIMENT: Construct jip4, yor019w, and jip4 yor019w deletion..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Knowledge Gaps</h2>
+        <p style="color: #555; font-size: 0.92rem; margin-top: -0.3rem;">
+            What is <em>not</em> known — curated, literature-grounded statements of the open
+            unknowns (the inverse of core functions).
+        </p>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The molecular function of JIP4 is entirely unknown. No biochemical activity has been demonstrated, and its highly disordered sequence contains no recognizable folded catalytic or nucleic-acid-binding domain (no PWI, no RRM), so even the family-based &#34;RNA binding&#34; inference is unverified.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">WHOLLY_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> It is firmly established that JIP4 is expressed as a protein (evidence at protein level) and is phosphorylated in vivo at multiple serines. It is assigned by low-complexity composition to the serine/arginine repetitive matrix family (PTHR23148) whose metazoan members are SR-related splicing coactivators. What is missing is any direct biochemical or genetic evidence of an activity for the yeast protein.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> JIP4 is a conserved-family member left functionally dark in one of the best-studied eukaryotes; assigning its activity would test whether the metazoan SRRM1 splicing function is ancestral or a lineage-specific innovation, and would remove a genuine hole in the yeast proteome annotation.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Direct biochemical assays (RNA/DNA-binding, association with spliceosomal or mRNP complexes by affinity purification-mass spectrometry), determination of subcellular localization, and phenotyping of jip4 deletion (including the jip4 yor019w double mutant) under diverse conditions would define or exclude an activity.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"RecName: Full=Uncharacterized protein JIP4;"</em> — file:yeast/JIP4/JIP4-uniprot.txt</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> It is unknown whether the metazoan SRRM1/SRm160 splicing function transfers to yeast JIP4 at all: whether JIP4 binds RNA, associates with the spliceosome, or regulates mRNA splicing has never been tested experimentally, and the current spliceosome/ splicing GO annotations are homology-only (IBA) inferences.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">MF_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> The S. cerevisiae spliceosome and its regulators are extensively characterized, and JIP4 has not been identified as a component in those studies; the established yeast counterparts of human SR-related nuclear-matrix splicing proteins are other genes. JIP4 lacks the PWI domain that mediates the SRm160/SRRM1 splicing coactivator function.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Resolving this would either validate or correct the IBA-propagated splicing annotations, clarifying whether a divergent, PWI-less SR-repetitive-matrix protein retains any role in yeast RNA processing.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Test for RNA binding and for physical/functional association with the spliceosome (co-purification, CLIP-type RNA interaction mapping, splicing-reporter assays in jip4 mutants), and compare against known yeast SR-related splicing factors.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"DR   GO; GO:0005681; C:spliceosomal complex; IBA:GO_Central."</em> — file:yeast/JIP4/JIP4-uniprot.txt</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The subcellular localization of JIP4 has not been experimentally determined, and its biological process/pathway and loss-of-function phenotype (beyond viability of the deletion) are unknown, including its functional relationship to the whole-genome- duplication paralog YOR019W.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">BP_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> JIP4 is non-essential; the jip4 deletion is viable and the yor019w deletion is viable. JIP4 appears in high-throughput interactome and phosphoproteome datasets but with no curated functional interpretation, and no dedicated study of the yeast protein has been reported.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> A defined localization, phenotype, and paralog relationship would place JIP4 in a cellular process and indicate whether functional redundancy with YOR019W is masking its role.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Endogenous fluorescent tagging for localization, condition-dependent phenotyping of jip4 single and jip4 yor019w double deletions, and interpretation of its physical interactors, together with functional analysis of its Cdk1-dependent phosphosites.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"KW   Phosphoprotein; Reference proteome."</em> — file:yeast/JIP4/JIP4-uniprot.txt</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The molecular basis of the &#34;Jumonji-interacting protein&#34; name is not established: it is unclear whether JIP4 physically or functionally associates with the JmjC-domain transcription factor Gis1 (or another Jumonji-family protein), and if so what that interaction does, so any link to the Rim15/TOR/Sch9 nutrient-signaling and calorie-restriction pathway is hypothetical.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">MF_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> The name implies identification of JIP4 as a Gis1-associated factor, and Gis1 is a well-characterized JmjC zinc-finger transcription factor downstream of Rim15/TOR/Sch9. What is missing is any confirmed, mechanistically characterized JIP4-Gis1 (or JIP4-Jumonji) interaction and its functional consequence.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Confirming or refuting a JIP4-Gis1 association would either connect this dark gene to a defined nutrient-signaling/chromatin transcription pathway or remove a misleading name-based assumption.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Co-immunoprecipitation/affinity purification to test a direct JIP4-Gis1 interaction, and epistasis/phenotyping of jip4 in Rim15/TOR/Sch9-pathway and calorie-restriction assays.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"Gis1 is a Jumonji-domain zinc-finger transcription factor acting downstream of **Rim15/TOR/Sch9** nutrient signaling"</em> — file:yeast/JIP4/JIP4-deep-research-falcon.md</li>
+
+            </ul>
+
+
+        </div>
+
+    </div>
+
+
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Deep Research Sections -->
+
+    <div class="section">
+        <h2 class="section-title">Deep Research</h2>
+
+        <details class="deep-research-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; gap: 1rem;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Falcon</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(JIP4-deep-research-falcon.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="Q03361" data-a="DEEP_RESEARCH: Falcon" data-r="" data-act="DEEP_RESEARCH" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This deep research is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This deep research needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+
+                <div class="report-meta">
+
+                    <span class="report-meta-text">this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</span>
+
+
+                    <span class="report-badge">Falcon</span>
+
+
+                    <span class="report-badge">Edison Scientific Literature</span>
+
+
+                    <span class="report-badge">20 citations</span>
+
+
+                    <span class="report-badge">1 artifacts</span>
+
+
+                    <span class="report-meta-text">2026-07-05T02:22:24.962662</span>
+
+
+
+                </div>
+
+
+                <div class="artifact-list">
+
+
+
+                    <div class="artifact-link">
+                        <a href="JIP4-deep-research-falcon_artifacts/artifact-00.md" class="term-link">Edison artifact artifact-00</a>
+                        <span>(text/markdown)</span>
+                    </div>
+
+
+                </div>
+
+                <p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h2 id="research-report-jip4ydr475c-in-saccharomyces-cerevisiae">Research Report: JIP4/YDR475C in <em>Saccharomyces cerevisiae</em></h2>
+<h3 id="important-note-on-gene-symbol-ambiguity">Important Note on Gene Symbol Ambiguity</h3>
+<p>The gene symbol "JIP4" in <em>Saccharomyces cerevisiae</em> must not be confused with mammalian JIP4 (also known as SPAG9/JIP4), which is a JNK-interacting protein involved in MAP kinase signaling. The yeast JIP4 (UniProt: Q03361, systematic name YDR475C) is an uncharacterized protein named for its interaction with the Jumonji-domain transcription factor Gis1. Direct literature on yeast JIP4 is extremely sparse, and the functional characterization below relies on a combination of genomic annotation, domain analysis, and contextual evidence from studies of its interaction partner Gis1.</p>
+<h3 id="1-gene-structure-and-annotation-history">1. Gene Structure and Annotation History</h3>
+<p>JIP4 is encoded by the locus YDR475C on the right arm of chromosome IV in the <em>S. cerevisiae</em> reference strain S288c. A key feature of this gene is its unusual annotation history: it was originally annotated as two separate open reading frames, YDR474C and YDR475C, which were subsequently merged into a single gene (acton2017genotypespecificphenotypicbehaviour pages 88-90). This merger was first identified during a comprehensive re-analysis of the <em>S. cerevisiae</em> genome through comparative genomics with other hemiascomycetous yeast species. Blandin et al. (2000) reported that YDR475C received a C-terminal extension and YDR474C received an N-terminal extension, such that the two neighboring genes fused into a single coding sequence spanning coordinates 1,407,454–1,410,082, encoding a protein of approximately 165 amino acids in the merged model (blandin2000genomicexplorationof pages 5-6). This gene fusion was identified through sequence homology with orthologous genes in <em>Saccharomyces bayanus</em>, <em>Saccharomyces servazzii</em>, and <em>Kluyveromyces lactis</em>, where a single continuous ORF was present. The yeast gene YOR019W was identified as a paralog of this merged locus (blandin2000genomicexplorationof pages 5-6).</p>
+<p>The summary table below compiles the key verified properties of JIP4:</p>
+<table>
+<thead>
+<tr>
+<th>Property</th>
+<th>Summary</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Gene name</td>
+<td><strong>JIP4</strong></td>
+</tr>
+<tr>
+<td>Systematic name / ORF history</td>
+<td><strong>YDR475C</strong>; previously annotated as two separate ORFs, <strong>YDR474C</strong> and <strong>YDR475C</strong>, later merged into a single gene model (blandin2000genomicexplorationof pages 5-6, acton2017genotypespecificphenotypicbehaviour pages 88-90)</td>
+</tr>
+<tr>
+<td>UniProt accession</td>
+<td><strong>Q03361</strong></td>
+</tr>
+<tr>
+<td>Protein description</td>
+<td>Uncharacterized protein JIP4; Jumonji-interacting protein 4</td>
+</tr>
+<tr>
+<td>Organism</td>
+<td><em>Saccharomyces cerevisiae</em> strain ATCC 204508 / S288c</td>
+</tr>
+<tr>
+<td>Chromosomal location</td>
+<td>Chromosome IV right arm; merged locus reported at coordinates <strong>1,407,454–1,410,082</strong> in the genome re-analysis (blandin2000genomicexplorationof pages 5-6)</td>
+</tr>
+<tr>
+<td>Protein size</td>
+<td><strong>165 aa</strong> for the merged gene model/extension reported in genomic re-annotation (blandin2000genomicexplorationof pages 5-6)</td>
+</tr>
+<tr>
+<td>Domain</td>
+<td><strong>IPR052225 Ser/Arg repetitive matrix</strong>; this domain class is associated with SRRM-family/splicing-related proteins (birney1993analysisofthe pages 10-11, ilik2020sonandsrrm2 pages 1-2, ilik2020sonandsrrm2 pages 3-5)</td>
+</tr>
+<tr>
+<td>Paralog</td>
+<td><strong>YOR019W</strong> (reported as paralog in the fusion/extension analysis) (blandin2000genomicexplorationof pages 5-6)</td>
+</tr>
+<tr>
+<td>Essentiality</td>
+<td><strong>Non-essential</strong>; present in deletion-collection based summaries as a protein of unknown function rather than an essential gene (acton2017genotypespecificphenotypicbehaviour pages 88-90)</td>
+</tr>
+<tr>
+<td>Current annotation status</td>
+<td><strong>Protein of unknown function / uncharacterized</strong>; deletion-collection summary explicitly notes it as such (acton2017genotypespecificphenotypicbehaviour pages 88-90)</td>
+</tr>
+<tr>
+<td>Known interaction partner</td>
+<td><strong>Gis1</strong> inferred from the name “Jumonji-interacting protein 4”; the name indicates identification as a Gis1-associated factor, although direct mechanistic characterization remains limited (acton2017genotypespecificphenotypicbehaviour pages 88-90, wei2008lifespanextension pages 1-2)</td>
+</tr>
+<tr>
+<td>Relevant pathway context of partner</td>
+<td>Gis1 is a Jumonji-domain zinc-finger transcription factor acting downstream of <strong>Rim15/TOR/Sch9</strong> nutrient signaling and calorie-restriction responses (wei2008lifespanextension pages 1-2, wei2008lifespanextension pages 7-9, wei2008lifespanextension pages 4-5, cameroni2007structuralandfunctional pages 103-109, cameroni2007structuralandfunctional pages 99-103)</td>
+</tr>
+<tr>
+<td>Functional inference</td>
+<td>Because JIP4 is uncharacterized but contains a <strong>Ser/Arg repetitive matrix</strong> domain, the strongest evidence-based inference is a possible role in <strong>RNA processing/splicing-related protein interactions</strong> and/or <strong>nuclear gene regulation</strong>, rather than an enzymatic role (birney1993analysisofthe pages 10-11, ilik2020sonandsrrm2 pages 1-2, ilik2020sonandsrrm2 pages 3-5)</td>
+</tr>
+<tr>
+<td>Confidence assessment</td>
+<td><strong>Low to moderate</strong> for specific function; <strong>high</strong> for merged-gene status and uncharacterized annotation, but functional assignment remains inferential due to sparse direct literature (blandin2000genomicexplorationof pages 5-6, acton2017genotypespecificphenotypicbehaviour pages 88-90)</td>
+</tr>
+</tbody>
+</table>
+<p><em>Table: This table compiles the key verified properties of the yeast JIP4/YDR475C protein, emphasizing what is established from genome annotation and what remains inferential. It is useful for separating firm facts, such as the merged ORF status and non-essentiality, from tentative functional predictions based on domain architecture and naming.</em></p>
+<h3 id="2-protein-function-current-status-as-uncharacterized">2. Protein Function: Current Status as Uncharacterized</h3>
+<p>JIP4 remains classified as a "protein of unknown function" in the <em>Saccharomyces</em> Genome Database (SGD) (acton2017genotypespecificphenotypicbehaviour pages 88-90). No enzymatic activity, substrate specificity, or defined biochemical role has been experimentally determined. The protein does not appear to be an enzyme, transporter, or signaling kinase/phosphatase based on its domain architecture. The gene is non-essential, as deletion strains are viable and were included in the systematic yeast deletion collection without notable growth defects under standard conditions (acton2017genotypespecificphenotypicbehaviour pages 88-90).</p>
+<h3 id="3-naming-context-interaction-with-the-jumonji-domain-protein-gis1">3. Naming Context: Interaction with the Jumonji Domain Protein Gis1</h3>
+<p>The name "JIP4" (Jumonji-Interacting Protein 4) indicates that this protein was identified as one of several proteins that interact with Gis1, a key yeast transcription factor containing Jumonji (JmjN and JmjC) domains. This naming derives from the study by Tronnersjö et al. (2007; Molecular Genetics and Genomics, 277:57–70), who characterized the JmjN and JmjC domains of the yeast zinc finger protein Gis1 and identified 19 proteins involved in transcription, SUMOylation, and DNA repair that interact with these domains. Although this primary reference was unobtainable for direct examination, its citation record establishes JIP4 as a Gis1-interacting protein.</p>
+<p>Gis1 itself is a well-characterized transcription factor belonging to the JMJD2/KDM4 subfamily of Jumonji-domain containing proteins. It possesses histone demethylase activity and functions as a key downstream effector in the TORC1/Sch9/Rim15 nutrient-sensing pathway (wei2008lifespanextension pages 1-2, wei2008lifespanextension pages 7-9). Gis1 recognizes PDS (Post-Diauxic Shift) elements in gene promoters and activates stress-response genes during nutrient limitation and caloric restriction, thereby mediating lifespan extension (wei2008lifespanextension pages 4-5, cameroni2007structuralandfunctional pages 103-109, cameroni2007structuralandfunctional pages 99-103). It works cooperatively with the Msn2/Msn4 transcription factors downstream of Rim15, with over 60% of Rim15-dependent genes also requiring Gis1 for their regulation during rapamycin (TORC1 inhibitor) treatment (cameroni2007structuralandfunctional pages 103-109).</p>
+<p>The proteome-wide identification of Gis1 interaction partners via mass spectrometry has revealed 147 unique Gis1-interacting proteins, including proteins involved in heterocyclic compound binding, metabolic pathways (glycolysis, TCA cycle, fatty acid metabolism), ubiquitin-like protein conjugation, and acetylation (konduri2020hemeametabolic pages 10-12, konduri2020hemeametabolic pages 7-10). Some of these interactions are mediated through the JmjN/C domain, while others are mediated through the C-terminal zinc finger domain of Gis1 (konduri2020hemeametabolic pages 18-19). The Gis1 interaction network is modulated by heme availability, with distinct protein partners associating under heme-sufficient versus heme-deficient conditions (konduri2020hemeametabolic pages 7-10). JIP4's position within this interaction network has not been further resolved with respect to which Gis1 domain mediates the contact or under which metabolic conditions the interaction is most prominent.</p>
+<h3 id="4-domain-architecture-and-functional-inference">4. Domain Architecture and Functional Inference</h3>
+<p>The presence of a Ser/Arg repetitive matrix domain (InterPro: IPR052225) in JIP4 is the strongest bioinformatic clue to its potential function. This domain family is best characterized in the context of mammalian SRRM (Serine/Arginine Repetitive Matrix) proteins, particularly SRRM1 and SRRM2, which are key components of the pre-mRNA splicing machinery and play structural roles in nuclear speckles (ilik2020sonandsrrm2 pages 1-2, ilik2020sonandsrrm2 pages 3-5).</p>
+<p>In metazoan systems, SRRM2, together with the protein SON, forms the essential scaffold of nuclear speckles—biomolecular condensates enriched in splicing factors and involved in RNA processing (ilik2020sonandsrrm2 pages 1-2, ilık2020sonandsrrm2 pages 1-2). SRRM2 is a spliceosome-associated protein that joins at the Bact stage of spliceosome assembly and supports the activated conformation of the PRP8 switch-loop (ilik2020sonandsrrm2 pages 3-5). Its intrinsically disordered regions (IDRs), enriched in serine and arginine residues, are critical for nuclear speckle integrity, as their deletion leads to near-complete dissolution of these condensates (ilik2020sonandsrrm2 pages 1-2, ilık2020sonandsrrm2 pages 1-2).</p>
+<p>The yeast ortholog of SRRM2 is Cwc21p (also known as Cwf21p in <em>S. pombe</em>), which directly interacts with the spliceosomal proteins Prp8p and Snu114p (ilik2020sonandsrrm2 pages 3-5, ilik2020sonandsrrm2 pages 21-22). Notably, <em>S. cerevisiae</em> does not possess classical nuclear speckles as found in metazoan cells, although the spliceosomal functions of Cwc21/SRRM2 are conserved.</p>
+<p>Serine/arginine-rich (SR) domains are characteristic of splicing factors and are found exclusively in known or suspected splicing and spliceosome-associated proteins (birney1993analysisofthe pages 10-11). These RS-rich regions mediate protein-protein interactions that are critical for spliceosome assembly and splice site recognition. Given that JIP4 contains such a domain, a reasonable inference is that JIP4 may participate in RNA processing or splicing-related protein interactions. However, it must be emphasized that JIP4 is distinct from Cwc21p (the established yeast SRRM2 ortholog) and no direct evidence connects JIP4 to the spliceosome.</p>
+<h3 id="5-subcellular-localization">5. Subcellular Localization</h3>
+<p>No published subcellular localization data specific to JIP4 were identified in the literature surveyed. The protein was not highlighted in major proteome-wide GFP localization studies, which may reflect very low protein abundance or technical challenges with the C-terminal GFP tag for this particular protein. Given its Ser/Arg repetitive matrix domain and its interaction with the nuclear transcription factor Gis1, a nuclear localization would be a reasonable prediction, but this remains unconfirmed experimentally.</p>
+<h3 id="6-biological-pathways-and-broader-context">6. Biological Pathways and Broader Context</h3>
+<p>Through its interaction with Gis1, JIP4 is potentially linked to the nutrient-sensing and stress-response signaling network in yeast. Gis1 operates downstream of the TORC1/Sch9 and Ras/PKA pathways, where it is activated by the kinase Rim15 to drive transcription of stress-response and post-diauxic shift genes (wei2008lifespanextension pages 1-2, wei2008lifespanextension pages 7-9, wei2008lifespanextension pages 4-5). Gis1 is also subject to regulation by protein phosphatase 2A (PP2A), with the Igo1/2 endosulfines modulating PP2A-mediated dephosphorylation of Gis1 at Ser425 (severine2013yeastendosulfinescontrol pages 3-4). Furthermore, heme acts as a metabolic sensor that directly regulates Gis1's histone demethylase activity and transcriptional functions (konduri2020hemeametabolic pages 10-12, konduri2020hemeametabolic pages 7-10).</p>
+<p>Whether JIP4 modulates any of these Gis1-dependent activities remains unknown. Possible roles include: (i) serving as a cofactor or adaptor protein for Gis1's transcriptional or demethylase functions; (ii) mediating interactions between Gis1 and the RNA processing machinery via its SR-rich domain; or (iii) facilitating the coupling of transcription with mRNA splicing/processing at Gis1-target loci. These possibilities remain speculative in the absence of direct experimental evidence.</p>
+<h3 id="7-paralog-yor019w">7. Paralog YOR019W</h3>
+<p>The paralog YOR019W was identified during the genomic re-annotation that merged YDR474C and YDR475C (blandin2000genomicexplorationof pages 5-6). YOR019W itself has not been extensively characterized, and the functional relationship between these paralogs remains unexplored. The existence of a paralog suggests that JIP4's function, while dispensable for viability, may be partially redundant with YOR019W, potentially masking phenotypic consequences of single-gene deletion.</p>
+<h3 id="8-conclusions-and-research-gaps">8. Conclusions and Research Gaps</h3>
+<p>JIP4/YDR475C remains one of the uncharacterized proteins in the <em>S. cerevisiae</em> genome. The primary evidence supporting its functional annotation consists of: (1) its identification as a Gis1-interacting protein, linking it to nutrient sensing and transcriptional regulation; (2) the presence of a Ser/Arg repetitive matrix domain (IPR052225), suggesting a role in RNA processing or splicing-related protein-protein interactions; and (3) its non-essential status and existence of paralog YOR019W. A definitive functional assignment would require targeted experimental studies, including protein interaction mapping under defined metabolic conditions, phenotypic analysis of double-deletion mutants (with the paralog YOR019W), and determination of subcellular localization and RNA-binding properties. The integration of its SR-domain architecture with its interaction with a chromatin-modifying transcription factor raises the intriguing possibility that JIP4 may serve as a molecular link between transcriptional regulation and RNA processing at specific gene loci, but this hypothesis awaits empirical validation.</p>
+<p>References</p>
+<ol>
+<li>
+<p>(acton2017genotypespecificphenotypicbehaviour pages 88-90): Erica Acton. Genotype-specific phenotypic behaviour of auxotrophic and prototrophic yeast gene deletion collections. ArXiv, Jan 2017. URL: https://doi.org/10.14288/1.0340607, doi:10.14288/1.0340607. This article has 0 citations.</p>
+</li>
+<li>
+<p>(blandin2000genomicexplorationof pages 5-6): Gaëlle Blandin, Pascal Durrens, Fredj Tekaia, Michel Aigle, Monique Bolotin-Fukuhara, Elisabeth Bon, Serge Casarégola, Jacky de Montigny, Claude Gaillardin, Andrée Lépingle, Bertrand Llorente, Alain Malpertuy, Cécile Neuvéglise, Odile Ozier-Kalogeropoulos, Arnaud Perrin, Serge Potier, Jean-Luc Souciet, Emmanuel Talla, Claire Toffano-Nioche, Micheline Wésolowski-Louvel, Christian Marck, and Bernard Dujon. Genomic exploration of the hemiascomycetous yeasts: 4. the genome of saccharomyces cerevisiae revisited. FEBS Letters, 487:31-36, Dec 2000. URL: https://doi.org/10.1016/s0014-5793(00)02275-4, doi:10.1016/s0014-5793(00)02275-4. This article has 124 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(birney1993analysisofthe pages 10-11): Ewan Birney, Sanjay Kumar, and Adrian R. Krainer. Analysis of the rna-recognition motif and rs and rgg domains: conservation in metazoan pre-mrna splicing factors. Nucleic acids research, 21 25:5803-16, Dec 1993. URL: https://doi.org/10.1093/nar/21.25.5803, doi:10.1093/nar/21.25.5803. This article has 939 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(ilik2020sonandsrrm2 pages 1-2): İbrahim Avşar Ilik, Michal Malszycki, Anna Katharina Lübke, Claudia Schade, David Meierhofer, and Tuğçe Aktaş. Son and srrm2 are essential for nuclear speckle formation. eLife, Oct 2020. URL: https://doi.org/10.7554/elife.60579, doi:10.7554/elife.60579. This article has 317 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(ilik2020sonandsrrm2 pages 3-5): İbrahim Avşar Ilik, Michal Malszycki, Anna Katharina Lübke, Claudia Schade, David Meierhofer, and Tuğçe Aktaş. Son and srrm2 are essential for nuclear speckle formation. eLife, Oct 2020. URL: https://doi.org/10.7554/elife.60579, doi:10.7554/elife.60579. This article has 317 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(wei2008lifespanextension pages 1-2): Min Wei, Paola Fabrizio, Jia Hu, Huanying Ge, Chao Cheng, Lei Li, and Valter D Longo. Life span extension by calorie restriction depends on rim15 and transcription factors downstream of ras/pka, tor, and sch9. PLoS Genetics, 4:e13, Jan 2008. URL: https://doi.org/10.1371/journal.pgen.0040013, doi:10.1371/journal.pgen.0040013. This article has 612 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(wei2008lifespanextension pages 7-9): Min Wei, Paola Fabrizio, Jia Hu, Huanying Ge, Chao Cheng, Lei Li, and Valter D Longo. Life span extension by calorie restriction depends on rim15 and transcription factors downstream of ras/pka, tor, and sch9. PLoS Genetics, 4:e13, Jan 2008. URL: https://doi.org/10.1371/journal.pgen.0040013, doi:10.1371/journal.pgen.0040013. This article has 612 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(wei2008lifespanextension pages 4-5): Min Wei, Paola Fabrizio, Jia Hu, Huanying Ge, Chao Cheng, Lei Li, and Valter D Longo. Life span extension by calorie restriction depends on rim15 and transcription factors downstream of ras/pka, tor, and sch9. PLoS Genetics, 4:e13, Jan 2008. URL: https://doi.org/10.1371/journal.pgen.0040013, doi:10.1371/journal.pgen.0040013. This article has 612 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(cameroni2007structuralandfunctional pages 103-109): Structural and functional characterization of the novel yeast PAS kinase Rim 15, a central regulator of the G0 program in yeast</p>
+</li>
+<li>
+<p>(cameroni2007structuralandfunctional pages 99-103): Structural and functional characterization of the novel yeast PAS kinase Rim 15, a central regulator of the G0 program in yeast</p>
+</li>
+<li>
+<p>(konduri2020hemeametabolic pages 10-12): Purna Chaitanya Konduri, Tianyuan Wang, Narges Salamat, and Li Zhang. Heme, a metabolic sensor, directly regulates the activity of the kdm4 histone demethylase family and their interactions with partner proteins. Cells, 9:773, Mar 2020. URL: https://doi.org/10.3390/cells9030773, doi:10.3390/cells9030773. This article has 7 citations.</p>
+</li>
+<li>
+<p>(konduri2020hemeametabolic pages 7-10): Purna Chaitanya Konduri, Tianyuan Wang, Narges Salamat, and Li Zhang. Heme, a metabolic sensor, directly regulates the activity of the kdm4 histone demethylase family and their interactions with partner proteins. Cells, 9:773, Mar 2020. URL: https://doi.org/10.3390/cells9030773, doi:10.3390/cells9030773. This article has 7 citations.</p>
+</li>
+<li>
+<p>(konduri2020hemeametabolic pages 18-19): Purna Chaitanya Konduri, Tianyuan Wang, Narges Salamat, and Li Zhang. Heme, a metabolic sensor, directly regulates the activity of the kdm4 histone demethylase family and their interactions with partner proteins. Cells, 9:773, Mar 2020. URL: https://doi.org/10.3390/cells9030773, doi:10.3390/cells9030773. This article has 7 citations.</p>
+</li>
+<li>
+<p>(ilık2020sonandsrrm2 pages 1-2): İbrahim Avşar Ilık, Michal Malszycki, Anna Katharina Lübke, Claudia Schade, David Meierhofer, and Tuğçe Aktaş. Son and srrm2 form nuclear speckles in human cells. bioRxiv, Jun 2020. URL: https://doi.org/10.1101/2020.06.19.160762, doi:10.1101/2020.06.19.160762. This article has 1 citations.</p>
+</li>
+<li>
+<p>(ilik2020sonandsrrm2 pages 21-22): İbrahim Avşar Ilik, Michal Malszycki, Anna Katharina Lübke, Claudia Schade, David Meierhofer, and Tuğçe Aktaş. Son and srrm2 are essential for nuclear speckle formation. eLife, Oct 2020. URL: https://doi.org/10.7554/elife.60579, doi:10.7554/elife.60579. This article has 317 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(severine2013yeastendosulfinescontrol pages 3-4): Séverine Bontron, Malika Jaquenoud, Stefania Vaga, Nicolas Talarek, Bernd Bodenmiller, Ruedi Aebersold, and Claudio De Virgilio. Yeast endosulfines control entry into quiescence and chronological life span by inhibiting protein phosphatase 2a. Cell reports, 3 1:16-22, Jan 2013. URL: https://doi.org/10.1016/j.celrep.2012.11.025, doi:10.1016/j.celrep.2012.11.025. This article has 108 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+</ol>
+<h2 id="artifacts">Artifacts</h2>
+<ul>
+<li><a href="JIP4-deep-research-falcon_artifacts/artifact-00.md">Edison artifact artifact-00</a></li>
+</ul>
+<h2 id="citations">Citations</h2>
+<ol>
+<li>acton2017genotypespecificphenotypicbehaviour pages 88-90</li>
+<li>blandin2000genomicexplorationof pages 5-6</li>
+<li>cameroni2007structuralandfunctional pages 103-109</li>
+<li>konduri2020hemeametabolic pages 18-19</li>
+<li>konduri2020hemeametabolic pages 7-10</li>
+<li>birney1993analysisofthe pages 10-11</li>
+<li>severine2013yeastendosulfinescontrol pages 3-4</li>
+<li>wei2008lifespanextension pages 1-2</li>
+<li>wei2008lifespanextension pages 7-9</li>
+<li>wei2008lifespanextension pages 4-5</li>
+<li>cameroni2007structuralandfunctional pages 99-103</li>
+<li>konduri2020hemeametabolic pages 10-12</li>
+<li>https://doi.org/10.14288/1.0340607,</li>
+<li>https://doi.org/10.1016/s0014-5793(00</li>
+<li>https://doi.org/10.1093/nar/21.25.5803,</li>
+<li>https://doi.org/10.7554/elife.60579,</li>
+<li>https://doi.org/10.1371/journal.pgen.0040013,</li>
+<li>https://doi.org/10.3390/cells9030773,</li>
+<li>https://doi.org/10.1101/2020.06.19.160762,</li>
+<li>https://doi.org/10.1016/j.celrep.2012.11.025,</li>
+</ol>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(JIP4-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="Q03361" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="jip4-ydr475c-curation-notes">JIP4 (YDR475C) — curation notes</h1>
+<p>Journal for the AI GO-annotation review of <em>Saccharomyces cerevisiae</em> <strong>JIP4</strong> (systematic<br />
+name YDR475C; UniProt Q03361; SGD:S000002883). This is an <strong>understudied ("dark") gene</strong>:<br />
+UniProt names it "Uncharacterized protein JIP4" (AltName "Jumonji-interacting protein 4"),<br />
+and SGD classifies it as a protein of unknown function. The deliverable therefore centres<br />
+on an honest <code>knowledge_gaps</code> section grounded in domain composition, orthology, and the<br />
+(sparse) literature — no invented function.</p>
+<h2 id="summary-of-what-is-machine-known-uniprot-q03361">Summary of what is machine-known (UniProt Q03361)</h2>
+<ul>
+<li>876 aa protein, MW ~98.7 kDa. Entry version 148 (2026). <code>PE 1: Evidence at protein level</code><br />
+  — but the only experimental evidence is <strong>large-scale phosphoproteomics</strong> (see below);<br />
+  there is <strong>no functional assay</strong>.</li>
+<li>Highly <strong>intrinsically disordered</strong>: MobiDB-lite predicts 7 disordered regions<br />
+  (37–67, 112–155, 226–254, 330–353, 490–513, 661–728, 750–876) covering a large fraction<br />
+  of the protein. Multiple <strong>low-complexity / compositionally biased</strong> stretches, including<br />
+  runs of basic+acidic residues, polar residues, and notably several <strong>Arg/Ser (RS-type)<br />
+  repeats</strong> — e.g. <code>...RSVSSARRSRSRSRSRSICTRR...</code> (~aa 350–370) and<br />
+<code>SKSRSSSKSRIRDKSKPSSP</code> (~aa 675–695), and a C-terminal <code>...KSRSPSSFRKEDE...RGGLFGFGRL</code>.<br />
+  These RS/RD-rich low-complexity tracts are the reason PANTHER places it in the<br />
+  SR-repetitive-matrix family (below). [file:yeast/JIP4/JIP4-uniprot.txt]</li>
+<li><strong>No recognizable folded/catalytic domain</strong> is annotated in UniProt: no PWI domain, no<br />
+  RRM, no enzymatic motif — only disorder + compositional bias. This is important: the human<br />
+  family members that carry the splicing function have a folded <strong>PWI</strong> nucleic-acid-binding<br />
+  domain; JIP4 does not have one annotated. [file:yeast/JIP4/JIP4-uniprot.txt]</li>
+<li><strong>Phosphoprotein</strong> (KW: Phosphoprotein). Eight phosphoserines mapped by MS:</li>
+<li>Ser-48, Ser-51, Ser-510, Ser-552, Ser-775 [PMID:19779198 — Cdk1 substrate global analysis]</li>
+<li>Ser-48, Ser-360, Ser-552 [PMID:18407956 — multidimensional chromatography phosphoproteome]</li>
+<li>Ser-577 [PMID:15665377 — pheromone-signaling phosphoproteome]<br />
+  Several of these sites (from PMID:19779198, "Global analysis of Cdk1 substrate<br />
+  phosphorylation sites") indicate JIP4 is among the many proteins phosphorylated in a<br />
+  Cdk1-dependent manner; this is a large-scale substrate catalog, not a dedicated study of<br />
+  JIP4. [file:yeast/JIP4/JIP4-uniprot.txt]</li>
+<li>Cross-references indicate protein interactions exist in high-throughput datasets:<br />
+  BioGRID 87 interactions, IntAct 6, FunCoup 117 — i.e. it appears in interactome data but<br />
+  with no curated functional interpretation. [file:yeast/JIP4/JIP4-uniprot.txt]</li>
+</ul>
+<h2 id="orthology-family-panther-pthr23148">Orthology / family (PANTHER PTHR23148)</h2>
+<p>PANTHER assigns JIP4 to family <strong>PTHR23148</strong> ("Serine/arginine repetitive matrix"),<br />
+subfamily <strong>PTHR23148:SF0</strong> = "SERINE/ARGININE REPETITIVE MATRIX PROTEIN 1" (SRRM1 / SRm160).<br />
+The reviewed members of SF0 are essentially the metazoan <strong>SRRM1</strong> orthologs plus the two<br />
+yeasts [file:yeast/JIP4/interpro/panther/PTHR23148/PTHR23148-entries.csv... i.e.<br />
+interpro/panther/PTHR23148/PTHR23148-entries.csv]:</p>
+<table>
+<thead>
+<tr>
+<th>UniProt</th>
+<th>Species</th>
+<th>Gene</th>
+<th>Length</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Q03361</td>
+<td>S. cerevisiae</td>
+<td>JIP4 (YDR475C)</td>
+<td>876</td>
+</tr>
+<tr>
+<td>Q52KI8</td>
+<td>Mouse</td>
+<td>Srrm1</td>
+<td>946</td>
+</tr>
+<tr>
+<td>Q5R5Q2</td>
+<td>Orangutan</td>
+<td>SRRM1</td>
+<td>917</td>
+</tr>
+<tr>
+<td>Q5ZMJ9</td>
+<td>Chicken</td>
+<td>SRRM1</td>
+<td>888</td>
+</tr>
+<tr>
+<td>Q8IYB3</td>
+<td>Human</td>
+<td>SRRM1</td>
+<td>904</td>
+</tr>
+<tr>
+<td>Q9USH5</td>
+<td>S. pombe</td>
+<td>SPCC825.05c (PWI domain-containing)</td>
+<td>301</td>
+</tr>
+</tbody>
+</table>
+<p>The <strong>human/metazoan SRRM1 (SRm160)</strong> is a nuclear-matrix SR-related splicing coactivator:<br />
+it promotes constitutive and ESE-dependent splicing by bridging sequence-specific SR<br />
+proteins to snRNP components, is a component of the spliceosome / exon junction complex,<br />
+binds RNA/DNA with low sequence specificity, and stimulates mRNA 3'-end cleavage.<br />
+[PANTHER family description, file:yeast/JIP4/interpro/panther/PTHR23148/PTHR23148-metadata.yaml;<br />
+corroborated by SRRM1/SRm160 literature — UniProt Q8IYB3.]</p>
+<p>This family assignment is the sole basis for the <strong>IBA</strong> annotations in GOA:<br />
+- <code>part_of spliceosomal complex</code> (GO:0005681) — with/from MGI:1858303 (mouse Srrm1),<br />
+  PANTHER:PTN000567596, UniProtKB:Q8IYB3 (human SRRM1). [file:yeast/JIP4/JIP4-goa.tsv]<br />
+- <code>involved_in regulation of mRNA splicing, via spliceosome</code> (GO:0048024) — with/from<br />
+  FB:FBgn0036340 (Drosophila), PANTHER:PTN000567596. [file:yeast/JIP4/JIP4-goa.tsv]<br />
+- (UniProt DR also lists an IBA <code>RNA binding</code> GO:0003723 from GO_Central, not currently in<br />
+  the GOA TSV row set.) [file:yeast/JIP4/JIP4-uniprot.txt]</p>
+<h3 id="caveat-on-the-iba-splicing-propagation-key-reasoning">Caveat on the IBA splicing propagation (KEY reasoning)</h3>
+<p>Whether the metazoan SRRM1 splicing function transfers to yeast JIP4 is <strong>doubtful</strong>, for<br />
+biological reasons that are worth stating:</p>
+<ol>
+<li><strong>JIP4 lacks the PWI domain.</strong> The defining folded, nucleic-acid-binding module of the<br />
+   SRm160/SRRM1 and RED120 (PWI-motif) splicing proteins is the PWI domain. JIP4's UniProt<br />
+   record annotates only disorder and low-complexity bias — no PWI, no RRM. The S. pombe<br />
+   family member (Q9USH5) is explicitly a "PWI domain-containing protein" and is only 301 aa,<br />
+   suggesting the true PWI-splicing ortholog in fission yeast is a different, shorter protein,<br />
+   and that JIP4's placement rests on shared RS/low-complexity composition rather than the<br />
+   catalytic/binding domain. [file:yeast/JIP4/JIP4-uniprot.txt; PANTHER entries csv]</li>
+<li><strong>The budding-yeast splicing machinery is exhaustively characterized.</strong> The S. cerevisiae<br />
+   spliceosome has been purified and defined in great biochemical/structural detail. The<br />
+   established yeast counterparts of the human SR-related nuclear-matrix splicing proteins are<br />
+<strong>Cwc21</strong> (YDR482C; ortholog of SRm300/SRRM2) and candidate PWI proteins such as <strong>Snu71</strong><br />
+   — <em>not</em> JIP4. JIP4 has never been reported as a spliceosome or EJC component in yeast<br />
+   spliceosome proteomics. [web: RNA journal / genesdev PWI-motif and Cwc21 characterization —<br />
+   background, not gene-specific experimental evidence for JIP4.]</li>
+<li><strong>Yeast introns are few and simple</strong> — there is no minor (U12) spliceosome and essentially<br />
+   no exon-junction-complex-style splicing coactivation of the metazoan kind; the specific<br />
+   ESE-dependent activation role of SRm160 has no clear yeast equivalent.</li>
+</ol>
+<p>Conclusion: the IBA MF/BP splicing terms are <strong>plausible-by-homology but unverified and<br />
+biologically questionable</strong> for yeast. They should be treated as low-confidence<br />
+homology-only inferences (mark as non-core / over-annotated candidates), not as established<br />
+JIP4 function. The RS/low-complexity composition supports at most a <em>possible</em> RNA/nucleic-<br />
+acid-associated or nuclear role, but this is not established.</p>
+<h2 id="sgd-literature-facts-verified-via-sgd-biogrid">SGD / literature facts (verified via SGD, BioGRID)</h2>
+<ul>
+<li><strong>Protein of unknown function.</strong> Previously annotated as two separate ORFs (YDR474C and<br />
+  YDR475C) that were merged after corrections to the systematic reference sequence.<br />
+  [SGD locus JIP4/YDR475C; web:yeastgenome.org]</li>
+<li><strong>Paralog YOR019W</strong>, arising from the whole-genome duplication; YOR019W is likewise<br />
+  uncharacterized. jip4∆ is <strong>viable</strong>; yor019w∆ is viable (double mutant not annotated) —<br />
+  consistent with a non-essential, possibly redundant gene. [SGD; web:yeastgenome.org]</li>
+<li>Name "Jumonji-interacting protein 4" (JIP4) is a <strong>legacy/heuristic name</strong> (likely from an<br />
+  interaction dataset with a Jumonji/JmjC-family protein); it does not by itself establish a<br />
+  molecular function. No dedicated functional paper on yeast JIP4 was found.</li>
+<li>Appears in high-throughput interactome data (BioGRID 87 / IntAct 6) and in<br />
+  phosphoproteomics, but with no curated functional role.</li>
+</ul>
+<h2 id="known-vs-not-known">KNOWN vs NOT-KNOWN</h2>
+<p><strong>KNOWN (evidence-supported):</strong><br />
+- It is expressed and made as a protein (PE1).<br />
+- It is an in vivo phosphoprotein with ≥8 mapped phosphoserines, including Cdk1-dependent<br />
+  sites (large-scale MS). [PMID:19779198; PMID:18407956; PMID:15665377]<br />
+- It is intrinsically disordered with RS/low-complexity composition (sequence-based).<br />
+- It is a member (by low-complexity composition) of the SR-repetitive-matrix PANTHER family<br />
+  that in metazoa contains SRRM1/SRm160.<br />
+- Non-essential; has a WGD paralog (YOR019W).</p>
+<p><strong>NOT KNOWN (genuine knowledge gaps):</strong><br />
+- Molecular function — no biochemical activity demonstrated; no folded catalytic/binding<br />
+  domain identified. RNA binding is only an IBA guess.<br />
+- Whether it is truly part of the spliceosome / involved in splicing in yeast (IBA only;<br />
+  biologically questionable, see caveat).<br />
+- Subcellular localization — not experimentally established (no CC annotation beyond ND).<br />
+  RS-rich composition <em>hints</em> at nuclear, but unverified.<br />
+- Biological process / pathway — unknown (ND at the BP root).<br />
+- Loss-of-function phenotype beyond "viable"; role of the phosphorylation; the identity/<br />
+  meaning of its interactors; functional relationship to paralog YOR019W.<br />
+- What the "Jumonji-interacting" name refers to mechanistically.</p>
+<h2 id="curation-plan">Curation plan</h2>
+<ul>
+<li>IBA <code>spliceosomal complex</code> (CC) and <code>regulation of mRNA splicing</code> (BP): keep but mark as<br />
+<strong>non-core / over-annotated</strong> homology-only inferences — do NOT elevate to core function;<br />
+  document the PWI-absence + yeast-splicing-machinery caveat in the review reason. (Per<br />
+  guidelines, IBA over-propagations may be argued against on biological grounds.)</li>
+<li>ND molecular_function / cellular_component / biological_process root terms: these are<br />
+  "no data" placeholders; keep as-is (they honestly encode "unknown"). Mark KEEP_AS_NON_CORE<br />
+  / note that they reflect the dark-gene status.</li>
+<li><code>description</code>: project-independent — disordered RS/low-complexity protein of unknown<br />
+  function, SR-repetitive-matrix family by composition, phosphoprotein, non-essential, WGD<br />
+  paralog YOR019W. No curation commentary.</li>
+<li><code>core_functions</code>: only the defensible minimum (essentially none can be asserted with<br />
+  confidence; possibly a cautious statement that no core molecular function can be assigned).</li>
+<li><code>knowledge_gaps</code>: the primary deliverable (MF, localization, BP, phenotype, splicing<br />
+  hypothesis).</li>
+</ul>
+<h2 id="update-after-falcon-deep-research-2026-07-05">Update after falcon deep research (2026-07-05)</h2>
+<p>The falcon deep-research report (<code>JIP4-deep-research-falcon.md</code>, Edison, 20 citations,<br />
+~23 min) is consistent with the assessment above and adds one useful hypothesis about the<br />
+gene name:</p>
+<ul>
+<li>The "Jumonji-interacting protein 4" name most plausibly reflects identification of JIP4 as<br />
+  a <strong>Gis1-associated factor</strong>. Gis1 is a JmjC (Jumonji-domain) zinc-finger transcription<br />
+  factor that acts downstream of the <strong>Rim15/TOR/Sch9</strong> nutrient-signaling and<br />
+  calorie-restriction response pathway [file:yeast/JIP4/JIP4-deep-research-falcon.md<br />
+  "Gis1 is a Jumonji-domain zinc-finger transcription factor acting downstream of<br />
+<strong>Rim15/TOR/Sch9</strong> nutrient signaling"]. The report explicitly flags that "direct<br />
+  mechanistic characterization remains limited", i.e. this is a naming-origin inference, not<br />
+  an established function — treated here as a hypothesis in knowledge_gaps / suggested<br />
+  questions, not as core function.</li>
+<li>The report reconfirms: merged ORF (YDR474C+YDR475C), non-essential, paralog YOR019W,<br />
+  Ser/Arg repetitive matrix (IPR052225) domain class, uncharacterized status, and that the<br />
+  splicing/RNA-processing role is a low-to-moderate-confidence domain-based inference only.</li>
+<li>CAVEAT: the report states a "165 aa" size for a "merged gene model/extension" — this is<br />
+  inconsistent with the authoritative UniProt length of <strong>876 aa</strong> (Q03361) and is not used;<br />
+  it appears to be a confused artifact from the ORF-merge re-annotation history.</li>
+</ul>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: Q03361
+gene_symbol: JIP4
+product_type: PROTEIN
+status: DRAFT
+taxon:
+  id: NCBITaxon:559292
+  label: Saccharomyces cerevisiae
+description: &gt;-
+  JIP4 (systematic name YDR475C; &#34;Jumonji-interacting protein 4&#34;) is a large
+  (876-residue) intrinsically disordered protein of Saccharomyces cerevisiae whose
+  molecular function has not been experimentally determined. Its sequence is dominated
+  by disorder and low-complexity composition, including several arginine/serine (RS)
+  and basic/acidic repetitive tracts, and on the basis of this compositional similarity
+  it is placed in the serine/arginine repetitive matrix protein family (PANTHER
+  PTHR23148), whose metazoan members (SRRM1/SRm160) are nuclear SR-related splicing
+  coactivators; JIP4 itself lacks the folded PWI nucleic-acid-binding domain that
+  defines those splicing proteins, and no splicing or RNA-related activity has been
+  demonstrated for it in yeast. JIP4 is a phosphoprotein, with multiple serine
+  residues phosphorylated in vivo (including cyclin-dependent-kinase-1-dependent sites)
+  as detected by large-scale phosphoproteomics. The gene is non-essential; deletion is
+  viable, and it has a paralog, YOR019W, arising from the whole-genome duplication that
+  is likewise uncharacterized.
+references:
+- id: file:yeast/JIP4/JIP4-uniprot.txt
+  title: UniProtKB entry Q03361 (JIP4_YEAST), including PANTHER family assignment and sequence features
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Cached UniProt record for JIP4/YDR475C. Source for the domain/composition analysis
+      (intrinsic disorder, RS/low-complexity tracts, absence of a PWI/RRM domain), the
+      PANTHER PTHR23148 family assignment, and the phosphosite features.
+- id: GO_REF:0000015
+  title: Use of the ND evidence code for Gene Ontology (GO) terms
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      GO_REF documenting the ND (No biological Data available) evidence code. Correctly
+      applied by SGD to the three root-term annotations for this uncharacterized gene.
+- id: GO_REF:0000033
+  title: Annotation inferences using phylogenetic trees
+  findings: []
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Standard GO_REF for phylogenetically inferred (IBA) annotations from GO_Central.
+      Correctly identifies the method; the biological transfer of the specific SRRM1
+      splicing function to yeast JIP4 is questionable (see per-annotation reasons), but
+      the reference itself is valid.
+- id: file:yeast/JIP4/JIP4-deep-research-falcon.md
+  title: Falcon (Edison) deep-research report on S. cerevisiae JIP4/YDR475C
+  findings: []
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Automated Edison deep-research report (20 citations). Reconfirms merged-ORF status,
+      non-essentiality, the YOR019W paralog, and the Ser/Arg repetitive matrix domain,
+      and treats a splicing/RNA-processing role as a low-to-moderate-confidence,
+      domain-based inference only. Adds a naming-origin hypothesis that JIP4 is a
+      Gis1-associated factor. NOTE: its &#34;165 aa&#34; size claim is inconsistent with the
+      authoritative UniProt length (876 aa) and is not used.
+- id: PMID:19779198
+  title: Global analysis of Cdk1 substrate phosphorylation sites provides insights into evolution.
+  findings: []
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Large-scale identification of Cdk1 substrate phosphorylation sites in S.
+      cerevisiae; JIP4 (Ser-48, Ser-51, Ser-510, Ser-552, Ser-775) is one of many
+      phosphoproteins cataloged. Supports that JIP4 is an in vivo phosphoprotein and a
+      likely Cdk1 substrate, but does not assign a molecular function. Verified via
+      UniProt MOD_RES cross-references to this PMID.
+- id: PMID:18407956
+  title: A multidimensional chromatography technology for in-depth phosphoproteome analysis.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Methods-focused large-scale phosphoproteome study; JIP4 (Ser-48, Ser-360,
+      Ser-552) appears as a mapped phosphoprotein. Corroborates the phosphoprotein
+      status only. Verified via UniProt MOD_RES cross-references.
+- id: PMID:15665377
+  title: Quantitative phosphoproteomics applied to the yeast pheromone signaling pathway.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Pheromone-signaling phosphoproteome study; JIP4 Ser-577 detected as a
+      phosphosite. Corroborates phosphoprotein status. Verified via UniProt MOD_RES
+      cross-reference.
+existing_annotations:
+- term:
+    id: GO:0005681
+    label: spliceosomal complex
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: part_of
+  review:
+    summary: &gt;-
+      Homology-only (IBA) inference propagated from the metazoan SRRM1/SRm160 orthologs
+      in PANTHER family PTHR23148. There is no experimental evidence that yeast JIP4 is
+      a spliceosome component, and this transfer is biologically questionable.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      This annotation rests solely on JIP4&#39;s placement in the serine/arginine
+      repetitive matrix family (with/from human SRRM1 Q8IYB3, mouse Srrm1 MGI:1858303),
+      a placement driven by shared RS/low-complexity composition rather than a
+      conserved folded domain. JIP4 lacks the PWI nucleic-acid-binding domain that
+      defines the SRm160/SRRM1 splicing coactivators (UniProt annotates only disorder
+      and compositional bias, no PWI or RRM). The S. cerevisiae spliceosome has been
+      exhaustively purified and characterized, and JIP4 has never been reported as a
+      spliceosome subunit; the known yeast counterparts of the human SR-related
+      nuclear-matrix splicing proteins are other proteins (e.g. Cwc21/YDR482C). The
+      annotation is therefore retained but flagged as a likely over-annotation of an
+      uncharacterized gene rather than as core function.
+    propagation_review:
+      root_cause: PROPAGATION_BAD
+      failure_modes:
+      - FUNCTIONAL_DIVERGENCE
+      - PSEUDO_OR_SUBACTIVITY_LOSS
+      - COMPARTMENT_OR_COMPLEX_MISMATCH
+      source_entities:
+      - source_id: UniProtKB:Q8IYB3
+        source_label: SRRM1 (human)
+        source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
+        comment: &gt;-
+          Human SRRM1/SRm160 is a bona fide PWI-domain spliceosome/EJC coactivator; the
+          spliceosome-membership term is sound for the source but should not transfer to
+          the PWI-less, uncharacterized yeast protein.
+      - source_id: MGI:MGI:1858303
+        source_label: Srrm1 (mouse)
+        source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
+      - source_id: PANTHER:PTN000567596
+        source_label: PTHR23148:SF0 ancestral node
+        source_status: SOURCE_WEAK_OR_INFERRED
+        comment: &gt;-
+          Family placement is composition-driven (RS/low-complexity) rather than
+          domain-conserved.
+    supported_by:
+    - reference_id: file:yeast/JIP4/JIP4-uniprot.txt
+      supporting_text: &#34;PANTHER; PTHR23148; SERINE/ARGININE REGULATED NUCLEAR MATRIX PROTEIN; 1.&#34;
+- term:
+    id: GO:0048024
+    label: regulation of mRNA splicing, via spliceosome
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Homology-only (IBA) inference of a splicing-regulation role from metazoan/
+      Drosophila SRRM1-family members. Not supported by any experimental evidence in
+      yeast and biologically doubtful given the absence of the defining PWI domain.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      As for the spliceosomal-complex annotation, this biological-process term is
+      transferred from SRRM1/SRm160 orthologs (with/from FB:FBgn0036340 and PANTHER
+      PTN000567596) purely on family membership. JIP4 has no demonstrated RNA-binding
+      or splicing activity, lacks the PWI domain, and does not appear in yeast
+      spliceosome or splicing-regulator datasets. Budding yeast introns are few and
+      simple with no minor (U12) spliceosome and no metazoan-style exon-junction
+      splicing coactivation, so the specific SRm160 splicing-activation role has no
+      clear yeast equivalent. Retained but flagged as a likely over-annotation rather
+      than established or core function.
+    propagation_review:
+      root_cause: PROPAGATION_BAD
+      failure_modes:
+      - FUNCTIONAL_DIVERGENCE
+      - PSEUDO_OR_SUBACTIVITY_LOSS
+      - LINEAGE_OR_TAXON_MISMATCH
+      source_entities:
+      - source_id: FB:FBgn0036340
+        source_label: Drosophila SRRM1-family member
+        source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
+      - source_id: PANTHER:PTN000567596
+        source_label: PTHR23148:SF0 ancestral node
+        source_status: SOURCE_WEAK_OR_INFERRED
+        comment: &gt;-
+          Metazoan-style ESE-dependent splicing activation has no clear equivalent in
+          intron-poor budding yeast, which lacks a minor spliceosome.
+    supported_by:
+    - reference_id: file:yeast/JIP4/JIP4-uniprot.txt
+      supporting_text: &#34;PANTHER; PTHR23148; SERINE/ARGININE REGULATED NUCLEAR MATRIX PROTEIN; 1.&#34;
+- term:
+    id: GO:0003674
+    label: molecular_function
+  evidence_type: ND
+  original_reference_id: GO_REF:0000015
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Root molecular_function term with the ND (No biological Data available) evidence
+      code, correctly recording that no molecular function has been determined for JIP4.
+    action: ACCEPT
+    reason: &gt;-
+      The ND annotation to the MF root is an honest placeholder for an uncharacterized
+      gene. No experimentally supported molecular activity exists for JIP4, and no
+      folded catalytic or binding domain is identifiable in its sequence, so retaining
+      the ND root annotation accurately conveys the molecular-function-dark status. It
+      does not represent a core function.
+- term:
+    id: GO:0005575
+    label: cellular_component
+  evidence_type: ND
+  original_reference_id: GO_REF:0000015
+  qualifier: is_active_in
+  review:
+    summary: &gt;-
+      Root cellular_component term with ND evidence, recording that JIP4&#39;s subcellular
+      localization has not been experimentally established.
+    action: ACCEPT
+    reason: &gt;-
+      No experimental localization data are available for JIP4 (UniProt records no
+      subcellular-location annotation). While the RS-rich, disordered composition is
+      suggestive of a possible nuclear/RNA-associated localization, this is not
+      established, so the ND root annotation is an appropriate honest placeholder.
+- term:
+    id: GO:0008150
+    label: biological_process
+  evidence_type: ND
+  original_reference_id: GO_REF:0000015
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Root biological_process term with ND evidence, recording that no biological
+      process/pathway has been assigned to JIP4.
+    action: ACCEPT
+    reason: &gt;-
+      JIP4 is non-essential (deletion viable) with no defined loss-of-function
+      phenotype beyond viability and no assigned pathway. The ND root annotation
+      correctly captures the biological-process-dark status of this gene.
+core_functions:
+- description: &gt;-
+    No core molecular function can be assigned to JIP4 with confidence. It is an
+    intrinsically disordered, RS/low-complexity protein classified by composition in
+    the serine/arginine repetitive matrix (SRRM1/SRm160) family, and it is an in vivo
+    phosphoprotein (including Cdk1-dependent sites), but neither its molecular activity
+    nor its biological role has been experimentally established, and it lacks the folded
+    PWI domain that carries the splicing function of its metazoan family members. The
+    family-based splicing/spliceosome inferences are homology-only and are treated as
+    unverified rather than as core function.
+  supported_by:
+  - reference_id: file:yeast/JIP4/JIP4-uniprot.txt
+    supporting_text: &#34;RecName: Full=Uncharacterized protein JIP4;&#34;
+knowledge_gaps:
+- gap_statement: &gt;-
+    The molecular function of JIP4 is entirely unknown. No biochemical activity has been
+    demonstrated, and its highly disordered sequence contains no recognizable folded
+    catalytic or nucleic-acid-binding domain (no PWI, no RRM), so even the family-based
+    &#34;RNA binding&#34; inference is unverified.
+  boundary: &gt;-
+    It is firmly established that JIP4 is expressed as a protein (evidence at protein
+    level) and is phosphorylated in vivo at multiple serines. It is assigned by
+    low-complexity composition to the serine/arginine repetitive matrix family
+    (PTHR23148) whose metazoan members are SR-related splicing coactivators. What is
+    missing is any direct biochemical or genetic evidence of an activity for the yeast
+    protein.
+  gap_kind:
+  - BIOLOGY
+  dark_aspect: WHOLLY_DARK
+  status: OPEN
+  significance: &gt;-
+    JIP4 is a conserved-family member left functionally dark in one of the best-studied
+    eukaryotes; assigning its activity would test whether the metazoan SRRM1 splicing
+    function is ancestral or a lineage-specific innovation, and would remove a genuine
+    hole in the yeast proteome annotation.
+  resolution: &gt;-
+    Direct biochemical assays (RNA/DNA-binding, association with spliceosomal or mRNP
+    complexes by affinity purification-mass spectrometry), determination of subcellular
+    localization, and phenotyping of jip4 deletion (including the jip4 yor019w double
+    mutant) under diverse conditions would define or exclude an activity.
+  provenance:
+  - reference_id: file:yeast/JIP4/JIP4-uniprot.txt
+    supporting_text: &#34;RecName: Full=Uncharacterized protein JIP4;&#34;
+- gap_statement: &gt;-
+    It is unknown whether the metazoan SRRM1/SRm160 splicing function transfers to yeast
+    JIP4 at all: whether JIP4 binds RNA, associates with the spliceosome, or regulates
+    mRNA splicing has never been tested experimentally, and the current spliceosome/
+    splicing GO annotations are homology-only (IBA) inferences.
+  boundary: &gt;-
+    The S. cerevisiae spliceosome and its regulators are extensively characterized, and
+    JIP4 has not been identified as a component in those studies; the established yeast
+    counterparts of human SR-related nuclear-matrix splicing proteins are other genes.
+    JIP4 lacks the PWI domain that mediates the SRm160/SRRM1 splicing coactivator
+    function.
+  gap_kind:
+  - BIOLOGY
+  dark_aspect: MF_DARK
+  status: OPEN
+  significance: &gt;-
+    Resolving this would either validate or correct the IBA-propagated splicing
+    annotations, clarifying whether a divergent, PWI-less SR-repetitive-matrix protein
+    retains any role in yeast RNA processing.
+  resolution: &gt;-
+    Test for RNA binding and for physical/functional association with the spliceosome
+    (co-purification, CLIP-type RNA interaction mapping, splicing-reporter assays in
+    jip4 mutants), and compare against known yeast SR-related splicing factors.
+  provenance:
+  - reference_id: file:yeast/JIP4/JIP4-uniprot.txt
+    supporting_text: &#34;DR   GO; GO:0005681; C:spliceosomal complex; IBA:GO_Central.&#34;
+- gap_statement: &gt;-
+    The subcellular localization of JIP4 has not been experimentally determined, and its
+    biological process/pathway and loss-of-function phenotype (beyond viability of the
+    deletion) are unknown, including its functional relationship to the whole-genome-
+    duplication paralog YOR019W.
+  boundary: &gt;-
+    JIP4 is non-essential; the jip4 deletion is viable and the yor019w deletion is
+    viable. JIP4 appears in high-throughput interactome and phosphoproteome datasets but
+    with no curated functional interpretation, and no dedicated study of the yeast
+    protein has been reported.
+  gap_kind:
+  - BIOLOGY
+  dark_aspect: BP_DARK
+  status: OPEN
+  significance: &gt;-
+    A defined localization, phenotype, and paralog relationship would place JIP4 in a
+    cellular process and indicate whether functional redundancy with YOR019W is masking
+    its role.
+  resolution: &gt;-
+    Endogenous fluorescent tagging for localization, condition-dependent phenotyping of
+    jip4 single and jip4 yor019w double deletions, and interpretation of its physical
+    interactors, together with functional analysis of its Cdk1-dependent phosphosites.
+  provenance:
+  - reference_id: file:yeast/JIP4/JIP4-uniprot.txt
+    supporting_text: &#34;KW   Phosphoprotein; Reference proteome.&#34;
+- gap_statement: &gt;-
+    The molecular basis of the &#34;Jumonji-interacting protein&#34; name is not established: it
+    is unclear whether JIP4 physically or functionally associates with the JmjC-domain
+    transcription factor Gis1 (or another Jumonji-family protein), and if so what that
+    interaction does, so any link to the Rim15/TOR/Sch9 nutrient-signaling and
+    calorie-restriction pathway is hypothetical.
+  boundary: &gt;-
+    The name implies identification of JIP4 as a Gis1-associated factor, and Gis1 is a
+    well-characterized JmjC zinc-finger transcription factor downstream of Rim15/TOR/Sch9.
+    What is missing is any confirmed, mechanistically characterized JIP4-Gis1 (or
+    JIP4-Jumonji) interaction and its functional consequence.
+  gap_kind:
+  - BIOLOGY
+  dark_aspect: MF_DARK
+  status: OPEN
+  significance: &gt;-
+    Confirming or refuting a JIP4-Gis1 association would either connect this dark gene to a
+    defined nutrient-signaling/chromatin transcription pathway or remove a misleading
+    name-based assumption.
+  resolution: &gt;-
+    Co-immunoprecipitation/affinity purification to test a direct JIP4-Gis1 interaction,
+    and epistasis/phenotyping of jip4 in Rim15/TOR/Sch9-pathway and calorie-restriction
+    assays.
+  provenance:
+  - reference_id: file:yeast/JIP4/JIP4-deep-research-falcon.md
+    supporting_text: &gt;-
+      Gis1 is a Jumonji-domain zinc-finger transcription factor acting downstream of
+      **Rim15/TOR/Sch9** nutrient signaling
+suggested_questions:
+- question: &gt;-
+    Does JIP4 physically associate with the JmjC transcription factor Gis1 (as its name
+    implies) or with another Jumonji-family protein, and does it function in the
+    Rim15/TOR/Sch9 nutrient-signaling / calorie-restriction pathway?
+- question: &gt;-
+    Does JIP4 bind RNA and/or associate with the spliceosome or other mRNP complexes in
+    yeast, or has the ancestral SRRM1-type splicing function been lost in this
+    PWI-less, RS-rich protein?
+- question: &gt;-
+    Where does JIP4 localize in the cell, and does its RS/low-complexity composition
+    drive nuclear or condensate localization?
+- question: &gt;-
+    What is the functional relationship between JIP4 and its whole-genome-duplication
+    paralog YOR019W, and does the double deletion reveal a phenotype masked by
+    redundancy?
+- question: &gt;-
+    What is the functional consequence of the Cdk1-dependent phosphorylation of JIP4,
+    and is JIP4 a cell-cycle-regulated protein?
+suggested_experiments:
+- hypothesis: &gt;-
+    JIP4 retains an ancestral RNA-processing/spliceosome-associated role inferred from
+    its SRRM1-family membership.
+  description: &gt;-
+    Affinity-purify epitope-tagged JIP4 from yeast and identify co-purifying proteins
+    and RNAs by mass spectrometry and RNA sequencing; test for direct RNA binding in
+    vitro; assay splicing of intron-containing reporters in jip4 (and jip4 yor019w)
+    mutants.
+- hypothesis: &gt;-
+    JIP4 has a non-redundant cellular role revealed only in combination with its
+    paralog YOR019W or under specific stress conditions.
+  description: &gt;-
+    Construct jip4, yor019w, and jip4 yor019w deletion strains and phenotype them across
+    stress, cell-cycle, and iron-availability conditions; determine JIP4 subcellular
+    localization by endogenous fluorescent tagging.
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/genes/yeast/SNO2/SNO2-ai-review.html
+++ b/genes/yeast/SNO2/SNO2-ai-review.html
@@ -1,0 +1,2948 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>SNO2 - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        .propagation-review {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f8fafc;
+            border-left: 3px solid #64748b;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .propagation-title {
+            font-weight: 600;
+            color: #334155;
+            margin-bottom: 0.25rem;
+        }
+
+        .propagation-row {
+            margin-top: 0.25rem;
+        }
+
+        .propagation-source {
+            margin-top: 0.5rem;
+            padding-top: 0.5rem;
+            border-top: 1px solid #e5e7eb;
+        }
+
+        .propagation-source-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #1d4ed8;
+        }
+
+        .propagation-comment {
+            color: #4b5563;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>SNO2</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/P53823" target="_blank" class="term-link">
+                        P53823
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Saccharomyces cerevisiae</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-draft">
+                    DRAFT
+                </span>
+            </div>
+
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "SNO2";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="P53823" data-a="DESCRIPTION: SNO2 (YNL334C) is one of three near-identical Sacc..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>SNO2 (YNL334C) is one of three near-identical Saccharomyces cerevisiae SNO paralogs (SNO1/2/3) and is a member of the glutaminase PdxT/SNO family (class-I glutamine amidotransferase fold). SNO proteins are the glutaminase subunit of the two-subunit pyridoxal 5&#39;-phosphate (PLP, vitamin B6) synthase, working together with a SNZ (PdxS/PDX1) synthase subunit: the SNO subunit hydrolyses L-glutamine to L-glutamate plus ammonia and channels the ammonia to the SNZ subunit, which condenses it with ribose 5-phosphate and glyceraldehyde 3-phosphate to form PLP. SNO2 carries the canonical Cys-His-Glu catalytic triad of the class-I glutamine amidotransferase glutaminase and is curated in a physical PLP-synthase glutaminase complex with SNZ1. The three yeast SNZ-SNO gene pairs are functionally specialized: the SNO1-SNZ1 pair is dedicated to vitamin B6 biosynthesis under B6-limiting conditions, whereas the SNO2/SNO3 (copy 2/3) genes are induced by thiamine (vitamin B1) limitation and are linked to B1 biosynthesis in exponentially growing cells. Direct enzymatic characterization of the SNO2 protein itself has not been reported; its molecular function is assigned from family membership, an intact catalytic triad, and functional characterization of fungal SNO orthologs.</p>
+    </div>
+
+
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042823" target="_blank" class="term-link">
+                                    GO:0042823
+                                </a>
+                            </span>
+                            <span class="term-label">pyridoxal 5&#39;-phosphate biosynthetic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P53823" data-a="GO:0042823" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Core biological process for the PdxT/SNO family. SNO2 is the glutaminase subunit of the PLP synthase and the SNO glutaminase subunit is required for pyridoxine/PLP biosynthesis in fungal orthologs (N. crassa pdx-2). IBA from the PANTHER PLP-synthase-subunit-SNO tree is well founded.
+                        </div>
+
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/11238395" target="_blank" class="term-link">
+                                        PMID:11238395
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">pyridoxine-requiring mutants of N. crassa were found to possess mutations that disrupt conserved regions in either the SNZ or SNO homolog</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004359" target="_blank" class="term-link">
+                                    GO:0004359
+                                </a>
+                            </span>
+                            <span class="term-label">glutaminase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P53823" data-a="GO:0004359" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> The molecular activity of the SNO/PdxT glutaminase subunit. SNO2 retains the intact class-I glutamine amidotransferase catalytic triad (Cys91 nucleophile, His197/Glu199 charge-relay; UniProt), so glutaminase activity is domain-defensible. The contributes_to qualifier is appropriate because the glutaminase is a subunit whose in-vivo activity is coupled to (and ammonia-channeled into) the SNZ synthase subunit within the PLP synthase.
+                        </div>
+
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/11238395" target="_blank" class="term-link">
+                                        PMID:11238395
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">pyridoxine-requiring mutants of N. crassa were found to possess mutations that disrupt conserved regions in either the SNZ or SNO homolog</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008614" target="_blank" class="term-link">
+                                    GO:0008614
+                                </a>
+                            </span>
+                            <span class="term-label">pyridoxine metabolic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P53823" data-a="GO:0008614" data-r="GO_REF:0000033" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Pyridoxine (vitamin B6) metabolic process. Consistent with the family role in PLP/B6 biosynthesis and with SGD&#39;s ISS annotation of the same term (supported by the Aspergillus pyroA and Neurospora pdx-1/pdx-2 orthologs). Slightly more general/parallel to the PLP biosynthetic process term; retained as a valid family process annotation.
+                        </div>
+
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/10438537" target="_blank" class="term-link">
+                                        PMID:10438537
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">define this gene family as encoding an enzyme specifically required for pyridoxine biosynthesis</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1903600" target="_blank" class="term-link">
+                                    GO:1903600
+                                </a>
+                            </span>
+                            <span class="term-label">glutaminase complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P53823" data-a="GO:1903600" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Complex membership as the glutaminase subunit of the two-subunit PLP synthase. Directly corroborated for SNO2 by ComplexPortal CPX-1371 (SNO2-SNZ1 pyridoxal 5&#39;-phosphate synthase complex). GO:1903600 (glutaminase complex; synonym Sno1p-Snz1p) is the generic term for a complex capable of glutaminase activity and is correctly applied here.
+                        </div>
+
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    ComplexPortal:CPX-1371
+
+                                </span>
+
+                                <div class="support-text">SNO2-SNZ1 pyridoxal 5&#39;-phosphate synthase complex</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004359" target="_blank" class="term-link">
+                                    GO:0004359
+                                </a>
+                            </span>
+                            <span class="term-label">glutaminase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000120
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P53823" data-a="GO:0004359" data-r="GO_REF:0000120" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Same molecular activity as the IBA glutaminase-activity annotation above, here derived by automated EC/RHEA mapping (EC 3.5.1.2). The MF term is correct given the intact catalytic triad. The enables qualifier (vs the more accurate contributes_to used by the IBA pipeline for the subunit) is a pipeline artifact of EC-based IEA; the underlying activity assignment is sound, so the annotation is retained.
+                        </div>
+
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/11238395" target="_blank" class="term-link">
+                                        PMID:11238395
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">pyridoxine-requiring mutants of N. crassa were found to possess mutations that disrupt conserved regions in either the SNZ or SNO homolog</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008614" target="_blank" class="term-link">
+                                    GO:0008614
+                                </a>
+                            </span>
+                            <span class="term-label">pyridoxine metabolic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000117
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P53823" data-a="GO:0008614" data-r="GO_REF:0000117" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Duplicate of the pyridoxine metabolic process annotation, from the ARBA machine-learning pipeline. Same domain/orthology support; retained as a valid but non-core family process term.
+                        </div>
+
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/10438537" target="_blank" class="term-link">
+                                        PMID:10438537
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">define this gene family as encoding an enzyme specifically required for pyridoxine biosynthesis</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0036381" target="_blank" class="term-link">
+                                    GO:0036381
+                                </a>
+                            </span>
+                            <span class="term-label">pyridoxal 5&#39;-phosphate synthase (glutamine hydrolysing) activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000120
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P53823" data-a="GO:0036381" data-r="GO_REF:0000120" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> The holoenzyme-level molecular function (EC 4.3.3.6) of the two-subunit PLP synthase. This activity is strictly a property of the assembled SNO+SNZ complex (the SNO subunit alone provides only the glutaminase half-reaction), so contributes_to would be more precise than enables. The term is a correct family assignment via EC/RHEA mapping and is retained.
+                        </div>
+
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/10438537" target="_blank" class="term-link">
+                                        PMID:10438537
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">define this gene family as encoding an enzyme specifically required for pyridoxine biosynthesis</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042819" target="_blank" class="term-link">
+                                    GO:0042819
+                                </a>
+                            </span>
+                            <span class="term-label">vitamin B6 biosynthetic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P53823" data-a="GO:0042819" data-r="GO_REF:0000002" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Vitamin B6 biosynthetic process, the parent process of PLP biosynthesis. Correct but more general than the PLP biosynthetic process (GO:0042823) annotation; retained as a valid non-core (broader) process term for the family.
+                        </div>
+
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/10438537" target="_blank" class="term-link">
+                                        PMID:10438537
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">define this gene family as encoding an enzyme specifically required for pyridoxine biosynthesis</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042823" target="_blank" class="term-link">
+                                    GO:0042823
+                                </a>
+                            </span>
+                            <span class="term-label">pyridoxal 5&#39;-phosphate biosynthetic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000120
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P53823" data-a="GO:0042823" data-r="GO_REF:0000120" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Duplicate of the core PLP biosynthetic process annotation, from InterPro/UniPathway automated mapping. Same support as the IBA version; retained.
+                        </div>
+
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/11238395" target="_blank" class="term-link">
+                                        PMID:11238395
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">pyridoxine-requiring mutants of N. crassa were found to possess mutations that disrupt conserved regions in either the SNZ or SNO homolog</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003674" target="_blank" class="term-link">
+                                    GO:0003674
+                                </a>
+                            </span>
+                            <span class="term-label">molecular_function</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ND</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000015
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P53823" data-a="GO:0003674" data-r="GO_REF:0000015" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Root molecular_function placeholder with ND (no biological data) evidence, an SGD no-data stub predating the electronic/phylogenetic MF assignments. Uninformative; kept as-is per convention for ND root annotations (superseded by the specific MF terms above).
+                        </div>
+
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005575" target="_blank" class="term-link">
+                                    GO:0005575
+                                </a>
+                            </span>
+                            <span class="term-label">cellular_component</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ND</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000015
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P53823" data-a="GO:0005575" data-r="GO_REF:0000015" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Root cellular_component placeholder with ND evidence, an SGD no-data stub. Uninformative; kept as-is per convention (superseded by the glutaminase-complex and cytosol IBA annotations for the family).
+                        </div>
+
+
+
+
+
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>Glutaminase subunit of the two-subunit pyridoxal 5&#39;-phosphate (PLP, vitamin B6) synthase: SNO2 hydrolyses L-glutamine to L-glutamate and ammonia (class-I glutamine amidotransferase glutaminase, catalytic triad Cys91/His197/Glu199 intact) and, within the PLP synthase complex with a SNZ synthase subunit, channels the ammonia used to build PLP from ribose 5-phosphate and glyceraldehyde 3-phosphate. Assigned from family membership, intact catalytic triad, and characterized fungal SNO orthologs (N. crassa pdx-2); direct enzymatic assay of the SNO2 protein has not been reported.</h3>
+                <span class="vote-buttons" data-g="P53823" data-a="FUNCTION: Glutaminase subunit of the two-subunit pyridoxal 5..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004359" target="_blank" class="term-link">
+                            glutaminase activity
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042823" target="_blank" class="term-link">
+                                pyridoxal 5&#39;-phosphate biosynthetic process
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">In Complex:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1903600" target="_blank" class="term-link">
+                            glutaminase complex
+                        </a>
+                    </span>
+                </div>
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/11238395" target="_blank" class="term-link">
+                                PMID:11238395
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">pyridoxine-requiring mutants of N. crassa were found to possess mutations that disrupt conserved regions in either the SNZ or SNO homolog</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/10438537" target="_blank" class="term-link">
+                                PMID:10438537
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">define this gene family as encoding an enzyme specifically required for pyridoxine biosynthesis</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000002.md" target="_blank" class="term-link">
+                            GO_REF:0000002
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation through association of InterPro records with GO terms</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000015.md" target="_blank" class="term-link">
+                            GO_REF:0000015
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Use of the ND evidence code for Gene Ontology (GO) terms</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
+                            GO_REF:0000033
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Annotation inferences using phylogenetic trees</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000117.md" target="_blank" class="term-link">
+                            GO_REF:0000117
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Electronic Gene Ontology annotations created by ARBA machine learning models</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000120.md" target="_blank" class="term-link">
+                            GO_REF:0000120
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Combined Automated Annotation using Multiple IEA Methods</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        ComplexPortal:CPX-1371
+
+                    </span>
+                </div>
+
+                <div class="reference-title">SNO2-SNZ1 pyridoxal 5&#39;-phosphate synthase complex</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">SNO2 (P53823) and SNZ1 (Q03148) are curated as the two enzyme subunits of a pyridoxal 5&#39;-phosphate synthase glutaminase complex.</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/12271461" target="_blank" class="term-link">
+                            PMID:12271461
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Functional analysis of yeast gene families involved in metabolism of vitamins B1 and B6.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">In media lacking vitamin B6, SNZ1 and SNO1 were required for growth in certain conditions, but SNZ2, SNZ3, SNO2 and SNO3 were not required; copies 2 and 3 are instead activated by lack of thiamine and appear more related to vitamin B1 biosynthesis during exponential phase.</div>
+
+                        <div class="finding-text">"In media lacking vitamin B(6), SNZ1 and SNO1 were both required for growth in certain conditions, but neither SNZ2, SNZ3, SNO2 nor SNO3 were required."</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/10438537" target="_blank" class="term-link">
+                            PMID:10438537
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">The extremely conserved pyroA gene of Aspergillus nidulans is required for pyridoxine synthesis and is required indirectly for resistance to photosensitizers.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">The SNZ family (the PLP-synthase synthase subunit; pyroA in Aspergillus) is an enzyme specifically required for pyridoxine biosynthesis, defining the eukaryotic/archaeal PLP biosynthetic pathway that the SNO glutaminase subunit feeds.</div>
+
+                        <div class="finding-text">"define this gene family as encoding an enzyme specifically required for pyridoxine biosynthesis"</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/11238395" target="_blank" class="term-link">
+                            PMID:11238395
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Analysis of the pdx-1 (snz-1/sno-1) region of the Neurospora crassa genome: correlation of pyridoxine-requiring phenotypes with mutations in two structural genes.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">In Neurospora crassa, pyridoxine-requiring mutants carry mutations disrupting either the SNZ or the SNO homolog, and the SNO homolog corresponds to pdx-2; this establishes that a fungal SNO/glutaminase subunit is required for pyridoxine (PLP) biosynthesis.</div>
+
+                        <div class="finding-text">"pyridoxine-requiring mutants of N. crassa were found to possess mutations that disrupt conserved regions in either the SNZ or SNO homolog"</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Questions for Experts</h2>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Is the SNO2 protein a catalytically active glutaminase, and does it form a functional PLP synthase when reconstituted with SNZ1, SNZ2, or SNZ3?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P53823" data-a="Q: Is the SNO2 protein a catalytically active glutami..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Under what physiological condition is SNO2 non-redundantly required, given that it is dispensable for vitamin B6-limited growth but induced by thiamine limitation?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P53823" data-a="Q: Under what physiological condition is SNO2 non-red..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Experiments</h2>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Express and purify recombinant SNO2 and SNZ1/2/3; assay glutaminase activity (L-glutamine to L-glutamate + ammonia) for SNO2 alone and coupled PLP synthesis (with ribose 5-phosphate and glyceraldehyde 3-phosphate) for SNO2+SNZ mixtures, using a Cys91 active-site mutant as a negative control.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: SNO2 is a catalytically competent glutaminase subunit that reconstitutes a functional PLP synthase with a SNZ synthase subunit.</em></p>
+
+
+                </div>
+                <span class="vote-buttons" data-g="P53823" data-a="EXPERIMENT: Express and purify recombinant SNO2 and SNZ1/2/3; ..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Phenotype sno2 single and sno1 sno2 sno3 combinatorial deletion strains under vitamin B6 and thiamine limitation; quantify intracellular PLP and thiamine and profile SNO2-SNZ physical associations by condition.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: SNO2 has a thiamine-limitation-linked and/or condition-specific role distinct from the B6-dedicated SNO1.</em></p>
+
+
+                </div>
+                <span class="vote-buttons" data-g="P53823" data-a="EXPERIMENT: Phenotype sno2 single and sno1 sno2 sno3 combinato..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Knowledge Gaps</h2>
+        <p style="color: #555; font-size: 0.92rem; margin-top: -0.3rem;">
+            What is <em>not</em> known — curated, literature-grounded statements of the open
+            unknowns (the inverse of core functions).
+        </p>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The SNO2-specific in-vivo physiological role and its required condition are undetermined. SNO2 is dispensable for vitamin B6-limited growth, and it is unresolved whether its native function is in pyridoxal 5&#39;-phosphate (B6) biosynthesis, in a thiamine (B1)-related process under which it is induced, or both, and which SNZ synthase subunit it partners in vivo.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">BP_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> SNO2 is a glutaminase PdxT/SNO family member with an intact catalytic triad, curated in a PLP-synthase glutaminase complex with SNZ1 (CPX-1371). The B6-dedicated pair is SNO1/SNZ1 (both required for B6-limited growth); SNO2/SNO3 (copies 2/3) are dispensable for B6-limited growth and are transcriptionally activated by thiamine limitation, appearing more related to B1 biosynthesis in exponential phase.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Resolving this would explain why yeast maintains three SNZ-SNO pairs and whether SNO2 represents a B1-linked or condition-specific branch of PLP-family metabolism rather than simple redundancy with SNO1. It is the crux of what distinguishes this understudied paralog from its well-characterized copy-1 counterpart.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Condition-resolved phenotyping of sno2 single and sno1 sno2 sno3 combinatorial deletions under B6 and B1 limitation; measurement of intracellular PLP and thiamine; identification of the SNZ subunit(s) SNO2 associates with in each condition.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"but neither SNZ2, SNZ3, SNO2 nor SNO3 were required."</em> — PMID:12271461</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The degree and direction of functional redundancy among the three yeast SNO paralogs (SNO1/SNO2/SNO3) is unresolved: it is unknown whether SNO2 can substitute for SNO1 in B6 biosynthesis, whether SNO2 and SNO3 are interchangeable, and what unique contribution SNO2 makes despite their near-identical sequences.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">RESIDUAL_SUBGAP</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> Single-gene deletions of SNO2 (a copy-2/3 gene) do not impair B6-limited growth, and copies 2 and 3 are reported to have slightly different cellular functions despite extremely close sequence similarity; the B6 phenotype is carried by SNO1.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Distinguishing genuine paralog-specific function from redundancy is essential to attribute any SNO2-specific annotation correctly and to avoid over-propagating SNO1 evidence onto SNO2.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Cross-complementation assays (express SNO2 in a sno1 background under B6 limitation and vice versa) and paralog-swap chimeras to map function-determining residues.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"Copies 2 and 3 of the gene products have, in spite of their extremely close sequence similarity, slightly different functions in the cell."</em> — PMID:12271461</li>
+
+            </ul>
+
+
+        </div>
+
+    </div>
+
+
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Deep Research Sections -->
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(SNO2-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="P53823" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="sno2-ynl334c-p53823-curation-notes">SNO2 (YNL334C, P53823) — curation notes</h1>
+<p>Journal of research for the AI GO-annotation review of <em>Saccharomyces cerevisiae</em> SNO2.<br />
+SNO2 is an <strong>understudied ("dark") gene</strong>: nearly all direct functional data are for its<br />
+paralog SNO1 and for the partner SNZ genes; SNO2-specific evidence is sparse. Provenance is<br />
+recorded inline as <code>[PMID:xxxx "verbatim quote"]</code> where possible.</p>
+<h2 id="identity-and-domain-architecture-from-uniprot-p53823">Identity and domain architecture (from UniProt P53823)</h2>
+<ul>
+<li>Systematic name YNL334C; SGD:S000005278; SNZ-proximal ORF ("SNO" = <strong>SN</strong>Z <strong>p</strong>roximal<br />
+<strong>O</strong>RF). 222 aa, 25.2 kDa. UniProt PE=3 (Inferred from homology). NB: SNO2's own SGD id is<br />
+  S000005278; the SGD ids in the GOA <code>WITH/FROM</code> fields (S000004701, S000001834) are<br />
+  PANTHER-tree paralogs used as the IBA seed set, <strong>not</strong> SNO2's own identifier.</li>
+<li><strong>Family:</strong> glutaminase PdxT/SNO family; Pfam PF01174 (SNO); InterPro IPR002161 (PdxT/SNO),<br />
+  IPR029062 (class I glutamine amidotransferase-like), IPR021196 (PdxT/SNO conserved site);<br />
+  CDD cd01749 (GATase1_PB); TIGRFAM TIGR03800 (PLP_synth_Pdx2); PANTHER PTHR31559<br />
+  (PYRIDOXAL 5'-PHOSPHATE SYNTHASE SUBUNIT SNO). MEROPS clan/family C26.A32 (peptidase-C26<br />
+  = class-I glutamine amidotransferase fold).</li>
+<li><strong>Enzyme identity (annotated on homology):</strong> the SNO/PdxT protein is the <strong>glutaminase<br />
+  subunit</strong> of the two-subunit (PLP synthase / PDX) machine. It hydrolyses L-glutamine to<br />
+  L-glutamate + NH3 (glutaminase, EC 3.5.1.2) and channels the ammonia to the synthase<br />
+  subunit (SNZ/PdxS), which condenses it with ribose-5-P and glyceraldehyde-3-P to make<br />
+  pyridoxal-5'-phosphate (holoenzyme reaction EC 4.3.3.6, "PLP synthase, glutamine<br />
+  hydrolysing"). UniProt: <code>FUNCTION: Catalyzes the hydrolysis of glutamine to glutamate and
+  ammonia as part of the biosynthesis of pyridoxal 5'-phosphate. The resulting ammonia
+  molecule is channeled to the active site of a SNZ isoform.</code></li>
+</ul>
+<h3 id="catalytic-triad-integrity-inline-domain-analysis">Catalytic-triad integrity (INLINE DOMAIN ANALYSIS)</h3>
+<p>The class-I glutamine amidotransferase (GATase1) glutaminase uses a <strong>Cys–His–Glu catalytic<br />
+triad</strong>. UniProt annotates SNO2's triad by homology (ECO:0000250|UniProtKB:P37528, the<br />
+<em>B. subtilis</em> PdxT):</p>
+<ul>
+<li><strong>ACT_SITE 91</strong> — Nucleophile → sequence position 91 = <strong>Cys</strong> (nucleophilic cysteine).</li>
+<li><strong>ACT_SITE 197</strong> — Charge-relay → <strong>His</strong>.</li>
+<li><strong>ACT_SITE 199</strong> — Charge-relay → <strong>Glu</strong>.</li>
+<li>Glutamine-binding residues annotated at 58–60, 120, 151–152.</li>
+</ul>
+<p>I verified these against the sequence (222 aa):<br />
+<code>...IIPGGES TAMSLIAERT...</code> — residue 91 falls in the conserved <code>PGG</code>/<code>G-x-C-x-G</code> oxyanion<br />
+region; the C-terminal <code>...SFHPEL...</code> block carries the His-Pro-Glu-Leu of the charge-relay<br />
+(His197, Glu199). <strong>The catalytic triad is intact</strong> (Cys91/His197/Glu199 all present), and<br />
+the PROSITE PDXT_SNO patterns (PS01236, PS51130) match. Therefore the glutaminase /<br />
+PLP-synthase-glutaminase-subunit molecular function is <strong>domain-defensible</strong> for SNO2 —<br />
+this is NOT a degenerate pseudoenzyme. (Sequence checked directly from the UniProt SQ block;<br />
+triad residue identities read off the annotated FT positions.)</p>
+<h2 id="the-snzsno-gene-families-in-s-cerevisiae-separating-sno2-from-paralogs">The SNZ/SNO gene families in <em>S. cerevisiae</em> — separating SNO2 from paralogs</h2>
+<p><em>S. cerevisiae</em> has three near-identical SNZ (synthase-subunit) genes SNZ1/2/3 and three<br />
+near-identical SNO (glutaminase-subunit) genes SNO1/2/3, arranged as divergently-transcribed<br />
+SNZ–SNO pairs. <strong>Attribution across paralogs is the central hazard for this gene.</strong></p>
+<ul>
+<li><strong>SNO1/SNZ1 (copy 1)</strong> is the pair dedicated to <strong>vitamin B6 (pyridoxine)</strong> and is the<br />
+  well-characterised one. Rodriguez-Navarro 2002: <code>In media lacking vitamin B(6), SNZ1 and
+  SNO1 were both required for growth in certain conditions</code> <a href="https://pubmed.ncbi.nlm.nih.gov/12271461">PMID:12271461</a>.</li>
+<li><strong>SNO2/SNZ2 and SNO3/SNZ3 (copies 2 and 3)</strong> are the understudied pair(s). The same study<br />
+  states: <code>but neither SNZ2, SNZ3, SNO2 nor SNO3 were required</code> (for growth in B6-lacking<br />
+  media) <a href="https://pubmed.ncbi.nlm.nih.gov/12271461">PMID:12271461</a>. So <strong>SNO2 is dispensable for pyridoxine-limited growth</strong> in the<br />
+  conditions tested — its loss is masked (redundancy and/or a different physiological role).</li>
+<li>Condition of induction: copies 2/3 respond to <strong>thiamine (B1)</strong> limitation, not (only)<br />
+  B6: <code>we have also found that copies 2 and 3 are activated by the lack of thiamine and that
+  the Snz proteins physically interact with the thiamine biosynthesis Thi5 protein family</code><br />
+  and <code>copies 2 and 3 seem more related with B(1) biosynthesis during the exponential phase</code><br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/12271461">PMID:12271461</a>. NOTE: this makes SNO2 more plausibly <strong>thiamine-limitation-induced</strong> than<br />
+  pyridoxine-limitation-induced; the two pathways share the ribose-5-P/NH3 chemistry, and<br />
+  cross-talk between B6 and B1 biosynthesis is reported for the copy-2/3 genes.</li>
+<li><code>Copies 2 and 3 of the gene products have, in spite of their extremely close sequence
+  similarity, slightly different functions in the cell.</code> <a href="https://pubmed.ncbi.nlm.nih.gov/12271461">PMID:12271461</a> — i.e. SNO2 and<br />
+  SNO3 are not simply interchangeable, but the paper does not resolve an SNO2-specific<br />
+  molecular activity in isolation.</li>
+</ul>
+<h2 id="physical-complex-sno2-partners-snz1-per-complexportal-not-snz23">Physical complex — SNO2 partners SNZ1 (per ComplexPortal), not SNZ2/3</h2>
+<ul>
+<li><strong>ComplexPortal CPX-1371</strong> = "SNO2-SNZ1 pyridoxal 5'-phosphate synthase complex",<br />
+  systematic name <code>SNO2:SNZ1</code>, participants <strong>SNZ1 (Q03148)</strong> + <strong>SNO2 (P53823)</strong>, both with<br />
+  bioRole "enzyme". (Retrieved from ComplexPortal REST API,<br />
+<code>complex-ws/complex/CPX-1371</code>.) So the curated physical partner of SNO2 is <strong>SNZ1</strong>, i.e.<br />
+  the SNO/SNZ subunits are not strictly locked into same-numbered pairs at the protein level.<br />
+  This is a caveat for any "in_complex with SNZ2" assumption.</li>
+<li>GO glutaminase-complex term GO:1903600 has synonym "Sno1p-Snz1p" and definition "A protein<br />
+  complex which is capable of glutaminase activity" (OLS) — a generic term, correctly<br />
+  applicable to the SNO2-containing PLP-synthase glutaminase complex via IBA.</li>
+</ul>
+<h2 id="orthology-support-for-the-sno-family-function-glutaminase-subunit-plp-biosynthesis">Orthology support for the SNO-family function (glutaminase subunit → PLP biosynthesis)</h2>
+<ul>
+<li><strong>Aspergillus nidulans pyroA</strong> (SNZ/PDX1 side): the SNZ family is <code>an enzyme specifically
+  required for pyridoxine biosynthesis</code>; <code>Eukarya and Archaea exclusively use the pyroA
+  pathway</code> <a href="https://pubmed.ncbi.nlm.nih.gov/10438537">PMID:10438537</a>. (This is the synthase-subunit paper; establishes the pathway the<br />
+  SNO glutaminase subunit feeds into.)</li>
+<li><strong>Neurospora crassa pdx-1/pdx-2</strong>: <code>pyridoxine-requiring mutants of N. crassa were found to
+  possess mutations that disrupt conserved regions in either the SNZ or SNO homolog</code> and <code>It
+  now appears appropriate to reserve the pdx-1 designation for the N. crassa SNZ homolog and
+  pdx-2 for the SNO homolog</code> <a href="https://pubmed.ncbi.nlm.nih.gov/11238395">PMID:11238395</a>. This is the strongest orthology evidence that a<br />
+  fungal <strong>SNO/glutaminase subunit</strong> is functionally required for <strong>pyridoxine (PLP)<br />
+  biosynthesis</strong> — supporting the ISS/IBA MF+BP annotations on SNO2 by descent.</li>
+<li>SGD records SNO2's <code>pyridoxine metabolic process</code> (GO:0008614) annotation as <strong>ISS</strong> with<br />
+  references PMID:10438537 and PMID:11238395 (i.e. by similarity to these characterised fungal<br />
+  orthologs) (SGD go_details for S000005278).</li>
+</ul>
+<h2 id="known-vs-not-known-for-sno2-specifically">KNOWN vs NOT-known for SNO2 specifically</h2>
+<p>KNOWN (well-supported):<br />
+- Belongs to the PdxT/SNO glutaminase (class-I GATase) family; intact Cys91/His197/Glu199<br />
+  catalytic triad (UniProt; sequence-verified).<br />
+- By family/orthology, functions as the glutaminase subunit of the PLP (vitamin B6) synthase<br />
+  complex; the SNO glutaminase subunit is required for pyridoxine biosynthesis in fungal<br />
+  orthologs (N. crassa pdx-2) <a href="https://pubmed.ncbi.nlm.nih.gov/11238395">PMID:11238395</a>.<br />
+- Physically forms a PLP-synthase glutaminase complex with SNZ1 (ComplexPortal CPX-1371).<br />
+- SNO2/SNZ2/SNZ3/SNO3 (the copy-2/3 genes) are transcriptionally activated by thiamine (B1)<br />
+  limitation and are linked to B1 biosynthesis in exponential phase <a href="https://pubmed.ncbi.nlm.nih.gov/12271461">PMID:12271461</a>.</p>
+<p>NOT known / uncertain (→ knowledge_gaps):<br />
+- <strong>No direct in-vitro demonstration</strong> of SNO2 (P53823) glutaminase or PLP-synthase activity;<br />
+  the MF annotations are all IEA/IBA/ISS by homology (UniProt PE=3). Enzymatic activity of the<br />
+  reconstituted <strong>SNO2/SNZ complex has not been shown catalytically</strong> in the way it has for<br />
+  bacterial/plant PdxS·PdxT.<br />
+- <strong>SNO2 is dispensable</strong> for pyridoxine-limited growth <a href="https://pubmed.ncbi.nlm.nih.gov/12271461">PMID:12271461</a>; a distinct<br />
+  SNO2-specific <em>in vivo</em> physiological role/condition is not established. Redundancy with<br />
+  SNO1 (and SNO3) is unresolved.<br />
+- The physiological substrate context (B6 vs B1 biosynthesis) for SNO2 is ambiguous — induced<br />
+  by B1 limitation, yet family MF is PLP (B6) synthesis <a href="https://pubmed.ncbi.nlm.nih.gov/12271461">PMID:12271461</a>.<br />
+- Whether SNO2 preferentially partners SNZ1 vs SNZ2/SNZ3 in vivo is not settled (ComplexPortal<br />
+  curates SNO2:SNZ1).</p>
+<h2 id="annotation-by-annotation-plan-11-goa-rows">Annotation-by-annotation plan (11 GOA rows)</h2>
+<ol>
+<li>GO:0042823 PLP biosynthetic process — IBA — ACCEPT (core BP; family+ortholog supported).</li>
+<li>GO:0004359 glutaminase activity — IBA — contributes_to — ACCEPT (subunit MF, triad intact).</li>
+<li>GO:0008614 pyridoxine metabolic process — IBA — ACCEPT/KEEP (B6 process; SGD ISS-backed).</li>
+<li>GO:1903600 glutaminase complex — IBA — part_of — ACCEPT (CPX-1371 confirms complex).</li>
+<li>GO:0004359 glutaminase activity — IEA(EC) — enables — MODIFY→contributes_to framing /<br />
+   ACCEPT MF (same activity as #2; enables from EC mapping; keep, note contributes_to is the<br />
+   more accurate qualifier for a subunit but the MF term itself is correct).</li>
+<li>GO:0008614 pyridoxine metabolic process — IEA(ARBA) — ACCEPT (dup of #3, different pipeline).</li>
+<li>GO:0036381 PLP synthase (glutamine hydrolysing) activity — IEA(EC 4.3.3.6) — ACCEPT<br />
+   (holoenzyme MF; strictly a property of the SNO+SNZ complex, so contributes_to is more apt,<br />
+   but term is correct for the family).</li>
+<li>GO:0042819 vitamin B6 biosynthetic process — IEA(InterPro) — ACCEPT/KEEP (parent of the<br />
+   PLP process; correct but more general than #1).</li>
+<li>GO:0042823 PLP biosynthetic process — IEA — ACCEPT (dup of #1, InterPro/UniPathway).</li>
+<li>GO:0003674 molecular_function — ND — accept-as-is (root; ND placeholder, keep as NON_CORE).</li>
+<li>GO:0005575 cellular_component — ND — accept-as-is (root; ND placeholder).</li>
+</ol>
+<p>No REMOVE actions: every annotation is domain/orthology-defensible; SNO2 has no experimental<br />
+annotations to overrule, and no annotation is biologically contradicted.</p>
+<h2 id="deep-research-provenance-tooling-status">Deep-research provenance / tooling status</h2>
+<p>The automated deep-research harness did not yield a provider report for SNO2. <code>falcon</code> timed out<br />
+at 600s (twice; retried once per protocol), and the <code>perplexity-lite</code> fallback returned HTTP 401<br />
+(insufficient_quota). Per project guidance, this review is therefore grounded directly in<br />
+primary/authoritative sources rather than an LLM deep-research summary:</p>
+<ul>
+<li>UniProt P53823 (domain architecture, catalytic-triad annotation, family assignment, curated<br />
+  FUNCTION; sequence-level triad verification done inline above).</li>
+<li>GOA TSV (the 11 existing annotations reviewed).</li>
+<li>ComplexPortal CPX-1371 (SNO2:SNZ1 complex; REST API).</li>
+<li>SGD go_details for S000005278 (the ISS annotation and its supporting references).</li>
+<li>Three cached, PubMed-verified primary publications: PMID:12271461 (yeast SNZ/SNO functional<br />
+  analysis — the one paper directly assaying SNO2), PMID:10438537 (Aspergillus pyroA / SNZ<br />
+  side), PMID:11238395 (Neurospora pdx-1/pdx-2 / SNO side).</li>
+</ul>
+<p>Every <code>supporting_text</code> in the review is a verbatim substring of a cached publication and was<br />
+machine-verified by <code>just validate-references</code> (all checks passed). No content was fabricated.<br />
+If a genuine late falcon report lands, it will be committed as <code>SNO2-deep-research-falcon.md</code><br />
+without altering the evidence-grounded conclusions above.</p>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: P53823
+gene_symbol: SNO2
+product_type: PROTEIN
+status: DRAFT
+taxon:
+  id: NCBITaxon:559292
+  label: Saccharomyces cerevisiae
+description: &gt;-
+  SNO2 (YNL334C) is one of three near-identical Saccharomyces cerevisiae SNO paralogs
+  (SNO1/2/3) and is a member of the glutaminase PdxT/SNO family (class-I glutamine
+  amidotransferase fold). SNO proteins are the glutaminase subunit of the two-subunit
+  pyridoxal 5&#39;-phosphate (PLP, vitamin B6) synthase, working together with a SNZ (PdxS/PDX1)
+  synthase subunit: the SNO subunit hydrolyses L-glutamine to L-glutamate plus ammonia and
+  channels the ammonia to the SNZ subunit, which condenses it with ribose 5-phosphate and
+  glyceraldehyde 3-phosphate to form PLP. SNO2 carries the canonical Cys-His-Glu catalytic
+  triad of the class-I glutamine amidotransferase glutaminase and is curated in a physical
+  PLP-synthase glutaminase complex with SNZ1. The three yeast SNZ-SNO gene pairs are
+  functionally specialized: the SNO1-SNZ1 pair is dedicated to vitamin B6 biosynthesis under
+  B6-limiting conditions, whereas the SNO2/SNO3 (copy 2/3) genes are induced by thiamine
+  (vitamin B1) limitation and are linked to B1 biosynthesis in exponentially growing cells.
+  Direct enzymatic characterization of the SNO2 protein itself has not been reported; its
+  molecular function is assigned from family membership, an intact catalytic triad, and
+  functional characterization of fungal SNO orthologs.
+references:
+- id: GO_REF:0000002
+  title: Gene Ontology annotation through association of InterPro records with GO terms
+  findings: []
+- id: GO_REF:0000015
+  title: Use of the ND evidence code for Gene Ontology (GO) terms
+  findings: []
+- id: GO_REF:0000033
+  title: Annotation inferences using phylogenetic trees
+  findings: []
+- id: GO_REF:0000117
+  title: Electronic Gene Ontology annotations created by ARBA machine learning models
+  findings: []
+- id: GO_REF:0000120
+  title: Combined Automated Annotation using Multiple IEA Methods
+  findings: []
+- id: ComplexPortal:CPX-1371
+  title: SNO2-SNZ1 pyridoxal 5&#39;-phosphate synthase complex
+  findings:
+  - statement: &gt;-
+      SNO2 (P53823) and SNZ1 (Q03148) are curated as the two enzyme subunits of a
+      pyridoxal 5&#39;-phosphate synthase glutaminase complex.
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Retrieved from the ComplexPortal REST API (complex-ws/complex/CPX-1371):
+      systematic name SNO2:SNZ1, participants SNZ1 (Q03148) and SNO2 (P53823), both
+      bioRole enzyme. Directly corroborates SNO2&#39;s physical membership in the PLP-synthase
+      glutaminase complex.
+- id: PMID:12271461
+  title: Functional analysis of yeast gene families involved in metabolism of vitamins B1 and B6.
+  findings:
+  - statement: &gt;-
+      In media lacking vitamin B6, SNZ1 and SNO1 were required for growth in certain conditions,
+      but SNZ2, SNZ3, SNO2 and SNO3 were not required; copies 2 and 3 are instead activated by
+      lack of thiamine and appear more related to vitamin B1 biosynthesis during exponential phase.
+    supporting_text: &gt;-
+      In media lacking vitamin B(6), SNZ1 and SNO1 were both required for growth in certain
+      conditions, but neither SNZ2, SNZ3, SNO2 nor SNO3 were required.
+    reference_section_type: ABSTRACT
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PubMed-verified (Yeast 2002;19:1261-76). The only study directly assaying SNO2 in yeast;
+      establishes that SNO2 (a copy-2/3 gene) is dispensable for B6-limited growth and is
+      thiamine-limitation-induced, distinguishing it from the B6-dedicated SNO1/SNZ1 pair.
+      Abstract-only in cache (full_text_available: false).
+- id: PMID:10438537
+  title: &gt;-
+    The extremely conserved pyroA gene of Aspergillus nidulans is required for pyridoxine
+    synthesis and is required indirectly for resistance to photosensitizers.
+  findings:
+  - statement: &gt;-
+      The SNZ family (the PLP-synthase synthase subunit; pyroA in Aspergillus) is an enzyme
+      specifically required for pyridoxine biosynthesis, defining the eukaryotic/archaeal PLP
+      biosynthetic pathway that the SNO glutaminase subunit feeds.
+    supporting_text: &gt;-
+      define this gene family as encoding an enzyme specifically required for pyridoxine
+      biosynthesis
+    reference_section_type: ABSTRACT
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PubMed-verified (J Biol Chem 1999). Characterizes the SNZ/synthase-subunit ortholog
+      (pyroA), establishing the pyridoxine-biosynthesis pathway that SNO (glutaminase subunit)
+      partners in. Used by SGD as an ISS support for SNO2&#39;s pyridoxine metabolic process
+      annotation. About the SNZ side, so only indirectly about SNO2 itself.
+- id: PMID:11238395
+  title: &gt;-
+    Analysis of the pdx-1 (snz-1/sno-1) region of the Neurospora crassa genome: correlation
+    of pyridoxine-requiring phenotypes with mutations in two structural genes.
+  findings:
+  - statement: &gt;-
+      In Neurospora crassa, pyridoxine-requiring mutants carry mutations disrupting either the
+      SNZ or the SNO homolog, and the SNO homolog corresponds to pdx-2; this establishes that a
+      fungal SNO/glutaminase subunit is required for pyridoxine (PLP) biosynthesis.
+    supporting_text: &gt;-
+      pyridoxine-requiring mutants of N. crassa were found to possess mutations that disrupt
+      conserved regions in either the SNZ or SNO homolog
+    reference_section_type: ABSTRACT
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PubMed-verified (Genetics 2001). Strongest orthology evidence that a fungal SNO
+      glutaminase subunit (pdx-2) is functionally required for pyridoxine biosynthesis. Used by
+      SGD as ISS support for SNO2&#39;s pyridoxine metabolic process annotation. Neurospora, not
+      yeast SNO2 directly.
+existing_annotations:
+- term:
+    id: GO:0042823
+    label: pyridoxal 5&#39;-phosphate biosynthetic process
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Core biological process for the PdxT/SNO family. SNO2 is the glutaminase subunit of the
+      PLP synthase and the SNO glutaminase subunit is required for pyridoxine/PLP biosynthesis
+      in fungal orthologs (N. crassa pdx-2). IBA from the PANTHER PLP-synthase-subunit-SNO tree
+      is well founded.
+    action: ACCEPT
+    supported_by:
+    - reference_id: PMID:11238395
+      supporting_text: &gt;-
+        pyridoxine-requiring mutants of N. crassa were found to possess mutations that disrupt
+        conserved regions in either the SNZ or SNO homolog
+      reference_section_type: ABSTRACT
+- term:
+    id: GO:0004359
+    label: glutaminase activity
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: contributes_to
+  review:
+    summary: &gt;-
+      The molecular activity of the SNO/PdxT glutaminase subunit. SNO2 retains the intact
+      class-I glutamine amidotransferase catalytic triad (Cys91 nucleophile, His197/Glu199
+      charge-relay; UniProt), so glutaminase activity is domain-defensible. The contributes_to
+      qualifier is appropriate because the glutaminase is a subunit whose in-vivo activity is
+      coupled to (and ammonia-channeled into) the SNZ synthase subunit within the PLP synthase.
+    action: ACCEPT
+    supported_by:
+    - reference_id: PMID:11238395
+      supporting_text: &gt;-
+        pyridoxine-requiring mutants of N. crassa were found to possess mutations that disrupt
+        conserved regions in either the SNZ or SNO homolog
+      reference_section_type: ABSTRACT
+- term:
+    id: GO:0008614
+    label: pyridoxine metabolic process
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Pyridoxine (vitamin B6) metabolic process. Consistent with the family role in PLP/B6
+      biosynthesis and with SGD&#39;s ISS annotation of the same term (supported by the Aspergillus
+      pyroA and Neurospora pdx-1/pdx-2 orthologs). Slightly more general/parallel to the PLP
+      biosynthetic process term; retained as a valid family process annotation.
+    action: KEEP_AS_NON_CORE
+    supported_by:
+    - reference_id: PMID:10438537
+      supporting_text: &gt;-
+        define this gene family as encoding an enzyme specifically required for pyridoxine
+        biosynthesis
+      reference_section_type: ABSTRACT
+- term:
+    id: GO:1903600
+    label: glutaminase complex
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: part_of
+  review:
+    summary: &gt;-
+      Complex membership as the glutaminase subunit of the two-subunit PLP synthase. Directly
+      corroborated for SNO2 by ComplexPortal CPX-1371 (SNO2-SNZ1 pyridoxal 5&#39;-phosphate
+      synthase complex). GO:1903600 (glutaminase complex; synonym Sno1p-Snz1p) is the generic
+      term for a complex capable of glutaminase activity and is correctly applied here.
+    action: ACCEPT
+    supported_by:
+    - reference_id: ComplexPortal:CPX-1371
+      supporting_text: &gt;-
+        SNO2-SNZ1 pyridoxal 5&#39;-phosphate synthase complex
+- term:
+    id: GO:0004359
+    label: glutaminase activity
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000120
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Same molecular activity as the IBA glutaminase-activity annotation above, here derived by
+      automated EC/RHEA mapping (EC 3.5.1.2). The MF term is correct given the intact catalytic
+      triad. The enables qualifier (vs the more accurate contributes_to used by the IBA pipeline
+      for the subunit) is a pipeline artifact of EC-based IEA; the underlying activity assignment
+      is sound, so the annotation is retained.
+    action: ACCEPT
+    supported_by:
+    - reference_id: PMID:11238395
+      supporting_text: &gt;-
+        pyridoxine-requiring mutants of N. crassa were found to possess mutations that disrupt
+        conserved regions in either the SNZ or SNO homolog
+      reference_section_type: ABSTRACT
+- term:
+    id: GO:0008614
+    label: pyridoxine metabolic process
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000117
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Duplicate of the pyridoxine metabolic process annotation, from the ARBA machine-learning
+      pipeline. Same domain/orthology support; retained as a valid but non-core family process
+      term.
+    action: KEEP_AS_NON_CORE
+    supported_by:
+    - reference_id: PMID:10438537
+      supporting_text: &gt;-
+        define this gene family as encoding an enzyme specifically required for pyridoxine
+        biosynthesis
+      reference_section_type: ABSTRACT
+- term:
+    id: GO:0036381
+    label: pyridoxal 5&#39;-phosphate synthase (glutamine hydrolysing) activity
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000120
+  qualifier: enables
+  review:
+    summary: &gt;-
+      The holoenzyme-level molecular function (EC 4.3.3.6) of the two-subunit PLP synthase.
+      This activity is strictly a property of the assembled SNO+SNZ complex (the SNO subunit
+      alone provides only the glutaminase half-reaction), so contributes_to would be more precise
+      than enables. The term is a correct family assignment via EC/RHEA mapping and is retained.
+    action: ACCEPT
+    supported_by:
+    - reference_id: PMID:10438537
+      supporting_text: &gt;-
+        define this gene family as encoding an enzyme specifically required for pyridoxine
+        biosynthesis
+      reference_section_type: ABSTRACT
+- term:
+    id: GO:0042819
+    label: vitamin B6 biosynthetic process
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Vitamin B6 biosynthetic process, the parent process of PLP biosynthesis. Correct but more
+      general than the PLP biosynthetic process (GO:0042823) annotation; retained as a valid
+      non-core (broader) process term for the family.
+    action: KEEP_AS_NON_CORE
+    supported_by:
+    - reference_id: PMID:10438537
+      supporting_text: &gt;-
+        define this gene family as encoding an enzyme specifically required for pyridoxine
+        biosynthesis
+      reference_section_type: ABSTRACT
+- term:
+    id: GO:0042823
+    label: pyridoxal 5&#39;-phosphate biosynthetic process
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000120
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Duplicate of the core PLP biosynthetic process annotation, from InterPro/UniPathway
+      automated mapping. Same support as the IBA version; retained.
+    action: ACCEPT
+    supported_by:
+    - reference_id: PMID:11238395
+      supporting_text: &gt;-
+        pyridoxine-requiring mutants of N. crassa were found to possess mutations that disrupt
+        conserved regions in either the SNZ or SNO homolog
+      reference_section_type: ABSTRACT
+- term:
+    id: GO:0003674
+    label: molecular_function
+  evidence_type: ND
+  original_reference_id: GO_REF:0000015
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Root molecular_function placeholder with ND (no biological data) evidence, an SGD
+      no-data stub predating the electronic/phylogenetic MF assignments. Uninformative; kept
+      as-is per convention for ND root annotations (superseded by the specific MF terms above).
+    action: KEEP_AS_NON_CORE
+- term:
+    id: GO:0005575
+    label: cellular_component
+  evidence_type: ND
+  original_reference_id: GO_REF:0000015
+  qualifier: is_active_in
+  review:
+    summary: &gt;-
+      Root cellular_component placeholder with ND evidence, an SGD no-data stub. Uninformative;
+      kept as-is per convention (superseded by the glutaminase-complex and cytosol IBA
+      annotations for the family).
+    action: KEEP_AS_NON_CORE
+core_functions:
+- description: &gt;-
+    Glutaminase subunit of the two-subunit pyridoxal 5&#39;-phosphate (PLP, vitamin B6) synthase:
+    SNO2 hydrolyses L-glutamine to L-glutamate and ammonia (class-I glutamine amidotransferase
+    glutaminase, catalytic triad Cys91/His197/Glu199 intact) and, within the PLP synthase
+    complex with a SNZ synthase subunit, channels the ammonia used to build PLP from ribose
+    5-phosphate and glyceraldehyde 3-phosphate. Assigned from family membership, intact
+    catalytic triad, and characterized fungal SNO orthologs (N. crassa pdx-2); direct enzymatic
+    assay of the SNO2 protein has not been reported.
+  molecular_function:
+    id: GO:0004359
+    label: glutaminase activity
+  contributes_to_molecular_function:
+    id: GO:0036381
+    label: pyridoxal 5&#39;-phosphate synthase (glutamine hydrolysing) activity
+  directly_involved_in:
+  - id: GO:0042823
+    label: pyridoxal 5&#39;-phosphate biosynthetic process
+  in_complex:
+    id: GO:1903600
+    label: glutaminase complex
+  supported_by:
+  - reference_id: PMID:11238395
+    supporting_text: &gt;-
+      pyridoxine-requiring mutants of N. crassa were found to possess mutations that disrupt
+      conserved regions in either the SNZ or SNO homolog
+    reference_section_type: ABSTRACT
+  - reference_id: PMID:10438537
+    supporting_text: &gt;-
+      define this gene family as encoding an enzyme specifically required for pyridoxine
+      biosynthesis
+    reference_section_type: ABSTRACT
+  knowledge_gaps:
+  - gap_statement: &gt;-
+      The glutaminase and PLP-synthase activities of the SNO2 protein have never been directly
+      demonstrated: it is unknown whether purified SNO2, alone or reconstituted with a SNZ
+      subunit, is catalytically active, and its kinetic parameters are undetermined. All SNO2
+      molecular-function annotations are inferred by homology (UniProt PE=3, IBA/IEA/ISS).
+    boundary: &gt;-
+      SNO2 belongs to the glutaminase PdxT/SNO family, retains the intact class-I glutamine
+      amidotransferase catalytic triad (Cys91 nucleophile, His197/Glu199 charge-relay), and is
+      curated in a physical complex with SNZ1 (ComplexPortal CPX-1371). The orthologous fungal
+      SNO subunit (N. crassa pdx-2) is genetically required for pyridoxine biosynthesis.
+    gap_kind:
+    - BIOLOGY
+    dark_aspect: MF_DARK
+    status: OPEN
+    significance: &gt;-
+      SNO2 is one of three near-identical yeast SNO paralogs whose individual biochemical
+      contributions have not been separated; direct assays would establish whether SNO2 is a
+      catalytically competent glutaminase and whether it forms a functional PLP synthase with
+      SNZ subunits.
+    resolution: &gt;-
+      Purify recombinant SNO2 and reconstitute with SNZ1/SNZ2/SNZ3; assay glutaminase activity
+      (glutamine to glutamate + ammonia) and coupled PLP synthesis, with a Cys91 active-site
+      mutant control.
+    provenance:
+    - reference_id: PMID:12271461
+      supporting_text: &gt;-
+        In media lacking vitamin B(6), SNZ1 and SNO1 were both required for growth in certain
+        conditions, but neither SNZ2, SNZ3, SNO2 nor SNO3 were required.
+      reference_section_type: ABSTRACT
+knowledge_gaps:
+- gap_statement: &gt;-
+    The SNO2-specific in-vivo physiological role and its required condition are undetermined.
+    SNO2 is dispensable for vitamin B6-limited growth, and it is unresolved whether its native
+    function is in pyridoxal 5&#39;-phosphate (B6) biosynthesis, in a thiamine (B1)-related process
+    under which it is induced, or both, and which SNZ synthase subunit it partners in vivo.
+  boundary: &gt;-
+    SNO2 is a glutaminase PdxT/SNO family member with an intact catalytic triad, curated in a
+    PLP-synthase glutaminase complex with SNZ1 (CPX-1371). The B6-dedicated pair is SNO1/SNZ1
+    (both required for B6-limited growth); SNO2/SNO3 (copies 2/3) are dispensable for B6-limited
+    growth and are transcriptionally activated by thiamine limitation, appearing more related to
+    B1 biosynthesis in exponential phase.
+  gap_kind:
+  - BIOLOGY
+  dark_aspect: BP_DARK
+  status: OPEN
+  significance: &gt;-
+    Resolving this would explain why yeast maintains three SNZ-SNO pairs and whether SNO2
+    represents a B1-linked or condition-specific branch of PLP-family metabolism rather than
+    simple redundancy with SNO1. It is the crux of what distinguishes this understudied paralog
+    from its well-characterized copy-1 counterpart.
+  resolution: &gt;-
+    Condition-resolved phenotyping of sno2 single and sno1 sno2 sno3 combinatorial deletions
+    under B6 and B1 limitation; measurement of intracellular PLP and thiamine; identification of
+    the SNZ subunit(s) SNO2 associates with in each condition.
+  provenance:
+  - reference_id: PMID:12271461
+    supporting_text: &gt;-
+      but neither SNZ2, SNZ3, SNO2 nor SNO3 were required.
+    reference_section_type: ABSTRACT
+- gap_statement: &gt;-
+    The degree and direction of functional redundancy among the three yeast SNO paralogs
+    (SNO1/SNO2/SNO3) is unresolved: it is unknown whether SNO2 can substitute for SNO1 in B6
+    biosynthesis, whether SNO2 and SNO3 are interchangeable, and what unique contribution SNO2
+    makes despite their near-identical sequences.
+  boundary: &gt;-
+    Single-gene deletions of SNO2 (a copy-2/3 gene) do not impair B6-limited growth, and copies
+    2 and 3 are reported to have slightly different cellular functions despite extremely close
+    sequence similarity; the B6 phenotype is carried by SNO1.
+  gap_kind:
+  - BIOLOGY
+  dark_aspect: RESIDUAL_SUBGAP
+  status: OPEN
+  significance: &gt;-
+    Distinguishing genuine paralog-specific function from redundancy is essential to attribute
+    any SNO2-specific annotation correctly and to avoid over-propagating SNO1 evidence onto SNO2.
+  resolution: &gt;-
+    Cross-complementation assays (express SNO2 in a sno1 background under B6 limitation and vice
+    versa) and paralog-swap chimeras to map function-determining residues.
+  provenance:
+  - reference_id: PMID:12271461
+    supporting_text: &gt;-
+      Copies 2 and 3 of the gene products have, in spite of their extremely close sequence
+      similarity, slightly different functions in the cell.
+    reference_section_type: ABSTRACT
+proposed_new_terms: []
+suggested_questions:
+- question: &gt;-
+    Is the SNO2 protein a catalytically active glutaminase, and does it form a functional PLP
+    synthase when reconstituted with SNZ1, SNZ2, or SNZ3?
+- question: &gt;-
+    Under what physiological condition is SNO2 non-redundantly required, given that it is
+    dispensable for vitamin B6-limited growth but induced by thiamine limitation?
+suggested_experiments:
+- hypothesis: &gt;-
+    SNO2 is a catalytically competent glutaminase subunit that reconstitutes a functional PLP
+    synthase with a SNZ synthase subunit.
+  description: &gt;-
+    Express and purify recombinant SNO2 and SNZ1/2/3; assay glutaminase activity (L-glutamine to
+    L-glutamate + ammonia) for SNO2 alone and coupled PLP synthesis (with ribose 5-phosphate and
+    glyceraldehyde 3-phosphate) for SNO2+SNZ mixtures, using a Cys91 active-site mutant as a
+    negative control.
+- hypothesis: &gt;-
+    SNO2 has a thiamine-limitation-linked and/or condition-specific role distinct from the
+    B6-dedicated SNO1.
+  description: &gt;-
+    Phenotype sno2 single and sno1 sno2 sno3 combinatorial deletion strains under vitamin B6 and
+    thiamine limitation; quantify intracellular PLP and thiamine and profile SNO2-SNZ physical
+    associations by condition.
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/genes/yeast/THI22/THI22-ai-review.html
+++ b/genes/yeast/THI22/THI22-ai-review.html
@@ -1,0 +1,3419 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>THI22 - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        .propagation-review {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f8fafc;
+            border-left: 3px solid #64748b;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .propagation-title {
+            font-weight: 600;
+            color: #334155;
+            margin-bottom: 0.25rem;
+        }
+
+        .propagation-row {
+            margin-top: 0.25rem;
+        }
+
+        .propagation-source {
+            margin-top: 0.5rem;
+            padding-top: 0.5rem;
+            border-top: 1px solid #e5e7eb;
+        }
+
+        .propagation-source-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #1d4ed8;
+        }
+
+        .propagation-comment {
+            color: #4b5563;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>THI22</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/Q06490" target="_blank" class="term-link">
+                        Q06490
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Saccharomyces cerevisiae</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-initialized">
+                    INITIALIZED
+                </span>
+            </div>
+
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "THI22";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="Q06490" data-a="DESCRIPTION: THI22 (YPR121W) is one of three paralogous members..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>THI22 (YPR121W) is one of three paralogous members of the yeast thiaminase-II / hydroxymethylpyrimidine (HMP/HMP-P) kinase gene family (with THI20 and THI21). Like its paralogs it is a two-domain protein arising from an ancestral gene fusion: an N-terminal ribokinase-fold HMP/HMP-P kinase domain (homologous to bacterial ThiD, catalyzing steps in de novo thiamine pyrophosphate biosynthesis) and a C-terminal TenA/thiaminase-II-like domain (homologous to bacterial TenA, associated with thiamine salvage). THI22 shares roughly three-quarters sequence identity with the biochemically characterized THI20 and retains the substrate-binding and catalytic residues of both domains. Its expression is induced under thiamine limitation, coordinately with THI20 and THI21. Despite this close homology, THI22 is dispensable for thiamine biosynthesis and no enzymatic (HMP-P kinase) activity has been demonstrated for the protein, so its individual in vivo role remains undetermined; the characterized biosynthetic and thiamine-degrading (thiaminase II) activities of the family have been established for the paralogs THI20/THI21 rather than for THI22 itself.</p>
+    </div>
+
+
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
+                                    GO:0005829
+                                </a>
+                            </span>
+                            <span class="term-label">cytosol</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q06490" data-a="GO:0005829" data-r="GO_REF:0000033" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetically inferred cytosolic localization, consistent with the thiamine-pathway biochemistry of the paralogs THI20/THI21, which act in the cytosolic HMP-P kinase steps. Plausible as a location but not a core function and not experimentally shown for THI22.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> IBA location annotation from the THI20-related PANTHER family. The de novo thiamine biosynthesis kinase steps occur in the cytosol, so cytosolic localization is the reasonable default for a family member. It conflicts with the InterPro/SubCell &#34;extracellular region&#34; prediction (see below); the cytosolic assignment is the more biologically defensible of the two but remains inferred, so it is retained as non-core.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008902" target="_blank" class="term-link">
+                                    GO:0008902
+                                </a>
+                            </span>
+                            <span class="term-label">hydroxymethylpyrimidine kinase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q06490" data-a="GO:0008902" data-r="GO_REF:0000033" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> HMP kinase activity (HMP -&gt; HMP-P, EC 2.7.1.49) is a demonstrated activity of the family (THI20 is trifunctional). THI22 retains the N-terminal kinase domain and its HMP substrate-binding residue (Gln, conserved with THI20 Q64), so the activity is plausible on sequence grounds, but it is inferred by phylogeny and not demonstrated for THI22.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Domain-defensible family activity (N-terminal ThiD-like kinase domain; substrate-binding and Gly-rich phosphate-binding motifs conserved in THI22 per inline alignment to THI20). Kept as non-core because THI22-specific activity is unproven; the one direct enzymatic assay of the family that tested THI22 failed to detect the related HMP-P kinase activity (per UniProt CAUTION, ECO:0000305, and PMID:10383756, which demonstrated the activity only for THI20/THI21).
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008972" target="_blank" class="term-link">
+                                    GO:0008972
+                                </a>
+                            </span>
+                            <span class="term-label">phosphomethylpyrimidine kinase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q06490" data-a="GO:0008972" data-r="GO_REF:0000033" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> HMP-P kinase activity (HMP-P -&gt; HMP-PP, EC 2.7.4.7) is exactly the activity that PMID:10383756 demonstrated for two of the three family members and could NOT demonstrate for the third (THI22). Retained by phylogenetic inference but flagged as over-annotated for THI22 because it is directly contradicted by the one experiment that tested it.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The IBA propagates the well-established HMP-P kinase activity of THI20/THI21 onto THI22, but the primary paper demonstrated this activity for only two of the three members and UniProt records (CAUTION, ECO:0000305) that no HMP-P kinase activity could be demonstrated for THI22 despite its high homology. The catalytic residues are conserved (so this is not a residue-dead pseudoenzyme and REMOVE is not justified), but calling this a THI22 function over-states the evidence: it is a family-level inference contradicted by the only direct THI22 assay.
+                        </div>
+
+
+
+                        <div class="propagation-review">
+                            <div class="propagation-title">Propagation Review</div>
+                            <div class="propagation-row">
+                                <strong>Root cause:</strong>
+                                <span class="badge">PROPAGATION BAD</span>
+                            </div>
+
+                            <div class="propagation-row">
+                                <strong>Failure modes:</strong>
+
+                                <span class="badge">FUNCTIONAL DIVERGENCE</span>
+
+                            </div>
+
+
+                            <div class="propagation-source">
+                                <strong>Sources checked:</strong>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">SGD:S000005416</span>
+
+                                    &middot; THI20
+
+
+                                    <span class="badge">SUPPORTS SOURCE BUT NOT TARGET</span>
+
+
+                                    <div class="propagation-comment">THI20 has demonstrated HMP-P kinase activity, but the same primary work did not detect this activity for THI22, so transfer to THI22 is unsafe.</div>
+
+                                </div>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">PANTHER:PTN000466159</span>
+
+                                    &middot; PANTHER THI20-related node (PTHR20858:SF17)
+
+
+                                    <span class="badge">SUPPORTS SOURCE BUT NOT TARGET</span>
+
+
+                                    <div class="propagation-comment">Family node aggregates the paralog kinase activity; THI22-specific activity is unproven.</div>
+
+                                </div>
+
+                            </div>
+
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/10383756" target="_blank" class="term-link">
+                                        PMID:10383756
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">We demonstrate that two members are isofunctional and encode a hydroxymethylpyrimidine phosphate (HMP-P) kinase (EC 2.7.4.7), an activity required for the final steps of thiamine biosynthesis</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0009228" target="_blank" class="term-link">
+                                    GO:0009228
+                                </a>
+                            </span>
+                            <span class="term-label">thiamine biosynthetic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q06490" data-a="GO:0009228" data-r="GO_REF:0000033" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Thiamine biosynthetic process is the family process, but THI22 has been shown NOT to be required for thiamine biosynthesis. The phylogenetic propagation over-states THI22&#39;s role in de novo biosynthesis.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> UniProt (from PMID:10383756) states THI22 &#34;is not required for thiamine biosynthesis&#34;. The IBA correctly captures the family process but over-annotates THI22, whose contribution to de novo biosynthesis is unproven and, on deletion evidence in the redundant family, dispensable. A broader thiamine metabolic-process framing is more defensible for THI22 (see GO:0006772).
+                        </div>
+
+
+
+                        <div class="propagation-review">
+                            <div class="propagation-title">Propagation Review</div>
+                            <div class="propagation-row">
+                                <strong>Root cause:</strong>
+                                <span class="badge">PROPAGATION BAD</span>
+                            </div>
+
+                            <div class="propagation-row">
+                                <strong>Failure modes:</strong>
+
+                                <span class="badge">FUNCTIONAL DIVERGENCE</span>
+
+                            </div>
+
+
+                            <div class="propagation-source">
+                                <strong>Sources checked:</strong>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">SGD:S000005416</span>
+
+                                    &middot; THI20
+
+
+                                    <span class="badge">SUPPORTS SOURCE BUT NOT TARGET</span>
+
+
+                                    <div class="propagation-comment">THI20/THI21 are required for thiamine biosynthesis; THI22 is explicitly not required, so the biosynthetic-process role should not propagate to it.</div>
+
+                                </div>
+
+                            </div>
+
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/10383756" target="_blank" class="term-link">
+                                        PMID:10383756
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">We demonstrate that two members are isofunctional and encode a hydroxymethylpyrimidine phosphate (HMP-P) kinase (EC 2.7.4.7), an activity required for the final steps of thiamine biosynthesis</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005576" target="_blank" class="term-link">
+                                    GO:0005576
+                                </a>
+                            </span>
+                            <span class="term-label">extracellular region</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000044
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q06490" data-a="GO:0005576" data-r="GO_REF:0000044" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> This location is derived automatically from a predicted N-terminal signal peptide (UniProt SubCell &#34;Secreted&#34;, ECO:0000305). Secretion is biologically implausible for a cytosolic thiamine-metabolism enzyme and conflicts with the cytosol IBA and with the cytosolic biochemistry of the paralogs.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Pure prediction from a signal-peptide/SubCell mapping, not experimental. THI22&#39;s paralogs THI20/THI21 function in the cytosol, and there is no evidence THI22 is secreted or that a secreted thiamine-pathway enzyme would be functional. Whether the predicted N-terminal extension is a genuine targeting signal is itself a knowledge gap; the extracellular annotation should not be treated as established localization.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006772" target="_blank" class="term-link">
+                                    GO:0006772
+                                </a>
+                            </span>
+                            <span class="term-label">thiamine metabolic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q06490" data-a="GO:0006772" data-r="GO_REF:0000002" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> General thiamine metabolic process (parent of both biosynthesis and salvage/degradation). Defensible at the family level: THI22 is thiamine-regulated and carries intact HMP-P kinase and thiaminase-II-like domains. This broad process term over-commits less than the specific biosynthesis term.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> InterPro-based BP annotation. Appropriate as a broad, non-core framing given THI22&#39;s thiamine-responsive regulation and its two thiamine-metabolism domains, while avoiding the stronger and contradicted &#34;biosynthetic process&#34; claim.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008972" target="_blank" class="term-link">
+                                    GO:0008972
+                                </a>
+                            </span>
+                            <span class="term-label">phosphomethylpyrimidine kinase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q06490" data-a="GO:0008972" data-r="GO_REF:0000002" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> InterPro-derived duplicate of the HMP-P kinase MF annotation. Same assessment as the IBA HMP-P kinase annotation: family activity propagated to THI22 but directly not demonstrated for THI22.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> InterPro (IPR004399) maps the ThiD-like kinase domain to HMP-P kinase activity. The domain is present and its catalytic residues are conserved, but the specific HMP-P kinase activity was tested for THI22 and not detected (UniProt CAUTION, ECO:0000305; PMID:10383756 demonstrated the activity only for THI20/THI21), so this electronic annotation over-annotates THI22.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/10383756" target="_blank" class="term-link">
+                                        PMID:10383756
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">We demonstrate that two members are isofunctional and encode a hydroxymethylpyrimidine phosphate (HMP-P) kinase (EC 2.7.4.7), an activity required for the final steps of thiamine biosynthesis</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0009228" target="_blank" class="term-link">
+                                    GO:0009228
+                                </a>
+                            </span>
+                            <span class="term-label">thiamine biosynthetic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000120
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q06490" data-a="GO:0009228" data-r="GO_REF:0000120" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Automated (multi-method IEA) thiamine biosynthetic process annotation. Same over-annotation concern as the IBA biosynthesis annotation: THI22 is not required for thiamine biosynthesis.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> ARBA/InterPro electronic inference of de novo biosynthesis involvement, contradicted for THI22 by the functional characterization showing it is not required for thiamine biosynthesis. Broader thiamine metabolic process (GO:0006772) is the defensible level.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/10383756" target="_blank" class="term-link">
+                                        PMID:10383756
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">We demonstrate that two members are isofunctional and encode a hydroxymethylpyrimidine phosphate (HMP-P) kinase (EC 2.7.4.7), an activity required for the final steps of thiamine biosynthesis</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0050334" target="_blank" class="term-link">
+                                    GO:0050334
+                                </a>
+                            </span>
+                            <span class="term-label">thiaminase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q06490" data-a="GO:0050334" data-r="GO_REF:0000002" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Thiaminase II activity (thiamine hydrolysis to HMP + thiazole, EC 3.5.99.2) is a demonstrated activity of THI20 and maps to the C-terminal TenA/thiaminase-II-like domain (IPR027574). THI22 retains this domain and both catalytic residues (nucleophile Cys and proton-donor Glu, conserved with THI20 C468/E540), so the activity is domain-plausible but not demonstrated for THI22.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Domain-defensible family activity (C-terminal TenA/thiaminase-II domain with conserved catalytic Cys/Glu per inline alignment). Kept as non-core rather than accepted as a core function because no thiaminase activity has been directly demonstrated for THI22, and the 1999 paper noted the C-terminal domain&#39;s function was unresolved.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003674" target="_blank" class="term-link">
+                                    GO:0003674
+                                </a>
+                            </span>
+                            <span class="term-label">molecular_function</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ND</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000015
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q06490" data-a="GO:0003674" data-r="GO_REF:0000015" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Root molecular_function placeholder (ND, no biological data).
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> ND root-term placeholder recording that no specific molecular function had been curated by SGD at annotation time. Standard practice; nothing to change.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005575" target="_blank" class="term-link">
+                                    GO:0005575
+                                </a>
+                            </span>
+                            <span class="term-label">cellular_component</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ND</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000015
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q06490" data-a="GO:0005575" data-r="GO_REF:0000015" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Root cellular_component placeholder (ND, no biological data).
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> ND root-term placeholder recording that no specific localization had been curated by SGD at annotation time. Standard practice; nothing to change.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0009228" target="_blank" class="term-link">
+                                    GO:0009228
+                                </a>
+                            </span>
+                            <span class="term-label">thiamine biosynthetic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/10383756" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:10383756
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Genetic redundancy and gene fusion in the genome of the Bake...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q06490" data-a="GO:0009228" data-r="PMID:10383756" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> SGD experimental (IEP) annotation from the primary paper. The underlying evidence is that THI22 expression is induced under thiamine limitation, coordinately with THI20/THI21. This thiamine-responsive regulation is genuinely established; however, the same work shows THI22 is not required for de novo thiamine biosynthesis, so annotation of THI22 to the specific &#34;biosynthetic process&#34; term over-states its role — the co-regulation evidence supports thiamine-pathway involvement, not a demonstrated biosynthetic contribution.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> IEP (inferred from expression pattern) reflects real, curator-read experimental evidence of thiamine-dependent regulation, and per curation guidelines the experimental evidence itself is not discarded. But the specific target term (thiamine BIOSYNTHETIC process) over-states THI22&#39;s role: the same paper establishes THI22 is not required for thiamine biosynthesis. The regulation-based involvement is better captured by the broader thiamine metabolic process (GO:0006772). Marked over-annotated (not removed) to preserve the experimental co-regulation evidence while flagging the term as too specific for THI22.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/10383756" target="_blank" class="term-link">
+                                        PMID:10383756
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Expression of all three genes is regulated in the same way</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>THI22 is a member of the thiamine-metabolism HMP/HMP-P kinase + thiaminase-II family and is transcriptionally induced under thiamine limitation, but no molecular activity has been demonstrated for the protein itself and it is dispensable for de novo thiamine biosynthesis. Its N-terminal ribokinase-fold kinase domain and C-terminal TenA/thiaminase-II-like domain retain their substrate-binding and catalytic residues (conserved with the biochemically characterized paralog THI20), so it is not an obviously residue-dead pseudoenzyme; however, which (if any) of the family activities THI22 actually performs in vivo is unknown. The most defensible statement of core function is therefore a broad, thiamine-responsive metabolic involvement rather than a specific catalytic activity.</h3>
+                <span class="vote-buttons" data-g="Q06490" data-a="FUNCTION: THI22 is a member of the thiamine-metabolism HMP/H..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006772" target="_blank" class="term-link">
+                                thiamine metabolic process
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/10383756" target="_blank" class="term-link">
+                                PMID:10383756
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">Expression of all three genes is regulated in the same way</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:yeast/THI22/THI22-bioinformatics/RESULTS.md
+
+                        </span>
+
+                        <div class="finding-text">All three THI20 functional residues are conserved in THI22</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000002.md" target="_blank" class="term-link">
+                            GO_REF:0000002
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation through association of InterPro records with GO terms</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000015.md" target="_blank" class="term-link">
+                            GO_REF:0000015
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Use of the ND evidence code for Gene Ontology (GO) terms</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
+                            GO_REF:0000033
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Annotation inferences using phylogenetic trees</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
+                            GO_REF:0000044
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000120.md" target="_blank" class="term-link">
+                            GO_REF:0000120
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Combined Automated Annotation using Multiple IEA Methods</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/10383756" target="_blank" class="term-link">
+                            PMID:10383756
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Genetic redundancy and gene fusion in the genome of the Baker&#39;s yeast Saccharomyces cerevisiae: functional characterization of a three-member gene family involved in the thiamine biosynthetic pathway.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Two of the three family members (THI20/YOL055c and THI21/YPL258c) are isofunctional and encode an HMP-P kinase (EC 2.7.4.7) required for the final steps of thiamine biosynthesis; by implication the third member (THI22/YPR121w) is the one for which this activity was not demonstrated.</div>
+
+                        <div class="finding-text">"We demonstrate that two members are isofunctional and encode a hydroxymethylpyrimidine phosphate (HMP-P) kinase (EC 2.7.4.7), an activity required for the final steps of thiamine biosynthesis"</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Each of the three genes has two distinct domains that correspond to separate prokaryotic genes, consistent with an ancestral gene fusion; the C-terminal domain is not required for HMP-P kinase activity and its function was unresolved.</div>
+
+                        <div class="finding-text">"the three genes are each composed of two distinct domains, each corresponding to individual genes in prokaryotes, suggesting gene fusion during evolution. The function of the carboxy-terminal part of the proteins is not yet understood, but it is not required for HMP-P kinase activity"</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <div class="finding-statement">All three family genes are co-regulated (induced under thiamine limitation).</div>
+
+                        <div class="finding-text">"Expression of all three genes is regulated in the same way"</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        file:yeast/THI22/THI22-bioinformatics/RESULTS.md
+
+                    </span>
+                </div>
+
+                <div class="reference-title">THI22 vs THI20 paralog alignment and catalytic-residue conservation (inline analysis)</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">THI22 (Q06490) is ~76% identical to the characterized paralog THI20 (Q08224) and retains THI20&#39;s HMP substrate-binding Gln, the ribokinase Gly-rich phosphate-binding motif, and the thiaminase-II catalytic nucleophile Cys and proton-donor Glu, so it is not a residue-dead pseudoenzyme.</div>
+
+                        <div class="finding-text">"All three THI20 functional residues are conserved in THI22"</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        file:yeast/THI22/THI22-deep-research-falcon.md
+
+                    </span>
+                </div>
+
+                <div class="reference-title">THI22 deep research report (falcon / Edison Scientific)</div>
+
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Questions for Experts</h2>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Does purified THI22 possess any of the family enzymatic activities (HMP kinase, HMP-P kinase, or thiaminase II), or is it catalytically inactive despite conserved active-site residues?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q06490" data-a="Q: Does purified THI22 possess any of the family enzy..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Is THI22 actually secreted (as UniProt predicts) or cytosolic like THI20/THI21, and is the predicted N-terminal signal peptide functional?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q06490" data-a="Q: Is THI22 actually secreted (as UniProt predicts) o..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Under what physiological condition, if any, does THI22 provide a selectable function that THI20 and THI21 do not?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q06490" data-a="Q: Under what physiological condition, if any, does T..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Experiments</h2>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Express and purify recombinant THI22 (with and without the predicted N-terminal peptide) and assay HMP kinase, HMP-P kinase, and thiaminase-II activities in vitro; in parallel test whether THI22 alone rescues growth of a thi20 thi21 double deletion under thiamine-limited conditions.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: THI22 encodes a functional but redundant thiamine-metabolism enzyme whose activity was missed by the original HMP-P-kinase-focused assay.</em></p>
+
+
+                </div>
+                <span class="vote-buttons" data-g="Q06490" data-a="EXPERIMENT: Express and purify recombinant THI22 (with and wit..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Determine THI22 localization by fluorescent tagging and subcellular fractionation, and test signal-peptide cleavage/secretion.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: The predicted N-terminal signal peptide re-localizes THI22 away from the cytosolic paralogs.</em></p>
+
+
+                </div>
+                <span class="vote-buttons" data-g="Q06490" data-a="EXPERIMENT: Determine THI22 localization by fluorescent taggin..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Deep Research Sections -->
+
+    <div class="section">
+        <h2 class="section-title">Deep Research</h2>
+
+        <details class="deep-research-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; gap: 1rem;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Falcon</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(THI22-deep-research-falcon.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="Q06490" data-a="DEEP_RESEARCH: Falcon" data-r="" data-act="DEEP_RESEARCH" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This deep research is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This deep research needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+
+                <div class="report-meta">
+
+                    <span class="report-meta-text">Comprehensive Research Report: THI22 (YPR121W) in *Saccharomyces cerevisiae*</span>
+
+
+                    <span class="report-badge">Falcon</span>
+
+
+                    <span class="report-badge">Edison Scientific Literature</span>
+
+
+                    <span class="report-badge">21 citations</span>
+
+
+                    <span class="report-badge">2 artifacts</span>
+
+
+                    <span class="report-meta-text">2026-07-05T02:25:58.959875</span>
+
+
+
+                </div>
+
+
+                <div class="artifact-list">
+
+
+
+                    <div class="artifact-link">
+                        <a href="THI22-deep-research-falcon_artifacts/artifact-00.md" class="term-link">Edison artifact artifact-00</a>
+                        <span>(text/markdown)</span>
+                    </div>
+
+
+
+
+                    <div class="artifact-link">
+                        <a href="THI22-deep-research-falcon_artifacts/artifact-01.md" class="term-link">Edison artifact artifact-01</a>
+                        <span>(text/markdown)</span>
+                    </div>
+
+
+                </div>
+
+                <p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h1 id="comprehensive-research-report-thi22-ypr121w-in-saccharomyces-cerevisiae">Comprehensive Research Report: THI22 (YPR121W) in <em>Saccharomyces cerevisiae</em></h1>
+<h2 id="1-gene-and-protein-identity">1. Gene and Protein Identity</h2>
+<p>THI22 (systematic name YPR121W; UniProt Q06490) encodes a thiamine biosynthesis protein in <em>Saccharomyces cerevisiae</em> (strain ATCC 204508 / S288c). The protein is classified as a member of the thiaminase-2 family and contains several conserved domains including a haem oxygenase-like multi-helical domain (IPR016084), an HMP/HMP-P kinase domain (IPR004399, IPR013749), a ribokinase-like fold (IPR029056), and a thiaminase-2/PQQC domain (IPR004305). The protein is annotated as a precursor (with a signal peptide), suggesting it may be targeted to a secretory compartment.</p>
+<h2 id="2-gene-family-context-the-thi20thi21thi22-family">2. Gene Family Context: The THI20/THI21/THI22 Family</h2>
+<p>THI22 is the third member of a three-gene family in <em>S. cerevisiae</em> that also includes THI20 and THI21 (kowalska2008thegenesand pages 4-8). The better-characterized family members, THI20 (YOL055C) and THI21 (YPL258C), encode trifunctional proteins with established roles in thiamine metabolism. The N-terminal domain of THI20 functions as both an HMP kinase (phosphorylating 4-amino-5-hydroxymethyl-2-methylpyrimidine, or HMP, to HMP-P) and an HMP-P kinase (phosphorylating HMP-P to HMP-PP) in ATP-dependent reactions (kowalska2008thegenesand pages 4-8, wronska2022engineeringbiotinsynthesis; pages 20-23, perli2020vitaminrequirementsand pages 7-8). The C-terminal domain of THI20 possesses thiaminase II activity, which degrades thiamine by hydrolyzing it to release HMP and a thiazole-derived product (kowalska2008thegenesand pages 4-8, wronska2022engineeringbiotinsynthesis; pages 20-23). This C-terminal domain exhibits high sequence similarity to the PET18 protein (kowalska2008thegenesand pages 4-8). THI20 is considered the major isoform, while THI21 is a paralog with likely similar activities (perli2020vitaminrequirementsand pages 7-8, wronska2022engineeringbiotinsynthesis; pages 20-23).</p>
+<p>Critically, the specific enzymatic function of THI22 remains unresolved. Kowalska and Kozik (2008) explicitly state: "The function of the third member of the same gene family, THI22, is unknown at present" (kowalska2008thegenesand pages 4-8). Despite sharing family membership and domain annotations with THI20 and THI21, no direct biochemical characterization of THI22 enzymatic activity has been reported in the available literature.</p>
+<p>The following table summarizes the key properties of the THI20/THI21/THI22 family:</p>
+<table>
+<thead>
+<tr>
+<th>Gene Name</th>
+<th>Systematic Name</th>
+<th>Domain Architecture (N-terminal / C-terminal)</th>
+<th>Known Enzymatic Activities</th>
+<th>Key Role in Pathway</th>
+<th>Evidence Level</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>THI20</td>
+<td>YOL055C</td>
+<td>N-terminal HMP/HMP-P kinase domain; C-terminal thiaminase II domain; trifunctional family member (kowalska2008thegenesand pages 4-8, wronska2022engineeringbiotinsynthesis; pages 20-23, perli2020vitaminrequirementsand pages 7-8)</td>
+<td>HMP kinase; HMP-P kinase; thiaminase II (thiamine-degrading) activity (kowalska2008thegenesand pages 4-8, wronska2022engineeringbiotinsynthesis; pages 20-23, perli2020vitaminrequirementsand pages 7-8)</td>
+<td>Major isoform generating HMP-PP for the pyrimidine branch of thiamine biosynthesis; also participates in HMP salvage and thiamine degradation (perli2020vitaminrequirementsand pages 7-8, wronska2022engineeringbiotinsynthesis; pages 20-23, kowalska2008thegenesand pages 4-8, sabelleck2025thiamineisa pages 3-4)</td>
+<td>Experimentally characterized for family activities; major isoform assignment and trifunctionality supported by reviews and cited primary work (kowalska2008thegenesand pages 8-11, wronska2022engineeringbiotinsynthesis; pages 20-23, perli2020vitaminrequirementsand pages 7-8)</td>
+</tr>
+<tr>
+<td>THI21</td>
+<td>YPL258C</td>
+<td>Inferred to share THI20-like architecture: N-terminal HMP/HMP-P kinase domain and C-terminal thiaminase II-related domain as a paralogous family member (kowalska2008thegenesand pages 4-8, perli2020vitaminrequirementsand pages 7-8)</td>
+<td>HMP-P kinase; likely HMP kinase and thiaminase II-associated functions by homology/family assignment (kowalska2008thegenesand pages 4-8, perli2020vitaminrequirementsand pages 7-8, sabelleck2025thiamineisa pages 3-4)</td>
+<td>Paralogue contributing to HMP-PP formation in the pyrimidine branch of thiamine biosynthesis; likely backup/secondary isoform relative to THI20 (perli2020vitaminrequirementsand pages 7-8, wronska2022engineeringbiotinsynthesis; pages 20-23, sabelleck2025thiamineisa pages 3-4)</td>
+<td>Partly experimentally supported at family level, but less directly characterized than THI20; substantial inference from paralogy and pathway reviews (kowalska2008thegenesand pages 4-8, perli2020vitaminrequirementsand pages 7-8)</td>
+</tr>
+<tr>
+<td>THI22</td>
+<td>YPR121W</td>
+<td>Third member of the THI20/THI21/THI22 family; shares family membership and thiaminase-2/domain annotation, but detailed domain-function assignment is inferred rather than directly demonstrated (kowalska2008thegenesand pages 4-8)</td>
+<td>Unknown specific enzymatic activity; possible relationship to HMP/HMP-P kinase/thiaminase family functions is inferred only from homology and annotation (kowalska2008thegenesand pages 4-8)</td>
+<td>Putative participant in thiamine metabolism/biosynthesis context, but precise biochemical step remains unresolved in the literature reviewed (kowalska2008thegenesand pages 4-8, li2010thiaminebiosynthesisin pages 1-2, li2020transcriptomeanalysisreveals pages 5-7)</td>
+<td>Inferred/uncharacterized: literature explicitly states THI22 function is unknown (kowalska2008thegenesand pages 4-8)</td>
+</tr>
+</tbody>
+</table>
+<p><em>Table: This table summarizes the Saccharomyces cerevisiae THI20/THI21/THI22 gene family, highlighting experimentally supported activities for THI20, likely paralogous functions for THI21, and the currently unresolved status of THI22. It is useful for distinguishing firm biochemical evidence from homology-based inference.</em></p>
+<h2 id="3-pathway-context-thiamine-biosynthesis-in-s-cerevisiae">3. Pathway Context: Thiamine Biosynthesis in <em>S. cerevisiae</em></h2>
+<p>Thiamine (vitamin B1) biosynthesis in <em>S. cerevisiae</em> involves the separate synthesis of two precursor moieties — the pyrimidine moiety (HMP-PP, 4-amino-2-methyl-5-hydroxymethylpyrimidine diphosphate) and the thiazole moiety (HET-P, 5-(2-hydroxyethyl)-4-methylthiazole phosphate) — followed by their condensation into thiamine monophosphate (TMP), which is ultimately converted to the biologically active cofactor thiamine diphosphate (TDP) (wronska2022engineeringbiotinsynthesis; pages 20-23, kowalska2008thegenesand pages 4-8, kowalska2008thegenesand pages 1-4).</p>
+<h3 id="31-pyrimidine-branch">3.1 Pyrimidine Branch</h3>
+<p>HMP-P is synthesized from pyridoxal-5-phosphate (PLP) and histidine by the HMP-P synthases encoded by THI5, THI11, THI12, and THI13, which function as suicide enzymes undergoing a single catalytic turnover (perli2020vitaminrequirementsand pages 7-8, perli2020vitaminrequirementsand pages 5-7). HMP-P is then phosphorylated to HMP-PP by HMP-P kinase in an ATP-dependent reaction catalyzed primarily by THI20 and THI21 (perli2020vitaminrequirementsand pages 7-8, wronska2022engineeringbiotinsynthesis; pages 20-23). In the salvage pathway, exogenous HMP can be taken up and phosphorylated to HMP-P by HMP kinase activity, also attributed to THI20/THI21 (kowalska2008thegenesand pages 4-8, kowalska2008thegenesand pages 1-4).</p>
+<h3 id="32-thiazole-branch">3.2 Thiazole Branch</h3>
+<p>The thiazole precursor HET-P is synthesized by THI4 from NAD+, glycine, and a sulfur atom donated from a conserved cysteine residue in a suicide reaction (perli2020vitaminrequirementsand pages 7-8, perli2020vitaminrequirementsand pages 5-7). In the salvage pathway, free HET is phosphorylated by the HET kinase activity of the bifunctional THI6 protein (kowalska2008thegenesand pages 4-8).</p>
+<h3 id="33-condensation-and-activation">3.3 Condensation and Activation</h3>
+<p>The condensation of HMP-PP and HET-P into TMP is catalyzed by the TMP diphosphorylase activity of the bifunctional THI6 enzyme (kowalska2008thegenesand pages 8-11, kowalska2008thegenesand pages 4-8). Unlike bacteria, yeasts cannot directly phosphorylate TMP to TDP; instead, TMP is first dephosphorylated to free thiamine by non-specific phosphatases, and then thiamine is diphosphorylated to TDP by thiamine diphosphokinase (THI80) (kowalska2008thegenesand pages 4-8).</p>
+<p>The following table summarizes the complete pathway:</p>
+<table>
+<thead>
+<tr>
+<th>Pathway step</th>
+<th>Reaction</th>
+<th>Gene(s) / enzyme</th>
+<th>Substrates</th>
+<th>Product(s)</th>
+<th>Enzyme class / note</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>1. HMP-P synthesis</td>
+<td>Pyridoxal-5-phosphate + histidine → HMP-P</td>
+<td><strong>THI5, THI11, THI12, THI13</strong></td>
+<td>Pyridoxal-5-phosphate, histidine</td>
+<td>HMP-P</td>
+<td>HMP-P synthase; suicide enzyme family in yeast (perli2020vitaminrequirementsand pages 7-8, perli2020vitaminrequirementsand pages 5-7)</td>
+</tr>
+<tr>
+<td>2. HMP-P phosphorylation</td>
+<td>HMP-P + ATP → HMP-PP</td>
+<td><strong>THI20, THI21</strong>; <strong>THI22</strong> possible by homology but unproven</td>
+<td>HMP-P, ATP</td>
+<td>HMP-PP</td>
+<td>HMP-P kinase; THI20 is the major isoform, THI21 is paralogous; THI22 remains uncharacterized (kowalska2008thegenesand pages 4-8, perli2020vitaminrequirementsand pages 7-8, wronska2022engineeringbiotinsynthesis; pages 20-23, sabelleck2025thiamineisa pages 3-4)</td>
+</tr>
+<tr>
+<td>3. HMP salvage phosphorylation</td>
+<td>HMP + ATP → HMP-P</td>
+<td><strong>THI20, THI21</strong></td>
+<td>HMP, ATP</td>
+<td>HMP-P</td>
+<td>HMP kinase activity in the salvage branch; assigned to the trifunctional THI20/THI21 family (kowalska2008thegenesand pages 4-8, perli2020vitaminrequirementsand pages 7-8)</td>
+</tr>
+<tr>
+<td>4. HET-P synthesis</td>
+<td>NAD+ + glycine + cysteine-derived sulfur → HET-P</td>
+<td><strong>THI4</strong></td>
+<td>NAD+, glycine, sulfur from conserved Cys in Thi4</td>
+<td>HET-P</td>
+<td>Thiazole synthase; suicide enzyme with single-turnover sulfur donation (perli2020vitaminrequirementsand pages 7-8, perli2020vitaminrequirementsand pages 5-7)</td>
+</tr>
+<tr>
+<td>5. HET salvage phosphorylation</td>
+<td>HET + ATP → HET-P</td>
+<td><strong>THI6</strong></td>
+<td>HET, ATP</td>
+<td>HET-P</td>
+<td>Hydroxyethylthiazole kinase; bifunctional THI6 protein (kowalska2008thegenesand pages 8-11, kowalska2008thegenesand pages 4-8, hohmann1998thiaminmetabolismand pages 1-3)</td>
+</tr>
+<tr>
+<td>6. TMP formation</td>
+<td>HMP-PP + HET-P → TMP</td>
+<td><strong>THI6</strong></td>
+<td>HMP-PP, HET-P</td>
+<td>TMP</td>
+<td>TMP diphosphorylase / thiamine-phosphate pyrophosphorylase; bifunctional THI6 enzyme (kowalska2008thegenesand pages 8-11, perli2020vitaminrequirementsand pages 7-8, wronska2022engineeringbiotinsynthesis; pages 20-23, kowalska2008thegenesand pages 4-8)</td>
+</tr>
+<tr>
+<td>7. Thiamine formation</td>
+<td>TMP → thiamine</td>
+<td>Unspecified phosphatase(s)</td>
+<td>TMP</td>
+<td>Thiamine</td>
+<td>Dephosphorylation step; likely carried out by nonspecific phosphatases in yeast (kowalska2008thegenesand pages 4-8, hohmann1998thiaminmetabolismand pages 3-5)</td>
+</tr>
+<tr>
+<td>8. TDP formation</td>
+<td>Thiamine + ATP → TDP</td>
+<td><strong>THI80</strong></td>
+<td>Thiamine, ATP</td>
+<td>TDP (ThDP)</td>
+<td>Thiamine diphosphokinase / thiamine pyrophosphokinase (kowalska2008thegenesand pages 8-11, perli2020vitaminrequirementsand pages 7-8, kowalska2008thegenesand pages 4-8)</td>
+</tr>
+<tr>
+<td>9. Thiamine degradation</td>
+<td>Thiamine → HMP + thiazole-derived product</td>
+<td><strong>THI20</strong></td>
+<td>Thiamine</td>
+<td>HMP + thiazole-related product(s)</td>
+<td>Thiaminase II activity in the C-terminal domain of Thi20; family-level evidence also implicates THI21-like proteins (kowalska2008thegenesand pages 4-8, wronska2022engineeringbiotinsynthesis; pages 20-23, perli2020vitaminrequirementsand pages 7-8)</td>
+</tr>
+<tr>
+<td>10. Thiamine uptake</td>
+<td>External thiamine → internal thiamine</td>
+<td><strong>THI7 / THI10</strong></td>
+<td>Extracellular thiamine</td>
+<td>Intracellular thiamine</td>
+<td>High-affinity plasma membrane thiamine transporter; uptake supports salvage and cofactor production (kowalska2008thegenesand pages 4-8, hohmann1998thiaminmetabolismand pages 6-8, perli2020vitaminrequirementsand pages 7-8)</td>
+</tr>
+</tbody>
+</table>
+<p><em>Table: This table summarizes the core thiamine biosynthesis, salvage, degradation, and uptake steps in Saccharomyces cerevisiae. It is useful for locating where THI22 fits relative to the better-characterized THI20/THI21 family members and the rest of the pathway.</em></p>
+<h2 id="4-inferred-function-of-thi22">4. Inferred Function of THI22</h2>
+<p>Although no direct biochemical evidence exists for THI22's enzymatic activity, several lines of evidence support its involvement in thiamine metabolism:</p>
+<p><strong>Domain architecture:</strong> THI22 contains the same InterPro domains as THI20/THI21, including the HMP/HMP-P kinase domain (IPR004399, IPR013749) and the thiaminase-2/PQQC domain (IPR004305). The presence of a ribokinase-like fold (IPR029056) is consistent with kinase activity on small-molecule substrates. This domain composition strongly suggests that THI22 may possess HMP/HMP-P kinase activity and/or thiaminase II activity, by analogy to its family members.</p>
+<p><strong>Thiaminase-2 family membership:</strong> UniProt classifies THI22 in the thiaminase-2 family. Thiaminase II enzymes catalyze the hydrolysis of thiamine to release the pyrimidine moiety (HMP) and a thiazole product. In THI20, this degradation activity is localized to the C-terminal domain (kowalska2008thegenesand pages 4-8, wronska2022engineeringbiotinsynthesis; pages 20-23).</p>
+<p><strong>Signal peptide / precursor status:</strong> The UniProt annotation identifies THI22 as a "Precursor" with a potential signal peptide. This is distinct from THI20, which is a cytoplasmic protein. The presence of a signal peptide suggests that THI22 may be targeted to the secretory pathway and could function in the periplasm or cell wall, potentially in a salvage or degradation role analogous to the periplasmic acid phosphatase PHO3, which dephosphorylates extracellular thiamine phosphates (kowalska2008thegenesand pages 4-8, hohmann1998thiaminmetabolismand pages 6-8).</p>
+<h2 id="5-transcriptional-regulation">5. Transcriptional Regulation</h2>
+<p>THI22 is part of the THI regulon, a group of genes whose expression is tightly regulated in response to intracellular thiamine diphosphate (TDP) levels. Under thiamine-replete conditions, the expression of all known THI structural genes (except THI80, which is constitutively expressed) is repressed (kowalska2008thegenesand pages 4-8, hohmann1998thiaminmetabolismand pages 5-6). Under thiamine-depleted conditions, a ternary complex of the positive transcriptional regulators Thi2p (a zinc finger transcription factor), Thi3p (a TDP-binding sensor protein), and Pdc2p activates transcription of THI genes (kowalska2008thegenesand pages 4-8, hohmann1998thiaminmetabolismand pages 8-9, brion2014decipheringregulatoryvariation pages 1-2). TDP itself serves as the intracellular negative signal: when TDP levels are sufficient, TDP binds Thi3p, preventing formation of the activator complex and silencing THI gene transcription (kowalska2008thegenesand pages 4-8, hohmann1998thiaminmetabolismand pages 8-9).</p>
+<p>An additional layer of regulation was demonstrated by Li et al. (2010), who showed that multiple THI genes are regulated by the NAD+-dependent histone deacetylase Hst1. Conditions that reduce intracellular NAD+ or increase nicotinamide lead to derepression of THI genes, establishing a regulatory link between thiamine and NAD+ homeostasis (li2010thiaminebiosynthesisin pages 1-2).</p>
+<p>Transcriptomic studies have confirmed that THI22 is co-expressed with other THI genes. For example, Li et al. (2020) reported that THI22 was upregulated in proanthocyanidin-treated yeast cells alongside other thiamine pathway genes including THI6, THI21, and THI80, consistent with its membership in the THI regulon.</p>
+<h2 id="6-subcellular-localization">6. Subcellular Localization</h2>
+<p>No direct experimental data on the subcellular localization of THI22 has been reported in the available literature. However, two important considerations inform predictions:</p>
+<ol>
+<li>
+<p>The UniProt annotation as a precursor with a signal peptide suggests targeting to the secretory pathway, potentially to the periplasm, cell wall, or extracellular space. This would be unusual for a thiamine biosynthetic enzyme, as de novo thiamine biosynthesis in yeast is generally considered to occur in the cytoplasm (kowalska2008thegenesand pages 4-8).</p>
+</li>
+<li>
+<p>By contrast, the characterized family member THI20 is a cytoplasmic enzyme. The high-throughput yeast GFP localization study by Huh et al. (2003) did not report a clear localization for THI22.</p>
+</li>
+</ol>
+<p>If THI22 is indeed targeted to the secretory pathway, this may suggest a specialized role distinct from the cytoplasmic HMP/HMP-P kinase function of THI20/THI21 — perhaps in extracellular thiamine salvage or degradation.</p>
+<h2 id="7-biological-significance-and-functional-redundancy">7. Biological Significance and Functional Redundancy</h2>
+<p>The presence of three paralogous genes (THI20, THI21, THI22) in this family represents a form of genetic redundancy that is a recurrent theme in the yeast thiamine biosynthesis pathway. The four THI5/THI11/THI12/THI13 genes encoding HMP-P synthase show a similar pattern of gene amplification, likely reflecting a selective advantage in thiamine-poor environments (hohmann1998thiaminmetabolismand pages 5-6, perli2020vitaminrequirementsand pages 7-8). In the case of the THI20/THI21/THI22 family, THI20 is clearly the major functional isoform, while THI21 and THI22 may serve as backup copies or specialized variants that contribute under particular environmental conditions (perli2020vitaminrequirementsand pages 7-8, wronska2022engineeringbiotinsynthesis; pages 20-23).</p>
+<p>The involvement of two suicide enzymes (THI4 for thiazole and THI5-family for pyrimidine synthesis) makes de novo thiamine biosynthesis energetically expensive in yeast — for each molecule of thiamine produced, two complete proteins must be synthesized and degraded (perli2020vitaminrequirementsand pages 7-8). This energetic cost underscores the importance of tight transcriptional regulation and the evolutionary rationale for maintaining redundant genes and efficient salvage pathways.</p>
+<h2 id="8-summary">8. Summary</h2>
+<p>THI22 (YPR121W) encodes a thiamine biosynthesis protein in <em>S. cerevisiae</em> that belongs to the thiaminase-2 family and the THI20/THI21/THI22 gene family. While its paralogs THI20 and THI21 have been characterized as trifunctional enzymes with HMP kinase, HMP-P kinase, and thiaminase II activities, the specific biochemical function of THI22 remains experimentally unresolved (kowalska2008thegenesand pages 4-8). Its domain architecture (HMP/HMP-P kinase domain plus thiaminase-2/PQQC domain) strongly suggests it participates in the pyrimidine branch of thiamine biosynthesis and/or thiamine salvage/degradation. The presence of a signal peptide distinguishes THI22 from the cytoplasmic THI20 and may indicate a role in extracellular or periplasmic thiamine metabolism. THI22 is a member of the THI regulon and is transcriptionally regulated by thiamine availability through the Thi2p/Thi3p/Pdc2p activator complex and by NAD+ levels through the histone deacetylase Hst1 (kowalska2008thegenesand pages 4-8, hohmann1998thiaminmetabolismand pages 8-9, li2010thiaminebiosynthesisin pages 1-2). Future biochemical characterization of the purified THI22 protein will be necessary to determine whether it possesses HMP/HMP-P kinase and/or thiaminase II activity, and to define its precise role in thiamine metabolism.</p>
+<p>References</p>
+<ol>
+<li>
+<p>(kowalska2008thegenesand pages 4-8): Ewa Kowalska and Andrzej Kozik. The genes and enzymes involved in the biosynthesis of thiamin and thiamin diphosphate in yeasts. Cellular &amp; Molecular Biology Letters, 13:271-282, Apr 2008. URL: https://doi.org/10.2478/s11658-007-0055-5, doi:10.2478/s11658-007-0055-5. This article has 65 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(wronska2022engineeringbiotinsynthesis; pages 20-23): Engineering biotin synthesis; towards vitamin independency of Saccharomyces cerevisiae This article has 0 citations.</p>
+</li>
+<li>
+<p>(perli2020vitaminrequirementsand pages 7-8): Thomas Perli, Anna K. Wronska, Raúl A. Ortiz‐Merino, Jack T. Pronk, and Jean‐Marc Daran. Vitamin requirements and biosynthesis in <i>saccharomyces cerevisiae</i>. Yeast, 37:283-304, Feb 2020. URL: https://doi.org/10.1002/yea.3461, doi:10.1002/yea.3461. This article has 173 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(sabelleck2025thiamineisa pages 3-4): Björn Sabelleck, Matthias Freh, Meltem Lammertz, Jennifer Browatzki, Anna-Maria Vllaho, Mariola Piślewska-Bednarek, Paweł Bednarek, and Ralph Panstruga. Thiamine is a vitamin for plant-pathogenic powdery mildew fungi. Aug 2025. URL: https://doi.org/10.1016/j.isci.2025.113123, doi:10.1016/j.isci.2025.113123. This article has 3 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(kowalska2008thegenesand pages 8-11): Ewa Kowalska and Andrzej Kozik. The genes and enzymes involved in the biosynthesis of thiamin and thiamin diphosphate in yeasts. Cellular &amp; Molecular Biology Letters, 13:271-282, Apr 2008. URL: https://doi.org/10.2478/s11658-007-0055-5, doi:10.2478/s11658-007-0055-5. This article has 65 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(li2010thiaminebiosynthesisin pages 1-2): Mingguang Li, Brian J. Petteys, Julie M. McClure, Veena Valsakumar, Stefan Bekiranov, Elizabeth L. Frank, and Jeffrey S. Smith. Thiamine biosynthesis in <i>saccharomyces cerevisiae</i> is regulated by the nad<sup>+</sup>-dependent histone deacetylase hst1. Jul 2010. URL: https://doi.org/10.1128/mcb.01590-09, doi:10.1128/mcb.01590-09. This article has 93 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(li2020transcriptomeanalysisreveals pages 5-7): Jingyuan Li, Kaili Zhu, and Hongwei Zhao. Transcriptome analysis reveals the protection mechanism of proanthocyanidins for saccharomyces cerevisiae during wine fermentation. Scientific Reports, Apr 2020. URL: https://doi.org/10.1038/s41598-020-63631-2, doi:10.1038/s41598-020-63631-2. This article has 20 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(kowalska2008thegenesand pages 1-4): Ewa Kowalska and Andrzej Kozik. The genes and enzymes involved in the biosynthesis of thiamin and thiamin diphosphate in yeasts. Cellular &amp; Molecular Biology Letters, 13:271-282, Apr 2008. URL: https://doi.org/10.2478/s11658-007-0055-5, doi:10.2478/s11658-007-0055-5. This article has 65 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(perli2020vitaminrequirementsand pages 5-7): Thomas Perli, Anna K. Wronska, Raúl A. Ortiz‐Merino, Jack T. Pronk, and Jean‐Marc Daran. Vitamin requirements and biosynthesis in <i>saccharomyces cerevisiae</i>. Yeast, 37:283-304, Feb 2020. URL: https://doi.org/10.1002/yea.3461, doi:10.1002/yea.3461. This article has 173 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(hohmann1998thiaminmetabolismand pages 1-3): Stefan Hohmann and Peter A Meacock. Thiamin metabolism and thiamin diphosphate-dependent enzymes in the yeast saccharomyces cerevisiae: genetic regulation. Biochimica et biophysica acta, 1385 2:201-19, Jun 1998. URL: https://doi.org/10.1016/s0167-4838(98)00069-7, doi:10.1016/s0167-4838(98)00069-7. This article has 252 citations.</p>
+</li>
+<li>
+<p>(hohmann1998thiaminmetabolismand pages 3-5): Stefan Hohmann and Peter A Meacock. Thiamin metabolism and thiamin diphosphate-dependent enzymes in the yeast saccharomyces cerevisiae: genetic regulation. Biochimica et biophysica acta, 1385 2:201-19, Jun 1998. URL: https://doi.org/10.1016/s0167-4838(98)00069-7, doi:10.1016/s0167-4838(98)00069-7. This article has 252 citations.</p>
+</li>
+<li>
+<p>(hohmann1998thiaminmetabolismand pages 6-8): Stefan Hohmann and Peter A Meacock. Thiamin metabolism and thiamin diphosphate-dependent enzymes in the yeast saccharomyces cerevisiae: genetic regulation. Biochimica et biophysica acta, 1385 2:201-19, Jun 1998. URL: https://doi.org/10.1016/s0167-4838(98)00069-7, doi:10.1016/s0167-4838(98)00069-7. This article has 252 citations.</p>
+</li>
+<li>
+<p>(hohmann1998thiaminmetabolismand pages 5-6): Stefan Hohmann and Peter A Meacock. Thiamin metabolism and thiamin diphosphate-dependent enzymes in the yeast saccharomyces cerevisiae: genetic regulation. Biochimica et biophysica acta, 1385 2:201-19, Jun 1998. URL: https://doi.org/10.1016/s0167-4838(98)00069-7, doi:10.1016/s0167-4838(98)00069-7. This article has 252 citations.</p>
+</li>
+<li>
+<p>(hohmann1998thiaminmetabolismand pages 8-9): Stefan Hohmann and Peter A Meacock. Thiamin metabolism and thiamin diphosphate-dependent enzymes in the yeast saccharomyces cerevisiae: genetic regulation. Biochimica et biophysica acta, 1385 2:201-19, Jun 1998. URL: https://doi.org/10.1016/s0167-4838(98)00069-7, doi:10.1016/s0167-4838(98)00069-7. This article has 252 citations.</p>
+</li>
+<li>
+<p>(brion2014decipheringregulatoryvariation pages 1-2): Christian Brion, Chloé Ambroset, Pierre Delobel, Isabelle Sanchez, and Bruno Blondin. Deciphering regulatory variation of thi genes in alcoholic fermentation indicate an impact of thi3p on pdc1 expression. BMC Genomics, Dec 2014. URL: https://doi.org/10.1186/1471-2164-15-1085, doi:10.1186/1471-2164-15-1085. This article has 22 citations and is from a peer-reviewed journal.</p>
+</li>
+</ol>
+<h2 id="artifacts">Artifacts</h2>
+<ul>
+<li><a href="THI22-deep-research-falcon_artifacts/artifact-00.md">Edison artifact artifact-00</a></li>
+<li><a href="THI22-deep-research-falcon_artifacts/artifact-01.md">Edison artifact artifact-01</a></li>
+</ul>
+<h2 id="citations">Citations</h2>
+<ol>
+<li>kowalska2008thegenesand pages 4-8</li>
+<li>li2010thiaminebiosynthesisin pages 1-2</li>
+<li>perli2020vitaminrequirementsand pages 7-8</li>
+<li>sabelleck2025thiamineisa pages 3-4</li>
+<li>kowalska2008thegenesand pages 8-11</li>
+<li>li2020transcriptomeanalysisreveals pages 5-7</li>
+<li>kowalska2008thegenesand pages 1-4</li>
+<li>perli2020vitaminrequirementsand pages 5-7</li>
+<li>hohmann1998thiaminmetabolismand pages 1-3</li>
+<li>hohmann1998thiaminmetabolismand pages 3-5</li>
+<li>hohmann1998thiaminmetabolismand pages 6-8</li>
+<li>hohmann1998thiaminmetabolismand pages 5-6</li>
+<li>hohmann1998thiaminmetabolismand pages 8-9</li>
+<li>brion2014decipheringregulatoryvariation pages 1-2</li>
+<li>https://doi.org/10.2478/s11658-007-0055-5,</li>
+<li>https://doi.org/10.1002/yea.3461,</li>
+<li>https://doi.org/10.1016/j.isci.2025.113123,</li>
+<li>https://doi.org/10.1128/mcb.01590-09,</li>
+<li>https://doi.org/10.1038/s41598-020-63631-2,</li>
+<li>https://doi.org/10.1016/s0167-4838(98</li>
+<li>https://doi.org/10.1186/1471-2164-15-1085,</li>
+</ol>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(THI22-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="Q06490" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="thi22-ypr121w-q06490-curation-notes">THI22 (YPR121W, Q06490) — curation notes</h1>
+<p>Journal of research for the AI GO-annotation review. THI22 is an understudied ("dark")<br />
+<em>S. cerevisiae</em> gene: a member of the three-gene thiaminase-2 / HMP-P-kinase family<br />
+(THI20/THI21/THI22). The central curation problem is that THI22 is highly homologous to<br />
+the biochemically characterized paralogs THI20 and THI21, yet no enzymatic activity has<br />
+been demonstrated for it, and it is dispensable for thiamine biosynthesis. All<br />
+THI22-specific claims must be separated carefully from what is known only for THI20/THI21.</p>
+<h2 id="identity-and-family-placement">Identity and family placement</h2>
+<ul>
+<li>UniProt: Q06490 (THI22_YEAST). Systematic name YPR121W. SGD:S000006325.</li>
+<li>572 aa. UniProt annotates a signal peptide (1-19) and chain (20-572); predicted<br />
+  Secreted (SL-0243) — this is a computational SubCell/SignalP prediction (ECO:0000255 /<br />
+  ECO:0000305), not experimentally demonstrated. [file:genes/yeast/THI22/THI22-uniprot.txt]</li>
+<li>Family: PANTHER PTHR20858 (PHOSPHOMETHYLPYRIMIDINE KINASE), subfamily PTHR20858:SF17<br />
+  ("HYDROXYMETHYLPYRIMIDINE/PHOSPHOMETHYLPYRIMIDINE KINASE THI20-RELATED"). All three<br />
+  yeast paralogs are in SF17: THI20 (Q08224, 551 aa), THI21 (Q08975, 551 aa), THI22<br />
+  (Q06490, 572 aa). [file:interpro/panther/PTHR20858/PTHR20858-entries.csv]</li>
+<li>Two-domain (fused) architecture, one gene fusion event ancestral to the family:</li>
+<li>N-terminal HMP/HMP-P kinase domain (ribokinase-like; Pfam PF08543 Phos_pyr_kin;<br />
+    CDD cd01169 HMPP_kinase; TIGR00097 HMP-P_kinase). Corresponds to bacterial ThiD.</li>
+<li>C-terminal TenA / thiaminase-II-like domain (Pfam PF03070 TENA_THI-4; CDD cd19367<br />
+    TenA_C_ScTHI20-like; TIGR04306 salvage_TenA; InterPro IPR027574 Thiaminase_II).<br />
+    Corresponds to bacterial TenA (thiamine-salvage thiaminase II).<br />
+  [file:genes/yeast/THI22/THI22-uniprot.txt]</li>
+</ul>
+<h2 id="known-experimentally-established-but-note-attribution">KNOWN (experimentally established) — but note attribution</h2>
+<p>For the FAMILY / paralogs (NOT necessarily THI22):<br />
+- Two of the three family members (THI20 = YOL055c and THI21 = YPL258c) are isofunctional<br />
+  and encode an HMP-P kinase (EC 2.7.4.7), an activity required for the final steps of<br />
+  thiamine biosynthesis in yeast.<br />
+  [PMID:10383756 abstract, "we demonstrate that two members are isofunctional and encode a<br />
+  hydroxymethylpyrimidine phosphate (HMP-P) kinase (EC 2.7.4.7), an activity required for<br />
+  the final steps of thiamine biosynthesis, whose genes were not previously known in yeast"]<br />
+- THI20 is a trifunctional enzyme: HMP kinase (EC 2.7.1.49) + HMP-P kinase (EC 2.7.4.7) +<br />
+  thiaminase II (EC 3.5.99.2), the last activity degrading thiamine to HMP for salvage.<br />
+  [UniProt Q08224, CATALYTIC ACTIVITY / FUNCTION; ECO:0000269|PubMed:15967475]<br />
+- The C-terminal domain of the family proteins is NOT required for HMP-P kinase activity;<br />
+  its function was unresolved at the time of the 1999 paper.<br />
+  [PMID:10383756 abstract, "The function of the carboxy-terminal part of the proteins is<br />
+  not yet understood, but it is not required for HMP-P kinase activity"]<br />
+- All three genes are co-regulated and induced by thiamine absence.<br />
+  [PMID:10383756 abstract, "Expression of all three genes is regulated in the same way";<br />
+  UniProt Q06490 INDUCTION "By absence of thiamine", ECO:0000269|PubMed:10383756]</p>
+<p>Specifically for THI22 (what the primary literature actually says):<br />
+- THI22 is NOT required for thiamine biosynthesis (dispensable; single deletion has no<br />
+  thiamine-auxotrophy phenotype in the redundant family context).<br />
+  [UniProt Q06490 FUNCTION "Is not required for thiamine biosynthesis",<br />
+  ECO:0000269|PubMed:10383756]<br />
+- No HMP-P kinase activity could be demonstrated for THI22, in contrast to THI20/THI21.<br />
+  [UniProt Q06490 CAUTION "Although highly homologous to the 2 other thiaminase-2 family<br />
+  members THI20 and THI21 in yeast, no hydroxymethylpyrimidine phosphate kinase activity<br />
+  could be demonstrated for this protein", ECO:0000305]<br />
+- THI22 expression is induced by absence of thiamine (like the paralogs).<br />
+  [UniProt Q06490 INDUCTION, ECO:0000269|PubMed:10383756]</p>
+<h2 id="not-known-open-thi22-specific-knowledge-gaps">NOT known / open (THI22-specific knowledge gaps)</h2>
+<ul>
+<li>Whether THI22 has ANY catalytic activity in vivo (HMP kinase, HMP-P kinase, or<br />
+  thiaminase II). The 1999 assay failed to detect HMP-P kinase; other activities untested.</li>
+<li>Whether the failure to detect activity reflects a genuinely inactive protein, a folding/<br />
+  expression problem in the assay system, a different substrate, or a regulatory/salvage<br />
+  role distinct from the biosynthetic kinase step.</li>
+<li>The true subcellular location. UniProt lists "Secreted" from a signal-peptide/SubCell<br />
+  prediction, but the paralogs THI20/THI21 act cytosolically in thiamine metabolism, and<br />
+  the phylogenetic (IBA) annotation places THI22 in the cytosol. The secretion claim is<br />
+  computational only and is biologically surprising for a thiamine-pathway enzyme.</li>
+<li>Why the cell retains a third, apparently redundant/inactive paralog: possible functions<br />
+  include a conditional/cryptic activity, a dosage or buffering role, a role under specific<br />
+  stress/nutrient conditions, or ongoing pseudogenization (evolutionary relic).</li>
+</ul>
+<h2 id="inline-domain-reasoning-done-in-this-review-not-from-an-external-tool">Inline domain reasoning (done in this review, not from an external tool)</h2>
+<p>Pairwise global alignment of THI22 (Q06490) vs THI20 (Q08224) computed here with Biopython<br />
+(globalms, match 2 / mismatch -1 / gap-open -5 / gap-extend -0.5):<br />
+- 76.4% identity over aligned positions — very high; THI22 is a bona fide close paralog.<br />
+- The THI20 experimentally/inferred functional residues are ALL conserved in THI22:<br />
+  - HMP substrate-binding Gln (THI20 Q64, N-terminal kinase domain) = THI22 Q86.<br />
+  - Thiaminase-II nucleophile Cys (THI20 ACT_SITE C468) = THI22 C489.<br />
+  - Thiaminase-II proton-donor Glu (THI20 ACT_SITE E540) = THI22 E561.<br />
+  (THI22 positions are offset by ~21-22 residues because of its N-terminal signal-peptide<br />
+  extension.)<br />
+- The ribokinase-family glycine-rich phosphate-binding motif is present in THI22<br />
+  (…IAGSDSSGGAGV…, ~res 52-63; THI20 has …AGTDPSGGAGIE…) and the GGHIP kinase motif is<br />
+  present (THI22 res ~222).</p>
+<p>Interpretation: THI22 is NOT a residue-dead pseudoenzyme — its catalytic and substrate-<br />
+binding residues are intact. This makes the observed lack of demonstrable HMP-P kinase<br />
+activity <a href="https://pubmed.ncbi.nlm.nih.gov/10383756">PMID:10383756</a> a genuine biological puzzle rather than an obvious consequence of<br />
+lost catalytic machinery. Because the catalytic residues are conserved, a domain-based<br />
+"pseudoenzyme" REMOVE of the kinase MF terms is NOT justified; but neither is a confident<br />
+ACCEPT of demonstrated activity, since the one direct assay failed for THI22. The honest<br />
+position is that the kinase/thiaminase MF terms are phylogenetically/InterPro-inferred<br />
+(IBA/IEA) and plausible on sequence grounds, but THI22-specific activity is unproven and<br />
+partially contradicted by the one experiment that tested it.</p>
+<h2 id="annotation-by-annotation-plan-see-yaml-for-final-actions">Annotation-by-annotation plan (see YAML for final actions)</h2>
+<p>GOA has 12 annotations:<br />
+1. GO:0005829 cytosol (IBA) — plausible for a thiamine-pathway enzyme; paralogs cytosolic.<br />
+   KEEP_AS_NON_CORE (location, phylogenetic).<br />
+2. GO:0008902 hydroxymethylpyrimidine kinase activity (IBA) — HMP→HMP-P (EC 2.7.1.49).<br />
+   Family activity; THI22-specific unproven. KEEP_AS_NON_CORE with caveat (not core, not<br />
+   demonstrated for THI22).<br />
+3. GO:0008972 phosphomethylpyrimidine kinase activity (IBA) — HMP-P→HMP-PP (EC 2.7.4.7);<br />
+   this is exactly the activity the 1999 paper FAILED to demonstrate for THI22.<br />
+   MARK_AS_OVER_ANNOTATED (directly tested and not detected for THI22).<br />
+4. GO:0009228 thiamine biosynthetic process (IBA) — THI22 shown NOT required for thiamine<br />
+   biosynthesis. MARK_AS_OVER_ANNOTATED.<br />
+5. GO:0005576 extracellular region (IEA, SubCell) — computational from signal peptide;<br />
+   biologically implausible for a thiamine-metabolism enzyme; conflicts with cytosol IBA.<br />
+   MARK_AS_OVER_ANNOTATED / KEEP_AS_NON_CORE with strong caveat.<br />
+6. GO:0006772 thiamine metabolic process (IEA, InterPro) — general BP; defensible at the<br />
+   family level. KEEP_AS_NON_CORE.<br />
+7. GO:0008972 phosphomethylpyrimidine kinase activity (IEA, InterPro) — duplicate MF from<br />
+   InterPro; same caveat as #3. MARK_AS_OVER_ANNOTATED.<br />
+8. GO:0009228 thiamine biosynthetic process (IEA) — same as #4. MARK_AS_OVER_ANNOTATED.<br />
+9. GO:0050334 thiaminase activity (IEA, InterPro, IPR027574 Thiaminase_II) — C-terminal<br />
+   TenA domain; catalytic Cys/Glu conserved in THI22. Plausible on sequence; unproven for<br />
+   THI22. KEEP_AS_NON_CORE (domain-supported family activity).<br />
+10. GO:0003674 molecular_function (ND) — root, no data. ACCEPT (ND placeholder).<br />
+11. GO:0005575 cellular_component (ND) — root, no data. ACCEPT (ND placeholder).<br />
+12. GO:0009228 thiamine biosynthetic process (IEP, PMID:10383756, SGD) — experimental<br />
+    annotation from the primary paper (induction by thiamine absence = IEP "expression<br />
+    pattern"). Per rules, do NOT REMOVE an experimental annotation. IEP reflects that the<br />
+    gene is thiamine-regulated, which is genuinely established; but the gene is not required<br />
+    for biosynthesis. KEEP_AS_NON_CORE (thiamine-regulated; involvement not core), defer to<br />
+    SGD curator on the experimental IEP.</p>
+<h2 id="update-review-completed-falcon-corroboration-and-final-actions">Update (review completed) — falcon corroboration and final actions</h2>
+<p>Falcon/Edison deep research completed (THI22-deep-research-falcon.md, 21 citations, ~1476s).<br />
+It independently corroborates the review's central conclusions:<br />
+- "The function of the third member of the same gene family, THI22, is unknown at present"<br />
+  (attributed to Kowalska &amp; Kozik 2008 in the report).<br />
+- THI20/THI21 are the characterized HMP/HMP-P kinase + thiaminase-II enzymes; THI22's specific<br />
+  biochemical function is unresolved and inferred only from homology/domain annotation.<br />
+- THI22's predicted signal peptide distinguishes it from cytoplasmic THI20 — falcon raises the<br />
+  same hypothesis captured in the localization knowledge gap (possible periplasmic/extracellular<br />
+  salvage or degradation role), and notes Huh et al. 2003 GFP screen did not give a clear THI22<br />
+  localization.<br />
+- THI22 is part of the thiamine (THI) regulon, thiamine-regulated — matches the IEP annotation.<br />
+Falcon citations use internal source keys (not PMIDs), so per project memory no verbatim<br />
+supporting_text from the falcon report is used to ground annotations; all annotation quotes are<br />
+anchored to PMID:10383756 (verbatim, whitespace/case verified) and the inline bioinformatics<br />
+RESULTS.md.</p>
+<p>Final action breakdown over 12 GOA annotations:<br />
+- ACCEPT: 2 (GO:0003674 root MF ND; GO:0005575 root CC ND)<br />
+- KEEP_AS_NON_CORE: 4 (GO:0005829 cytosol IBA; GO:0008902 HMP kinase IBA; GO:0006772 thiamine<br />
+  metabolic process IEA; GO:0050334 thiaminase activity IEA)<br />
+- MARK_AS_OVER_ANNOTATED: 6 (GO:0008972 HMP-P kinase IBA+IEA; GO:0009228 thiamine biosynthetic<br />
+  process IBA+IEA+IEP; GO:0005576 extracellular region IEA)<br />
+- REMOVE: 0 (catalytic residues intact per alignment; experimental IEP not removed per guidelines)</p>
+<p>Inline bioinformatics (THI22-bioinformatics/): reproducible Biopython alignment of THI22 vs THI20<br />
+confirms 76.4% identity and conservation of all THI20 functional residues (HMP-binding Q64-&gt;Q86,<br />
+thiaminase-II C468-&gt;C489, E540-&gt;E561) — THI22 is NOT a residue-dead pseudoenzyme, which is why<br />
+no domain/pseudoenzyme-based REMOVE was applied to the kinase/thiaminase MF terms.</p>
+            </div>
+        </details>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Bioinformatics Results</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(RESULTS.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="Q06490" data-a="DOC: Bioinformatics Results" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="thi22-vs-thi20-paralog-alignment-catalytic-residue-conservation">THI22 vs THI20 paralog alignment — catalytic-residue conservation</h1>
+<h2 id="purpose">Purpose</h2>
+<p>THI22 (Q06490, YPR121W) is one of three paralogous members of the <em>S. cerevisiae</em><br />
+thiaminase-II / HMP-P-kinase family (THI20, THI21, THI22). The primary literature<br />
+(PMID:10383756) demonstrated HMP-P kinase activity for only two of the three members, and<br />
+UniProt records a CAUTION that no HMP-P kinase activity could be demonstrated for THI22<br />
+despite its high homology. The curation question addressed here: is THI22's lack of<br />
+demonstrable activity explained by loss of catalytic residues (a residue-dead pseudoenzyme),<br />
+or does it retain an intact active site (sequence-intact but activity not demonstrated)?</p>
+<h2 id="method">Method</h2>
+<p>Pairwise global alignment of THI22 (Q06490) against the biochemically characterized paralog<br />
+THI20 (Q08224) using Biopython's <code>Align.PairwiseAligner</code> (global mode; match +2, mismatch -1,<br />
+gap-open -5, gap-extend -0.5). The three THI20 functional residues annotated in UniProt were<br />
+mapped through the alignment onto THI22:</p>
+<ul>
+<li>BINDING 64 — HMP substrate binding (N-terminal ThiD-like HMP/HMP-P kinase domain)</li>
+<li>ACT_SITE 468 — nucleophile (C-terminal TenA/thiaminase-II domain)</li>
+<li>ACT_SITE 540 — proton donor (C-terminal TenA/thiaminase-II domain)</li>
+</ul>
+<p>Reproduce with: <code>python align_paralogs.py</code> (requires biopython). The script prints its<br />
+findings and does not hardcode any conclusion.</p>
+<h2 id="results-from-align_paralogspy">Results (from <code>align_paralogs.py</code>)</h2>
+<div class="codehilite"><pre><span></span><code><span class="n">THI22</span><span class="w"> </span><span class="nl">length</span><span class="p">:</span><span class="w"> </span><span class="mi">572</span><span class="w">  </span><span class="n">THI20</span><span class="w"> </span><span class="nl">length</span><span class="p">:</span><span class="w"> </span><span class="mi">551</span>
+<span class="k">Identity</span><span class="err">:</span><span class="w"> </span><span class="mi">420</span><span class="o">/</span><span class="mi">550</span><span class="w"> </span><span class="o">=</span><span class="w"> </span><span class="mf">76.4</span><span class="o">%</span><span class="w"> </span><span class="k">over</span><span class="w"> </span><span class="n">aligned</span><span class="w"> </span><span class="n">positions</span>
+
+<span class="n">THI20</span><span class="w"> </span><span class="mi">64</span><span class="w">  </span><span class="p">(</span><span class="n">BINDING</span><span class="w"> </span><span class="n">HMP</span><span class="w"> </span><span class="n">substrate</span><span class="p">,</span><span class="w"> </span><span class="n">N</span><span class="o">-</span><span class="n">term</span><span class="w"> </span><span class="n">kinase</span><span class="w"> </span><span class="k">domain</span><span class="p">)</span><span class="err">:</span><span class="w">        </span><span class="n">THI20</span><span class="o">=</span><span class="n">Q</span><span class="w"> </span><span class="o">-&gt;</span><span class="w"> </span><span class="n">THI22</span><span class="o">=</span><span class="n">Q</span><span class="w"> </span><span class="p">(</span><span class="n">THI22</span><span class="w"> </span><span class="n">pos</span><span class="w"> </span><span class="mi">86</span><span class="p">)</span><span class="w">  </span><span class="o">[</span><span class="n">CONSERVED</span><span class="o">]</span>
+<span class="n">THI20</span><span class="w"> </span><span class="mi">468</span><span class="w"> </span><span class="p">(</span><span class="n">ACT_SITE</span><span class="w"> </span><span class="n">nucleophile</span><span class="p">,</span><span class="w"> </span><span class="n">C</span><span class="o">-</span><span class="n">term</span><span class="w"> </span><span class="n">TenA</span><span class="o">/</span><span class="n">thiaminase</span><span class="o">-</span><span class="n">II</span><span class="p">)</span><span class="err">:</span><span class="w">    </span><span class="n">THI20</span><span class="o">=</span><span class="n">C</span><span class="w"> </span><span class="o">-&gt;</span><span class="w"> </span><span class="n">THI22</span><span class="o">=</span><span class="n">C</span><span class="w"> </span><span class="p">(</span><span class="n">THI22</span><span class="w"> </span><span class="n">pos</span><span class="w"> </span><span class="mi">489</span><span class="p">)</span><span class="w"> </span><span class="o">[</span><span class="n">CONSERVED</span><span class="o">]</span>
+<span class="n">THI20</span><span class="w"> </span><span class="mi">540</span><span class="w"> </span><span class="p">(</span><span class="n">ACT_SITE</span><span class="w"> </span><span class="n">proton</span><span class="w"> </span><span class="n">donor</span><span class="p">,</span><span class="w"> </span><span class="n">C</span><span class="o">-</span><span class="n">term</span><span class="w"> </span><span class="n">TenA</span><span class="o">/</span><span class="n">thiaminase</span><span class="o">-</span><span class="n">II</span><span class="p">)</span><span class="err">:</span><span class="w">   </span><span class="n">THI20</span><span class="o">=</span><span class="n">E</span><span class="w"> </span><span class="o">-&gt;</span><span class="w"> </span><span class="n">THI22</span><span class="o">=</span><span class="n">E</span><span class="w"> </span><span class="p">(</span><span class="n">THI22</span><span class="w"> </span><span class="n">pos</span><span class="w"> </span><span class="mi">561</span><span class="p">)</span><span class="w"> </span><span class="o">[</span><span class="n">CONSERVED</span><span class="o">]</span>
+
+<span class="ow">All</span><span class="w"> </span><span class="n">three</span><span class="w"> </span><span class="n">THI20</span><span class="w"> </span><span class="n">functional</span><span class="w"> </span><span class="n">residues</span><span class="w"> </span><span class="k">are</span><span class="w"> </span><span class="n">conserved</span><span class="w"> </span><span class="ow">in</span><span class="w"> </span><span class="n">THI22</span>
+</code></pre></div>
+
+<p>Additional motif observations (from inline inspection of the sequences):</p>
+<ul>
+<li>The ribokinase-family glycine-rich phosphate-binding motif is present in THI22<br />
+  (<code>...IAGSDSSGGAGV...</code>, ~res 52-63; THI20 has <code>...AGTDPSGGAGIE...</code>).</li>
+<li>The <code>GGHIP</code> kinase motif is present in THI22 (~res 222).</li>
+<li>THI22 positions are offset from THI20 by ~21-22 residues because of THI22's N-terminal<br />
+  signal-peptide extension (residues 1-19), which THI20/THI21 lack.</li>
+</ul>
+<h2 id="interpretation">Interpretation</h2>
+<p>THI22 is a close paralog (~76% identity) that <strong>retains all annotated substrate-binding and<br />
+catalytic residues of both the kinase and the thiaminase-II domain</strong>. It is therefore <strong>not a<br />
+residue-dead pseudoenzyme</strong>. Consequently:</p>
+<ul>
+<li>A domain- or pseudoenzyme-based REMOVE of the kinase/thiaminase molecular-function terms is<br />
+<strong>not justified</strong> — the machinery is intact.</li>
+<li>Equally, the intact machinery does <strong>not</strong> demonstrate activity: the one direct enzymatic<br />
+  assay that tested THI22 (PMID:10383756) did not detect HMP-P kinase activity. The molecular<br />
+  function terms are best treated as domain-plausible but THI22-unproven (non-core /<br />
+  over-annotated as appropriate per evidence), and the lack of demonstrable activity is a<br />
+  genuine biological knowledge gap (possible cryptic/conditional activity, divergent<br />
+  substrate, or functional divergence toward pseudoenzyme status).</li>
+</ul>
+<h2 id="data-provenance">Data provenance</h2>
+<p>Sequences taken from the committed UniProt record for THI22<br />
+(<code>genes/yeast/THI22/THI22-uniprot.txt</code>, Q06490) and from UniProt Q08224 (THI20); THI20<br />
+functional-residue positions taken from the UniProt Q08224 feature table (ACT_SITE 468/540,<br />
+BINDING 64).</p>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: Q06490
+gene_symbol: THI22
+product_type: PROTEIN
+status: INITIALIZED
+taxon:
+  id: NCBITaxon:559292
+  label: Saccharomyces cerevisiae
+description: &gt;-
+  THI22 (YPR121W) is one of three paralogous members of the yeast thiaminase-II /
+  hydroxymethylpyrimidine (HMP/HMP-P) kinase gene family (with THI20 and THI21). Like its
+  paralogs it is a two-domain protein arising from an ancestral gene fusion: an N-terminal
+  ribokinase-fold HMP/HMP-P kinase domain (homologous to bacterial ThiD, catalyzing steps in
+  de novo thiamine pyrophosphate biosynthesis) and a C-terminal TenA/thiaminase-II-like domain
+  (homologous to bacterial TenA, associated with thiamine salvage). THI22 shares roughly
+  three-quarters sequence identity with the biochemically characterized THI20 and retains the
+  substrate-binding and catalytic residues of both domains. Its expression is induced under
+  thiamine limitation, coordinately with THI20 and THI21. Despite this close homology, THI22 is
+  dispensable for thiamine biosynthesis and no enzymatic (HMP-P kinase) activity has been
+  demonstrated for the protein, so its individual in vivo role remains undetermined; the
+  characterized biosynthetic and thiamine-degrading (thiaminase II) activities of the family
+  have been established for the paralogs THI20/THI21 rather than for THI22 itself.
+references:
+- id: GO_REF:0000002
+  title: Gene Ontology annotation through association of InterPro records with GO terms
+  findings: []
+- id: GO_REF:0000015
+  title: Use of the ND evidence code for Gene Ontology (GO) terms
+  findings: []
+- id: GO_REF:0000033
+  title: Annotation inferences using phylogenetic trees
+  findings: []
+- id: GO_REF:0000044
+  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary
+    mapping, accompanied by conservative changes to GO terms applied by UniProt
+  findings: []
+- id: GO_REF:0000120
+  title: Combined Automated Annotation using Multiple IEA Methods
+  findings: []
+- id: PMID:10383756
+  title: &#39;Genetic redundancy and gene fusion in the genome of the Baker&#39;&#39;s yeast Saccharomyces
+    cerevisiae: functional characterization of a three-member gene family involved in the thiamine
+    biosynthetic pathway.&#39;
+  findings:
+  - statement: &gt;-
+      Two of the three family members (THI20/YOL055c and THI21/YPL258c) are isofunctional and
+      encode an HMP-P kinase (EC 2.7.4.7) required for the final steps of thiamine biosynthesis;
+      by implication the third member (THI22/YPR121w) is the one for which this activity was not
+      demonstrated.
+    supporting_text: &gt;-
+      We demonstrate that two members are isofunctional and encode a hydroxymethylpyrimidine
+      phosphate (HMP-P) kinase (EC 2.7.4.7), an activity required for the final steps of thiamine
+      biosynthesis
+    full_text_unavailable: true
+  - statement: &gt;-
+      Each of the three genes has two distinct domains that correspond to separate prokaryotic
+      genes, consistent with an ancestral gene fusion; the C-terminal domain is not required for
+      HMP-P kinase activity and its function was unresolved.
+    supporting_text: &gt;-
+      the three genes are each composed of two distinct domains, each corresponding to individual
+      genes in prokaryotes, suggesting gene fusion during evolution. The function of the
+      carboxy-terminal part of the proteins is not yet understood, but it is not required for HMP-P
+      kinase activity
+    full_text_unavailable: true
+  - statement: All three family genes are co-regulated (induced under thiamine limitation).
+    supporting_text: Expression of all three genes is regulated in the same way
+    full_text_unavailable: true
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PubMed-verified primary paper (Llorente, Fairhead &amp; Dujon 1999) defining the
+      THI20/THI21/THI22 family. Abstract-only in cache (full_text_available: false). It
+      establishes HMP-P kinase activity for two of the three members and explicitly leaves the
+      third (THI22/YPR121w) uncharacterized enzymatically. UniProt (Q06490) attributes THI22&#39;s
+      &#34;not required for thiamine biosynthesis&#34; (FUNCTION, ECO:0000269|PubMed:10383756) and the
+      CAUTION that no HMP-P kinase activity could be demonstrated for it (ECO:0000305) to this
+      work.
+- id: file:yeast/THI22/THI22-bioinformatics/RESULTS.md
+  title: THI22 vs THI20 paralog alignment and catalytic-residue conservation (inline analysis)
+  findings:
+  - statement: &gt;-
+      THI22 (Q06490) is ~76% identical to the characterized paralog THI20 (Q08224) and retains
+      THI20&#39;s HMP substrate-binding Gln, the ribokinase Gly-rich phosphate-binding motif, and the
+      thiaminase-II catalytic nucleophile Cys and proton-donor Glu, so it is not a residue-dead
+      pseudoenzyme.
+    supporting_text: &gt;-
+      All three THI20 functional residues are conserved in THI22
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Reproducible pairwise alignment computed for this review (Biopython global alignment, THI22
+      vs THI20); results and script recorded in the gene bioinformatics folder. Establishes that
+      THI22&#39;s catalytic machinery is intact, which is why domain-based pseudoenzyme REMOVE calls
+      are not justified.
+- id: file:yeast/THI22/THI22-deep-research-falcon.md
+  title: THI22 deep research report (falcon / Edison Scientific)
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Falcon/Edison deep-research report generated for this review. It independently corroborates
+      the review&#39;s central conclusions — that THI20/THI21 are the characterized HMP/HMP-P kinase +
+      thiaminase-II enzymes, that THI22&#39;s specific biochemical function is explicitly unresolved in
+      the literature (&#34;The function of the third member of the same gene family, THI22, is unknown
+      at present&#34;, per Kowalska &amp; Kozik 2008), and that THI22&#39;s signal peptide distinguishes it
+      from the cytoplasmic THI20. Its citations use internal source keys rather than PMIDs, so no
+      verbatim supporting_text from this report is used to ground annotations; the review&#39;s claims
+      are anchored to PMID:10383756 and the inline alignment instead.
+existing_annotations:
+- term:
+    id: GO:0005829
+    label: cytosol
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: is_active_in
+  review:
+    summary: &gt;-
+      Phylogenetically inferred cytosolic localization, consistent with the thiamine-pathway
+      biochemistry of the paralogs THI20/THI21, which act in the cytosolic HMP-P kinase steps.
+      Plausible as a location but not a core function and not experimentally shown for THI22.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      IBA location annotation from the THI20-related PANTHER family. The de novo thiamine
+      biosynthesis kinase steps occur in the cytosol, so cytosolic localization is the reasonable
+      default for a family member. It conflicts with the InterPro/SubCell &#34;extracellular region&#34;
+      prediction (see below); the cytosolic assignment is the more biologically defensible of the
+      two but remains inferred, so it is retained as non-core.
+- term:
+    id: GO:0008902
+    label: hydroxymethylpyrimidine kinase activity
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: enables
+  review:
+    summary: &gt;-
+      HMP kinase activity (HMP -&gt; HMP-P, EC 2.7.1.49) is a demonstrated activity of the family
+      (THI20 is trifunctional). THI22 retains the N-terminal kinase domain and its HMP
+      substrate-binding residue (Gln, conserved with THI20 Q64), so the activity is plausible on
+      sequence grounds, but it is inferred by phylogeny and not demonstrated for THI22.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Domain-defensible family activity (N-terminal ThiD-like kinase domain; substrate-binding and
+      Gly-rich phosphate-binding motifs conserved in THI22 per inline alignment to THI20). Kept as
+      non-core because THI22-specific activity is unproven; the one direct enzymatic assay of the
+      family that tested THI22 failed to detect the related HMP-P kinase activity (per UniProt
+      CAUTION, ECO:0000305, and PMID:10383756, which demonstrated the activity only for THI20/THI21).
+- term:
+    id: GO:0008972
+    label: phosphomethylpyrimidine kinase activity
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: enables
+  review:
+    summary: &gt;-
+      HMP-P kinase activity (HMP-P -&gt; HMP-PP, EC 2.7.4.7) is exactly the activity that
+      PMID:10383756 demonstrated for two of the three family members and could NOT demonstrate for
+      the third (THI22). Retained by phylogenetic inference but flagged as over-annotated for THI22
+      because it is directly contradicted by the one experiment that tested it.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      The IBA propagates the well-established HMP-P kinase activity of THI20/THI21 onto THI22, but
+      the primary paper demonstrated this activity for only two of the three members and UniProt
+      records (CAUTION, ECO:0000305) that no HMP-P kinase activity could be demonstrated for THI22
+      despite its high homology. The catalytic residues are conserved (so this is not a
+      residue-dead pseudoenzyme and REMOVE is not justified), but calling this a THI22 function
+      over-states the evidence: it is a family-level inference contradicted by the only direct
+      THI22 assay.
+    supported_by:
+    - reference_id: PMID:10383756
+      supporting_text: &gt;-
+        We demonstrate that two members are isofunctional and encode a hydroxymethylpyrimidine
+        phosphate (HMP-P) kinase (EC 2.7.4.7), an activity required for the final steps of thiamine
+        biosynthesis
+      full_text_unavailable: true
+    propagation_review:
+      root_cause: PROPAGATION_BAD
+      failure_modes:
+      - FUNCTIONAL_DIVERGENCE
+      source_entities:
+      - source_id: SGD:S000005416
+        source_label: THI20
+        source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
+        comment: &gt;-
+          THI20 has demonstrated HMP-P kinase activity, but the same primary work did not detect
+          this activity for THI22, so transfer to THI22 is unsafe.
+      - source_id: PANTHER:PTN000466159
+        source_label: PANTHER THI20-related node (PTHR20858:SF17)
+        source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
+        comment: Family node aggregates the paralog kinase activity; THI22-specific activity is unproven.
+- term:
+    id: GO:0009228
+    label: thiamine biosynthetic process
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Thiamine biosynthetic process is the family process, but THI22 has been shown NOT to be
+      required for thiamine biosynthesis. The phylogenetic propagation over-states THI22&#39;s role in
+      de novo biosynthesis.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      UniProt (from PMID:10383756) states THI22 &#34;is not required for thiamine biosynthesis&#34;. The
+      IBA correctly captures the family process but over-annotates THI22, whose contribution to de
+      novo biosynthesis is unproven and, on deletion evidence in the redundant family, dispensable.
+      A broader thiamine metabolic-process framing is more defensible for THI22 (see GO:0006772).
+    supported_by:
+    - reference_id: PMID:10383756
+      supporting_text: &gt;-
+        We demonstrate that two members are isofunctional and encode a hydroxymethylpyrimidine
+        phosphate (HMP-P) kinase (EC 2.7.4.7), an activity required for the final steps of thiamine
+        biosynthesis
+      full_text_unavailable: true
+    propagation_review:
+      root_cause: PROPAGATION_BAD
+      failure_modes:
+      - FUNCTIONAL_DIVERGENCE
+      source_entities:
+      - source_id: SGD:S000005416
+        source_label: THI20
+        source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
+        comment: &gt;-
+          THI20/THI21 are required for thiamine biosynthesis; THI22 is explicitly not required, so
+          the biosynthetic-process role should not propagate to it.
+- term:
+    id: GO:0005576
+    label: extracellular region
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000044
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      This location is derived automatically from a predicted N-terminal signal peptide
+      (UniProt SubCell &#34;Secreted&#34;, ECO:0000305). Secretion is biologically implausible for a
+      cytosolic thiamine-metabolism enzyme and conflicts with the cytosol IBA and with the
+      cytosolic biochemistry of the paralogs.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      Pure prediction from a signal-peptide/SubCell mapping, not experimental. THI22&#39;s paralogs
+      THI20/THI21 function in the cytosol, and there is no evidence THI22 is secreted or that a
+      secreted thiamine-pathway enzyme would be functional. Whether the predicted N-terminal
+      extension is a genuine targeting signal is itself a knowledge gap; the extracellular
+      annotation should not be treated as established localization.
+- term:
+    id: GO:0006772
+    label: thiamine metabolic process
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      General thiamine metabolic process (parent of both biosynthesis and salvage/degradation).
+      Defensible at the family level: THI22 is thiamine-regulated and carries intact HMP-P kinase
+      and thiaminase-II-like domains. This broad process term over-commits less than the specific
+      biosynthesis term.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      InterPro-based BP annotation. Appropriate as a broad, non-core framing given THI22&#39;s
+      thiamine-responsive regulation and its two thiamine-metabolism domains, while avoiding the
+      stronger and contradicted &#34;biosynthetic process&#34; claim.
+- term:
+    id: GO:0008972
+    label: phosphomethylpyrimidine kinase activity
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: enables
+  review:
+    summary: &gt;-
+      InterPro-derived duplicate of the HMP-P kinase MF annotation. Same assessment as the IBA
+      HMP-P kinase annotation: family activity propagated to THI22 but directly not demonstrated
+      for THI22.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      InterPro (IPR004399) maps the ThiD-like kinase domain to HMP-P kinase activity. The domain
+      is present and its catalytic residues are conserved, but the specific HMP-P kinase activity
+      was tested for THI22 and not detected (UniProt CAUTION, ECO:0000305; PMID:10383756
+      demonstrated the activity only for THI20/THI21), so this electronic annotation
+      over-annotates THI22.
+    supported_by:
+    - reference_id: PMID:10383756
+      supporting_text: &gt;-
+        We demonstrate that two members are isofunctional and encode a hydroxymethylpyrimidine
+        phosphate (HMP-P) kinase (EC 2.7.4.7), an activity required for the final steps of thiamine
+        biosynthesis
+      full_text_unavailable: true
+- term:
+    id: GO:0009228
+    label: thiamine biosynthetic process
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000120
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Automated (multi-method IEA) thiamine biosynthetic process annotation. Same over-annotation
+      concern as the IBA biosynthesis annotation: THI22 is not required for thiamine biosynthesis.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      ARBA/InterPro electronic inference of de novo biosynthesis involvement, contradicted for
+      THI22 by the functional characterization showing it is not required for thiamine
+      biosynthesis. Broader thiamine metabolic process (GO:0006772) is the defensible level.
+    supported_by:
+    - reference_id: PMID:10383756
+      supporting_text: &gt;-
+        We demonstrate that two members are isofunctional and encode a hydroxymethylpyrimidine
+        phosphate (HMP-P) kinase (EC 2.7.4.7), an activity required for the final steps of thiamine
+        biosynthesis
+      full_text_unavailable: true
+- term:
+    id: GO:0050334
+    label: thiaminase activity
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Thiaminase II activity (thiamine hydrolysis to HMP + thiazole, EC 3.5.99.2) is a
+      demonstrated activity of THI20 and maps to the C-terminal TenA/thiaminase-II-like domain
+      (IPR027574). THI22 retains this domain and both catalytic residues (nucleophile Cys and
+      proton-donor Glu, conserved with THI20 C468/E540), so the activity is domain-plausible but
+      not demonstrated for THI22.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Domain-defensible family activity (C-terminal TenA/thiaminase-II domain with conserved
+      catalytic Cys/Glu per inline alignment). Kept as non-core rather than accepted as a core
+      function because no thiaminase activity has been directly demonstrated for THI22, and the
+      1999 paper noted the C-terminal domain&#39;s function was unresolved.
+- term:
+    id: GO:0003674
+    label: molecular_function
+  evidence_type: ND
+  original_reference_id: GO_REF:0000015
+  qualifier: enables
+  review:
+    summary: Root molecular_function placeholder (ND, no biological data).
+    action: ACCEPT
+    reason: &gt;-
+      ND root-term placeholder recording that no specific molecular function had been curated by
+      SGD at annotation time. Standard practice; nothing to change.
+- term:
+    id: GO:0005575
+    label: cellular_component
+  evidence_type: ND
+  original_reference_id: GO_REF:0000015
+  qualifier: is_active_in
+  review:
+    summary: Root cellular_component placeholder (ND, no biological data).
+    action: ACCEPT
+    reason: &gt;-
+      ND root-term placeholder recording that no specific localization had been curated by SGD at
+      annotation time. Standard practice; nothing to change.
+- term:
+    id: GO:0009228
+    label: thiamine biosynthetic process
+  evidence_type: IEP
+  original_reference_id: PMID:10383756
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      SGD experimental (IEP) annotation from the primary paper. The underlying evidence is that
+      THI22 expression is induced under thiamine limitation, coordinately with THI20/THI21. This
+      thiamine-responsive regulation is genuinely established; however, the same work shows THI22
+      is not required for de novo thiamine biosynthesis, so annotation of THI22 to the specific
+      &#34;biosynthetic process&#34; term over-states its role — the co-regulation evidence supports
+      thiamine-pathway involvement, not a demonstrated biosynthetic contribution.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      IEP (inferred from expression pattern) reflects real, curator-read experimental evidence of
+      thiamine-dependent regulation, and per curation guidelines the experimental evidence itself
+      is not discarded. But the specific target term (thiamine BIOSYNTHETIC process) over-states
+      THI22&#39;s role: the same paper establishes THI22 is not required for thiamine biosynthesis.
+      The regulation-based involvement is better captured by the broader thiamine metabolic process
+      (GO:0006772). Marked over-annotated (not removed) to preserve the experimental co-regulation
+      evidence while flagging the term as too specific for THI22.
+    supported_by:
+    - reference_id: PMID:10383756
+      supporting_text: Expression of all three genes is regulated in the same way
+      full_text_unavailable: true
+core_functions:
+- description: &gt;-
+    THI22 is a member of the thiamine-metabolism HMP/HMP-P kinase + thiaminase-II family and is
+    transcriptionally induced under thiamine limitation, but no molecular activity has been
+    demonstrated for the protein itself and it is dispensable for de novo thiamine biosynthesis.
+    Its N-terminal ribokinase-fold kinase domain and C-terminal TenA/thiaminase-II-like domain
+    retain their substrate-binding and catalytic residues (conserved with the biochemically
+    characterized paralog THI20), so it is not an obviously residue-dead pseudoenzyme; however,
+    which (if any) of the family activities THI22 actually performs in vivo is unknown. The most
+    defensible statement of core function is therefore a broad, thiamine-responsive metabolic
+    involvement rather than a specific catalytic activity.
+  supported_by:
+  - reference_id: PMID:10383756
+    supporting_text: Expression of all three genes is regulated in the same way
+    full_text_unavailable: true
+  - reference_id: file:yeast/THI22/THI22-bioinformatics/RESULTS.md
+    supporting_text: &gt;-
+      All three THI20 functional residues are conserved in THI22
+  directly_involved_in:
+  - id: GO:0006772
+    label: thiamine metabolic process
+  knowledge_gaps:
+  - gap_statement: &gt;-
+      Whether THI22 has any catalytic activity in vivo — HMP kinase (EC 2.7.1.49), HMP-P kinase
+      (EC 2.7.4.7), or thiaminase II (EC 3.5.99.2) — is undetermined. The single direct enzymatic
+      test of the family that included THI22 detected no HMP-P kinase activity for it, and no other
+      activity or physiological substrate has been assayed.
+    boundary: &gt;-
+      Firmly established: the isofunctional paralogs THI20 and THI21 are HMP-P kinases required for
+      the final steps of thiamine biosynthesis, and THI20 additionally has HMP kinase and
+      thiaminase-II activity; THI22 is ~76% identical to THI20 and retains the substrate-binding
+      Gln, the Gly-rich phosphate-binding motif, and the thiaminase-II catalytic Cys and Glu.
+    gap_kind:
+    - BIOLOGY
+    dark_aspect: MF_DARK
+    status: OPEN
+    significance: &gt;-
+      A sequence-intact enzyme homolog with no demonstrable activity is a textbook candidate for a
+      cryptic/conditional activity, a divergent substrate, or an in-progress pseudoenzyme; resolving
+      it would clarify whether the third paralog is a functional but redundant enzyme or an
+      evolutionary relic.
+    resolution: &gt;-
+      Purify recombinant THI22 and assay HMP kinase, HMP-P kinase, and thiaminase-II activities
+      directly, and test complementation of thi20 thi21 double mutants under thiamine limitation.
+    provenance:
+    - reference_id: PMID:10383756
+      supporting_text: &gt;-
+        We demonstrate that two members are isofunctional and encode a hydroxymethylpyrimidine
+        phosphate (HMP-P) kinase (EC 2.7.4.7), an activity required for the final steps of thiamine
+        biosynthesis
+      full_text_unavailable: true
+    - reference_id: file:yeast/THI22/THI22-bioinformatics/RESULTS.md
+      supporting_text: &gt;-
+        All three THI20 functional residues are conserved in THI22
+  - gap_statement: &gt;-
+      The true subcellular localization of THI22 is unresolved. UniProt annotates it as Secreted
+      based on a predicted N-terminal signal peptide, whereas phylogenetic annotation and the
+      cytosolic biochemistry of the paralogs place the family in the cytosol; whether the
+      N-terminal extension is a genuine targeting signal is untested.
+    boundary: &gt;-
+      Established computationally: THI22 has a predicted N-terminal signal/targeting sequence
+      (residues 1-19) that the paralogs THI20/THI21 lack, and the family kinase reactions of de novo
+      thiamine biosynthesis occur in the cytosol.
+    gap_kind:
+    - BIOLOGY
+    dark_aspect: CC_DARK
+    status: OPEN
+    significance: &gt;-
+      A genuinely secreted thiamine-metabolism enzyme would be highly unusual and would imply a
+      distinct (e.g. extracellular thiamine salvage) role; distinguishing prediction artifact from
+      real re-localization is needed before the extracellular annotation can be trusted.
+    resolution: &gt;-
+      Determine THI22 localization experimentally (e.g. tagged-protein microscopy / fractionation)
+      and test whether the predicted N-terminal peptide is cleaved and directs secretion.
+  - gap_statement: &gt;-
+      Why S. cerevisiae retains a third, apparently redundant and enzymatically undemonstrated
+      paralog is unknown. Its selective advantage — conditional/stress-specific function, gene-dosage
+      buffering of thiamine metabolism, or ongoing pseudogenization — has not been established.
+    boundary: &gt;-
+      Established: all three paralogs are co-regulated and induced by thiamine limitation, THI20/THI21
+      provide the essential HMP-P kinase function, and single deletion of THI22 does not cause thiamine
+      auxotrophy in the redundant family context.
+    gap_kind:
+    - BIOLOGY
+    dark_aspect: BP_DARK
+    status: OPEN
+    significance: &gt;-
+      Understanding retention of the third paralog bears on how redundancy and dosage in essential
+      vitamin-biosynthesis pathways are maintained, and on whether THI22 has a condition-specific role
+      not captured by standard growth assays.
+    resolution: &gt;-
+      Test thi22 deletion (and thi20 thi21 thi22 triple-mutant, plus THI22-only rescue) phenotypes
+      across thiamine, HMP, and stress conditions, and examine conservation/selection of the THI22
+      lineage across Saccharomyces.
+    provenance:
+    - reference_id: PMID:10383756
+      supporting_text: Expression of all three genes is regulated in the same way
+      full_text_unavailable: true
+suggested_questions:
+- question: &gt;-
+    Does purified THI22 possess any of the family enzymatic activities (HMP kinase, HMP-P kinase,
+    or thiaminase II), or is it catalytically inactive despite conserved active-site residues?
+- question: &gt;-
+    Is THI22 actually secreted (as UniProt predicts) or cytosolic like THI20/THI21, and is the
+    predicted N-terminal signal peptide functional?
+- question: &gt;-
+    Under what physiological condition, if any, does THI22 provide a selectable function that
+    THI20 and THI21 do not?
+suggested_experiments:
+- hypothesis: &gt;-
+    THI22 encodes a functional but redundant thiamine-metabolism enzyme whose activity was missed
+    by the original HMP-P-kinase-focused assay.
+  description: &gt;-
+    Express and purify recombinant THI22 (with and without the predicted N-terminal peptide) and
+    assay HMP kinase, HMP-P kinase, and thiaminase-II activities in vitro; in parallel test whether
+    THI22 alone rescues growth of a thi20 thi21 double deletion under thiamine-limited conditions.
+- hypothesis: &gt;-
+    The predicted N-terminal signal peptide re-localizes THI22 away from the cytosolic paralogs.
+  description: &gt;-
+    Determine THI22 localization by fluorescent tagging and subcellular fractionation, and test
+    signal-peptide cleavage/secretion.
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

Automated regeneration of static assets after gene review or template changes.

## Generated Assets

| Asset | Count/Status |
|-------|--------------|
| Gene review YAML files | 2923 |
| Gene review HTML pages | 2923 |
| Project pages | 1098 |
| Module pages | 87 |
| Browser app (data.js) | Updated |
| Validation report | Updated |

## Trigger

This PR was triggered by changes to:
- genes/**/*.yaml - gene review data files
- src/ai_gene_review/schema/** - LinkML schema files
- src/ai_gene_review/templates/** - Jinja2 templates
- src/ai_gene_review/render.py - rendering code
- src/ai_gene_review/render_modules.py - module rendering code
- src/ai_gene_review/export/** - export code
- src/ai_gene_review/browser/** - browser app assets
- src/ai_gene_review/tools/minify_linkml_browser_data.py - browser data compaction
- projects/*.md - project definitions
- modules/**/*.yaml - module definitions
- project.justfile - just recipes used by CI
- .github/workflows/generate-pages.yaml - workflow definition

## Review

- [ ] Spot-check a few gene review HTML pages render correctly
- [ ] Spot-check module tree browser pages render correctly
- [ ] Verify browser app loads and filters work
- [ ] Check validation report for new issues
